### PR TITLE
Org reader: Read inline math, recognize definition lists

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -54,6 +54,10 @@ tests =
           "=Robot.rock()=" =?>
           para (code "Robot.rock()")
 
+      , "Math" =:
+          "$E=mc^2$" =?>
+           para (math "E=mc^2")
+
       , "Verbatim" =:
           "~word for word~" =?>
           para (rawInline "" "word for word")


### PR DESCRIPTION
The patches allow the reader to recognize inline math like `$E=mc^2$` as well as definition lists like `- term :: definition`.
