### PR TITLE
Removed Monoid datatype context from RenderState.

### DIFF
--- a/src/Text/Pandoc/Pretty.hs
+++ b/src/Text/Pandoc/Pretty.hs
@@ -81,8 +81,7 @@ import Data.String
 import Control.Monad.State
 import Data.Char (isSpace)
 
-data Monoid a =>
-     RenderState a = RenderState{
+data RenderState a = RenderState{
          output       :: [a]        -- ^ In reverse order
        , prefix       :: String
        , usePrefix    :: Bool


### PR DESCRIPTION
Reasons against removing:
    - Code isn't broken

Reasons for removing:
    - It's not Haskell2010
    - Code not broken, but breaks some tools, like hdevtools
    - Doesn't actually do anything
    - RenderState doesn't even have a Monoid instance
