### PR TITLE
Add --include-macros command line option

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -168,7 +168,11 @@ Extra-Source-Files:
                  tests/lhs-test.latex+lhs,
                  tests/lhs-test.html,
                  tests/lhs-test.html+lhs,
-                 tests/lhs-test.fragment.html+lhs
+                 tests/lhs-test.fragment.html+lhs,
+                 tests/include-macros.tex,
+                 tests/include-macros-1.tex,
+                 tests/include-macros.txt,
+                 tests/include-macros.native
 Extra-Tmp-Files: man/man1/pandoc.1,
                  man/man5/pandoc_markdown.5
 

--- a/src/Tests/Old.hs
+++ b/src/Tests/Old.hs
@@ -61,6 +61,12 @@ tests = [ testGroup "markdown"
             , lhsReaderTest "markdown+lhs"
             ]
           , testGroup "citations" markdownCitationTests
+          , testGroup "include-macros"
+            [ test "basic" ["-f", "markdown", "-t", "native", 
+                            "--include-macros=include-macros.tex",
+                            "--include-macros=include-macros-1.tex"]
+              "include-macros.txt" "include-macros.native"
+            ]
           ]
         , testGroup "rst"
           [ testGroup "writer" (writerTests "rst" ++ lhsWriterTests "rst")

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -28,6 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 Conversion of LaTeX to 'Pandoc' document.
 -}
 module Text.Pandoc.Readers.LaTeX ( readLaTeX,
+                                   readMacros,
                                    rawLaTeXInline,
                                    rawLaTeXBlock,
                                    handleIncludes
@@ -47,6 +48,7 @@ import Data.Monoid
 import System.FilePath (replaceExtension)
 import Data.List (intercalate)
 import qualified Data.Map as M
+import Text.TeXMath.Macros (Macro)
 
 -- | Parse LaTeX from string and return 'Pandoc' document.
 readLaTeX :: ParserState   -- ^ Parser state, including options for parser
@@ -63,6 +65,17 @@ parseLaTeX = do
   let authors' = stateAuthors st
   let date' = stateDate st
   return $ Pandoc (Meta title' authors' date') $ toList bs
+
+-- | Parse LaTeX from string and return the macros defined throughout the document
+readMacros :: ParserState -> String -> [Macro]
+readMacros = readWith parseMacros
+
+parseMacros :: LP [Macro]
+parseMacros = do
+  blocks
+  eof
+  st <- getState
+  return $ stateMacros st
 
 type LP = GenParser Char ParserState
 

--- a/src/pandoc.hs
+++ b/src/pandoc.hs
@@ -31,7 +31,7 @@ writers.
 module Main where
 import Text.Pandoc
 import Text.Pandoc.PDF (tex2pdf)
-import Text.Pandoc.Readers.LaTeX (handleIncludes)
+import Text.Pandoc.Readers.LaTeX (handleIncludes, readMacros)
 import Text.Pandoc.Shared ( tabFilter, ObfuscationMethod (..), readDataFile,
                             headerShift, findDataFile, normalize, err, warn )
 import Text.Pandoc.XML ( toEntities, fromEntities )
@@ -388,6 +388,17 @@ options =
                                   optStandalone = True })
                   "FILENAME")
                  "" -- "File to include after document body"
