### PR TITLE
README: linkable extensions

### DIFF
--- a/README
+++ b/README
@@ -930,7 +930,7 @@ A paragraph is one or more lines of text followed by one or more blank line.
 Newlines are treated as spaces, so you can reflow your paragraphs as you like.
 If you need a hard line break, put two or more spaces at the end of a line.
 
-### Extension: `escaped_line_breaks` ###
+#### Extension: `escaped_line_breaks` ####
 
 A backslash followed by a newline is also a hard line break.
 Note:  in multiline and grid table cells, this is the only way
@@ -1129,7 +1129,7 @@ other block quotes. That is, block quotes can be nested:
     >
     > > A block quote within a block quote.
 
-### Extension: `blank_before_blockquote` ###
+#### Extension: `blank_before_blockquote` ####
 
 Standard markdown syntax does not require a blank line before a block
 quote.  Pandoc does require this (except, of course, at the beginning of the
@@ -1238,7 +1238,7 @@ To set the highlighting style, use `--highlight-style`.
 Line blocks
 -----------
 
-### Extension: `line_blocks` ###
+#### Extension: `line_blocks` ####
 
 A line block is a sequence of lines beginning with a vertical bar (`|`)
 followed by a space.  The division into lines will be preserved in
@@ -1610,14 +1610,14 @@ Four kinds of tables may be used. The first three kinds presuppose the use of
 a fixed-width font, such as Courier. The fourth kind can be used with
 proportionally spaced fonts, as it does not require lining up columns.
 
-### Extension: `table_captions` ###
+#### Extension: `table_captions` ####
 
 A caption may optionally be provided with all 4 kinds of tables (as 
 illustrated in the examples below). A caption is a paragraph beginning
 with the string `Table:` (or just `:`), which will be stripped off.
 It may appear either before or after the table.
 
-### Extension: `simple_tables` ###
+#### Extension: `simple_tables` ####
 
 Simple tables look like this:
 
@@ -1661,7 +1661,7 @@ When headers are omitted, column alignments are determined on the basis
 of the first line of the table body. So, in the tables above, the columns
 would be right, left, center, and right aligned, respectively.
 
-### Extension: `multiline_tables` ###
+#### Extension: `multiline_tables` ####
 
 Multiline tables allow headers and table rows to span multiple lines
 of text (but cells that span multiple columns or rows of the table are
@@ -1711,7 +1711,7 @@ It is possible for a multiline table to have just one row, but the row
 should be followed by a blank line (and then the row of dashes that ends
 the table), or the table may be interpreted as a simple table.
 
-### Extension: `grid_tables` ###
+#### Extension: `grid_tables` ####
 
 Grid tables look like this:
 
@@ -1735,7 +1735,7 @@ columns or rows. Grid tables can be created easily using [Emacs table mode].
 
   [Emacs table mode]: http://table.sourceforge.net/
 
-### Extension: `pipe_tables` ###
+#### Extension: `pipe_tables` ####
 
 Pipe tables look like this:
 
@@ -1784,7 +1784,7 @@ you'll need to add colons as above.
 Metadata blocks
 ---------------
 
-### Extension: `pandoc_title_block` ###
+#### Extension: `pandoc_title_block` ####
 
 If the file begins with a title block
 
@@ -1860,7 +1860,7 @@ will also have "Pandoc User Manuals" in the footer.
 
 will also have "Version 4.0" in the header.
 
-### Extension: `yaml_metadata_block` ###
+#### Extension: `yaml_metadata_block` ####
 
 A YAML metadata block is a valid YAML object, delimited by a line of three
 hyphens (`---`) at the top and a line of three hyphens (`---`) or three dots
@@ -1928,7 +1928,7 @@ custom template.  For example:
 Backslash escapes
 -----------------
 
-### Extension: `all_symbols_escapable` ###
+#### Extension: `all_symbols_escapable` ####
 
 Except inside a code block or inline code, any punctuation or space
 character preceded by a backslash will be treated literally, even if it
@@ -1967,7 +1967,7 @@ Backslash escapes do not work in verbatim contexts.
 Smart punctuation
 -----------------
 
-### Extension ###
+#### Extension ####
 
 If the `--smart` option is specified, pandoc will produce typographically
 correct output, converting straight quotes to curly quotes, `---` to
@@ -2008,7 +2008,7 @@ just part of a word, use `*`:
 
 ### Strikeout ###
 
-#### Extension:  `strikeout` ####
+#### Extension: `strikeout` ####
 
 To strikeout a section of text with a horizontal line, begin and end it
 with `~~`. Thus, for example,
@@ -2075,7 +2075,7 @@ colon.) This will work in all output formats that support small caps.
 Math
 ----
 
-### Extension: `tex_math_dollars` ###
+#### Extension: `tex_math_dollars` ####
 
 Anything between two `$` characters will be treated as TeX math.  The
 opening `$` must have a character immediately to its right, while the
@@ -2177,7 +2177,7 @@ HTML, Slidy, DZSlides, S5, EPUB
 Raw HTML
 --------
 
-### Extension: `raw_html` ###
+#### Extension: `raw_html` ####
 
 Markdown allows you to insert raw HTML (or DocBook) anywhere in a document
 (except verbatim contexts, where `<`, `>`, and `&` are interpreted
@@ -2189,7 +2189,7 @@ The raw HTML is passed through unchanged in HTML, S5, Slidy, Slideous,
 DZSlides, EPUB, Markdown, and Textile output, and suppressed in other
 formats.
 
-### Extension: `markdown_in_html_blocks` ###
+#### Extension: `markdown_in_html_blocks` ####
 
 Standard markdown allows you to include HTML "blocks":  blocks
 of HTML between balanced tags that are separated from the surrounding text
@@ -2230,7 +2230,7 @@ from being interpreted as markdown.
 Raw TeX
 -------
 
-### Extension: `raw_tex` ###
+#### Extension: `raw_tex` ####
 
 In addition to raw HTML, pandoc allows raw LaTeX, TeX, and ConTeXt to be
 included in a document. Inline TeX commands will be preserved and passed
@@ -2257,7 +2257,7 @@ and ConTeXt.
 LaTeX macros
 ------------
 
-### Extension: `latex_macros` ###
+#### Extension: `latex_macros` ####
 
 For output formats other than LaTeX, pandoc will parse LaTeX `\newcommand` and
 `\renewcommand` definitions and apply the resulting macros to all LaTeX
@@ -2379,7 +2379,7 @@ The link text will be used as the image's alt text:
 
     [movie reel]: movie.gif
 
-### Extension: `implicit_figures` ###
+#### Extension: `implicit_figures` ####
 
 An image occurring by itself in a paragraph will be rendered as
 a figure with a caption.[^5] (In LaTeX, a figure environment will be
@@ -2403,7 +2403,7 @@ nonbreaking space after the image:
 Footnotes
 ---------
 
-### Extension: `footnotes` ###
+#### Extension: `footnotes` ####
 
 Pandoc's markdown allows footnotes, using the following syntax:
 
@@ -2434,7 +2434,7 @@ The footnotes themselves need not be placed at the end of the
 document.  They may appear anywhere except inside other block elements
 (lists, block quotes, tables, etc.).
 
-### Extension: `inline_notes` ###
+#### Extension: `inline_notes` ####
 
 Inline footnotes are also allowed (though, unlike regular notes,
 they cannot contain multiple paragraphs).  The syntax is as follows:
@@ -2449,7 +2449,7 @@ Inline and regular footnotes may be mixed freely.
 Citations
 ---------
 
-### Extension: `citations` ###
+#### Extension: `citations` ####
 
 Using an external filter, `pandoc-citeproc`, pandoc can automatically generate
 citations and a bibliography in a number of styles.  Basic usage is
@@ -2571,43 +2571,43 @@ in pandoc, but may be enabled by adding `+EXTENSION` to the format
 name, where `EXTENSION` is the name of the extension.  Thus, for
 example, `markdown+hard_line_breaks` is markdown with hard line breaks.
 
-### Extension:  `lists_without_preceding_blankline` ###
+#### Extension: `lists_without_preceding_blankline` ####
 
 Allow a list to occur right after a paragraph, with no intervening
 blank space.
 
-### Extension:  `hard_line_breaks` ###
+#### Extension: `hard_line_breaks` ####
 
 Causes all newlines within a paragraph to be interpreted as hard line
 breaks instead of spaces.
 
-### Extension:  `ignore_line_breaks` ###
+#### Extension: `ignore_line_breaks` ####
 
 Causes newlines within a paragraph to be ignored, rather than being
 treated as spaces or as hard line breaks.  This option is intended for
 use with East Asian languages where spaces are not used between words,
 but text is divided into lines for readability.
 
-### Extension: `tex_math_single_backslash` ###
+#### Extension: `tex_math_single_backslash` ####
 
 Causes anything between `\(` and `\)` to be interpreted as inline
 TeX math, and anything between `\[` and `\]` to be interpreted
 as display TeX math.  Note: a drawback of this extension is that
 it precludes escaping `(` and `[`.
 
-### Extension: `tex_math_double_backslash` ###
+#### Extension: `tex_math_double_backslash` ####
 
 Causes anything between `\\(` and `\\)` to be interpreted as inline
 TeX math, and anything between `\\[` and `\\]` to be interpreted
 as display TeX math.
 
-### Extension: `markdown_attribute` ###
+#### Extension: `markdown_attribute` ####
 
 By default, pandoc interprets material inside block-level tags as markdown.
 This extension changes the behavior so that markdown is only parsed
 inside block-level tags if the tags have the attribute `markdown=1`.
 
-### Extension: `mmd_title_block` ###
+#### Extension: `mmd_title_block` ####
 
 Enables a [MultiMarkdown] style title block at the top of
 the document, for example:
@@ -2624,7 +2624,7 @@ See the MultiMarkdown documentation for details.  If `pandoc_title_block` or
 
   [MultiMarkdown]: http://fletcherpenney.net/multimarkdown/
 
-### Extension: `abbreviations` ###
+#### Extension: `abbreviations` ####
 
 Parses PHP Markdown Extra abbreviation keys, like
 
@@ -2634,29 +2634,29 @@ Note that the pandoc document model does not support
 abbreviations, so if this extension is enabled, abbreviation keys are
 simply skipped (as opposed to being parsed as paragraphs).
 
-### Extension: `autolink_bare_uris` ###
+#### Extension: `autolink_bare_uris` ####
 
 Makes all absolute URIs into links, even when not surrounded by
 pointy braces `<...>`.
 
-### Extension: `ascii_identifiers` ###
+#### Extension: `ascii_identifiers` ####
 
 Causes the identifiers produced by `auto_identifiers` to be pure ASCII.
 Accents are stripped off of accented latin letters, and non-latin
 letters are omitted.
 
-### Extension: `link_attributes` ###
+#### Extension: `link_attributes` ####
 
 Parses multimarkdown style key-value attributes on link and image references.
 Note that pandoc's internal document model provides nowhere to put
 these, so they are presently just ignored.
 
-### Extension: `mmd_header_identifiers` ###
+#### Extension: `mmd_header_identifiers` ####
 
 Parses multimarkdown style header identifiers (in square brackets,
 after the header but before any trailing `#`s in an ATX header).
 
-### Extension: `compact_definition_lists` ###
+#### Extension: `compact_definition_lists` ####
 
 Activates the definition list syntax of pandoc 1.12.x and earlier.
 This syntax differs from the one described [above](#definition-lists)


### PR DESCRIPTION
I'd like to be able to deep-link to any extension in the user guide.
The Nth time I wanted to link in some discussion to a specific pandoc syntax, I realized I can send a pull request and see what you think :-)

This is one approach, turning them into sections.  Another alternative I see would be:

```
**Extension: `inline_code_attributes`{#inline_code_attributes}**
```

But that'd be repetitively repetitive in the source.

The main drawback of sections is non-uniformity — some'll appear as h3, some as h4.
Sections also bloat the TOC, but that's a feature — otherwise there is no way to discover the permalink (without inspecting the DOM).
