### PR TITLE
DocBook reader: add support for calloutlist and callout

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -70,8 +70,8 @@ List of all DocBook tags, with [x] indicating implemented,
 [x] book - A book
 [x] bookinfo - Meta-information for a Book
 [x] bridgehead - A free-floating heading
-[ ] callout - A “called out” description of a marked Area
-[ ] calloutlist - A list of Callouts
+[x] callout - A “called out” description of a marked Area
+[x] calloutlist - A list of Callouts
 [x] caption - A caption
 [x] caution - A note of caution
 [x] chapter - A chapter, as of a book
@@ -603,7 +603,7 @@ isBlockElement (Elem e) = qName (elName e) `elem` blocktags
            "important","caution","note","tip","warning","qandadiv",
            "question","answer","abstract","itemizedlist","orderedlist",
            "variablelist","article","book","table","informaltable",
-           "screen","programlisting","example"]
+           "screen","programlisting","example","calloutlist"]
 isBlockElement _ = False
 
 -- Trim leading and trailing newline characters
@@ -712,6 +712,7 @@ parseBlock (Elem e) =
         "question" -> addToStart (strong (str "Q:") <> str " ") <$> getBlocks e
         "answer" -> addToStart (strong (str "A:") <> str " ") <$> getBlocks e
         "abstract" -> blockQuote <$> getBlocks e
+        "calloutlist" -> bulletList <$> callouts
         "itemizedlist" -> bulletList <$> listitems
         "orderedlist" -> do
           let listStyle = case attrValue "numeration" e of
@@ -785,6 +786,7 @@ parseBlock (Elem e) =
             contents <- getBlocks e
             return $ blockQuote (contents <> attrib)
          listitems = mapM getBlocks $ filterChildren (named "listitem") e
+         callouts = mapM getBlocks $ filterChildren (named "callout") e
          deflistitems = mapM parseVarListEntry $ filterChildren
                      (named "varlistentry") e
          parseVarListEntry e' = do

--- a/tests/docbook-reader.docbook
+++ b/tests/docbook-reader.docbook
@@ -509,6 +509,25 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
       B. Williams
     </para>
   </sect2>
+  <sect2 id="callout">
+    <title>Callout</title>
+    <para>Simple.</para>
+      <calloutlist>
+	<callout arearefs="loop1-letrec-co" id="loop1-letrec">
+	  <para id="x_QA1">A <code>__letrec</code> is equivalent to a normal
+	    Haskell &let;.</para>
+	</callout>
+	<callout arearefs="loop1-def-co" id="loop1-def">
+	  <para id="x_RA1">&GHC; compiled the body of our list comprehension into
+	    a loop named <function>go_s1YC</function>.</para>
+	</callout>
+	<callout arearefs="loop1-pat-empty-co" id="loop1-pat-empty">
+	  <para id="x_SA1">If our &case; expression matches the empty list, we
+	    return the empty list.  This is reassuringly
+	    familiar.</para>
+	</callout>
+      </calloutlist>
+  </sect2>
 </sect1>
 <sect1 id="definition-lists">
   <title>Definition Lists</title>

--- a/tests/docbook-reader.native
+++ b/tests/docbook-reader.native
@@ -134,6 +134,12 @@ Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Spa
 ,Para [Str "Should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "list",Space,Str "item:"]
 ,Para [Str "M.A.\160\&2007"]
 ,Para [Str "B.",Space,Str "Williams"]
+,Header 2 ("",[],[]) [Str "Callout"]
+,Para [Str "Simple."]
+,BulletList
+ [[Para [Str "A",Space,Code ("",[],[]) "__letrec",Space,Str "is",Space,Str "equivalent",Space,Str "to",Space,Str "a",Space,Str "normal",Space,Str "Haskell",Space,Str "LET."]]
+ ,[Para [Str "GHC",Space,Str "compiled",Space,Str "the",Space,Str "body",Space,Str "of",Space,Str "our",Space,Str "list",Space,Str "comprehension",Space,Str "into",Space,Str "a",Space,Str "loop",Space,Str "named",Space,Code ("",[],[]) "go_s1YC",Str "."]]
+ ,[Para [Str "If",Space,Str "our",Space,Str "CASE",Space,Str "expression",Space,Str "matches",Space,Str "the",Space,Str "empty",Space,Str "list,",Space,Str "we",Space,Str "return",Space,Str "the",Space,Str "empty",Space,Str "list.",Space,Str "This",Space,Str "is",Space,Str "reassuringly",Space,Str "familiar."]]]
 ,Header 1 ("",[],[]) [Str "Definition",Space,Str "Lists"]
 ,DefinitionList
  [([Str "apple"],


### PR DESCRIPTION
We treat a calloutlist as a bulleted list. This works well in practice, and is certainly far better than the current behaviour of making callout lists vanish entirely :-)
