### PR TITLE
\ref instruction support

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -570,6 +570,9 @@ inlineToLaTeX (RawInline "tex" str) = return $ text str
 inlineToLaTeX (RawInline _ _) = return empty
 inlineToLaTeX (LineBreak) = return "\\\\"
 inlineToLaTeX Space = return space
+inlineToLaTeX (Link [] ('#':ident, _)) = do
+  ident' <- stringToLaTeX False ident
+  return $ text "\\ref" <> braces (text ident') 
 inlineToLaTeX (Link txt ('#':ident, _)) = do
   contents <- inlineListToLaTeX txt
   ident' <- stringToLaTeX False ident


### PR DESCRIPTION
Suggestion: instead of generating a \hyperref instruction, internal links without text could generate a \ref instruction, which will render the section number.

Example Markdown input to trigger new behavior:
`Take a look at section [](#some-section).`

Will render something like 'Take a look at section 2.1'
