### PR TITLE
Fix textile reader hanging.

### DIFF
--- a/src/Text/Pandoc/Readers/Textile.hs
+++ b/src/Text/Pandoc/Readers/Textile.hs
@@ -513,7 +513,8 @@ link = try $ do
   char '"' *> notFollowedBy (oneOf " \t\n\r")
   attr <- attributes
   name <- trimInlines . mconcat <$>
-          withQuoteContext InSingleQuote (manyTill inline (try (string "\":")))
+          withQuoteContext InDoubleQuote (many1Till inline (try (char '"')))
+  char ':'
   let stop = if bracketed
                 then char ']'
                 else lookAhead $ space <|>


### PR DESCRIPTION
Textile reader hung on

```
pandoc -f textile http://johnmacfarlane.net/pandoc/demo/example25.textile
```

The reader no longer hangs.
