### PR TITLE
normalizeDate: Allow dates with year only (%Y)

### DIFF
--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -270,7 +270,7 @@ normalizeDate s = fmap (formatTime defaultTimeLocale "%F")
   (msum $ map (\fs -> parsetimeWith fs s) formats :: Maybe Day)
    where parsetimeWith = parseTime defaultTimeLocale
          formats = ["%x","%m/%d/%Y", "%D","%F", "%d %b %Y",
-                    "%d %B %Y", "%b. %d, %Y", "%B %d, %Y"]
+                    "%d %B %Y", "%b. %d, %Y", "%B %d, %Y", "%Y"]
 
 --
 -- Pandoc block and inline list processing


### PR DESCRIPTION
Where source metadata has dates in the form of 2013, the normalizeDate function destroys them.

Often only they year portion of a dates (say copyright) is known.
dc metadata supports dates "at any level of granularity":
http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#terms-date

ISO 8601 W3CDTF (which is recommended best practice) specifically allows YYYY.
see http://www.w3.org/TR/NOTE-datetime

Ideally year only dates would be left as is; currently they have January 1 added to them to adhere to format %F.
