### PR TITLE
Shared: Added function insertMedia which is an alias for M.insert

### DIFF
--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -50,6 +50,7 @@ module Text.Pandoc.Shared (
                      tabFilter,
                      -- * Media Handling
                      MediaBag,
+                     insertMedia,
                      -- * Date/time
                      normalizeDate,
                      -- * Pandoc block and inline list processing
@@ -292,8 +293,14 @@ tabFilter tabStop =
 ---
 
 -- | A map of media paths to their binary representations.
-
 type MediaBag = M.Map String BL.ByteString
+
+-- | Insert a media item into a `MediaBag`
+insertMedia :: FilePath
+            -> BL.ByteString
+            -> MediaBag
+            -> MediaBag
+insertMedia = M.insert
 
 --
 -- Date/time


### PR DESCRIPTION
I think ultimately it is better design to make MediaBag a newtype and interact with it through a fixed interface. Firstly this means you don't have to know about the IR and import Data.Map, secondly it will be easy to perform normalisation on the contents in the future if we need to. (Also, we can defined a nicer Show instance for it which doesn't spam the console when debugging.)
