### PR TITLE
OMath parser: Change signature of exported function.

### DIFF
--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -321,7 +321,7 @@ runToInlines (InlineDrawing fp bs) = do
   modify $ \s -> s { docxMediaBag = insertMedia fp Nothing bs mediaBag }
   return [Image [] (fp, "")]
 
-  
+
 
 
 parPartToInlines :: ParPart -> DocxContext [Inline]
@@ -507,10 +507,9 @@ bodyPartToBlocks (Tbl cap _ look (r:rs)) = do
       widths = replicate size 0 :: [Double]
 
   return [Table caption alignments widths hdrCells cells]
-bodyPartToBlocks (OMathPara exps) = do
-  return [Para $
-          map (\e -> Math DisplayMath (writeTeX e))
-          exps]
+bodyPartToBlocks (OMathPara e) = do
+  return [Para [Math DisplayMath (writeTeX e)]]
+
 
 -- replace targets with generated anchors.
 rewriteLink :: Inline -> DocxContext Inline


### PR DESCRIPTION
This changes the signature of the exported `readOMML` to `String ->
Either String [Exp]`, so it can now, in theory, be slotted into
TeXMath. It doesn't have any real error reporting yet, but that might
make more sense once I put it in a branch, and understand how it works
in the other readers.

It also now reads strings that parse to either oMath or oMathPara
elements. Note that the distinction is lost in the output. It's up to
the caller to remember the display type.
