### PR TITLE
Command line option to specify that DocBook should use recursive <section> elements

### DIFF
--- a/README
+++ b/README
@@ -370,6 +370,11 @@ Options affecting specific writers
     memoir class, this option is implied.  If `--beamer` is used,
     top-level headers will become `\part{..}`.
 
+`--recursive-sections`
+:   Use nested `<section>` tags rather than `<sect1>`, `<sect2>`,
+    `<sect3>`, `<sect4>`, `<sect5>` and `<simplesect>` when writing
+    DocBook.
+
 `-N`, `--number-sections`
 :   Number section headings in LaTeX, ConTeXt, or HTML output.
     By default, sections are not numbered.

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -216,6 +216,7 @@ data WriterOptions = WriterOptions
   , writerBeamer           :: Bool       -- ^ Produce beamer LaTeX slide show
   , writerSlideLevel       :: Maybe Int  -- ^ Force header level of slides
   , writerChapters         :: Bool       -- ^ Use "chapter" for top-level sects
+  , writerRecursiveSections :: Bool       -- ^ Use "section" not "sect1" ... "sect5"
   , writerListings         :: Bool       -- ^ Use listings package for code
   , writerHighlight        :: Bool       -- ^ Highlight source code
   , writerHighlightStyle   :: Style      -- ^ Style to use for highlighting
@@ -254,6 +255,7 @@ instance Default WriterOptions where
                       , writerBeamer           = False
                       , writerSlideLevel       = Nothing
                       , writerChapters         = False
+                      , writerRecursiveSections = False
                       , writerListings         = False
                       , writerHighlight        = False
                       , writerHighlightStyle   = pygments

--- a/src/Text/Pandoc/Writers/Docbook.hs
+++ b/src/Text/Pandoc/Writers/Docbook.hs
@@ -99,10 +99,14 @@ elementToDocbook opts lvl (Sec _ _num id' title elements) =
   let elements' = if null elements
                     then [Blk (Para [])]
                     else elements
-      tag = case lvl of
-                 n | n == 0           -> "chapter"
-                   | n >= 1 && n <= 5 -> "sect" ++ show n
-                   | otherwise        -> "simplesect"
+      tag = if writerRecursiveSections opts
+               then case lvl of
+                          n | n == 0           -> "chapter"
+                            | otherwise        -> "section"
+               else case lvl of
+                          n | n == 0           -> "chapter"
+                            | n >= 1 && n <= 5 -> "sect" ++ show n
+                            | otherwise        -> "simplesect"
   in  inTags True tag [("id",id')] $
       inTagsSimple "title" (inlinesToDocbook opts title) $$
       vcat (map (elementToDocbook opts (lvl + 1)) elements')

--- a/src/pandoc.hs
+++ b/src/pandoc.hs
@@ -124,6 +124,7 @@ data Opt = Opt
     , optHighlight         :: Bool    -- ^ Highlight source code
     , optHighlightStyle    :: Style   -- ^ Style to use for highlighted code
     , optChapters          :: Bool    -- ^ Use chapter for top-level sects
+    , optRecursiveSections :: Bool    -- ^ Use <section> not <sect1> ... <sect5> in DocBook
     , optHTMLMathMethod    :: HTMLMathMethod -- ^ Method to print HTML math
     , optReferenceODT      :: Maybe FilePath -- ^ Path of reference.odt
     , optReferenceDocx     :: Maybe FilePath -- ^ Path of reference.docx
@@ -176,6 +177,7 @@ defaultOpts = Opt
     , optHighlight         = True
     , optHighlightStyle    = pygments
     , optChapters          = False
+    , optRecursiveSections = False
     , optHTMLMathMethod    = PlainMath
     , optReferenceODT      = Nothing
     , optReferenceDocx     = Nothing
@@ -450,6 +452,11 @@ options =
                  (NoArg
                   (\opt -> return opt { optChapters = True }))
                  "" -- "Use chapter for top-level sections in LaTeX, DocBook"
+
+    , Option "" ["recursive-sections"]
+                 (NoArg
+                  (\opt -> return opt { optRecursiveSections = True }))
+                 "" -- "Use <section> instead of <sect1> ... <sect5> and <simplesect> in DocBook"
 
     , Option "N" ["number-sections"]
                  (NoArg
@@ -812,6 +819,7 @@ main = do
               , optHighlight         = highlight
               , optHighlightStyle    = highlightStyle
               , optChapters          = chapters
+              , optRecursiveSections = recursiveSections
               , optHTMLMathMethod    = mathMethod
               , optReferenceODT      = referenceODT
               , optReferenceDocx     = referenceDocx
@@ -976,6 +984,7 @@ main = do
                             writerUserDataDir      = datadir,
                             writerHtml5            = html5,
                             writerChapters         = chapters,
+                            writerRecursiveSections = recursiveSections,
                             writerListings         = listings,
                             writerBeamer           = False,
                             writerSlideLevel       = slideLevel,


### PR DESCRIPTION
I'm using [Publican](https://fedorahosted.org/publican/) and it expects the nested [section tags](http://docbook.org/tdg5/en/html/section.html) rather than the [sect1 ... sect5](http://www.docbook.org/tdg/en/html/sect1.html) tags.

Currently I've got some hacks to work around it, but it would be nice if pandoc could do it.
Would you consider something like this?

This is working for me. My devel environment is Fedora 17.

Does it need a test? Do you think --nested-sections would be a better name for it? (I was considering --docbook-recursive-sections but thought it was a bit long).
