### PR TITLE
Org fix links

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -205,6 +205,10 @@ tests =
           "[[../file.txt][moin]]" =?>
           (para $ link "../file.txt" "" "moin")
 
+      , "Empty link (for gitit interop)" =:
+          "[[][New Link]]" =?>
+          (para $ link "" "" "New Link")
+
       , "Image link" =:
           "[[sunset.png][dusk.svg]]" =?>
           (para $ link "sunset.png" "" (image "dusk.svg" "" ""))


### PR DESCRIPTION
Fix problems with links parsing in the org reader:
- properly parse absolute and relative file paths
- allow empty links (not supported in Emacs, but required by gitit)
