### PR TITLE
add info about templates to m2pdf section in README

### DIFF
--- a/README
+++ b/README
@@ -119,6 +119,17 @@ included in your LaTeX distribution, you can get them from
 [CTAN]. A full [TeX Live] or [MacTeX] distribution will have all of
 these packages.
 
+Note the PDF output is not strictly identical to other pandoc
+formats. Details of the PDF can be controlled via customization of
+the LaTeX template. A custom template usually derives from
+`default.latex` and can be given as argument to `markdown2pdf`:
+
+    markdown2pdf sample.txt --template=mylatex
+
+See the [Wiki: User contributed templates] page for examples.
+
+[Wiki: User contributed templates]: https://github.com/jgm/pandoc/wiki/User-contributed-templates
+
 `hsmarkdown`
 ------------
 


### PR DESCRIPTION
Hello,
this looks better, of course, it's just a proposition.
