### PR TITLE
Don't add pandoc-citeproc filter if natbib or biblatex is used

### DIFF
--- a/pandoc.hs
+++ b/pandoc.hs
@@ -962,7 +962,6 @@ main = do
   let filters' = case M.lookup "bibliography" metadata of
                        Just _ | optCiteMethod opts /= Natbib &&
                                 optCiteMethod opts /= Biblatex &&
-                                isNothing (M.lookup "biblatex" metadata) &&
                                 all (\f -> takeBaseName f /= "pandoc-citeproc")
                                 filters -> "pandoc-citeproc" : filters
                        _                -> filters


### PR DESCRIPTION
See https://github.com/jgm/pandoc-templates/issues/42
