### PR TITLE
Docx reader: Fixes to block Normalization

### DIFF
--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -144,6 +144,10 @@ runElemToString (Tab) = ['\t']
 runElemsToString :: [RunElem] -> String
 runElemsToString = concatMap runElemToString
 
+--- We use this instead of the more general
+--- Text.Pandoc.Shared.normalize for reasons of efficiency. For
+--- whatever reason, `normalize` makes a run take almost twice as
+--- long. (It does more, but this does what we need)
 strNormalize :: [Inline] -> [Inline]
 strNormalize [] = []
 strNormalize (Str "" : ils) = strNormalize ils


### PR DESCRIPTION
These patches offer some fixes to the block normalization functions in yesterday's tab pull-request. They 
1. fix two problems (`blockNormalize` didn't deal with Headers quite right, and left out DefinitionLists)
2. simplify the definition of `blockNormalize`,
3. add a comment explain why I'm sticking with a homemade string normalization function instead of using `normalize` from Text.Pandoc.Shared. (It more than doubles run time on tests on some large files.)

The heaeder error actually passed the tests. The issue is that the `toString` function in Tests.Helpers normalizes, so it makes it hard to test normalization. I'll be adding a different test soon to cover this.
