### PR TITLE
Docx Reader: No indent for paragraphs with hanging indent

### DIFF
--- a/src/Text/Pandoc/Readers/Docx/Parse.hs
+++ b/src/Text/Pandoc/Readers/Docx/Parse.hs
@@ -361,10 +361,16 @@ elemToParagraphStyle ns element =
           (findAttr (QName "val" (lookup "w" ns) (Just "w")))
           (findChildren (QName "pStyle" (lookup "w" ns) (Just "w")) pPr)
       , indent =
-        findChild (QName "ind" (lookup "w" ns) (Just "w")) pPr >>=
-        findAttr (QName "left" (lookup "w" ns) (Just "w")) >>=
-        stringToInteger
-        }
+          case 
+            findChild (QName "ind" (lookup "w" ns) (Just "w")) pPr >>= 
+            findAttr (QName "hanging" (lookup "w" ns) (Just "w")) 
+          of
+            Just _ -> Nothing
+            Nothing ->
+              findChild (QName "ind" (lookup "w" ns) (Just "w")) pPr >>=    
+              findAttr (QName "left" (lookup "w" ns) (Just "w")) >>= 
+              stringToInteger
+      }
     Nothing -> defaultParagraphStyle
 
 


### PR DESCRIPTION
Set indent to Nothing for paragraphs with hanging indent (which is common in documents such as academic bibliographies). Previous code was converting any paragraph with a hanging indent to a block quote, as noted in discussion on #1370.

Still learning Haskell, so please feel free to reject or correct.
