### PR TITLE
Added an embed-archive-data user option.

### DIFF
--- a/pandoc.hs
+++ b/pandoc.hs
@@ -179,6 +179,7 @@ data Opt = Opt
     , optTeXLigatures      :: Bool       -- ^ Use TeX ligatures for quotes/dashes
     , optDefaultImageExtension :: String -- ^ Default image extension
     , optTrace             :: Bool       -- ^ Print debug information
+    , optEmbedArchiveData  :: Bool       -- ^ Embed data from DocX or EPUB archive in output
     }
 
 -- | Defaults for command-line options.
@@ -235,6 +236,7 @@ defaultOpts = Opt
     , optTeXLigatures          = True
     , optDefaultImageExtension = ""
     , optTrace                 = False
+    , optEmbedArchiveData      = False
     }
 
 -- | A list of functions, each transforming the options data structure
@@ -781,6 +783,11 @@ options =
                   (\opt -> return opt { optTrace = True }))
                  "" -- "Turn on diagnostic tracing in readers."
 
+    , Option "" ["embed-archive-data"]
+                 (NoArg
+                  (\opt -> return opt { optEmbedArchiveData = True}))
+                 "" -- "Embed data from DocX or EPUB in output"
+
     , Option "" ["dump-args"]
                  (NoArg
                   (\opt -> return opt { optDumpArgs = True }))
@@ -977,6 +984,7 @@ main = do
               , optTeXLigatures          = texLigatures
               , optDefaultImageExtension = defaultImageExtension
               , optTrace                 = trace
+              , optEmbedArchiveData      = embedArchiveData
              } = opts
 
   when dumpArgs $
@@ -1101,6 +1109,7 @@ main = do
                       , readerApplyMacros = not laTeXOutput
                       , readerDefaultImageExtension = defaultImageExtension
                       , readerTrace = trace
+                      , readerEmbedArchiveData = embedArchiveData
                       }
 
   let writerOptions = def { writerStandalone       = standalone',

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -211,6 +211,7 @@ data ReaderOptions = ReaderOptions{
                                        -- indented code blocks
        , readerDefaultImageExtension :: String -- ^ Default extension for images
        , readerTrace           :: Bool -- ^ Print debugging info
+       , readerEmbedArchiveData :: Bool -- ^ Embed data from DocX or EPUB archive in output
 } deriving (Show, Read)
 
 instance Default ReaderOptions
@@ -227,6 +228,7 @@ instance Default ReaderOptions
                , readerIndentedCodeClasses   = []
                , readerDefaultImageExtension = ""
                , readerTrace                 = False
+               , readerEmbedArchiveData      = False
                }
 
 --


### PR DESCRIPTION
In preparation for DocX and EPUB readers. Defaults to false. For embedding image data as data URI in output from archive formates (DocX, EPUB).
