### PR TITLE
LaTeX writer: Make Horizontal Rules more flexible

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -465,7 +465,7 @@ blockToLaTeX (DefinitionList lst) = do
   return $ text ("\\begin{description}" ++ inc) $$ spacing $$ vcat items $$
                "\\end{description}"
 blockToLaTeX HorizontalRule = return $
-  "\\begin{center}\\rule{3in}{0.4pt}\\end{center}"
+  "\\begin{center}\\rule{0.5\\linewidth}{\\linethickness}\\end{center}"
 blockToLaTeX (Header level (id',classes,_) lst) =
   sectionHeader ("unnumbered" `elem` classes) id' level lst
 blockToLaTeX (Table caption aligns widths heads rows) = do

--- a/tests/writer.latex
+++ b/tests/writer.latex
@@ -69,7 +69,7 @@
 This is a set of tests for pandoc. Most of them are adapted from John Gruber's
 markdown test suite.
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Headers}\label{headers}
 
@@ -94,7 +94,7 @@ with no blank line
 
 with no blank line
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Paragraphs}\label{paragraphs}
 
@@ -108,7 +108,7 @@ Here's one with a bullet. * criminey.
 
 There should be a hard line break\\here.
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Block Quotes}\label{block-quotes}
 
@@ -153,7 +153,7 @@ This should not be a block quote: 2 \textgreater{} 1.
 
 And a following paragraph.
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Code Blocks}\label{code-blocks}
 
@@ -177,7 +177,7 @@ And:
 These should not be escaped:  \$ \\ \> \[ \{
 \end{verbatim}
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Lists}\label{lists}
 
@@ -485,7 +485,7 @@ M.A.~2007
 
 B. Williams
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Definition Lists}\label{definition-lists}
 
@@ -650,7 +650,7 @@ Code:
 
 Hr's:
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Inline Markup}\label{inline-markup}
 
@@ -682,7 +682,7 @@ H\textsubscript{many~of~them}O.
 These should not be superscripts or subscripts, because of the unescaped
 spaces: a\^{}b c\^{}d, a\textasciitilde{}b c\textasciitilde{}d.
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Smart quotes, ellipses, dashes}\label{smart-quotes-ellipses-dashes}
 
@@ -703,7 +703,7 @@ Dashes between numbers: 5--7, 255--66, 1987--1999.
 
 Ellipses\ldots{}and\ldots{}and\ldots{}.
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{LaTeX}\label{latex}
 
@@ -751,7 +751,7 @@ Dog    & 2      \\
 Cat    & 1      \\ \hline
 \end{tabular}
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Special Characters}\label{special-characters}
 
@@ -813,7 +813,7 @@ Plus: +
 
 Minus: -
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Links}\label{links}
 
@@ -905,7 +905,7 @@ Auto-links should not occur here:
 or here: <http://example.com/>
 \end{verbatim}
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Images}\label{images}
 
@@ -919,7 +919,7 @@ From ``Voyage dans la Lune'' by Georges Melies (1902):
 
 Here is a movie \includegraphics{movie.jpg} icon.
 
-\begin{center}\rule{3in}{0.4pt}\end{center}
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 
 \section{Footnotes}\label{footnotes}
 


### PR DESCRIPTION
Currently, pandoc has hard-coded the following in order to make horizontal rules in LaTeX:

``` hs
"\\begin{center}\\rule{3in}{0.4pt}\\end{center}"
```

Which is fine, but does not allow customizations.  It also does not take into consideration the current line width.

I'm proposing this change:

``` diff
@@ In Writers/LaTeX.hs:
-"\\begin{center}\\rule{3in}{0.4pt}\\end{center}"
+"\\begin{center}\\rule{0.5\\linewidth}{\\linethickness}\\end{center}"
```
