### PR TITLE
Use Link instead of RawInline for reference backlinks

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -663,8 +663,7 @@ blockListToNote :: WriterOptions -> String -> [Block] -> State WriterState Html
 blockListToNote opts ref blocks =
   -- If last block is Para or Plain, include the backlink at the end of
   -- that block. Otherwise, insert a new Plain block with the backlink.
-  let backlink = [RawInline "html" $ " <a href=\"#" ++ writerIdentifierPrefix opts ++ "fnref" ++ ref ++
-                 "\" class=\"footnoteBackLink\">↩</a>"]
+  let backlink = [Link [Str "↩"] ("#" ++ writerIdentifierPrefix opts ++ "fnref" ++ ref,[])]
       blocks'  = if null blocks
                     then []
                     else let lastBlock   = last blocks


### PR DESCRIPTION
If you try to convert Pandoc -> Blaze-Html -> XmlHtml, i.e. for use with Snap/Heist, the backlinks for references will be escaped since they are inlined manually. I just started mucking about in the Pandoc internals so I'm not sure how to keep the "footnoteBacklink" class.
