### PR TITLE
remove %URI encoding before href creation from Link

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -608,7 +608,7 @@ inlineToHtml opts inline =
                         return $ obfuscateLink opts (show linkText) s
     (Link txt (s,tit)) -> do
                         linkText <- inlineListToHtml opts txt
-                        return $ anchor ! ([href s] ++
+                        return $ anchor ! ([href (unescapeURI s)] ++
                                  if null tit then [] else [title tit]) $
                                  linkText
     (Image txt (s,tit)) | treatAsImage s -> do


### PR DESCRIPTION
Hello,

this resolves #292 in principle by removing the %AB style URI encoding from
the Link address. This address is given to href which then encodes via the
usual &amp;#123; mechanism.
