### PR TITLE
MediaWiki reader doesn't recognize german "Bild"

### DIFF
--- a/src/Text/Pandoc/Readers/MediaWiki.hs
+++ b/src/Text/Pandoc/Readers/MediaWiki.hs
@@ -569,7 +569,8 @@ endline = () <$ try (newline <*
 
 imageIdentifiers :: [MWParser ()]
 imageIdentifiers = [sym (identifier ++ ":") | identifier <- identifiers]
-    where identifiers = ["File", "Image", "Archivo", "Datei", "Fichier"]
+    where identifiers = ["File", "Image", "Archivo", "Datei", "Fichier",
+                         "Bild"]
 
 image :: MWParser Inlines
 image = try $ do


### PR DESCRIPTION
In german, `Bild` means the same as `Image` and it is frequently used in Wikipedia to denote images.
This pull request adds `Bild` to the list of recognized tags.
