### PR TITLE
export more Html functions and use StateT monad transformer instead of S...

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -41,8 +41,13 @@ module Text.Pandoc.Writers.HTML (
   writeSlidy,
   writeSlideous,
   writeDZSlides,
-  writeRevealJs
-  ) where
+  writeRevealJs,
+  defaultWriterState,
+  WriterState,
+  inlineListToHtml,
+  unordList)
+where
+import Text.Pandoc.Definition
 import Control.Monad.State.Strict
 import Data.Char (ord, toLower)
 import Data.Text (Text)
@@ -91,6 +96,7 @@ import Text.XML.Light (elChildren, unode, unqual)
 import qualified Text.XML.Light as XML
 import Text.XML.Light.Output
 
+-- | State of the writer
 data WriterState = WriterState
     { stNotes        :: [Html]  -- ^ List of notes
     , stMath         :: Bool    -- ^ Math is used in document
@@ -103,6 +109,7 @@ data WriterState = WriterState
     , stSlideVariant :: HTMLSlideVariant
     }
 
+-- | Default state of the writer (e.g. before writing)
 defaultWriterState :: WriterState
 defaultWriterState = WriterState {stNotes= [], stMath = False, stQuotes = False,
                                   stHighlighting = False, stSecNum = [],

--- a/test/Tests/Readers/Muse.hs
+++ b/test/Tests/Readers/Muse.hs
@@ -145,6 +145,30 @@ tests =
                     , "  with a continuation"
                     ] =?>
           blockQuote (para "This is a quotation with a continuation")
+        , "Verse" =:
+          T.unlines [ "> This is"
+                    , "> First stanza"
+                    , ">" -- Emacs produces verbatim ">" here, we follow Amusewiki
+                    , "> And this is"
+                    , ">   Second stanza"
+                    , ">"
+                    , ""
+                    , ">"
+                    , ""
+                    , "> Another verse"
+                    , ">    is here"
+                    ] =?>
+          lineBlock [ "This is"
+                    , "First stanza"
+                    , ""
+                    , "And this is"
+                    , "\160\160Second stanza"
+                    , ""
+                    ] <>
+          lineBlock [ "" ] <>
+          lineBlock [ "Another verse"
+                    , "\160\160\160is here"
+                    ]
         ]
       , "Quote tag" =: "<quote>Hello, world</quote>" =?> blockQuote (para $ text "Hello, world")
       , "Verse tag" =:


### PR DESCRIPTION
...tate in order to implement Toc extending to subpage in gitit2:
jgm/gitit2/issues/11
Additional exported functions: `defaultWriterState`, `WriterState`, `inlineListToHtml`, `unordList`
