### PR TITLE
Replace line breaks in headers in the TOC

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -258,7 +258,12 @@ elementToListItem opts (Sec lev num (id',classes,_) headerText subsecs)
                    then (H.span ! A.class_ "toc-section-number"
                         $ toHtml $ showSecNum num') >> preEscapedString " "
                    else mempty
-  txt <- liftM (sectnum >>) $ inlineListToHtml opts headerText
+  let replaceLineBreak LineBreak = Str " "
+      replaceLineBreak x = x
+  let headerText' = if "linebreaks" `elem` classes
+                       then headerText
+                       else map replaceLineBreak headerText
+  txt <- liftM (sectnum >>) $ inlineListToHtml opts headerText'
   subHeads <- mapM (elementToListItem opts) subsecs >>= return . catMaybes
   let subList = if null subHeads
                    then mempty

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -714,9 +714,7 @@ sectionHeader unnumbered linebreaks ref level lst = do
   lab <- text `fmap` toLabel ref
   plain <- stringToLaTeX TextString $ foldl (++) "" $ map stringify lst
   let noNote (Note _) = Str ""
-      noNote LineBreak
-       | linebreaks = LineBreak
-       | otherwise = Str " "
+      noNote LineBreak = if linebreaks then LineBreak else Str ""
       noNote x        = x
   let lstNoNotes = walk noNote lst
   txtNoNotes <- inlineListToLaTeX lstNoNotes


### PR DESCRIPTION
This is an improved patch. I have created a new topic branch for the changes.

Most headers do not contain line breaks in the TOC, therefore Pandoc will remove line breaks in headers in the TOC by default. If the header has the class `unnumbered` then the line breaks in the TOC won't be removed.

Only the LaTeX and HTML writers are supported at this time.

Markdown:
```
## JSON\
filters
```

LaTeX:
```latex
\subsection[JSON filters]{JSON\\filters}\label{json-filters}
```