### PR TITLE
EPUB: condition Blaze Utf8 module name import on blaze-html version

### DIFF
--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -56,7 +56,11 @@ import Network.URI ( unEscapeString )
 import Text.Pandoc.MIME (getMimeType)
 import Prelude hiding (catch)
 import Control.Exception (catch, SomeException)
+#ifdef MIN_VERSION_blaze-html(0,5,0)
 import Text.Blaze.Html.Renderer.Utf8 (renderHtml)
+#else
+import Text.Blaze.Renderer.Utf8 (renderHtml)
+#endif
 
 -- | Produce an EPUB file from a Pandoc document.
 writeEPUB :: WriterOptions  -- ^ Writer options


### PR DESCRIPTION
blaze-html/blaze-markup-0.5 has Text.Blaze.Html.Renderer.Utf8
whereas blaze-html-0.4 has Text.Blaze.Renderer.Utf8.
So this needs to be conditional on the version for pandoc
still be with blaze-html-0.4.x
