### PR TITLE
Org reader: parse LaTeX-style MathML entities

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -276,6 +276,18 @@ tests =
           "\\notacommand{foo}" =?>
           para (rawInline "latex" "\\notacommand{foo}")
 
+      , "MathML symbol in LaTeX-style" =:
+          "There is a hackerspace in Lübeck, Germany, called nbsp (unicode symbol: '\\nbsp')." =?>
+          para ("There is a hackerspace in Lübeck, Germany, called nbsp (unicode symbol: ' ').")
+
+      , "MathML symbol in LaTeX-style, including braces" =:
+          "\\Aacute{}stor" =?>
+          para "Ástor"
+
+      , "MathML copy sign" =:
+          "\\copy" =?>
+          para "©"
+
       , "LaTeX citation" =:
           "\\cite{Coffee}" =?>
           let citation = Citation


### PR DESCRIPTION
Org supports special symbols which can be included using LaTeX syntax,
but are actually MathML entities.  Examples for this are
`\nbsp` (non-breaking space), `\Aacute` (the letter A with accent acute)
or `\copy` (the copyright sign ©).

This fixes #1657.
