### PR TITLE
Better treating of headings in beamer mode

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -200,14 +200,18 @@ inCmd :: String -> Doc -> Doc
 inCmd cmd contents = char '\\' <> text cmd <> braces contents
 
 toSlides :: [Block] -> State WriterState [Block]
-toSlides (Header n ils : bs) = do
+toSlides (Header 4 ils : bs) = do
+  tit <- inlineListToLaTeX ils
+  result <- (RawBlock "latex" ("\\framesubtitle{" ++ render Nothing tit ++ "}") :)
+            `fmap` toSlides bs
+  return $ result
+toSlides (Header 3 ils : bs) = do
   tit <- inlineListToLaTeX ils
   firstFrame <- gets stFirstFrame
   modify $ \s -> s{ stFirstFrame = False }
   -- note: [fragile] is required or verbatim breaks
-  result <- ((Header n ils :) .
-             (RawBlock "latex" ("\\begin{frame}[fragile]\n" ++
-               "\\frametitle{" ++ render Nothing tit ++ "}") :))
+  result <- (RawBlock "latex" ("\\begin{frame}[fragile]\n" ++
+               "\\frametitle{" ++ render Nothing tit ++ "}") :)
          `fmap` toSlides bs
   if firstFrame
      then return result


### PR DESCRIPTION
Hi,

I saw that you recently added a latex-beamer mode, but found that it didn't support the style that I usually find in beamer samples. In the current state, it mostly adds a slide with a \frametitle for each heading level. I think it would be better it it actually didn't add any slides for section and subsection (especially as beamer might do this on his own) and gives more control about \frametitle and \framesubtitle without adding them using raw latex.

This patch interprets level 3 and level 4 headings as \frametitle and \framesubtitle, e.g. it turns the following document:

```
# Test1
## Test2
### Test3
#### Test4

sometext

---------------------------------------

some more text

* fooo
* bar
```

into the following:

```
\section{Test1}

\subsection{Test2}

\begin{frame}[fragile]
\frametitle{Test3}

\framesubtitle{Test4}

sometext

\end{frame}

\begin{frame}[fragile]

some more text

\begin{itemize}
\item
  fooo
\item
  bar
\end{itemize}
\end{frame}
```
