### PR TITLE
Strip querystring in ODT write

### DIFF
--- a/src/Text/Pandoc/Writers/ODT.hs
+++ b/src/Text/Pandoc/Writers/ODT.hs
@@ -138,7 +138,8 @@ transformPicMath opts entriesRef (Image lab (src,_)) = do
        let (w,h) = fromMaybe (0,0) $ sizeInPoints `fmap` size
        let tit' = show w ++ "x" ++ show h
        entries <- readIORef entriesRef
-       let newsrc = "Pictures/" ++ show (length entries) ++ takeExtension src
+       let extension = takeExtension $ takeWhile (/='?') src
+       let newsrc = "Pictures/" ++ show (length entries) ++ extension
        let toLazy = B.fromChunks . (:[])
        epochtime <- floor `fmap` getPOSIXTime
        let entry = toEntry newsrc epochtime $ toLazy img


### PR DESCRIPTION
- Resolve #1682 
- Strip querystring from filename before rendering ODT files, LibreOffice cannot
  handle querystrings in ODT files.
