### PR TITLE
Docx reader: Make dropcap combining more efficient.

### DIFF
--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -462,7 +462,9 @@ bodyPartToBlocks (Paragraph pPr parparts)
 bodyPartToBlocks (Paragraph pPr parparts) = do
   ils <- parPartsToInlines parparts >>= (return . normalizeSpaces)
   dropIls <- gets docxDropCap
-  let ils' = reduceList $ dropIls ++ ils
+  let ils' = case ils of
+        (x:xs) -> reduceList (dropIls ++ [x]) ++ xs
+        []     -> dropIls
   if dropCap pPr
     then do modify $ \s -> s { docxDropCap = ils' }
             return []


### PR DESCRIPTION
Before, we had to run reduceList on the whole combined paragraph, which
was redundant, and could take some time for long paragraphs. We only
need to combine the drop cap with the first inline of the next
paragraph.
