### PR TITLE
Building on 7.4.1 on OS X Lion reports an ambiguity in the use of (<>).

### DIFF
--- a/src/Text/Pandoc/Pretty.hs
+++ b/src/Text/Pandoc/Pretty.hs
@@ -74,7 +74,7 @@ module Text.Pandoc.Pretty (
 where
 import Data.DList (DList, fromList, toList, cons, singleton)
 import Data.List (intercalate)
-import Data.Monoid
+import Data.Monoid hiding ((<>))
 import Data.String
 import Control.Monad.State
 import Data.Char (isSpace)


### PR DESCRIPTION
 This hides the unnecessary occurrence in Monoid.
