### PR TITLE
Texinfo writer: retain directories in image paths.

### DIFF
--- a/src/Text/Pandoc/Writers/Texinfo.hs
+++ b/src/Text/Pandoc/Writers/Texinfo.hs
@@ -415,7 +415,7 @@ inlineToTexinfo (Image alternate (source, _)) = do
            text (ext ++ "}")
   where
     ext     = drop 1 $ takeExtension source'
-    base    = takeBaseName source'
+    base    = dropExtension source'
     source' = if isAbsoluteURI source
                  then source
                  else unEscapeString source


### PR DESCRIPTION
The output for

```
![lalune](images/lalune.jpg)
```

should be

```
@image{images/lalune,,,lalune,jpg}
```

instead of

```
@image{lalune,,,lalune,jpg}
```
