### PR TITLE
Add --prefer-fenced-code-blocks option

### DIFF
--- a/README
+++ b/README
@@ -466,6 +466,11 @@ Options affecting specific writers
 :   Use ATX style headers in markdown and asciidoc output. The default is
     to use setext-style headers for levels 1-2, and then ATX headers.
 
+`--prefer-fenced-code-blocks`
+:   Use fenced code blocks if no attributes in markdown. The default is
+    to use indented code blocks if no attributes. Blocks, that has some
+    attributes, uses fenced code blocks regardless of this option.
+
 `--chapters`
 :   Treat top-level headers as chapters in LaTeX, ConTeXt, and DocBook
     output.  When the LaTeX template uses the report, book, or

--- a/pandoc.hs
+++ b/pandoc.hs
@@ -199,6 +199,7 @@ data Opt = Opt
     , optLaTeXEngine       :: String     -- ^ Program to use for latex -> pdf
     , optSlideLevel        :: Maybe Int  -- ^ Header level that creates slides
     , optSetextHeaders     :: Bool       -- ^ Use atx headers for markdown level 1-2
+    , optPreferFenced      :: Bool       -- ^ Use fenced code blocks if no attributes in markdown
     , optAscii             :: Bool       -- ^ Use ascii characters only in html
     , optTeXLigatures      :: Bool       -- ^ Use TeX ligatures for quotes/dashes
     , optDefaultImageExtension :: String -- ^ Default image extension
@@ -259,6 +260,7 @@ defaultOpts = Opt
     , optLaTeXEngine           = "pdflatex"
     , optSlideLevel            = Nothing
     , optSetextHeaders         = True
+    , optPreferFenced          = False
     , optAscii                 = False
     , optTeXLigatures          = True
     , optDefaultImageExtension = ""
@@ -570,6 +572,11 @@ options =
                  (NoArg
                   (\opt -> return opt { optSetextHeaders = False } ))
                  "" -- "Use atx-style headers for markdown"
