### PR TITLE
Add "--revealjs-title-content" to flags

### DIFF
--- a/README
+++ b/README
@@ -515,6 +515,12 @@ Options affecting specific writers
     based on the contents of the document; see
     [Structuring the slide show](#structuring-the-slide-show), below.
 
+`--revealjs-title-content`
+:   Specifies that slides higher than the slide level (thus, level < slideLevel)
+    should include content when generated with Reveal.js.  This allows for
+    slide-shows that have content slides in both the horizontal and vertical
+    directions, as well as section title slides that have content.
+
 `--section-divs`
 :   Wrap sections in `<div>` tags (or `<section>` tags in HTML5),
     and attach identifiers to the enclosing `<div>` (or `<section>`)

--- a/pandoc.hs
+++ b/pandoc.hs
@@ -207,6 +207,7 @@ data Opt = Opt
     , optTrackChanges      :: TrackChanges -- ^ Accept or reject MS Word track-changes.
     , optKaTeXStylesheet   :: Maybe String     -- ^ Path to stylesheet for KaTeX
     , optKaTeXJS           :: Maybe String     -- ^ Path to js file for KaTeX
+    , optRevealjsTitleContent :: Bool
     }
 
 -- | Defaults for command-line options.
@@ -267,6 +268,7 @@ defaultOpts = Opt
     , optTrackChanges          = AcceptChanges
     , optKaTeXStylesheet       = Nothing
     , optKaTeXJS               = Nothing
+    , optRevealjsTitleContent  = False
     }
 
 -- | A list of functions, each transforming the options data structure
@@ -616,6 +618,12 @@ options =
                                     "slide level must be a number between 1 and 6")
                  "NUMBER")
                  "" -- "Force header level for slides"
+
+    , Option "" ["revealjs-title-content"]
+                 (NoArg
+                  (\opt -> do
+                      return opt { optRevealjsTitleContent = True } ))
+                 "" -- "Render content on horizontal title slides with Reveal.js"
 
     , Option "" ["section-divs"]
                  (NoArg
@@ -1082,6 +1090,7 @@ main = do
               , optTrackChanges          = trackChanges
               , optKaTeXStylesheet       = katexStylesheet
               , optKaTeXJS               = katexJS
+              , optRevealjsTitleContent  = revealjsTitleContent
              } = opts
 
   when dumpArgs $
@@ -1291,6 +1300,7 @@ main = do
                             writerListings         = listings,
                             writerBeamer           = False,
                             writerSlideLevel       = slideLevel,
+                            writerRevealjsTitleContent = revealjsTitleContent,
                             writerHighlight        = highlight,
                             writerHighlightStyle   = highlightStyle,
                             writerSetextHeaders    = setextHeaders,

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -308,6 +308,7 @@ data WriterOptions = WriterOptions
   , writerHtmlQTags        :: Bool       -- ^ Use @<q>@ tags for quotes in HTML
   , writerBeamer           :: Bool       -- ^ Produce beamer LaTeX slide show
   , writerSlideLevel       :: Maybe Int  -- ^ Force header level of slides
+  , writerRevealjsTitleContent :: Bool -- ^ Render content for Reveal.js title slides
   , writerChapters         :: Bool       -- ^ Use "chapter" for top-level sects
   , writerListings         :: Bool       -- ^ Use listings package for code
   , writerHighlight        :: Bool       -- ^ Highlight source code
@@ -351,6 +352,7 @@ instance Default WriterOptions where
                       , writerHtmlQTags        = False
                       , writerBeamer           = False
                       , writerSlideLevel       = Nothing
+                      , writerRevealjsTitleContent = False
                       , writerChapters         = False
                       , writerListings         = False
                       , writerHighlight        = False

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -308,6 +308,11 @@ elementToHtml slideLevel opts (Sec level num (id',classes,keyvals) title' elemen
                                           []     -> []
                                           (x:xs) -> x ++ concatMap inDiv xs
                                 else elements
+  titleSlideContents <- mapM (elementToHtml slideLevel opts)
+                        $ if (writerRevealjsTitleContent opts &&
+                              writerSlideVariant opts == RevealJsSlides)
+                          then filter (not . isSec) elements
+                          else []
   let inNl x = mconcat $ nl opts : intersperse (nl opts) x ++ [nl opts]
   let classes' = ["titleslide" | titleSlide] ++ ["slide" | slide] ++
                   ["section" | (slide || writerSectionDivs opts) &&
@@ -322,7 +327,7 @@ elementToHtml slideLevel opts (Sec level num (id',classes,keyvals) title' elemen
               then (if writerSlideVariant opts == RevealJsSlides
                        then H5.section
                        else id) $ mconcat $
-                       (addAttrs opts attr $ secttag $ header') : innerContents
+                       (addAttrs opts attr $ secttag $ (mconcat $ header' : titleSlideContents)) : innerContents
               else if writerSectionDivs opts || slide
                    then addAttrs opts attr
                         $ secttag $ inNl $ header' : innerContents


### PR DESCRIPTION
First off @jgm, Pandoc is a wonderful creation.  Thanks for all your hard work!

Whenever I have to give a presentation, I turn to Pandoc to generate my slides.  Previously, I used slidy, but Reveal.js has really caught my eye.

I love being able to pull a presentation from Markdown, but I don't like being constrained to a certain format (even if the reasons for this are very, very good), particularly the inability to mix vertical and horizontal content slides with Pandoc + Reveal.js.

For that reason, I've thrown together a new CLI option that allows Pandoc to still generate the content for title slides with level < slideLevel when using the Reveal.js writer.  I've already found it useful in piecing together my presentations, and I hope it can benefit others as well!

Again, thanks for all your work on Pandoc & Co!