+
+    , Option "" ["include-macros"]
+                 (ReqArg
+                  (\arg opt -> do
+                     text <- UTF8.readFile arg
+                     -- add new ones to end, so they're included in order specified
+                     let newvars = optVariables opt ++ [("include-macros",text)]
+                     return opt { optVariables = newvars,
+                                  optStandalone = True })
+                  "FILENAME")
+                 "" -- "File containing latex macros to include"
 
     , Option "" ["self-contained"]
                  (NoArg
@@ -983,7 +994,18 @@ main = do
                            then handleIncludes
                            else return
 
-  doc <- (reader startParserState) `fmap` (readSources sources >>=
+  -- parse included macros from the imported files
+  let includedMacros = readMacros startParserState $
+        intercalate "\n" $
+        map snd $
+        filter (\(name,_) -> name == "include-macros") variables
+
+  -- initial parser state contains included macros
+  let startParserState' = startParserState
+                {stateMacros = includedMacros ++
+                    stateMacros startParserState}
+
+  doc <- (reader startParserState') `fmap` (readSources sources >>=
              handleIncludes' . convertTabs . intercalate "\n")
 
   let doc0 = foldr ($) doc transforms

--- a/tests/include-macros-1.tex
+++ b/tests/include-macros-1.tex
@@ -1,0 +1,4 @@
+
+% should redefine \third in include-macros.tex
+
+\renewcommand{\third}{0.333}

--- a/tests/include-macros.native
+++ b/tests/include-macros.native
@@ -1,0 +1,4 @@
+Pandoc (Meta {docTitle = [], docAuthors = [], docDate = []})
+[Para [Str "some",Space,Str "text",Space,Math InlineMath "1/2",Space,Str "and",Space,Str "then",Space,Str "another",Space,Str "formula",Space,Math InlineMath "\\frac{1}{\\sin(25)}"]
+,Para [Str "this",Space,Str "shouldn",Str "'",Str "t",Space,Str "be",Space,Str "replaced",Space,Math DisplayMath "\n\\inactive\n"]
+,Para [Str "test",Space,Str "of",Space,Str "redefining",Space,Str "a",Space,Str "macro",Space,Math DisplayMath "\n0.333== 0.333\n"]]

--- a/tests/include-macros.tex
+++ b/tests/include-macros.tex
@@ -1,0 +1,16 @@
+
+% some command
+
+\newcommand{\half}{1/2}
+
+% command with argument
+
+\newcommand{\func}[1]{\sin(#1)}
+
+% commented out macro
+
+%\newcommand{\inactive}{wrong}
+
+% another
+
+\newcommand{\third}{1/(1+2)}

--- a/tests/include-macros.txt
+++ b/tests/include-macros.txt
@@ -1,0 +1,11 @@
+some text $\half$ and then another formula $\frac{1}{\func{25}}$
+
+this shouldn't be replaced
+$$
+\inactive
+$$
+
+test of redefining a macro
+$$
+\third == 0.333
+$$


### PR DESCRIPTION
**Motivation.** I have been using pandoc for a while now. I use it mainly to take various notes. It is a wonderful tool, but I found it seriously lacking this feature. I get to type a lot of formulas. Therefore I have a set of predefined macros that I reuse in all my writing. A typical example is `\e` for `\varepsilon`.

However, there did not seem to be a clean way how to import `\{re}newcommand` macros from an external LaTeX file. It is of course possible to specify multiple input files as in

```
pandoc macros.tex file.md
```

that will be merged and processed at once. This would work fine, if it were not for the pandoc metadata in the preamble. These get garbled since now they appear in a block of text after `macros.tex`.

Up to now, I resolved to preprocessing the input file using a batch to inject the macros after the preamble, but this requires to actually parse the preamble, or put a tag after the preamble into the input. I did not find it satisfactory, since pandoc excels in a clean customization of the output in every other way. This led me to implement this extension.

**Description.** The new option `--include-macros` enables the user to include supported LaTeX macros from arbitrary external LaTeX files. These macros are then applied when processing LaTeX formulas, depending on the input and output formats.

It is implemented using the pandoc LaTeX parser in `Text.Readers.LaTeX`, only the `stateMacros` is returned instead of the parsed document.

The usage follows the pattern of the other options, for instance `--include-in-header`, etc.:

```
pandoc ... --include-macros=FILE1 --include-macros=FILE2 ...
```

The loaded files can be inserted verbatim into the output template using the variable
array `$include-macros$`. To this extend I am also submitting a related pull request to jgm/pandoc-templates.

I have also added a test that uses a set of `include-macros*` files, and added it to `Tests.Old`. Running `cabal test` shows that all the tests PASS (Ubuntu 11.10).

I appreciate any comments or suggestions. It would be nice to have this feature in the official pandoc distribution.

Best,
Norbert
