### PR TITLE
Docx writer: write track changes.

### DIFF
--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -149,7 +149,7 @@ writeDocx :: WriterOptions  -- ^ Writer options
 writeDocx opts doc@(Pandoc meta _) = do
   let datadir = writerUserDataDir opts
   let doc' = walk fixDisplayMath doc
-  username <- lookupEnv "USERNAME"
+  username <- lookup "USERNAME" <$> getEnvironment
   utctime <- getCurrentTime
   refArchive <- liftM (toArchive . toLazy) $
        case writerReferenceDocx opts of


### PR DESCRIPTION
This allows the docx writer to write track-changes information as currently output by `--track-changes=all`. If merged, this should close #1562.

If the author and date information is given in the "insertion" and "deletion" spans, it will be used. If not, the reader will attempt to get the username and system time (the writer already works in IO, so this isn't a radical change). It does require a few new state variables, just so we can keep track of insertion and deletion ids, and whether we're in a deletion or not (docx uses a different text tag inside a deletion, for some reason).

I know there's an ongoing debate about the internal representation of insertions and deletions. This doesn't tie us particularly to the current span-based representation. Should we change it, it would be trivial to change this and the reader over.
