### PR TITLE
Fix build dependencies for the trypandoc flag.

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -374,10 +374,10 @@ Executable pandoc
 Executable trypandoc
   Main-Is:         trypandoc.hs
   Hs-Source-Dirs:  trypandoc
-  build-depends:   base, aeson, pandoc, highlighting-kate,
-                   text, wai-extra, wai >= 0.3, http-types
   default-language: Haskell2010
   if flag(trypandoc)
+    build-depends: base, aeson, pandoc, highlighting-kate,
+                   text, wai-extra, wai >= 0.3, http-types
     Buildable:     True
   else
     Buildable:     False


### PR DESCRIPTION
Build dependencies of the `trypandoc` executable are required, regardless of the `trypandoc` flag was set to either `True` or `False.`  Correct package description to make them truly optional.
