### PR TITLE
Escape inline verbatim spaces in LaTeX output

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -746,8 +746,10 @@ inlineToLaTeX (Code (_,classes,_) str) = do
                   Nothing -> rawCode
                   Just  h -> modify (\st -> st{ stHighlighting = True }) >>
                              return (text h)
-         rawCode = liftM (text . (\s -> "\\texttt{" ++ s ++ "}"))
+         rawCode = liftM (text . (\s -> "\\texttt{" ++ escapeSpaces s ++ "}"))
                           $ stringToLaTeX CodeString str
+           where
+             escapeSpaces =  concatMap (\c -> if c == ' ' then "\\ " else [c])
 inlineToLaTeX (Quoted qt lst) = do
   contents <- inlineListToLaTeX lst
   csquotes <- liftM stCsquotes get

--- a/tests/writer.latex
+++ b/tests/writer.latex
@@ -734,7 +734,7 @@ These shouldn't be math:
 \begin{itemize}
 \itemsep1pt\parskip0pt\parsep0pt
 \item
-  To get the famous equation, write \texttt{\$e = mc\^{}2\$}.
+  To get the famous equation, write \texttt{\$e\ =\ mc\^{}2\$}.
 \item
   \$22,000 is a \emph{lot} of money. So is \$34,000. (It worked if ``lot'' is
   emphasized.)


### PR DESCRIPTION
This implements the proposed fix and addresses the problems described in #1694. The test reference has also been updated. (I note that the latex writer had an unrelated test failure before these changes, which I have not addressed.)
