### PR TITLE
Option for settings listings code block environment name

### DIFF
--- a/pandoc.hs
+++ b/pandoc.hs
@@ -132,6 +132,7 @@ data Opt = Opt
     , optCslFile           :: Maybe FilePath
     , optAbbrevsFile       :: Maybe FilePath
     , optListings          :: Bool       -- ^ Use listings package for code blocks
+    , optListingsEnv       :: String     -- ^ Name of LaTex environment when using listings
     , optLaTeXEngine       :: String     -- ^ Program to use for latex -> pdf
     , optSlideLevel        :: Maybe Int  -- ^ Header level that creates slides
     , optSetextHeaders     :: Bool       -- ^ Use atx headers for markdown level 1-2
@@ -187,6 +188,7 @@ defaultOpts = Opt
     , optCslFile           = Nothing
     , optAbbrevsFile       = Nothing
     , optListings          = False
+    , optListingsEnv       = "lstlisting"
     , optLaTeXEngine       = "pdflatex"
     , optSlideLevel        = Nothing
     , optSetextHeaders     = True
@@ -473,6 +475,12 @@ options =
                  (NoArg
                   (\opt -> return opt { optListings = True }))
                  "" -- "Use listings package for LaTeX code blocks"
+
+    , Option "" ["listings-env"]
+                 (ReqArg
+                  (\arg opt -> return opt { optListingsEnv = arg })
+                  "STRING")
+                 "" -- "Name of listings environment for LaTeX code blocks"
 
     , Option "i" ["incremental"]
                  (NoArg
@@ -850,6 +858,7 @@ main = do
               , optAbbrevsFile       = cslabbrevs
               , optCiteMethod        = citeMethod
               , optListings          = listings
+              , optListingsEnv       = listingsEnv
               , optLaTeXEngine       = latexEngine
               , optSlideLevel        = slideLevel
               , optSetextHeaders     = setextHeaders
@@ -1021,6 +1030,7 @@ main = do
                             writerHtmlQTags        = htmlQTags,
                             writerChapters         = chapters,
                             writerListings         = listings,
+                            writerListingsEnv      = listingsEnv,
                             writerBeamer           = False,
                             writerSlideLevel       = slideLevel,
                             writerHighlight        = highlight,

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -286,6 +286,7 @@ data WriterOptions = WriterOptions
   , writerSlideLevel       :: Maybe Int  -- ^ Force header level of slides
   , writerChapters         :: Bool       -- ^ Use "chapter" for top-level sects
   , writerListings         :: Bool       -- ^ Use listings package for code
+  , writerListingsEnv      :: String     -- ^ Name of LaTex environment when using listings
   , writerHighlight        :: Bool       -- ^ Highlight source code
   , writerHighlightStyle   :: Style      -- ^ Style to use for highlighting
   , writerSetextHeaders    :: Bool       -- ^ Use setext headers for levels 1-2 in markdown
@@ -328,6 +329,7 @@ instance Default WriterOptions where
                       , writerSlideLevel       = Nothing
                       , writerChapters         = False
                       , writerListings         = False
+                      , writerListingsEnv      = "lstlisting"
                       , writerHighlight        = False
                       , writerHighlightStyle   = pygments
                       , writerSetextHeaders    = True

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -337,8 +337,9 @@ blockToLaTeX (CodeBlock (_,classes,keyvalAttr) str) = do
                printParams
                    | null params = empty
                    | otherwise   = brackets $ hsep (intersperse "," (map text params))
-           return $ flush ("\\begin{lstlisting}" <> printParams $$ text str $$
-                    "\\end{lstlisting}") $$ cr
+           let env = writerListingsEnv (stOptions st)
+           return $ flush (text("\\begin{" ++ env ++ "}") <> printParams $$ text str $$
+                    text("\\end{" ++ env ++ "}")) $$ cr
          highlightedCodeBlock =
            case highlight formatLaTeXBlock ("",classes,keyvalAttr) str of
                   Nothing -> rawCodeBlock


### PR DESCRIPTION
Added `--listings-env` option to allow settings the name of the code block environment when using listings.

This allow using a template with `\lstnewenvironment` for settings a custom environment.

I tested manually and with `test-pandoc` and everything passed
