### PR TITLE
Add possibility to use listings package for code blocks in LaTeX

### DIFF
--- a/README
+++ b/README
@@ -269,6 +269,9 @@ Options
 :   Number section headings in LaTeX, ConTeXt, or HTML output.
     By default, sections are not numbered.
 
+`--listings`
+:   Use listings package for LaTeX code blocks
+
 `--section-divs`
 :   Wrap sections in `<div>` tags (or `<section>` tags in HTML5),
     and attach identifiers to the enclosing `<div>` (or `<section>`)

--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -483,6 +483,7 @@ data WriterOptions = WriterOptions
   , writerBiblioFiles      :: [FilePath] -- ^ Biblio files to use for citations
   , writerHtml5            :: Bool       -- ^ Produce HTML5
   , writerChapters         :: Bool       -- ^ Use "chapter" for top-level sects
+  , writerListings         :: Bool       -- ^ Use listings package for code
   } deriving Show
 
 -- | Default writer options.
@@ -514,6 +515,7 @@ defaultWriterOptions =
                 , writerBiblioFiles      = []
                 , writerHtml5            = False
                 , writerChapters         = False
+                , writerListings         = False
                 }
 
 --

--- a/src/pandoc.hs
+++ b/src/pandoc.hs
@@ -122,6 +122,7 @@ data Opt = Opt
     , optCiteMethod        :: CiteMethod -- ^ Method to output cites
     , optBibliography      :: [String]
     , optCslFile           :: FilePath
+    , optListings          :: Bool       -- ^ Use listings package for code blocks
     }
 
 -- | Defaults for command-line options.
@@ -164,6 +165,7 @@ defaultOpts = Opt
     , optCiteMethod        = Citeproc
     , optBibliography      = []
     , optCslFile           = ""
+    , optListings          = False
     }
 
 -- | A list of functions, each transforming the options data structure
@@ -311,6 +313,11 @@ options =
                  (NoArg
                   (\opt -> return opt { optNumberSections = True }))
                  "" -- "Number sections in LaTeX"
+
+    , Option "" ["listings"]
+                 (NoArg
+                  (\opt -> return opt { optListings = True }))
+                 "" -- "Use listings package for LaTeX code blocks"
 
     , Option "" ["section-divs"]
                  (NoArg
@@ -667,6 +674,7 @@ main = do
               , optBibliography      = reffiles
               , optCslFile           = cslfile
               , optCiteMethod        = citeMethod
+              , optListings          = listings 
              } = opts
 
   when dumpArgs $
@@ -795,7 +803,8 @@ main = do
                                       writerUserDataDir      = datadir,
                                       writerHtml5            = html5 &&
                                                                "html" `isPrefixOf` writerName',
-                                      writerChapters         = chapters }
+                                      writerChapters         = chapters, 
+                                      writerListings         = listings }
 
   when (isNonTextOutput writerName' && outputFile == "-") $
     do UTF8.hPutStrLn stderr ("Error:  Cannot write " ++ writerName ++ " output to stdout.\n" ++

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -69,6 +69,9 @@ $endif$
 \usepackage[breaklinks=true,unicode=true,pdfborder={0 0 0}]{hyperref}
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
+$if(listings)$
+\usepackage{listings}
+$endif$
 $if(numbersections)$
 $else$
 \setcounter{secnumdepth}{0}


### PR DESCRIPTION
This patch adds the possibility to use the listings package for code when generating LaTeX. I think these changes are mostly straight forward. The only controversial thing is that I allow classes like ".Haskell" to be translated into "Language=Haskell". The purpose it to make my markdown documents a little more portable.
