### PR TITLE
specify minor version number of hslua's upper bound (see details below)

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -256,7 +256,7 @@ Library
                  yaml >= 0.8.8.2 && < 0.9,
                  scientific >= 0.2 && < 0.4,
                  vector >= 0.10 && < 0.11,
-                 hslua >= 0.3 && < 0.4,
+                 hslua >= 0.3 && <= 0.3.12,
                  binary >= 0.5 && < 0.8,
                  SHA >= 1.6 && < 1.7,
                  haddock-library >= 1.0 && < 1.1


### PR DESCRIPTION
According to the PVP(Package Versioning Policy), adding a non-orphan instance requires a minor version bump. I'll add `StackValue ByteString` and `StackValue a => StackValue [a]` instances to hslua but that'll break Pandoc, because `Text.Pandoc.Writers.Custom` defines these as orphan instances, and minor upper version of hslua dependency is not specified.

This patch adds minor upper bound to hslua so that orphan instances defined in Pandoc won't cause a breakage after hslua updates.
