### PR TITLE
Epub Writer: Add cover reference to guide element

### DIFF
--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -260,8 +260,10 @@ writeEPUB opts doc@(Pandoc meta _) = do
                                                     else "no")] $ ()) :
                   map chapterRefNode chapterEntries)
           , unode "guide" $
-              unode "reference" !
-                [("type","toc"),("title",plainTitle),("href","nav.xhtml")] $ ()
+              [ unode "reference" !
+                [("type","toc"),("title",plainTitle),("href","nav.xhtml")] $ () ]
+              ++ [ unode "reference" !
+                [("type","cover"),("title","Cover"),("href","cover.xhtml")] $ () ]
           ]
   let contentsEntry = mkEntry "content.opf" contentsData
 


### PR DESCRIPTION
Fixes an issue with calibre http://calibre-ebook.com/ putting the
cover at the end of the book if the spine has linear="no".

Apparently this is best practice for other converters as well.

http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6
