### PR TITLE
LaTeX writer: Use a declaration for tight lists

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -411,7 +411,7 @@ blockToLaTeX (BulletList lst) = do
   let inc = if incremental then "[<+->]" else ""
   items <- mapM listItemToLaTeX lst
   let spacing = if isTightList lst
-                   then text "\\itemsep1pt\\parskip0pt\\parsep0pt"
+                   then text "\\tightlist"
                    else empty
   return $ text ("\\begin{itemize}" ++ inc) $$ spacing $$ vcat items $$
              "\\end{itemize}"
@@ -446,7 +446,7 @@ blockToLaTeX (OrderedList (start, numstyle, numdelim) lst) = do
                         else "\\setcounter" <> braces enum <>
                               braces (text $ show $ start - 1)
   let spacing = if isTightList lst
-                   then text "\\itemsep1pt\\parskip0pt\\parsep0pt"
+                   then text "\\tightlist"
                    else empty
   return $ text ("\\begin{enumerate}" ++ inc)
          $$ stylecommand
@@ -460,7 +460,7 @@ blockToLaTeX (DefinitionList lst) = do
   let inc = if incremental then "[<+->]" else ""
   items <- mapM defListItemToLaTeX lst
   let spacing = if all isTightList (map snd lst)
-                   then text "\\itemsep1pt\\parskip0pt\\parsep0pt"
+                   then text "\\tightlist"
                    else empty
   return $ text ("\\begin{description}" ++ inc) $$ spacing $$ vcat items $$
                "\\end{description}"

