### PR TITLE
pandoc.hs: Add --include-early argument option

### DIFF
--- a/README
+++ b/README
@@ -752,6 +752,9 @@ Some variables are set automatically by pandoc.  These vary somewhat
 depending on the output format, but include metadata fields (such
 as `title`, `author`, and `date`) as well as the following:
 
+`early-includes`
+:   contents specified by `-E/--include-early` (may have multiple
+    values)
 `header-includes`
 :   contents specified by `-H/--include-in-header` (may have multiple
     values)

--- a/pandoc.hs
+++ b/pandoc.hs
@@ -443,6 +443,17 @@ options =
                  "STYLE")
                  "" -- "Style for highlighted code"
 
+    , Option "E" ["include-early"]
+                 (ReqArg
+                  (\arg opt -> do
+                     text <- UTF8.readFile arg
+                     -- add new ones to end, so they're included in order specified
+                     let newvars = optVariables opt ++ [("early-includes",text)]
+                     return opt { optVariables = newvars,
+                                  optStandalone = True })
+                  "FILENAME")
+                 "" -- "File to include early in header (implies -s)"
+
     , Option "H" ["include-in-header"]
                  (ReqArg
                   (\arg opt -> do


### PR DESCRIPTION
- Command line option of -E/--include-early and yaml entry of early-includes.
- Include contents as early as validly possible for the target type.
- Along with -H, -B, -A contents can be included before/after template included
  header data and before/after source body data.

Signed-off-by: Thell Fowler thell@tbfowler.name
