### PR TITLE
Add empty and multiblock table entry samples

### DIFF
--- a/tests/tables.docbook
+++ b/tests/tables.docbook
@@ -430,3 +430,33 @@
     </tbody>
   </tgroup>
 </informaltable>
+<para>
+  Table with empty entries:
+</para>
+<informaltable>
+  <tgroup cols="1">
+    <tbody>
+      <row>
+        <entry></entry>
+      </row>
+      <row>
+        <entry/>
+      </row>
+    </tbody>
+  </tgroup>
+</informaltable>
+<para>
+  Table with multiblock entry:
+</para>
+<informaltable>
+  <tgroup cols="1">
+    <tbody>
+      <row>
+        <entry>
+          <para>Para 1</para>
+          <para>Para 2</para>
+        </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</informaltable>


### PR DESCRIPTION
I'm not sure if this is complete enough to be accepted as a pull request, but I've added content that can be used to reproduce Issue #1245 and Issue #1246 to the `tables.docbook` test file.