--- a/tests/Tests/Writers/LaTeX.hs
+++ b/tests/Tests/Writers/LaTeX.hs
@@ -42,7 +42,7 @@ tests = [ testGroup "code blocks"
         , testGroup "definition lists"
           [ "with internal link" =: definitionList [(link "#go" "" (str "testing"),
              [plain (text "hi there")])] =?>
-            "\\begin{description}\n\\itemsep1pt\\parskip0pt\\parsep0pt\n\\item[{\\hyperref[go]{testing}}]\nhi there\n\\end{description}"
+            "\\begin{description}\n\\tightlist\n\\item[{\\hyperref[go]{testing}}]\nhi there\n\\end{description}"
           ]
         , testGroup "math"
           [ "escape |" =: para (math "\\sigma|_{\\{x\\}}") =?>

--- a/tests/lhs-test.latex
+++ b/tests/lhs-test.latex
@@ -64,6 +64,8 @@
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
+\newcommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{0}
 
 \date{}

--- a/tests/lhs-test.latex+lhs
+++ b/tests/lhs-test.latex+lhs
@@ -45,6 +45,8 @@
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
+\newcommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{0}
 
 \date{}

--- a/tests/writer.latex
+++ b/tests/writer.latex
@@ -56,6 +56,8 @@
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
+\newcommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{0}
 \VerbatimFootnotes % allows verbatim text in footnotes
 
@@ -131,7 +133,7 @@ A list:
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   item one
 \item
@@ -186,7 +188,7 @@ These should not be escaped:  \$ \\ \> \[ \{
 Asterisks tight:
 
 \begin{itemize}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   asterisk 1
 \item
@@ -209,7 +211,7 @@ Asterisks loose:
 Pluses tight:
 
 \begin{itemize}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   Plus 1
 \item
@@ -232,7 +234,7 @@ Pluses loose:
 Minuses tight:
 
 \begin{itemize}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   Minus 1
 \item
@@ -258,7 +260,7 @@ Tight:
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   First
 \item
@@ -271,7 +273,7 @@ and:
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   One
 \item
@@ -321,17 +323,17 @@ Multiple paragraphs:
 \subsection{Nested}\label{nested}
 
 \begin{itemize}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   Tab
 
   \begin{itemize}
-  \itemsep1pt\parskip0pt\parsep0pt
+  \tightlist
   \item
     Tab
 
     \begin{itemize}
-    \itemsep1pt\parskip0pt\parsep0pt
+    \tightlist
     \item
       Tab
     \end{itemize}
@@ -342,14 +344,14 @@ Here's another:
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   First
 \item
   Second:
 
   \begin{itemize}
-  \itemsep1pt\parskip0pt\parsep0pt
+  \tightlist
   \item
     Fee
   \item
@@ -371,7 +373,7 @@ Same thing but with paragraphs:
   Second:
 
   \begin{itemize}
-  \itemsep1pt\parskip0pt\parsep0pt
+  \tightlist
   \item
     Fee
   \item
@@ -414,7 +416,7 @@ Same thing but with paragraphs:
   \begin{enumerate}
   \def\labelenumii{\roman{enumii}.}
   \setcounter{enumii}{3}
-  \itemsep1pt\parskip0pt\parsep0pt
+  \tightlist
   \item
     sublist with roman numerals, starting with 4
   \item
@@ -422,7 +424,7 @@ Same thing but with paragraphs:
 
     \begin{enumerate}
     \def\labelenumiii{(\Alph{enumiii})}
-    \itemsep1pt\parskip0pt\parsep0pt
+    \tightlist
     \item
       a subsublist
     \item
@@ -435,27 +437,27 @@ Nesting:
 
 \begin{enumerate}
 \def\labelenumi{\Alph{enumi}.}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   Upper Alpha
 
   \begin{enumerate}
   \def\labelenumii{\Roman{enumii}.}
-  \itemsep1pt\parskip0pt\parsep0pt
+  \tightlist
   \item
     Upper Roman.
 
     \begin{enumerate}
     \def\labelenumiii{(\arabic{enumiii})}
     \setcounter{enumiii}{5}
-    \itemsep1pt\parskip0pt\parsep0pt
+    \tightlist
     \item
       Decimal start with 6
 
       \begin{enumerate}
       \def\labelenumiv{\alph{enumiv})}
       \setcounter{enumiv}{2}
-      \itemsep1pt\parskip0pt\parsep0pt
+      \tightlist
       \item
         Lower alpha with paren
       \end{enumerate}
@@ -466,14 +468,14 @@ Nesting:
 Autonumbering:
 
 \begin{enumerate}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   Autonumber.
 \item
   More.
 
   \begin{enumerate}
-  \itemsep1pt\parskip0pt\parsep0pt
+  \tightlist
   \item
     Nested.
   \end{enumerate}
@@ -492,7 +494,7 @@ B. Williams
 Tight using spaces:
 
 \begin{description}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item[apple]
 red fruit
 \item[orange]
@@ -504,7 +506,7 @@ yellow fruit
 Tight using tabs:
 
 \begin{description}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item[apple]
 red fruit
 \item[orange]
@@ -546,7 +548,7 @@ orange block quote
 Multiple definitions, tight:
 
 \begin{description}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item[apple]
 red fruit
 
@@ -582,7 +584,7 @@ orange fruit
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   sublist
 \item
@@ -708,7 +710,7 @@ Ellipses\ldots{}and\ldots{}and\ldots{}.
 \section{LaTeX}\label{latex}
 
 \begin{itemize}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   \cite[22-23]{smith.1899}
 \item
@@ -731,7 +733,7 @@ Ellipses\ldots{}and\ldots{}and\ldots{}.
 These shouldn't be math:
 
 \begin{itemize}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   To get the famous equation, write \texttt{\$e = mc\^{}2\$}.
 \item
@@ -758,7 +760,7 @@ Cat    & 1      \\ \hline
 Here is some unicode:
 
 \begin{itemize}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   I hat: Î
 \item
@@ -882,7 +884,7 @@ Here's an \href{/script?foo=1\&bar=2}{inline link in pointy braces}.
 With an ampersand: \url{http://example.com/?foo=1\&bar=2}
 
 \begin{itemize}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   In a list?
 \item
@@ -948,7 +950,7 @@ Notes can go in quotes.\footnote{In quote.}
 
 \begin{enumerate}
 \def\labelenumi{\arabic{enumi}.}
-\itemsep1pt\parskip0pt\parsep0pt
+\tightlist
 \item
   And in list items.\footnote{In list.}
 \end{enumerate}


### PR DESCRIPTION
Currently, pandoc has hard-coded the following in order to make tight lists in LaTeX:

```hs
text "\\itemsep1pt\\parskip0pt\\parsep0pt"
```

Which is fine, but does not allow customizations.  For example, the `memoir` class already has a `\tightlist` declaration for this purpose:

```tex
\newcommand{\tightlist}{%
  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
```

I'm proposing to use a similar solution:

```diff
@@ In Writers/LaTeX.hs:
-then text "\\itemsep1pt\\parskip0pt\\parsep0pt"
+then text "\\tightlist"

@@ In templates/default.latex:
+\newcommand{\tightlist}{%
+  \setlength{\itemsep}{1pt}\setlength{\parskip}{0pt}\setlength{\parsep}{0pt}}
```

This allows us to customize the tightness to our needs.

### Backward Compatibility

If a person is using a custom LaTeX template (not based upon the `memoir` class), the `\tightlist` declaration must be added.