### PR TITLE
Use '=' instead of '#' for atx-style headers in markdown+lhs.

### DIFF
--- a/README
+++ b/README
@@ -3080,7 +3080,8 @@ literate Haskell source. This means that
 
   - In markdown input, "bird track" sections will be parsed as Haskell
     code rather than block quotations.  Text between `\begin{code}`
-    and `\end{code}` will also be treated as Haskell code.
+    and `\end{code}` will also be treated as Haskell code.  For
+    atx-style headers the character '=' will be used instead of '#'.
 
   - In markdown output, code blocks with classes `haskell` and `literate`
     will be rendered using bird tracks, and block quotations will be

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -487,9 +487,15 @@ block = do
 header :: MarkdownParser (F Blocks)
 header = setextHeader <|> atxHeader <?> "header"
 
+atxChar :: MarkdownParser Char
+atxChar = do
+  exts <- getOption readerExtensions
+  return $ if Set.member Ext_literate_haskell exts
+    then '=' else '#'
+
 atxHeader :: MarkdownParser (F Blocks)
 atxHeader = try $ do
-  level <- many1 (char '#') >>= return . length
+  level <- atxChar >>= many1 . char >>= return . length
   notFollowedBy $ guardEnabled Ext_fancy_lists >>
                   (char '.' <|> char ')') -- this would be a list
   skipSpaces
@@ -502,7 +508,7 @@ atxClosing :: MarkdownParser Attr
 atxClosing = try $ do
   attr' <- option nullAttr
              (guardEnabled Ext_mmd_header_identifiers >> mmdHeaderIdentifier)
-  skipMany (char '#')
+  skipMany . char =<< atxChar
   skipSpaces
   attr <- option attr'
              (guardEnabled Ext_header_attributes >> attributes)
@@ -1614,7 +1620,7 @@ endline = try $ do
   when (stateParserContext st == ListItemState) $ notFollowedBy listStart
   guardDisabled Ext_lists_without_preceding_blankline <|> notFollowedBy listStart
   guardEnabled Ext_blank_before_blockquote <|> notFollowedBy emailBlockQuoteStart
-  guardEnabled Ext_blank_before_header <|> notFollowedBy (char '#') -- atx header
+  guardEnabled Ext_blank_before_header <|> (notFollowedBy . char =<< atxChar) -- atx header
   guardDisabled Ext_backtick_code_blocks <|>
      notFollowedBy (() <$ (lookAhead (char '`') >> codeBlockFenced))
   notFollowedByHtmlCloser


### PR DESCRIPTION
Using atx-style headers in markdown+lhs doesn't give a legal literate haskell file, since the usage of '#' is reserved.  I suggest supporting '=' instead of '#' for headings of level 3 or more.  This should pose no compatibility problems, since '#' is already illegal, and the '=' syntax is not used for anything else.  Using html style subheaders works only when generating html, not for other backends.