### PR TITLE
Org reader: support for inline LaTeX

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -31,6 +31,7 @@ Conversion of LaTeX to 'Pandoc' document.
 module Text.Pandoc.Readers.LaTeX ( readLaTeX,
                                    rawLaTeXInline,
                                    rawLaTeXBlock,
+                                   inlineCommand,
                                    handleIncludes
                                  ) where
 

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -247,6 +247,33 @@ tests =
                          , citationNoteNum = 0
                          , citationHash = 0}
           in (para $ cite [citation] "[see @item1 p. 34-35]")
+
+      , "Inline LaTeX symbol" =:
+          "\\dots" =?>
+          para "…"
+
+      , "Inline LaTeX command" =:
+          "\\textit{Emphasised}" =?>
+          para (emph "Emphasised")
+
+      , "Inline LaTeX math symbol" =:
+          "\\tau" =?>
+          para (emph "τ")
+
+      , "Unknown inline LaTeX command" =:
+          "\\notacommand{foo}" =?>
+          para (rawInline "latex" "\\notacommand{foo}")
+
+      , "LaTeX citation" =:
+          "\\cite{Coffee}" =?>
+          let citation = Citation
+                         { citationId = "Coffee"
+                         , citationPrefix = []
+                         , citationSuffix = []
+                         , citationMode = AuthorInText
+                         , citationNoteNum = 0
+                         , citationHash = 0}
+          in (para . cite [citation] $ rawInline "latex" "\\cite{Coffee}")
       ]
 
   , testGroup "Meta Information" $


### PR DESCRIPTION
Inline LaTeX is now accepted and parsed by the org-mode reader.  Both,
math symbols (like \tau) and LaTeX commands (like \cite{Coffee}), can be
used without any further escaping.
