### PR TITLE
Fix for #1641 (docx table captions above tables)

### DIFF
--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -715,7 +715,8 @@ blockToOpenXML opts (Table caption aligns widths headers rows) = do
   let mkgridcol w = mknode "w:gridCol"
                        [("w:w", show (floor (textwidth * w) :: Integer))] ()
   return $
-    mknode "w:tbl" []
+    caption' ++
+    [mknode "w:tbl" []
       ( mknode "w:tblPr" []
         (   mknode "w:tblStyle" [("w:val","TableNormal")] () :
             mknode "w:tblW" [("w:type", "pct"), ("w:w", show rowwidth)] () :
@@ -727,7 +728,7 @@ blockToOpenXML opts (Table caption aligns widths headers rows) = do
             else map mkgridcol widths)
       : [ mkrow True headers' | not (all null headers) ] ++
       map (mkrow False) rows'
-      ) : caption'
+      )]
 blockToOpenXML opts (BulletList lst) = do
   let marker = BulletMarker
   addList marker


### PR DESCRIPTION
Word doesn't really treat table captions as something special. It's just a paragraph with special style, nothing more, so simple reversal of output order in writer works fine.

Closes #1641 
