### PR TITLE
Bump JuicyPixels upper version bounds

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -249,7 +249,7 @@ Library
                  haddock-library >= 1.1 && < 1.2,
                  old-time,
                  deepseq-generics >= 0.1 && < 0.2,
-                 JuicyPixels >= 3.1.6.1 && < 3.2
+                 JuicyPixels >= 3.1.6.1 && < 3.3
   if flag(network-uri)
      Build-Depends: network-uri >= 2.6 && < 2.7, network >= 2.6
   else


### PR DESCRIPTION
Allow `pandoc` to build with the latest version of `JuicyPixels` (3.2).
