### PR TITLE
extended test-framework dep range

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -351,7 +351,7 @@ Executable test-pandoc
     else
       Ghc-Options:    -Wall
     Extensions:       CPP
-    Build-Depends:    base >= 4 && < 5, Diff, test-framework >= 0.3 && < 0.4,
+    Build-Depends:    base >= 4 && < 5, Diff, test-framework >= 0.3 && < 0.5,
                       test-framework-hunit >= 0.2 && < 0.3,
                       test-framework-quickcheck2 >= 0.2.9 && < 0.3,
                       QuickCheck >= 2.4 && < 2.6,


### PR DESCRIPTION
I've also noticed latex test failures:

```
Failed: 
------------------------------------------------------------------------
--- writer.latex
+++ ../dist/build/pandoc/pandoc --data-dir .. testsuite.native -r native -w latex --columns=78 -s
-   3 \usepackage{ifxetex,ifluatex}
+   3 \usepackage{ifxetex}
+   4 \usepackage{ifluatex}
-  12     \usepackage[utf8]{inputenc}
+  13     \usepackage[mathletters]{ucs}
+  14     \usepackage[utf8x]{inputenc}
------------------------------------------------------------------------
```

And random timeout failures:
    p_write_rt: [65]
    [=======================================>                                     ]Pandoc (Meta {docTitle = [Link [EmDash,EmDash]("%20sZ2'd","Qmi5086dp"),Space,Subscript [Str "['\1920@TLL[",Strong [Str "1\4000\m:"]],EnDash,EnDash], docAuthors = [[Link [Apostrophe,Link [Str "b5IR\7473>/FI"]("!oEo8M7F","FRdB4er"),EnDash,Subscript [Str "!2CO]0{4bB"]]("E7~!@",".3891,n"),Str "Rz\2024&7/lFv",Strong [Str "\[\8930a",Strong [EmDash,Space,RawInline "latex" "\my{command}"]]]], docDate = [Str "\7024=",Superscript [EmDash,Str "9[p!\3770xG4(8V"],EmDash,Str "**6v&@\2064",Space,Math InlineMath "B"]}) [RawBlock "latex" "\begin[opt]{env}\n    p_write_rt: [Failed]
Falsifiable with seed 8624799705760031255, after 70 tests. Reason: Exception: '<<timeout>>'
    p_write_blocks_rt: [53]
