### PR TITLE
Docx reader: move dropcap combining logic to Reducible

### DIFF
--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -462,9 +462,7 @@ bodyPartToBlocks (Paragraph pPr parparts)
 bodyPartToBlocks (Paragraph pPr parparts) = do
   ils <- parPartsToInlines parparts >>= (return . normalizeSpaces)
   dropIls <- gets docxDropCap
-  let ils' = case ils of
-        (x:xs) -> reduceList (dropIls ++ [x]) ++ xs
-        []     -> dropIls
+  let ils' = concatR dropIls ils
   if dropCap pPr
     then do modify $ \s -> s { docxDropCap = ils' }
             return []

--- a/src/Text/Pandoc/Readers/Docx/Reducible.hs
+++ b/src/Text/Pandoc/Readers/Docx/Reducible.hs
@@ -39,6 +39,7 @@ module Text.Pandoc.Readers.Docx.Reducible ((<++>),
                                            innards,
                                            reduceList,
                                            reduceListB,
+                                           concatR,
                                            rebuild)
        where
 
@@ -77,6 +78,15 @@ reduceList' as (x:xs) = reduceList' (init as ++ (last as <++> x) ) xs
 
 reduceList :: (Reducible a) => [a] -> [a]
 reduceList = reduceList' []
+
+concatR :: (Reducible a) => [a] -> [a] -> [a]
+concatR [] [] = []
+concatR [] ss = ss
+concatR rs [] = rs
+concatR rs ss = let (x:xs) = reverse rs
+                    (y:ys) = ss
+                in
+                 reverse xs ++ ( x <++> y ) ++ ys
 
 combineReducibles :: (Reducible a, Eq a) => a -> a -> [a]
 combineReducibles r s =


### PR DESCRIPTION
Introduces a new function in Reducibles, concatR.  The idea is that if we
have two list of Reducibles (blocks or inlines), we can combine them and
just perform the reduction on the joining parts (the last element of the
first list, the first element of the second list). This is useful in cases
where the two lists are already reduced, and we're only worried about the
joining elements.

This actually improves the efficiency a bit further, because concatR can be
smart about empty lists.
