### PR TITLE
add mime type for WebVTT

### DIFF
--- a/src/Text/Pandoc/MIME.hs
+++ b/src/Text/Pandoc/MIME.hs
@@ -477,6 +477,7 @@ mimeTypesList = -- List borrowed from happstack-server.
            ,("vrml","model/vrml")
            ,("vs","text/plain")
            ,("vsd","application/vnd.visio")
+           ,("vtt","text/vtt")
            ,("wad","application/x-doom")
            ,("wav","audio/x-wav")
            ,("wax","audio/x-ms-wax")


### PR DESCRIPTION
Now that https://github.com/jgm/pandoc/issues/1664 includes WebVTT track files as data-URIs when using --self-contained, it is necessary to add the WebVTT MIME type text/vtt. 
http://dev.w3.org/html5/webvtt/#webvtt-file-structure
