### PR TITLE
Org reader: Read inline code blocks

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -207,6 +207,24 @@ tests =
           "<<anchor>> Link here later." =?>
           (para $ spanWith ("anchor", [], []) mempty <>
                   "Link" <> space <> "here" <> space <> "later.")
+
+      , "Inline code block" =:
+          "src_emacs-lisp{(message \"Hello\")}" =?>
+          (para $ codeWith ( ""
+                           , [ "commonlisp", "rundoc-block" ]
+                           , [ ("rundoc-language", "emacs-lisp") ])
+                           "(message \"Hello\")")
+
+      , "Inline code block with arguments" =:
+          "src_sh[:export both :results output]{echo 'Hello, World'}" =?>
+          (para $ codeWith ( ""
+                           , [ "bash", "rundoc-block" ]
+                           , [ ("rundoc-language", "sh")
+                             , ("rundoc-export", "both")
+                             , ("rundoc-results", "output")
+                             ]
+                           )
+                           "echo 'Hello, World'")
       ]
 
   , testGroup "Meta Information" $


### PR DESCRIPTION
Org's inline code blocks take forms like `src_haskell(print "hi")` and
are frequently used to include results from computations called from
within the document.  The blocks are read as inline code and marked with
the special class `rundoc-block`.  Proper handling and execution of
these blocks is the subject of a separate library, `rundoc`, which is
work in progress.
