### PR TITLE
Force failure of a Travis build if GHC produces warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_install:
 install:
   - cabal-dev install-deps --enable-tests
 script:
-  - 'cabal-dev configure --enable-tests && cabal-dev build && cabal-dev test'
+  - 'cabal-dev configure --enable-tests && cabal-dev build --ghc-options=-Werror && cabal-dev test'


### PR DESCRIPTION
Pandoc should, as stated in CONTRIBUTING.md, always compile without
warnings.  This patch forces GHC to treat warnings like errors during
Travis builds, making it possible to catch mistakes (like missing
top-level type definitions) early.
