### PR TITLE
Add ReaderOptions to the docx tests

### DIFF
--- a/tests/Tests/Readers/Docx.hs
+++ b/tests/Tests/Readers/Docx.hs
@@ -8,20 +8,23 @@ import Test.Framework
 import qualified Data.ByteString.Lazy as B
 import Text.Pandoc.Readers.Docx
 
-compareOutput :: FilePath -> FilePath -> IO (Pandoc, Pandoc)
-compareOutput docxFile nativeFile = do
+compareOutput :: ReaderOptions -> FilePath -> FilePath -> IO (Pandoc, Pandoc)
+compareOutput opts docxFile nativeFile = do
   df <- B.readFile docxFile
   nf <- Prelude.readFile nativeFile
-  return $ (readDocx def df, readNative nf)
+  return $ (readDocx opts df, readNative nf)
 
-testCompare' :: String -> FilePath -> FilePath -> IO Test
-testCompare' name docxFile nativeFile = do
-  (dp, np) <- compareOutput docxFile nativeFile
+testCompareWithOptsIO :: ReaderOptions -> String -> FilePath -> FilePath -> IO Test
+testCompareWithOptsIO opts name docxFile nativeFile = do
+  (dp, np) <- compareOutput opts docxFile nativeFile
   return $ test id name (dp, np)
 
+testCompareWithOpts :: ReaderOptions -> String -> FilePath -> FilePath -> Test
+testCompareWithOpts opts name docxFile nativeFile =
+  buildTest $ testCompareWithOptsIO opts name docxFile nativeFile
+
 testCompare :: String -> FilePath -> FilePath -> Test
-testCompare name docxFile nativeFile =
-  buildTest $ testCompare' name docxFile nativeFile
+testCompare = testCompareWithOpts def
 
 
 tests :: [Test]


### PR DESCRIPTION
This was bunched in with the "--self-contained" push. Regardless of what we do there, this should be part of the docx tests.
