### PR TITLE
Org reader: fix rules for emphasis recognition

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -927,7 +927,7 @@ parseInlines = trimInlinesF . mconcat <$> many1 inline
 
 -- treat these as potentially non-text when parsing inline:
 specialChars :: [Char]
-specialChars = "\"$'()*+-./:<=>[\\]^_{|}~"
+specialChars = "\"$'()*+-,./:<=>[\\]^_{|}~"
 
 
 whitespace :: OrgParser (F Inlines)
@@ -1205,10 +1205,10 @@ displayMath = return . B.displayMath <$> choice [ rawMathBetween "\\[" "\\]"
                                                 ]
 symbol :: OrgParser (F Inlines)
 symbol = return . B.str . (: "") <$> (oneOf specialChars >>= updatePositions)
- where updatePositions c
-           | c `elem` emphasisPreChars = c <$ updateLastPreCharPos
-           | c `elem` emphasisForbiddenBorderChars = c <$ updateLastForbiddenCharPos
-           | otherwise = return c
+ where updatePositions c = do
+         when (c `elem` emphasisPreChars) updateLastPreCharPos
+         when (c `elem` emphasisForbiddenBorderChars) updateLastForbiddenCharPos
+         return c
 
 emphasisBetween :: Char
                 -> OrgParser (F Inlines)

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -126,6 +126,14 @@ tests =
                        , (emph "b") <> "."
                        ])
 
+      , "Quotes are forbidden border chars" =:
+          "/'nope/ *nope\"*" =?>
+          para ("/'nope/" <> space <> "*nope\"*")
+
+      , "Commata are forbidden border chars" =:
+          "/nada,/" =?>
+          para "/nada,/"
+
       , "Markup should work properly after a blank line" =:
         unlines ["foo", "", "/bar/"] =?>
         (para $ text "foo") <> (para $ emph $ text "bar")


### PR DESCRIPTION
Things like `/hello,/` or `/hi'/` were falsy recognized as emphasised
strings.  This is wrong, as `,` and `'` are forbidden border chars and
may not occur on the inner border of emphasized text.  This patch
enables the reader to matches the reference implementation in that it
reads the above strings as plain text.
