### PR TITLE
markdown additional Image width parameter for HTML/Epub, LaTeX/PDF output formats

### DIFF
--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -350,7 +350,7 @@ pImage = do
   let url = fromAttrib "src" tag
   let title = fromAttrib "title" tag
   let alt = fromAttrib "alt" tag
-  return [Image (toList $ text alt) (escapeURI url, title)]
+  return [Image (toList $ text alt) (escapeURI url, title) "100"]
 
 pCode :: TagParser [Inline]
 pCode = try $ do

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -906,7 +906,7 @@ image = try $ do
   let (src,tit) = case args' of
                        []    -> ("", "")
                        (x:_) -> (stripFirstAndLast x, "")
-  return $ Image [Str "image"] (escapeURI src, tit)
+  return $ Image [Str "image"] (escapeURI src, tit) "100"
 
 footnote :: GenParser Char ParserState Inline
 footnote = try $ do

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1199,7 +1199,8 @@ image :: GenParser Char ParserState Inline
 image = try $ do
   char '!'
   (Link lab src) <- link
-  return $ Image lab src
+  width <- option [] (try $ char '@' >> many digit)
+  return $ Image lab src (if (null width) then "100" else width)
 
 note :: GenParser Char ParserState Inline
 note = try $ do

--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -256,8 +256,8 @@ imageBlock = try $ do
   optional blanklines
   case lookup "alt" fields of
         Just alt -> return $ Plain [Image [Str $ removeTrailingSpace alt]
-                             (src, "")]
-        Nothing  -> return $ Plain [Image [Str "image"] (src, "")]
+                             (src, "") "100"]
+        Nothing  -> return $ Plain [Image [Str "image"] (src, "") "100"]
 --
 -- header blocks
 --
@@ -868,7 +868,7 @@ image = try $ do
   (src,tit) <- case lookupKeySrc keyTable (toKey ref) of
                      Nothing     -> fail "no corresponding key"
                      Just target -> return target
-  return $ Image (normalizeSpaces ref) (src, tit)
+  return $ Image (normalizeSpaces ref) (src, tit) "100"
 
 note :: GenParser Char ParserState Inline
 note = try $ do

--- a/src/Text/Pandoc/Readers/Textile.hs
+++ b/src/Text/Pandoc/Readers/Textile.hs
@@ -481,7 +481,7 @@ image = try $ do
   src <- manyTill anyChar (lookAhead $ oneOf "!(")
   alt <- option "" (try $ (char '(' >> manyTill anyChar (char ')')))
   char '!'
