### PR TITLE
Initial support for supporting School of Haskell Markdown

### DIFF
--- a/src/Text/Pandoc.hs
+++ b/src/Text/Pandoc.hs
@@ -197,6 +197,7 @@ readers = [("native"       , \_ s -> return $ readNative s)
           ,("markdown_phpextra" , markdown)
           ,("markdown_github" , markdown)
           ,("markdown_mmd",  markdown)
+          ,("markdown_soh" , markdown)
           ,("rst"          , \o s -> return $ readRST o s)
           ,("mediawiki"    , \o s -> return $ readMediaWiki o s)
           ,("docbook"      , \o s -> return $ readDocBook o s)
@@ -252,6 +253,7 @@ writers = [
   ,("markdown_strict" , PureStringWriter writeMarkdown)
   ,("markdown_phpextra" , PureStringWriter writeMarkdown)
   ,("markdown_github" , PureStringWriter writeMarkdown)
+  ,("markdown_soh" , PureStringWriter writeMarkdown)
   ,("markdown_mmd" , PureStringWriter writeMarkdown)
   ,("plain"        , PureStringWriter writePlain)
   ,("rst"          , PureStringWriter writeRST)
@@ -267,6 +269,7 @@ getDefaultExtensions "markdown_strict" = strictExtensions
 getDefaultExtensions "markdown_phpextra" = phpMarkdownExtraExtensions
 getDefaultExtensions "markdown_mmd" = multimarkdownExtensions
 getDefaultExtensions "markdown_github" = githubMarkdownExtensions
+getDefaultExtensions "markdown_soh" = sohMarkdownExtensions
 getDefaultExtensions _        = pandocExtensions
 
 -- | Retrieve reader based on formatSpec (format+extensions).

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -34,6 +34,7 @@ module Text.Pandoc.Options ( Extension(..)
                            , phpMarkdownExtraExtensions
                            , githubMarkdownExtensions
                            , multimarkdownExtensions
+                           , sohMarkdownExtensions
                            , ReaderOptions(..)
                            , HTMLMathMethod (..)
                            , CiteMethod (..)
@@ -72,6 +73,7 @@ data Extension =
     | Ext_fenced_code_blocks  -- ^ Parse fenced code blocks
     | Ext_fenced_code_attributes  -- ^ Allow attributes on fenced code blocks
     | Ext_backtick_code_blocks    -- ^ Github style ``` code blocks
+    | Ext_backtick_code_multi     -- ^ School of Haskell style ``` code blocks with mutiple attributes 
     | Ext_inline_code_attributes  -- ^ Allow attributes on inline code
     | Ext_markdown_in_html_blocks -- ^ Interpret as markdown inside HTML blocks
     | Ext_markdown_attribute      -- ^ Interpret text inside HTML as markdown
@@ -119,6 +121,7 @@ pandocExtensions = Set.fromList
   , Ext_fenced_code_blocks
   , Ext_fenced_code_attributes
   , Ext_backtick_code_blocks
+  , Ext_backtick_code_multi
   , Ext_inline_code_attributes
   , Ext_markdown_in_html_blocks
   , Ext_escaped_line_breaks
@@ -182,6 +185,13 @@ multimarkdownExtensions = Set.fromList
   , Ext_implicit_header_references
   , Ext_auto_identifiers
   , Ext_mmd_header_identifiers
+  ]
+
+sohMarkdownExtensions :: Set Extension
+sohMarkdownExtensions = Set.fromList
+  [ Ext_raw_html
+  , Ext_backtick_code_blocks
+  , Ext_backtick_code_multi
   ]
 
 strictExtensions :: Set Extension

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -538,6 +538,7 @@ codeBlockFenced = try $ do
   skipMany spaceChar
   attr <- option ([],[],[]) $
             try (guardEnabled Ext_fenced_code_attributes >> attributes)
+           <|> (guardEnabled Ext_backtick_code_multi >> ((\xs -> ("", xs, [])) <$> (identifier `sepBy1` (many1 (char ' ')))))
            <|> ((\x -> ("",[x],[])) <$> identifier)
   blankline
   contents <- manyTill anyLine (blockDelimiter (== c) (Just size))

--- a/src/Text/Pandoc/Templates.hs
+++ b/src/Text/Pandoc/Templates.hs
@@ -97,6 +97,7 @@ getDefaultTemplate user writer = do
        "markdown_strict" -> getDefaultTemplate user "markdown"
        "multimarkdown"   -> getDefaultTemplate user "markdown"
        "markdown_github" -> getDefaultTemplate user "markdown"
+       "markdown_soh"    -> getDefaultTemplate user "markdown"
        _        -> let fname = "templates" </> "default" <.> format
                    in  E.try $ readDataFileUTF8 user fname
 


### PR DESCRIPTION
Add some support for a School of Haskell markdown extensions. My primary use case is to down-convert pandoc markdown documents to school of haskell compatible documents.

https://www.fpcomplete.com/school/how-to-use-the-school-of-haskell/soh-markdown

School of Haskell markdown is mostly strict markdown with two extensions.
- @@@ fences to 'hide solution'
- ``` style github code blocks

The current github code block parser only supports a single atttribute like:

`````` haskell

But School of Haskell (http://www.fpcomplete.org) allows multiple attributes like:

 ``` haskell active web

This patch adds a new extension

    Ext_backtick_code_multi

which could probably be better named. Or, perhaps the normal github parser should be extended to always allow this?

The Markdown Reader has been extended with:

           <|> (guardEnabled Ext_backtick_code_multi >> ((\xs -> ("", xs, [])) <$> (identifier `sepBy1` (many1 (char ' ')))))

Which could possibly be improved. The writer has been extended as well.
``````
