### PR TITLE
allow footnotes followed by newline without space chars in reST

### DIFF
--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -526,8 +526,8 @@ noteBlock = try $ do
   string ".."
   spaceChar >> skipMany spaceChar
   ref <- noteMarker
-  spaceChar >> skipMany spaceChar
-  first <- anyLine
+  first <- (spaceChar >> skipMany spaceChar >> anyLine)
+        <|> (newline >> return "")
   blanks <- option "" blanklines
   rest <- option "" indentedBlock
   endPos <- getPosition


### PR DESCRIPTION
Current pandoc cannot parse footnotes of tests/writer.rst, because all footnote marks on noteblocks in writer.rst has no trailing characters, but pandoc need that.

This patch make padoc can parse writer.rst.

Thanks!
