### PR TITLE
Org reader: Support code block headers, fix reading of block content

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -357,12 +357,8 @@ rawBlockContent :: BlockProperties -> OrgParser String
 rawBlockContent (indent, blockType) = try $
   unlines . map commaEscaped <$> manyTill indentedLine blockEnder
  where
-   indentedLine = try $
-     choice [ blankline         *> pure "\n"
-            , indentWith indent *> anyLine
-            ]
-   blockEnder = try $
-     indentWith indent *> stringAnyCase ("#+end_" <> blockType)
+   indentedLine = try $ ("" <$ blankline) <|> (indentWith indent *> anyLine)
+   blockEnder = try $ indentWith indent *> stringAnyCase ("#+end_" <> blockType)
 
 parsedBlockContent :: BlockProperties -> OrgParser (F Blocks)
 parsedBlockContent blkProps = try $ do

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -920,5 +920,14 @@ tests =
                              (unlines [ "fmap id = id"
                                       , "fmap (p . q) = (fmap p) . (fmap q)"
                                       ])))
+
+      , "Convert blank lines in blocks to single newlines" =:
+          unlines [ "#+begin_html"
+                  , ""
+                  , "<span>boring</span>"
+                  , ""
+                  , "#+end_html"
+                  ] =?>
+          rawBlock "html" "\n<span>boring</span>\n\n"
       ]
   ]


### PR DESCRIPTION
- Refactor code to read `#+BEGIN .. #+END` style blocks
- Support header arguments of source blocks
- Fix parsing of blank lines in blocks

The last two combined fix issue #1286.