+
+    , Option "" ["prefer-fenced-code-blocks"]
+                 (NoArg
+                  (\opt -> return opt { optPreferFenced = True } ))
+                 "" -- "Use fenced code blocks if no attributes in markdown"
 
     , Option "" ["chapters"]
                  (NoArg
@@ -1074,6 +1081,7 @@ main = do
               , optLaTeXEngine           = latexEngine
               , optSlideLevel            = slideLevel
               , optSetextHeaders         = setextHeaders
+              , optPreferFenced          = preferFenced
               , optAscii                 = ascii
               , optTeXLigatures          = texLigatures
               , optDefaultImageExtension = defaultImageExtension
@@ -1294,6 +1302,7 @@ main = do
                             writerHighlight        = highlight,
                             writerHighlightStyle   = highlightStyle,
                             writerSetextHeaders    = setextHeaders,
+                            writerPreferFenced     = preferFenced,
                             writerTeXLigatures     = texLigatures,
                             writerEpubMetadata     = epubMetadata,
                             writerEpubStylesheet   = epubStylesheet,

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -313,6 +313,7 @@ data WriterOptions = WriterOptions
   , writerHighlight        :: Bool       -- ^ Highlight source code
   , writerHighlightStyle   :: Style      -- ^ Style to use for highlighting
   , writerSetextHeaders    :: Bool       -- ^ Use setext headers for levels 1-2 in markdown
+  , writerPreferFenced     :: Bool       -- ^ Use fenced code blocks if no attributes in markdown
   , writerTeXLigatures     :: Bool       -- ^ Use tex ligatures quotes, dashes in latex
   , writerEpubVersion      :: Maybe EPUBVersion -- ^ Nothing or EPUB version
   , writerEpubMetadata     :: String     -- ^ Metadata to include in EPUB
@@ -356,6 +357,7 @@ instance Default WriterOptions where
                       , writerHighlight        = False
                       , writerHighlightStyle   = pygments
                       , writerSetextHeaders    = True
+                      , writerPreferFenced     = False
                       , writerTeXLigatures     = True
                       , writerEpubVersion      = Nothing
                       , writerEpubMetadata     = ""

--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -392,8 +392,8 @@ blockToMarkdown opts (CodeBlock (_,classes,_) str)
     isEnabled Ext_literate_haskell opts =
   return $ prefixed "> " (text str) <> blankline
 blockToMarkdown opts (CodeBlock attribs str) = return $
-  case attribs == nullAttr of
-     False | isEnabled Ext_backtick_code_blocks opts ->
+  case attribs /= nullAttr of
+     True | isEnabled Ext_backtick_code_blocks opts ->
           backticks <> attrs <> cr <> text str <> cr <> backticks <> blankline
            | isEnabled Ext_fenced_code_blocks opts ->
           tildes <> attrs <> cr <> text str <> cr <> tildes <> blankline

--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -392,7 +392,7 @@ blockToMarkdown opts (CodeBlock (_,classes,_) str)
     isEnabled Ext_literate_haskell opts =
   return $ prefixed "> " (text str) <> blankline
 blockToMarkdown opts (CodeBlock attribs str) = return $
-  case attribs /= nullAttr of
+  case attribs /= nullAttr || writerPreferFenced opts of
      True | isEnabled Ext_backtick_code_blocks opts ->
           backticks <> attrs <> cr <> text str <> cr <> backticks <> blankline
            | isEnabled Ext_fenced_code_blocks opts ->
@@ -409,7 +409,9 @@ blockToMarkdown opts (CodeBlock attribs str) = return $
                                           n | n < 3 -> "```"
                                             | otherwise -> replicate (n+1) '`'
          attrs  = if isEnabled Ext_fenced_code_attributes opts
-                     then nowrap $ " " <> attrsToMarkdown attribs
+                     then nowrap $ if attribs == nullAttr
+                                       then ""
+                                       else " " <> attrsToMarkdown attribs
                      else case attribs of
                                 (_,(cls:_),_) -> " " <> text cls
                                 _             -> empty


### PR DESCRIPTION
I like `fenced code blocks`. It makes me to paste many codes without indenting. So, I want to use `fenced code blocks` if there are no attributes too. Before this pull-request, Pandoc uses `indented code blocks` if there are no attributes.

Same mind is here: https://groups.google.com/forum/#!topic/pandoc-discuss/Wl0R4Ja0xus

This pull-request adds `--prefer-fenced-code-blocks` option to resolve it.

---

Input file is:

``` sh
yuya@yoshiyuki|18:34:00|0% cat /tmp/a.textile
<pre>
no attributes.
</pre>

<pre id="foo-id" class="bar-class" baz="quux">
some attributes.
</pre>
```

Output without `--prefer-fenced-code-blocks`:

``````
yuya@yoshiyuki|18:34:11|0% ./dist/build/pandoc/pandoc -t markdown /tmp/a.textile

    no attributes.

``` {#foo-id .bar-class baz="quux"}
some attributes.
```
``````

Output with `--prefer-fenced-code-blocks`:

``````
yuya@yoshiyuki|18:34:45|0% ./dist/build/pandoc/pandoc --prefer-fenced-code-blocks -t markdown /tmp/a.textile
```
no attributes.
```

``` {#foo-id .bar-class baz="quux"}
some attributes.
```
``````

---

My mind history:
1. Pandoc is written in Haskell. I didn't know it. So I enjoyed Haskell book.
2. I checked first delimited code blocks commit ( 8889ae8b5b091eb9d35bdf4698d39c562cb2e374). and I think `indented code blocks` is prefered than `fenced code blocks`. I must keep this behavior.
3. In `Ext_backtick_code_blocks` or `Ext_fenced_code_blocks`, I tried following changes:

`````` diff
diff --git a/src/Text/Pandoc/Writers/Markdown.hs b/src/Text/Pandoc/Writers/Markdown.hs
index f06f1d6..2863cde 100644
--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -391,13 +391,12 @@ blockToMarkdown opts (CodeBlock (_,classes,_) str)
   | "haskell" `elem` classes && "literate" `elem` classes &&
     isEnabled Ext_literate_haskell opts =
   return $ prefixed "> " (text str) <> blankline
-blockToMarkdown opts (CodeBlock attribs str) = return $
-  case attribs == nullAttr of
-     False | isEnabled Ext_backtick_code_blocks opts ->
-          backticks <> attrs <> cr <> text str <> cr <> backticks <> blankline
-           | isEnabled Ext_fenced_code_blocks opts ->
-          tildes <> attrs <> cr <> text str <> cr <> tildes <> blankline
-     _ -> nest (writerTabStop opts) (text str) <> blankline
+blockToMarkdown opts (CodeBlock attribs str)
+  | isEnabled Ext_backtick_code_blocks opts =
+  return $ backticks <> attrs <> cr <> text str <> cr <> backticks <> blankline
+  | isEnabled Ext_fenced_code_blocks opts =
+  return $ tildes <> attrs <> cr <> text str <> cr <> tildes <> blankline
+  | True = return $ nest (writerTabStop opts) (text str) <> blankline
    where tildes    = text $ case [ln | ln <- lines str, all (=='~') ln] of
                                [] -> "~~~~"
                                xs -> case maximum $ map length xs of
@@ -409,7 +408,9 @@ blockToMarkdown opts (CodeBlock attribs str) = return $
                                           n | n < 3 -> "```"
                                             | otherwise -> replicate (n+1) '`'
          attrs  = if isEnabled Ext_fenced_code_attributes opts
-                     then nowrap $ " " <> attrsToMarkdown attribs
+                     then nowrap $ if attribs == nullAttr
+                                       then ""
+                                       else " " <> attrsToMarkdown attribs
                      else case attribs of
                                 (_,(cls:_),_) -> " " <> text cls
                                 _             -> empty
``````

   But `pandocExtensions` uses both options (`Ext_fenced_code_blocks` and `Ext_backtick_code_blocks`), so these changes makes no hybrid way (`indented code blocks` and `fenced code blocks`). These changes were discarded.
4. I tried to add option (this PR changes). I thought following option names and select `--prefer-fenced-code-blocks`
- `--default-delimited-code-blocks`
- `--default-fenced-code-blocks`
- `--prefer-fenced-code-blocks`
- `--prefer-fenced`
