### PR TITLE
Docx reader: Change behavior of Super/Subscript

### DIFF
--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -257,10 +257,10 @@ runStyleToTransform rPr
       smallcaps . (runStyleToTransform rPr {isSmallCaps = Nothing})
   | Just True <- isStrike rPr =
       strikeout . (runStyleToTransform rPr {isStrike = Nothing})
-  | isSuperScript rPr =
-      superscript . (runStyleToTransform rPr {isSuperScript = False})
-  | isSubScript rPr =
-      subscript . (runStyleToTransform rPr {isSubScript = False})
+  | Just SupScrpt <- rVertAlign rPr =
+      superscript . (runStyleToTransform rPr {rVertAlign = Nothing})
+  | Just SubScrpt <- rVertAlign rPr =
+      subscript . (runStyleToTransform rPr {rVertAlign = Nothing})
   | Just "single" <- rUnderline rPr =
       emph . (runStyleToTransform rPr {rUnderline = Nothing})
   | otherwise = id


### PR DESCRIPTION
In docx, super- and subscript are attributes of Vertalign. It makes more
sense to follow this, and have different possible values of Vertalign in
runStyle. This is mainly a preparatory step for real style parsing,
since it can distinguish between vertical align being explicitly turned
off and it not being set.

In addition, it makes parsing a bit clearer, and makes sure we don't do
docx-impossible things like being simultaneously super and sub.
