### PR TITLE
Text.Pandoc.Pretty: Improve performance of realLength

### DIFF
--- a/src/Text/Pandoc/Pretty.hs
+++ b/src/Text/Pandoc/Pretty.hs
@@ -534,4 +534,4 @@ charWidth c =
 -- | Get real length of string, taking into account combining and double-wide
 -- characters.
 realLength :: String -> Int
-realLength = sum . map charWidth
+realLength = foldr (\a b -> charWidth a + b) 0


### PR DESCRIPTION
Eliminates memory usage and twofold increase in speed.
