### PR TITLE
Remove newline character from LineBreak output

### DIFF
--- a/src/Text/Pandoc/Writers/MediaWiki.hs
+++ b/src/Text/Pandoc/Writers/MediaWiki.hs
@@ -371,7 +371,7 @@ inlineToMediaWiki _ (RawInline "mediawiki" str) = return str
 inlineToMediaWiki _ (RawInline "html" str) = return str
 inlineToMediaWiki _ (RawInline _ _) = return ""
 
-inlineToMediaWiki _ (LineBreak) = return "<br />\n"
+inlineToMediaWiki _ (LineBreak) = return "<br />"
 
 inlineToMediaWiki _ Space = return " "
 


### PR DESCRIPTION
There's no particular need for a newline (other than making the
generated MediaWiki source look nice to a human), and in fact
sometimes it is incorrect: in particular, inside an enumeration, list
items cannot have embedded newline characters.
