### PR TITLE
Update pandoc.cabal, Bumping JuicyPixels upper bound

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -249,7 +249,7 @@ Library
                  haddock-library >= 1.1 && < 1.2,
                  old-time,
                  deepseq-generics >= 0.1 && < 0.2,
-                 JuicyPixels >= 3.1.6.1 && < 3.2
+                 JuicyPixels >= 3.1.6.1 && < 3.3
   if flag(network-uri)
      Build-Depends: network-uri >= 2.6 && < 2.7, network >= 2.6
   else


### PR DESCRIPTION
The newly released version of JuicyPixels is compatible with Pandoc's use and can now load TGA files and come with some various minor bugfixes. Proposing to bump the upper bound to propagate this changes.
