### PR TITLE
Linebreak handling control

### DIFF
--- a/README
+++ b/README
@@ -237,6 +237,11 @@ Reader options
 `-p`, `--preserve-tabs`
 :   Preserve tabs instead of converting them to spaces (the default).
 
+`--linebreak=`*METHOD*
+:   Specify the treatment of newline characters within paragraphs.
+    *METHOD* can be `space`, `skip`, or `preserve` (defaults to `space`).
+    This option currently has effect only on `markdown` input.
+
 `--tab-stop=`*NUMBER*
 :   Specify the number of spaces per tab (default is 4).
 

--- a/src/Text/Pandoc.hs
+++ b/src/Text/Pandoc.hs
@@ -73,6 +73,7 @@ module Text.Pandoc
                , readNative
                -- * Parser state used in readers
                , ParserState (..)
+               , LineBreakConv (..)
                , defaultParserState
                , ParserContext (..)
                , QuoteContext (..)

--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -60,6 +60,7 @@ module Text.Pandoc.Parsing ( (>>~),
                              gridTableWith,
                              readWith,
                              testStringWith,
+                             LineBreakConv (..),
                              ParserState (..),
                              defaultParserState,
                              HeaderType (..),
@@ -625,6 +626,13 @@ testStringWith :: (Show a) => GenParser Char ParserState a
 testStringWith parser str = UTF8.putStrLn $ show $
                             readWith parser defaultParserState str
 
+-- | Experimental line break control options.
+data LineBreakConv
+    = LineBreakSpace    -- ^ Convert newline characters to spaces
+    | LineBreakSkip     -- ^ Skip newline characters within paragraphs
+    | LineBreakPreserve -- ^ Preverve all newline characters
+    deriving Show
+
 -- | Parsing options.
 data ParserState = ParserState
     { stateParseRaw        :: Bool,          -- ^ Parse raw HTML and LaTeX?
@@ -654,7 +662,8 @@ data ParserState = ParserState
       stateHasChapters     :: Bool,          -- ^ True if \chapter encountered
       stateApplyMacros     :: Bool,          -- ^ Apply LaTeX macros?
       stateMacros          :: [Macro],       -- ^ List of macros defined so far
-      stateRstDefaultRole  :: String         -- ^ Current rST default interpreted text role
+      stateRstDefaultRole  :: String,        -- ^ Current rST default interpreted text role
+      stateLineBreakConv   :: LineBreakConv  -- ^ How to convert line breaks?
     }
     deriving Show
 
@@ -685,7 +694,8 @@ defaultParserState =
                   stateHasChapters     = False,
                   stateApplyMacros     = True,
                   stateMacros          = [],
-                  stateRstDefaultRole  = "title-reference"}
+                  stateRstDefaultRole  = "title-reference",
+                  stateLineBreakConv   = LineBreakSpace}
 
 data HeaderType 
     = SingleHeader Char  -- ^ Single line of characters underneath

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -111,7 +111,11 @@ atMostSpaces n = (char ' ' >> atMostSpaces (n-1)) <|> return ()
 litChar :: GenParser Char ParserState Char
 litChar = escapedChar'
        <|> noneOf "\n"
-       <|> (newline >> notFollowedBy blankline >> return ' ')
+       <|> (newline >> notFollowedBy blankline >> do state <- getState
+                                                     case stateLineBreakConv state of
+                                                         LineBreakSpace    -> return ' '
+                                                         LineBreakSkip     -> litChar
+                                                         LineBreakPreserve -> fail "end of line")
 
 -- | Fail unless we're at beginning of a line.
 failUnlessBeginningOfLine :: GenParser tok st () 
@@ -1148,7 +1152,10 @@ endline = try $ do
   when (stateParserContext st == ListItemState) $ do
      notFollowedBy' bulletListStart
      notFollowedBy' anyOrderedListStart
-  return Space
+  case stateLineBreakConv st of
+       LineBreakSpace    -> return Space
+       LineBreakSkip     -> return $ Str ""
+       LineBreakPreserve -> return LineBreak
 
 --
 -- links

--- a/src/pandoc.hs
+++ b/src/pandoc.hs
@@ -104,6 +104,7 @@ nonTextFormats = ["odt","docx","epub"]
 data Opt = Opt
     { optTabStop           :: Int     -- ^ Number of spaces per tab
     , optPreserveTabs      :: Bool    -- ^ Preserve tabs instead of converting to spaces
+    , optLineBreakConv     :: LineBreakConv -- ^ Linebreak conversion
     , optStandalone        :: Bool    -- ^ Include header, footer
     , optReader            :: String  -- ^ Reader format
     , optWriter            :: String  -- ^ Writer format
@@ -157,6 +158,7 @@ defaultOpts :: Opt
 defaultOpts = Opt
     { optTabStop           = 4
     , optPreserveTabs      = False
+    , optLineBreakConv     = LineBreakSpace
     , optStandalone        = False
     , optReader            = ""    -- null for default reader
     , optWriter            = ""    -- null for default writer
@@ -285,6 +287,19 @@ options =
                  (NoArg
                   (\opt -> return opt { optPreserveTabs = True }))
                  "" -- "Preserve tabs instead of converting to spaces"
+
+    , Option "" ["linebreak"]
+                 (ReqArg
+                  (\arg opt -> do
+                     method <- case arg of
+                            "space"      -> return LineBreakSpace
+                            "skip"       -> return LineBreakSkip
+                            "preserve"   -> return LineBreakPreserve
+                            _            -> err 51
+                               ("Unknown line-break conversion method: " ++ arg)
+                     return opt { optLineBreakConv = method })
+                  "space|skip|none")
+                 "" -- "Method for converting line breaks"
 
     , Option "" ["tab-stop"]
                  (ReqArg
@@ -781,6 +796,7 @@ main = do
 
   let Opt    {  optTabStop           = tabStop
               , optPreserveTabs      = preserveTabs
+              , optLineBreakConv     = lineBreakConv
               , optStandalone        = standalone
               , optReader            = readerName
               , optWriter            = writerName
@@ -947,7 +963,8 @@ main = do
                               stateColumns         = columns,
                               stateStrict          = strict,
                               stateIndentedCodeClasses = codeBlockClasses,
-                              stateApplyMacros     = not laTeXOutput
+                              stateApplyMacros     = not laTeXOutput,
+                              stateLineBreakConv   = lineBreakConv
                               }
 
   let writerOptions = defaultWriterOptions


### PR DESCRIPTION
There are languages (Chinese, Japanese, etc) that do not use spaces to separate words. This is my hack to add a new option `--linebreak` to change the default newline conversion for `markdown` input. It can be either `space` (the default, original behavior), `skip`, or `preserve` now. I'd like to hear your opinions on this and work on this patch more. For example make this option work for other kinds of input.

Ideally we should be able to mark a particular region with a particular language, and the conversion should be context-aware. I only implemented the basic control here, and it's valid only for `markdown` input. For related information one can see [`text-space-collapse` in current CSS3 draft](http://www.w3.org/TR/css3-text/#white-space-collapsing) and [some question on stackoverflow](http://stackoverflow.com/q/8550112/985527).
