### PR TITLE
Add support for pagebreaks for LaTeX input and HTML output.

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -283,6 +283,7 @@ blockCommands = M.fromList $
   , ("item", skipopts *> loose_item)
   , ("documentclass", skipopts *> braced *> preamble)
   , ("centerline", (para . trimInlines) <$> (skipopts *> tok))
+  , ("newpage", pure newPage)
   ] ++ map ignoreBlocks
   -- these commands will be ignored unless --parse-raw is specified,
   -- in which case they will appear as raw latex blocks

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -128,6 +128,7 @@ blockToAsciiDoc opts (Para inlines) = do
 blockToAsciiDoc _ (RawBlock _ _) = return empty
 blockToAsciiDoc _ HorizontalRule =
   return $ blankline <> text "'''''" <> blankline
+blockToAsciiDoc _ NewPage = return $ "\f"
 blockToAsciiDoc opts (Header level (ident,_,_) inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   let len = offset contents

--- a/src/Text/Pandoc/Writers/ConTeXt.hs
+++ b/src/Text/Pandoc/Writers/ConTeXt.hs
@@ -189,6 +189,7 @@ blockToConTeXt (OrderedList (start, style', delim) lst) = do
              "\\stopitemize" <> blankline
 blockToConTeXt (DefinitionList lst) =
   liftM vcat $ mapM defListItemToConTeXt lst
+blockToConTeXt NewPage = return $ "\\page"
 blockToConTeXt HorizontalRule = return $ "\\thinrule" <> blankline
 -- If this is ever executed, provide a default for the reference identifier.
 blockToConTeXt (Header level attr lst) = sectionHeader attr level lst

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -431,6 +431,7 @@ blockToHtml opts (Para lst) = do
   return $ H.p contents
 blockToHtml _ (RawBlock "html" str) = return $ preEscapedString str
 blockToHtml _ (RawBlock _ _) = return mempty
+blockToHtml _ (NewPage) = return $ H.div (return()) ! A.style "page-break-before:always;" <> mempty
 blockToHtml opts (HorizontalRule) = return $ if writerHtml5 opts then H5.hr else H.hr
 blockToHtml opts (CodeBlock (id',classes,keyvals) rawCode) = do
   let tolhs = isEnabled Ext_literate_haskell opts &&


### PR DESCRIPTION
This patch requires a new type in pandoc-types.  I have submitted a pull request there too.
Depends on
https://github.com/DavidGriffith/pandoc-types/commit/4aa6b78bb83f85714055fafd72240dec79a95a03 in pandoc-types
