### PR TITLE
Bump blaze-html upper bound to allow 0.6

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -203,7 +203,7 @@ Source-repository head
   location:      git://github.com/jgm/pandoc.git
 
 Flag blaze_html_0_5
-  Description:   Use blaze-html 0.5 and blaze-markup 0.5
+  Description:   Use blaze-html >= 0.5 and blaze-markup 0.5
   Default:       True
 Flag embed_data_files
   Description:   Embed data files in binary for relocatable executable.
@@ -240,7 +240,7 @@ Library
                  temporary >= 1.1 && < 1.2
   if flag(blaze_html_0_5)
     build-depends:
-                 blaze-html >= 0.5 && < 0.6,
+                 blaze-html >= 0.5 && < 0.7,
                  blaze-markup >= 0.5.1 && < 0.6
   else
     build-depends:


### PR DESCRIPTION
See https://github.com/jaspervdj/blaze-html/issues/78 .

Compiles fine with blaze-html-0.6, and the test suite has the same number of passing/failing tests as it does when built against blaze-html-0.5.