-  return $ Image [Str alt] (src, alt)
+  return $ Image [Str alt] (src, alt) "100"
 
 -- | Any special symbol defined in specialChars
 symbol :: GenParser Char ParserState Inline

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -353,7 +353,7 @@ inlineToAsciiDoc opts (Link txt (src', _tit)) = do
   return $ if useAuto
               then text srcSuffix
               else prefix <> text src <> "[" <> linktext <> "]"
-inlineToAsciiDoc opts (Image alternate (src', tit)) = do
+inlineToAsciiDoc opts (Image alternate (src', tit) _) = do
 -- image:images/logo.png[Company logo, title="blah"]
   let txt = if (null alternate) || (alternate == [Str ""])
                then [Str "image"]

--- a/src/Text/Pandoc/Writers/ConTeXt.hs
+++ b/src/Text/Pandoc/Writers/ConTeXt.hs
@@ -113,7 +113,7 @@ blockToConTeXt :: Block
                -> State WriterState Doc
 blockToConTeXt Null = return empty
 blockToConTeXt (Plain lst) = inlineListToConTeXt lst
-blockToConTeXt (Para [Image txt (src,_)]) = do
+blockToConTeXt (Para [Image txt (src,_) size]) = do
   capt <- inlineListToConTeXt txt
   return $ blankline $$ "\\placefigure[here,nonumber]" <> braces capt <>
            braces ("\\externalfigure" <> brackets (text src)) <> blankline
@@ -284,7 +284,7 @@ inlineToConTeXt (Link txt (src, _)) = do
            brackets (text $ escapeStringUsing [('#',"\\#")] src) <>
            brackets empty <> brackets label <>
            "\\from" <> brackets (text ref)
-inlineToConTeXt (Image _ (src, _)) = do
+inlineToConTeXt (Image _ (src, _) _) = do
   let src' = if isAbsoluteURI src
                 then src
                 else unEscapeString src

--- a/src/Text/Pandoc/Writers/Docbook.hs
+++ b/src/Text/Pandoc/Writers/Docbook.hs
@@ -135,7 +135,7 @@ blockToDocbook :: WriterOptions -> Block -> Doc
 blockToDocbook _ Null = empty
 blockToDocbook _ (Header _ _) = empty -- should not occur after hierarchicalize
 blockToDocbook opts (Plain lst) = inlinesToDocbook opts lst
-blockToDocbook opts (Para [Image txt (src,_)]) =
+blockToDocbook opts (Para [Image txt (src,_) _]) =
   let capt = inlinesToDocbook opts txt
   in  inTagsIndented "figure" $
         inTagsSimple "title" capt $$
@@ -272,7 +272,7 @@ inlineToDocbook opts (Link txt (src, _)) =
               then inTags False "link" [("linkend", drop 1 src)]
               else inTags False "ulink" [("url", src)]) $
           inlinesToDocbook opts txt
-inlineToDocbook _ (Image _ (src, tit)) = 
+inlineToDocbook _ (Image _ (src, tit) _ ) = 
   let titleDoc = if null tit
                    then empty
                    else inTagsIndented "objectinfo" $

--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -236,9 +236,9 @@ transformInlines :: HTMLMathMethod
                  -> IORef [(FilePath, FilePath)] -- ^ (oldpath, newpath) images
                  -> [Inline]
                  -> IO [Inline]
-transformInlines _ _ _ (Image lab (src,_) : xs) | isNothing (imageTypeOf src) =
+transformInlines _ _ _ (Image lab (src,_) _ : xs) | isNothing (imageTypeOf src) =
   return $ Emph lab : xs
-transformInlines _ sourceDir picsRef (Image lab (src,tit) : xs) = do
+transformInlines _ sourceDir picsRef (Image lab (src,tit) size : xs) = do
   let src' = unEscapeString src
   pics <- readIORef picsRef
   let oldsrc = sourceDir </> src'
@@ -249,7 +249,7 @@ transformInlines _ sourceDir picsRef (Image lab (src,tit) : xs) = do
                         let new = "images/img" ++ show (length pics) ++ ext
                         modifyIORef picsRef ( (oldsrc, new): )
                         return new
-  return $ Image lab (newsrc, tit) : xs
+  return $ Image lab (newsrc, tit) size : xs
 transformInlines (MathML _) _ _ (x@(Math _ _) : xs) = do
   let writeHtmlInline opts z = removeTrailingSpace $
          writeHtmlString opts $ Pandoc (Meta [] [] []) [Plain [z]]

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -332,8 +332,8 @@ treatAsImage fp =
 blockToHtml :: WriterOptions -> Block -> State WriterState Html
 blockToHtml _ Null = return noHtml
 blockToHtml opts (Plain lst) = inlineListToHtml opts lst
-blockToHtml opts (Para [Image txt (s,tit)]) = do
-  img <- inlineToHtml opts (Image txt (s,tit))
+blockToHtml opts (Para [Image txt (s,tit) w]) = do
+  img <- inlineToHtml opts (Image txt (s,tit) w)
   capt <- inlineListToHtml opts txt
   return $ if writerHtml5 opts
               then tag "figure" <<
@@ -611,22 +611,28 @@ inlineToHtml opts inline =
                         return $ anchor ! ([href s] ++
                                  if null tit then [] else [title tit]) $
                                  linkText
-    (Image txt (s,tit)) | treatAsImage s -> do
+    (Image txt (s,tit) w) | treatAsImage s -> do
                         let alternate' = stringify txt
                         let attributes = [src s] ++
                                          (if null tit
                                             then []
                                             else [title tit]) ++
+																				 (if null w
+																				    then []
+																						else  [width (w ++ "%")]) ++
                                          if null txt
                                             then []
                                             else [alt alternate']
                         return $ image ! attributes
                         -- note:  null title included, as in Markdown.pl
-    (Image _ (s,tit)) -> do
+    (Image _ (s,tit) w) -> do
                         let attributes = [src s] ++
                                          (if null tit
                                             then []
-                                            else [title tit])
+                                            else [title tit]) ++
+																				 (if null w
+																				    then []
+																						else [width (w ++ "%")])
                         return $ itag "embed" ! attributes
                         -- note:  null title included, as in Markdown.pl
     (Note contents)          -> do

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -168,9 +168,9 @@ blockToLaTeX :: Block     -- ^ Block to convert
              -> State WriterState Doc
 blockToLaTeX Null = return empty
 blockToLaTeX (Plain lst) = inlineListToLaTeX lst
-blockToLaTeX (Para [Image txt (src,tit)]) = do
+blockToLaTeX (Para [Image txt (src,tit) size]) = do
   capt <- inlineListToLaTeX txt
-  img <- inlineToLaTeX (Image txt (src,tit))
+  img <- inlineToLaTeX (Image txt (src,tit) size)
   return $ "\\begin{figure}[htbp]" $$ "\\centering" $$ img $$
            ("\\caption{" <> capt <> char '}') $$ "\\end{figure}" $$ blankline
 blockToLaTeX (Para lst) = do
@@ -436,12 +436,13 @@ inlineToLaTeX (Link txt (src, _)) =
         _ -> do contents <- inlineListToLaTeX txt
                 return $ text ("\\href{" ++ stringToLaTeX True src ++ "}{") <>
                          contents <> char '}'
-inlineToLaTeX (Image _ (source, _)) = do
+inlineToLaTeX (Image _ (source, _) w) = do
   modify $ \s -> s{ stGraphics = True }
   let source' = if isAbsoluteURI source
                    then source
                    else unEscapeString source
-  return $ "\\includegraphics" <> braces (text source')
+  let widthOption = text ("\\includegraphics[width=" ++ (show ((read w)/100.0::Float)) ++ "\\textwidth]")
+  return $ widthOption <> braces (text source')
 inlineToLaTeX (Note contents) = do
   modify (\s -> s{stInNote = True})
   contents' <- blockListToLaTeX contents

--- a/src/Text/Pandoc/Writers/Man.hs
+++ b/src/Text/Pandoc/Writers/Man.hs
@@ -326,7 +326,7 @@ inlineToMan opts (Link txt (src, _)) = do
            [Code _ s]
              | s == srcSuffix -> char '<' <> text srcSuffix <> char '>' 
            _                  -> linktext <> text " (" <> text src <> char ')'
-inlineToMan opts (Image alternate (source, tit)) = do
+inlineToMan opts (Image alternate (source, tit) _) = do
   let txt = if (null alternate) || (alternate == [Str ""]) || 
                (alternate == [Str source]) -- to prevent autolinks
                then [Str "image"]

--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -77,7 +77,7 @@ plainify = bottomUp go
         go (Math _ s) = Str s
         go (RawInline _ _) = Str ""
         go (Link xs _) = SmallCaps xs
-        go (Image xs _) = SmallCaps $ [Str "["] ++ xs ++ [Str "]"]
+        go (Image xs _ _) = SmallCaps $ [Str "["] ++ xs ++ [Str "]@"]
         go (Cite _ cits) = SmallCaps cits
         go x = x
 
@@ -518,13 +518,14 @@ inlineToMarkdown opts (Link txt (src', tit)) = do
                            in  first <> second
                       else "[" <> linktext <> "](" <> 
                            text src <> linktitle <> ")"
-inlineToMarkdown opts (Image alternate (source, tit)) = do
+inlineToMarkdown opts (Image alternate (source, tit) size) = do
   let txt = if (null alternate) || (alternate == [Str ""]) || 
                (alternate == [Str source]) -- to prevent autolinks
                then [Str "image"]
                else alternate
   linkPart <- inlineToMarkdown opts (Link txt (source, tit))
-  return $ "!" <> linkPart
+  sizePart <- inlineToMarkdown opts (Str ("@" ++ size))
+  return $ "!" <> linkPart <> sizePart
 inlineToMarkdown _ (Note contents) = do 
   modify (\st -> st{ stNotes = contents : stNotes st })
   st <- get

--- a/src/Text/Pandoc/Writers/MediaWiki.hs
+++ b/src/Text/Pandoc/Writers/MediaWiki.hs
@@ -80,7 +80,7 @@ blockToMediaWiki _ Null = return ""
 blockToMediaWiki opts (Plain inlines) = 
   inlineListToMediaWiki opts inlines
 
-blockToMediaWiki opts (Para [Image txt (src,tit)]) = do
+blockToMediaWiki opts (Para [Image txt (src,tit) size]) = do
   capt <- inlineListToMediaWiki opts txt 
   let opt = if null txt
                then ""
@@ -388,7 +388,7 @@ inlineToMediaWiki opts (Link txt (src, _)) = do
                      where src' = case src of
                                      '/':xs -> xs  -- with leading / it's a
                                      _      -> src -- link to a help page
-inlineToMediaWiki opts (Image alt (source, tit)) = do
+inlineToMediaWiki opts (Image alt (source, tit) size) = do
   alt' <- inlineListToMediaWiki opts alt
   let txt = if (null tit)
                then if null alt

--- a/src/Text/Pandoc/Writers/ODT.hs
+++ b/src/Text/Pandoc/Writers/ODT.hs
@@ -100,13 +100,13 @@ writeODT mbRefOdt opts doc = do
   return $ fromArchive archive'
 
 transformPic :: FilePath -> IORef [Entry] -> Inline -> IO Inline
-transformPic sourceDir entriesRef (Image lab (src,tit)) = do
+transformPic sourceDir entriesRef (Image lab (src,tit) size) = do
   let src' = unEscapeString src
   entries <- readIORef entriesRef
   let newsrc = "Pictures/" ++ show (length entries) ++ takeExtension src'
   catch (readEntry [] (sourceDir </> src') >>= \entry ->
            modifyIORef entriesRef (entry{ eRelativePath = newsrc } :) >>
-           return (Image lab (newsrc, tit)))
+           return (Image lab (newsrc, tit) size))
         (\_ -> return (Emph lab))
 transformPic _ _ x = return x
 

--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -382,7 +382,7 @@ inlineToOpenDocument o ils
     | RawInline "html" s <- ils = preformatted s  -- for backwards compat.
     | RawInline _ _ <- ils = return empty
     | Link  l (s,t) <- ils = mkLink s t <$> inlinesToOpenDocument o l
-    | Image _ (s,_) <- ils = return $ mkImg  s
+    | Image _ (s,_) _ <- ils = return $ mkImg  s
     | Note        l <- ils = mkNote l
     | otherwise            = return empty
     where

--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -108,9 +108,9 @@ blockToOrg :: Block         -- ^ Block element
            -> State WriterState Doc 
 blockToOrg Null = return empty
 blockToOrg (Plain inlines) = inlineListToOrg inlines
-blockToOrg (Para [Image txt (src,tit)]) = do
+blockToOrg (Para [Image txt (src,tit) size]) = do
   capt <- inlineListToOrg txt
-  img <- inlineToOrg (Image txt (src,tit))
+  img <- inlineToOrg (Image txt (src,tit) size)
   return $ "#+CAPTION: " <> capt <> blankline <> img
 blockToOrg (Para inlines) = do
   contents <- inlineListToOrg inlines
@@ -272,7 +272,7 @@ inlineToOrg (Link txt (src, _)) = do
         _ -> do contents <- inlineListToOrg txt
                 modify $ \s -> s{ stLinks = True }
                 return $ "[[" <> text src <> "][" <> contents <> "]]"
-inlineToOrg (Image _ (source', _)) = do
+inlineToOrg (Image _ (source', _) _) = do
   let source = unescapeURI source'
   modify $ \s -> s{ stImages = True }
   return $ "[[" <> text source <> "]]"

--- a/src/Text/Pandoc/Writers/RST.hs
+++ b/src/Text/Pandoc/Writers/RST.hs
@@ -139,7 +139,7 @@ blockToRST :: Block         -- ^ Block element
            -> State WriterState Doc 
 blockToRST Null = return empty
 blockToRST (Plain inlines) = inlineListToRST inlines
-blockToRST (Para [Image txt (src,tit)]) = do
+blockToRST (Para [Image txt (src,tit) size]) = do
   capt <- inlineListToRST txt
   let fig = "figure:: " <> text src
   let align = ":align: center"
@@ -311,7 +311,7 @@ inlineToRST (Link txt (src', tit)) = do
             modify $ \st -> st { stLinks = refs' }
             return $ "`" <> linktext <> "`_"
     else return $ "`" <> linktext <> " <" <> text src <> ">`_"
-inlineToRST (Image alternate (source', tit)) = do
+inlineToRST (Image alternate (source', tit) size) = do
   let source = unescapeURI source'
   pics <- get >>= return . stImages
   let labelsUsed = map fst pics 

--- a/src/Text/Pandoc/Writers/RTF.hs
+++ b/src/Text/Pandoc/Writers/RTF.hs
@@ -42,7 +42,7 @@ import Network.URI ( isAbsoluteURI, unEscapeString )
 -- | Convert Image inlines into a raw RTF embedded image, read from a file.
 -- If file not found or filetype not jpeg or png, leave the inline unchanged.
 rtfEmbedImage :: Inline -> IO Inline
-rtfEmbedImage x@(Image _ (src,_)) = do
+rtfEmbedImage x@(Image _ (src,_) _) = do
   let ext = map toLower (takeExtension src)
   if ext `elem` [".jpg",".jpeg",".png"] && not (isAbsoluteURI src)
      then do
@@ -302,7 +302,7 @@ inlineToRTF Space = " "
 inlineToRTF (Link text (src, _)) = 
   "{\\field{\\*\\fldinst{HYPERLINK \"" ++ (codeStringToRTF src) ++ 
   "\"}}{\\fldrslt{\\ul\n" ++ (inlineListToRTF text) ++ "\n}}}\n"
-inlineToRTF (Image _ (source, _)) = 
+inlineToRTF (Image _ (source, _) _) = 
   "{\\cf1 [image: " ++ source ++ "]\\cf0}" 
 inlineToRTF (Note contents) =
   "{\\super\\chftn}{\\*\\footnote\\chftn\\~\\plain\\pard " ++ 

--- a/src/Text/Pandoc/Writers/Texinfo.hs
+++ b/src/Text/Pandoc/Writers/Texinfo.hs
@@ -111,9 +111,9 @@ blockToTexinfo Null = return empty
 blockToTexinfo (Plain lst) =
   inlineListToTexinfo lst
 
-blockToTexinfo (Para [Image txt (src,tit)]) = do
+blockToTexinfo (Para [Image txt (src,tit) size]) = do
   capt <- inlineListToTexinfo txt
-  img  <- inlineToTexinfo (Image txt (src,tit))
+  img  <- inlineToTexinfo (Image txt (src,tit) size)
   return $ text "@float" $$ img $$ (text "@caption{" <> capt <> char '}') $$
            text "@end float"
 
@@ -409,7 +409,7 @@ inlineToTexinfo (Link txt (src, _)) = do
                 return $ text ("@uref{" ++ src1 ++ ",") <> contents <>
                          char '}'
 
-inlineToTexinfo (Image alternate (source, _)) = do
+inlineToTexinfo (Image alternate (source, _) _) = do
   content <- inlineListToTexinfo alternate
   return $ text ("@image{" ++ base ++ ",,,") <> content <> text "," <>
            text (ext ++ "}")

--- a/src/Text/Pandoc/Writers/Textile.hs
+++ b/src/Text/Pandoc/Writers/Textile.hs
@@ -96,9 +96,9 @@ blockToTextile _ Null = return ""
 blockToTextile opts (Plain inlines) = 
   inlineListToTextile opts inlines
 
-blockToTextile opts (Para [Image txt (src,tit)]) = do
+blockToTextile opts (Para [Image txt (src,tit) size]) = do
   capt <- blockToTextile opts (Para txt)
-  im <- inlineToTextile opts (Image txt (src,tit))
+  im <- inlineToTextile opts (Image txt (src,tit) size)
   return $ im ++ "\n" ++ capt
 
 blockToTextile opts (Para inlines) = do
@@ -403,7 +403,7 @@ inlineToTextile opts (Link txt (src, _)) = do
                 _           -> inlineListToTextile opts txt
   return $ "\"" ++ label ++ "\":" ++ src
 
-inlineToTextile opts (Image alt (source, tit)) = do
+inlineToTextile opts (Image alt (source, tit) size) = do
   alt' <- inlineListToTextile opts alt
   let txt = if null tit
                then if null alt'


### PR DESCRIPTION
Hello,
this resolves #332 and provides implementations in the HTML and LaTeX writers.
It is dependent on the two patches

* https://gist.github.com/1380600
* https://gist.github.com/1382799

What does it do? The markdown

    ![alttext](image.jpg)

will produce markdown output

    ![alttext](image.jpg)@100

or HTML output

    <div class="figure">
    <img src="image.jpg" width="100%" alt="alttext" /><p class="caption">alttext</p>
    </div>

or LaTeX output

    \begin{figure}[htbp]
    \centering
    \includegraphics[width=1.0\textwidth]{image.jpg}
     \caption{alttext}
     \end{figure}

Any digits after the @ character will be interpreted as width percentage, atm
