### PR TITLE
MediaWiki reader: Accept image links in more languages

### DIFF
--- a/src/Text/Pandoc/Readers/MediaWiki.hs
+++ b/src/Text/Pandoc/Readers/MediaWiki.hs
@@ -549,10 +549,14 @@ endline = () <$ try (newline <*
                      notFollowedBy' header <*
                      notFollowedBy anyListStart)
 
+imageIdentifiers :: [MWParser ()]
+imageIdentifiers = [sym (identifier ++ ":") | identifier <- identifiers]
+    where identifiers = ["File", "Image", "Archivo", "Datei", "Fichier"]
+
 image :: MWParser Inlines
 image = try $ do
   sym "[["
-  sym "File:" <|> sym "Image:"
+  choice imageIdentifiers
   fname <- many1 (noneOf "|]")
   _ <- many (try $ char '|' *> imageOption)
   caption <-   (B.str fname <$ sym "]]")

--- a/tests/mediawiki-reader.native
+++ b/tests/mediawiki-reader.native
@@ -88,6 +88,7 @@ Pandoc (Meta {unMeta = fromList []})
 ,Para [Image [Str "the",Space,Emph [Str "caption"],Space,Str "with",Space,Link [Str "external",Space,Str "link"] ("http://google.com","")] ("example.jpg","fig:the caption with external link")]
 ,Para [Image [Str "caption"] ("example.jpg","fig:caption")]
 ,Para [Image [Str "example.jpg"] ("example.jpg","fig:example.jpg")]
+,Para [Image [Str "example_es.jpg"] ("example_es.jpg","fig:example_es.jpg")]
 ,Header 2 ("lists",[],[]) [Str "lists"]
 ,BulletList
  [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]

--- a/tests/mediawiki-reader.wiki
+++ b/tests/mediawiki-reader.wiki
@@ -173,6 +173,8 @@ http://johnmacfarlane.net/pandoc/
 
 [[File:example.jpg]]
 
+[[Archivo:example_es.jpg]]
+
 == lists ==
 
 * Start each line


### PR DESCRIPTION
In some of the Wikipedia versions the local version of 'File' is used (for example 'Archivo' in Spanish)

The list is no complete, I have look at the mediawiki source and there seems to be a lot of languages that have their own identifier. So I don't really know how good is this addition.
