### PR TITLE
Bump text, random, http-client upper bounds

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -219,14 +219,14 @@ Library
                  process >= 1 && < 1.3,
                  directory >= 1 && < 1.3,
                  bytestring >= 0.9 && < 0.11,
-                 text >= 0.11 && < 1.2,
+                 text >= 0.11 && < 1.3,
                  zip-archive >= 0.2.3.4 && < 0.3,
                  old-locale >= 1 && < 1.1,
                  time >= 1.2 && < 1.5,
                  HTTP >= 4000.0.5 && < 4000.3,
                  texmath >= 0.8 && < 0.9,
                  xml >= 1.3.12 && < 1.4,
-                 random >= 1 && < 1.1,
+                 random >= 1 && < 1.2,
                  extensible-exceptions >= 0.1 && < 0.2,
                  pandoc-types >= 1.12.4 && < 1.13,
                  aeson >= 0.7 && < 0.9,
@@ -253,7 +253,7 @@ Library
   else
      Build-Depends: network >= 2 && < 2.6
   if flag(https)
-     Build-Depends: http-client >= 0.3.2 && < 0.4,
+     Build-Depends: http-client >= 0.3.2 && < 0.5,
                     http-client-tls >= 0.2 && < 0.3,
                     http-types >= 0.8 && < 0.9
      cpp-options:   -DHTTP_CLIENT
@@ -348,7 +348,7 @@ Executable pandoc
                  base >= 4.2 && <5,
                  directory >= 1 && < 1.3,
                  filepath >= 1.1 && < 1.4,
-                 text >= 0.11 && < 1.2,
+                 text >= 0.11 && < 1.3,
                  bytestring >= 0.9 && < 0.11,
                  extensible-exceptions >= 0.1 && < 0.2,
                  highlighting-kate >= 0.5.8.5 && < 0.6,
@@ -409,7 +409,7 @@ Test-Suite test-pandoc
                   pandoc,
                   pandoc-types >= 1.12.4 && < 1.13,
                   bytestring >= 0.9 && < 0.11,
-                  text >= 0.11 && < 1.2,
+                  text >= 0.11 && < 1.3,
                   directory >= 1 && < 1.3,
                   filepath >= 1.1 && < 1.4,
                   process >= 1 && < 1.3,


### PR DESCRIPTION
Allow `pandoc` to use the latest versions of `text`, `random`, and `http-client`.
