### PR TITLE
LaTeX reader: add support for Verb macro

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -455,6 +455,7 @@ inlineCommands = M.fromList $
   , ("footnote", (note . mconcat) <$> (char '{' *> manyTill block (char '}')))
   , ("verb", doverb)
   , ("lstinline", doverb)
+  , ("Verb", doverb)
   , ("texttt", (code . stringify . toList) <$> tok)
   , ("url", (unescapeURL <$> braced) >>= \url ->
        pure (link url "" (str url)))


### PR DESCRIPTION
Currently the `pandoc` LaTeX reader does not support the `Verb` macro from the `fancyvrb` package although other macros from `fancyvrb` are supported.  This merge makes the `Verb` macro act like `verb` and `lstinline`.

E.g. currently, the following LaTeX document 

``` latex
\documentclass{article}
\usepackage{fancyvrb}
\begin{document}
Hello \Verb|a__|
\end{document}
```

will produce the following error:

``` console
$ pandoc --version
pandoc 1.11.1
Compiled with citeproc-hs 0.3.8, texmath 0.6.1.3, highlighting-kate 0.5.3.8.
Syntax highlighting is supported for the following languages:
    actionscript, ada, apache, asn1, asp, awk, bash, bibtex, boo, c, changelog,
    clojure, cmake, coffee, coldfusion, commonlisp, cpp, cs, css, curry, d,
    diff, djangotemplate, doxygen, doxygenlua, dtd, eiffel, email, erlang,
    fortran, fsharp, gnuassembler, go, haskell, haxe, html, ini, java, javadoc,
    javascript, json, jsp, julia, latex, lex, literatecurry, literatehaskell,
    lua, makefile, mandoc, matlab, maxima, metafont, mips, modula2, modula3,
    monobasic, nasm, noweb, objectivec, objectivecpp, ocaml, octave, pascal,
    perl, php, pike, postscript, prolog, python, r, relaxngcompact, rhtml, ruby,
    rust, scala, scheme, sci, sed, sgml, sql, sqlmysql, sqlpostgresql, tcl,
    texinfo, verilog, vhdl, xml, xorg, xslt, xul, yacc, yaml
Default user data directory: /home/jrnold/.pandoc
Copyright (C) 2006-2013 John MacFarlane
Web:  http://johnmacfarlane.net/pandoc
This is free software; see the source for copying conditions.  There is no
warranty, not even for merchantability or fitness for a particular purpose.

$ pandoc foo.tex
pandoc: 
Error:
"source" (line 4, column 15):
unexpected "_"
expecting "{" or "\\"
```
