### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{markdown,md}]
+trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ Please follow these guidelines:
 3.  Follow the stylistic conventions you find in the existing
     pandoc code.  Use spaces, not tabs, and wrap code to 80 columns.
     Always include type signatures for top-level functions.
+    Consider installing [EditorConfig], this will help you to follow the
+    coding style prevalent in pandoc.
 
 4.  Your code should compile without warnings (`-Wall` clean).
 
@@ -177,5 +179,6 @@ The library is structured as follows:
 [issue tracker]: https://github.com/jgm/pandoc/issues
 [User's Guide]: http://johnmacfarlane.net/pandoc/README.html
 [FAQs]:  http://johnmacfarlane.net/pandoc/faqs.html
+[EditorConfig]: http://editorconfig.org/
 [Haskell platform]: http://www.haskell.org/platform/
 [hsb2hs]: http://hackage.haskell.org/package/hsb2hs


### PR DESCRIPTION
Use EditorConfig to define a some basic styling rules for code.  This
should also help to reduce the number of commits introducing trailing
whitespace.

See http://editorconfig.org/ for details.

Apologies for the commits in which I violated the guidelines for contributing.
