### PR TITLE
date metadata handling in EPUB writer

### DIFF
--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -311,6 +311,7 @@ pageTemplate = unlines
  , "$for(author)$"
  , "<h2 class=\"author\">$author$</h2>"
  , "$endfor$"
+ , "<h4 class=\"date\">$date$</h4>"
  , "$else$"
  , "<h1>$title$</h1>"
  , "$if(toc)$"


### PR DESCRIPTION
Hello,
this should fix #323

Note that other metadata fields aren't pulled in, either, by the EPUB writer.
However, I'm mighty glad I could even fix the date issue

Best,
ralf
