### PR TITLE
parse RST quoted literal blocks and class directives

### DIFF
--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -47,7 +47,7 @@ import Text.Pandoc.Builder (Inlines, Blocks, trimInlines, (<>))
 import qualified Text.Pandoc.Builder as B
 import Data.Monoid (mconcat, mempty)
 import Data.Sequence (viewr, ViewR(..))
-import Data.Char (toLower, isHexDigit)
+import Data.Char (toLower, isHexDigit, isSpace)
 
 -- | Parse reStructuredText string and return Pandoc document.
 readRST :: ReaderOptions -- ^ Reader options
@@ -521,7 +521,6 @@ directive = try $ do
 -- TODO: line-block, parsed-literal, table, csv-table, list-table
 -- date
 -- include
--- class
 -- title
 directive' :: RSTParser Blocks
 directive' = do
@@ -602,6 +601,13 @@ directive' = do
                           Just t  -> B.link (escapeURI $ trim t) ""
                                      $ B.image src "" alt
                           Nothing -> B.image src "" alt
+        "class" -> do
+            let attrs = ("", (splitBy isSpace $ trim top), map (\(k,v) -> (k, trimr v)) fields)
+            --  directive content or the first immediately following element
+            children <- case body of
+                "" -> block
+                _ -> parseFromString parseBlocks  body'
+            return $ B.divWith attrs children
         _     -> return mempty
 
 -- TODO:

--- a/tests/Tests/Readers/RST.hs
+++ b/tests/Tests/Readers/RST.hs
@@ -83,4 +83,10 @@ tests = [ "line block with blank line" =:
             =?> codeBlock "> quoted\n> block" <> para "Ordinary paragraph"
           , "quoted literal block using | (not  a line block)" =: "::\n\n| quoted\n| block\n\nOrdinary paragraph"
             =?> codeBlock "| quoted\n| block" <> para "Ordinary paragraph"
+            , "class directive with single paragraph" =: ".. class:: special\n\nThis is a \"special\" paragraph."
+              =?> divWith ("", ["special"], []) (para "This is a \"special\" paragraph.")
+            , "class directive with two paragraphs" =: ".. class:: exceptional remarkable\n\n    First paragraph.\n\n    Second paragraph."
+              =?> divWith ("", ["exceptional", "remarkable"], []) (para "First paragraph." <> para "Second paragraph.")
+            , "class directive around literal block" =: ".. class:: classy\n\n::\n\n    a\n    b"
+              =?> divWith ("", ["classy"], []) (codeBlock "a\nb")
         ]


### PR DESCRIPTION
A couple of additions to the RST reader, and associated tests, per discussion https://groups.google.com/forum/#!searchin/pandoc-discuss/class/pandoc-discuss/q1ELmf2et9o/MH75rcf_VrIJ.  

The note about how this is different from the rst2xml output should probably go in the docs somewhere, but I'm not sure where.
