### PR TITLE
Link the test suite using -threaded

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -449,7 +449,7 @@ Test-Suite test-pandoc
                   Tests.Writers.Plain
                   Tests.Writers.AsciiDoc
                   Tests.Writers.LaTeX
-  Ghc-Options:  -rtsopts -Wall -fno-warn-unused-do-bind
+  Ghc-Options:  -rtsopts -Wall -fno-warn-unused-do-bind -threaded
   Default-Language: Haskell98
 
 benchmark benchmark-pandoc


### PR DESCRIPTION
This allows the test suite to be run using "+RTS -N".

Doing so improves the performance of the test suite on my quad-core Mac laptop as follows:

Before: 8.2 seconds
After:  2.5 seconds
