### PR TITLE
Dokuwiki writer: Add a test for multiblock table cells.

### DIFF
--- a/tests/Tests/Old.hs
+++ b/tests/Tests/Old.hs
@@ -128,6 +128,8 @@ tests = [ testGroup "markdown"
           [ testGroup "writer" $ writerTests "dokuwiki"
           , test "inline_formatting" ["-r", "native", "-w", "dokuwiki", "-s"]
             "dokuwiki_inline_formatting.native" "dokuwiki_inline_formatting.dokuwiki"
+          , test "multiblock table" ["-r", "native", "-w", "dokuwiki", "-s"]
+            "dokuwiki_multiblock_table.native" "dokuwiki_multiblock_table.dokuwiki"
           ]
         , testGroup "opml"
           [ test "basic" ["-r", "native", "-w", "opml", "--columns=78", "-s"]

--- a/tests/dokuwiki_multiblock_table.dokuwiki
+++ b/tests/dokuwiki_multiblock_table.dokuwiki
@@ -1,0 +1,4 @@
+Sample grid table.
+^ Fruit ^ Price ^ Advantages ^
+| Bananas | $1.34 | built-in wrapper\\ \\ potassium |
+| Oranges | $2.10 | * cures scurvy\\ * tasty |

--- a/tests/dokuwiki_multiblock_table.native
+++ b/tests/dokuwiki_multiblock_table.native
@@ -1,0 +1,13 @@
+[Table [Str "Sample",Space,Str "grid",Space,Str "table."] [AlignDefault,AlignDefault,AlignDefault] [0.2222222222222222,0.2222222222222222,0.2916666666666667]
+ [[Plain [Str "Fruit"]]
+ ,[Plain [Str "Price"]]
+ ,[Plain [Str "Advantages"]]]
+ [[[Para [Str "Bananas"]]
+  ,[Para [Str "$1.34"]]
+  ,[Para [Str "built-in",Space,Str "wrapper"]
+   ,Para [Str "potassium"]]]
+ ,[[Para [Str "Oranges"]]
+  ,[Para [Str "$2.10"]]
+  ,[BulletList
+    [[Plain [Str "cures",Space,Str "scurvy"]]
+    ,[Plain [Str "tasty"]]]]]]]


### PR DESCRIPTION
We have to add a new file, because the original table tests don't look
for this.
