### PR TITLE
Docx Parser: Produce endnotes.

### DIFF
--- a/src/Text/Pandoc/Readers/Docx/Parse.hs
+++ b/src/Text/Pandoc/Readers/Docx/Parse.hs
@@ -857,8 +857,8 @@ elemToRun ns element
     notes <- asks envNotes
     case lookupEndnote enId notes of
       Just e -> do bps <- mapD (elemToBodyPart ns) (elChildren e)
-                   return $ Footnote bps
-      Nothing  -> return $ Footnote []
+                   return $ Endnote bps
+      Nothing  -> return $ Endnote []
 elemToRun ns element
   | isElem ns "w" "r" element = do
     runElems <- elemToRunElems ns element


### PR DESCRIPTION
The parser had been changing both footnotes and endnotes into footnotes. This
hasn't been a problem, because they're later collapsed anyway, but the parser should
maintain as much of the docx structure as is defined, and let the
toplevel reader worry about how to translate it into Pandoc. (This would
be an issue when, as is planned, the docx parser spins off into its
own module.)

The output is the same, so no test change is required.
