### PR TITLE
Relax test-framework version dependency to allow building with GHC 7.4.1

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -400,7 +400,7 @@ Executable test-pandoc
   else
     Buildable:        False
   Other-Extensions: TemplateHaskell, QuasiQuotes
-  Build-Depends:    Diff, test-framework >= 0.3 && < 0.5,
+  Build-Depends:    Diff, test-framework >= 0.3 && < 0.6,
                     test-framework-hunit >= 0.2 && < 0.3,
                     test-framework-quickcheck2 >= 0.2.9 && < 0.3,
                     QuickCheck >= 2.4 && < 2.6,


### PR DESCRIPTION
Breaks in trying to configure the pandoc-tests executable. The problem is an explicit dependency `test-framework >= 0.3 && < 0.5`, since 0.5 is the first version on Hackage that builds under 7.4.1.
