### PR TITLE
Add --parts command line option to LaTeX writer.

### DIFF
--- a/README
+++ b/README
@@ -455,8 +455,12 @@ Options affecting specific writers
 `--chapters`
 :   Treat top-level headers as chapters in LaTeX, ConTeXt, and DocBook
     output.  When the LaTeX template uses the report, book, or
-    memoir class, this option is implied.  If `beamer` is the output
-    format, top-level headers will become `\part{..}`.
+    memoir class, or if `--parts` is used then this option is implied.
+    If `beamer` is the output format, top-level headers will become `\part{..}`.
+
+`--parts`
+:   Treat top-level headers as parts in LaTeX output. The second level
+    headers will be chapters. This does not effect the `beamer` output format.
 
 `-N`, `--number-sections`
 :   Number section headings in LaTeX, ConTeXt, HTML, or EPUB output.
@@ -1578,9 +1582,9 @@ cases" involving lists.  Consider this source:
 
     +   First
     +   Second:
-    	-   Fee
-    	-   Fie
-    	-   Foe
+      -   Fee
+      -   Fie
+      -   Foe
 
     +   Third
 
@@ -2246,19 +2250,19 @@ by default, pandoc interprets material between HTML block tags as markdown.
 Thus, for example, Pandoc will turn
 
     <table>
-    	<tr>
-    		<td>*one*</td>
-    		<td>[a link](http://google.com)</td>
-    	</tr>
+      <tr>
+        <td>*one*</td>
+        <td>[a link](http://google.com)</td>
+      </tr>
     </table>
 
 into
 
     <table>
-    	<tr>
-    		<td><em>one</em></td>
-    		<td><a href="http://google.com">a link</a></td>
-    	</tr>
+      <tr>
+        <td><em>one</em></td>
+        <td><a href="http://google.com">a link</a></td>
+      </tr>
     </table>
 
 whereas `Markdown.pl` will preserve it as is.

--- a/changelog
+++ b/changelog
@@ -1,3 +1,8 @@
+
+  * `Text.Pandoc.Shared`:
+
+    + Added `writerParts` to `WriterOptions`.
+
 pandoc (1.13.0.1)
 
   * Docx writer:

--- a/pandoc.hs
+++ b/pandoc.hs
@@ -176,6 +176,7 @@ data Opt = Opt
     , optHighlight         :: Bool    -- ^ Highlight source code
     , optHighlightStyle    :: Style   -- ^ Style to use for highlighted code
     , optChapters          :: Bool    -- ^ Use chapter for top-level sects
+    , optParts             :: Bool    -- ^ Use parts for top-level sects in latex
     , optHTMLMathMethod    :: HTMLMathMethod -- ^ Method to print HTML math
     , optReferenceODT      :: Maybe FilePath -- ^ Path of reference.odt
     , optReferenceDocx     :: Maybe FilePath -- ^ Path of reference.docx
@@ -234,6 +235,7 @@ defaultOpts = Opt
     , optHighlight             = True
     , optHighlightStyle        = pygments
     , optChapters              = False
+    , optParts                 = False
     , optHTMLMathMethod        = PlainMath
     , optReferenceODT          = Nothing
     , optReferenceDocx         = Nothing
@@ -571,6 +573,11 @@ options =
                  (NoArg
                   (\opt -> return opt { optChapters = True }))
                  "" -- "Use chapter for top-level sections in LaTeX, DocBook"
+
+    , Option "" ["parts"]
+                 (NoArg
+                  (\opt -> return opt { optParts = True }))
+                 "" -- "Use part for top-level sections in LaTeX"
 
     , Option "N" ["number-sections"]
                  (NoArg
@@ -1027,6 +1034,7 @@ main = do
               , optHighlight             = highlight
               , optHighlightStyle        = highlightStyle
               , optChapters              = chapters
+              , optParts                 = parts
               , optHTMLMathMethod        = mathMethod
               , optReferenceODT          = referenceODT
               , optReferenceDocx         = referenceDocx
@@ -1247,6 +1255,7 @@ main = do
                             writerHtml5            = html5,
                             writerHtmlQTags        = htmlQTags,
                             writerChapters         = chapters,
+                            writerParts            = parts,
                             writerListings         = listings,
                             writerBeamer           = False,
                             writerSlideLevel       = slideLevel,

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -308,6 +308,7 @@ data WriterOptions = WriterOptions
   , writerBeamer           :: Bool       -- ^ Produce beamer LaTeX slide show
   , writerSlideLevel       :: Maybe Int  -- ^ Force header level of slides
   , writerChapters         :: Bool       -- ^ Use "chapter" for top-level sects
+  , writerParts            :: Bool       -- ^ Use "part" for top-level sects in LaTeX
   , writerListings         :: Bool       -- ^ Use listings package for code
   , writerHighlight        :: Bool       -- ^ Highlight source code
   , writerHighlightStyle   :: Style      -- ^ Style to use for highlighting
@@ -351,6 +352,7 @@ instance Default WriterOptions where
                       , writerBeamer           = False
                       , writerSlideLevel       = Nothing
                       , writerChapters         = False
+                      , writerParts            = False
                       , writerListings         = False
                       , writerHighlight        = False
                       , writerHighlightStyle   = pygments


### PR DESCRIPTION
Add --parts command line argument.
This only effects LaTeX writer, and only for non-beamer output formats.
It changes the output levels so the top level is 'part', the next
'chapter' and then into sections.
