### PR TITLE
Org Writer: Write anchor elements

### DIFF
--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -238,6 +238,8 @@ inlineListToOrg lst = mapM inlineToOrg lst >>= return . hcat
 
 -- | Convert Pandoc inline element to Org.
 inlineToOrg :: Inline -> State WriterState Doc
+inlineToOrg (Span (uid, [], []) []) =
+  return $ "<<" <> text uid <> ">>"
 inlineToOrg (Span _ lst) =
   inlineListToOrg lst
 inlineToOrg (Emph lst) = do


### PR DESCRIPTION
The Org Writer now writes empty span elements which have an id as an anchor.

For example `Span ("uid", [], []) []` becomes `<<uid>>`

Closes #1300
