### PR TITLE
fixed escape for literal paragraph

### DIFF
--- a/README
+++ b/README
@@ -2498,8 +2498,8 @@ citing them in the body text, you can define a dummy `nocite` metadata
 field and put the citations there:
 
     ---
-    nocite:
-     | @item1, @item2
+    nocite: | 
+              @item1, @item2
     ...
 
     @item3


### PR DESCRIPTION
The pipe to begin a literal paragraph was on the wrong line for the no cite example. This lead to a few strange messages about unexpected characters.
