### PR TITLE
Org reader: Fix block parameter reader, relax constraints

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -929,5 +929,17 @@ tests =
                   , "#+end_html"
                   ] =?>
           rawBlock "html" "\n<span>boring</span>\n\n"
+
+      , "Non-letter chars in source block parameters" =:
+          unlines [ "#+BEGIN_SRC C :tangle xxxx.c :city Zürich"
+                  , "code body"
+                  , "#+END_SRC"
+                  ] =?>
+          let classes = [ "c", "rundoc-block" ]
+              params  = [ ("rundoc-language", "C")
+                        , ("rundoc-tangle", "xxxx.c")
+                        , ("rundoc-city", "Zürich")
+                        ]
+          in codeBlockWith ( "", classes, params) "code body\n"
       ]
   ]


### PR DESCRIPTION
The reader produced wrong results for block containing non-letter chars
in their parameter arguments.  This patch relaxes constraints in that it
allows block header arguments to contain any non-space character (except
for ']' for inline blocks).

Thanks to Xiao Hanyu for noticing this.
