### PR TITLE
Markdown writer: Add --bullet-list-marker argument option.

### DIFF
--- a/README
+++ b/README
@@ -462,6 +462,9 @@ Options affecting specific writers
 :   Use reference-style links, rather than inline links, in writing markdown
     or reStructuredText.  By default inline links are used.
 
+`--bullet-list-marker=`*minus|plus|asterisk*
+:   Specify bullet list marker in markdown. The default is `minus`.
+
 `--atx-headers`
 :   Use ATX style headers in markdown and asciidoc output. The default is
     to use setext-style headers for levels 1-2, and then ATX headers.

--- a/pandoc.hs
+++ b/pandoc.hs
@@ -198,6 +198,7 @@ data Opt = Opt
     , optListings          :: Bool       -- ^ Use listings package for code blocks
     , optLaTeXEngine       :: String     -- ^ Program to use for latex -> pdf
     , optSlideLevel        :: Maybe Int  -- ^ Header level that creates slides
+    , optBulletListMarker  :: Char       -- ^ Bullet list marker in markdown
     , optSetextHeaders     :: Bool       -- ^ Use atx headers for markdown level 1-2
     , optAscii             :: Bool       -- ^ Use ascii characters only in html
     , optTeXLigatures      :: Bool       -- ^ Use TeX ligatures for quotes/dashes
@@ -258,6 +259,7 @@ defaultOpts = Opt
     , optListings              = False
     , optLaTeXEngine           = "pdflatex"
     , optSlideLevel            = Nothing
+    , optBulletListMarker      = '-'
     , optSetextHeaders         = True
     , optAscii                 = False
     , optTeXLigatures          = True
@@ -565,6 +567,19 @@ options =
                  (NoArg
                   (\opt -> return opt { optReferenceLinks = True } ))
                  "" -- "Use reference links in parsing HTML"
+
+    , Option "" ["bullet-list-marker"]
+                 (ReqArg
+                  (\arg opt -> do
+                     marker <- case arg of
+                            "minus"    -> return '-'
+                            "plus"     -> return '+'
+                            "asterisk" -> return '*'
+                            _          -> err 6
+                               ("Unknown bullet list marker: " ++ arg)
+                     return opt { optBulletListMarker = marker })
+                  "minus|plus|asterisk")
+                 "" -- "Marker for bullet list in Markdown"
 
     , Option "" ["atx-headers"]
                  (NoArg
@@ -1073,6 +1088,7 @@ main = do
               , optListings              = listings
               , optLaTeXEngine           = latexEngine
               , optSlideLevel            = slideLevel
+              , optBulletListMarker      = bulletListMarker
               , optSetextHeaders         = setextHeaders
               , optAscii                 = ascii
               , optTeXLigatures          = texLigatures
@@ -1293,6 +1309,7 @@ main = do
                             writerSlideLevel       = slideLevel,
                             writerHighlight        = highlight,
                             writerHighlightStyle   = highlightStyle,
+                            writerBulletListMarker = bulletListMarker,
                             writerSetextHeaders    = setextHeaders,
                             writerTeXLigatures     = texLigatures,
                             writerEpubMetadata     = epubMetadata,

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -312,6 +312,7 @@ data WriterOptions = WriterOptions
   , writerListings         :: Bool       -- ^ Use listings package for code
   , writerHighlight        :: Bool       -- ^ Highlight source code
   , writerHighlightStyle   :: Style      -- ^ Style to use for highlighting
+  , writerBulletListMarker :: Char       -- ^ Bullet list marker in markdown
   , writerSetextHeaders    :: Bool       -- ^ Use setext headers for levels 1-2 in markdown
   , writerTeXLigatures     :: Bool       -- ^ Use tex ligatures quotes, dashes in latex
   , writerEpubVersion      :: Maybe EPUBVersion -- ^ Nothing or EPUB version
@@ -355,6 +356,7 @@ instance Default WriterOptions where
                       , writerListings         = False
                       , writerHighlight        = False
                       , writerHighlightStyle   = pygments
+                      , writerBulletListMarker = '-'
                       , writerSetextHeaders    = True
                       , writerTeXLigatures     = True
                       , writerEpubVersion      = Nothing

--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -575,7 +575,7 @@ bulletListItemToMarkdown :: WriterOptions -> [Block] -> State WriterState Doc
 bulletListItemToMarkdown opts items = do
   contents <- blockListToMarkdown opts items
   let sps = replicate (writerTabStop opts - 2) ' '
-  let start = text ('-' : ' ' : sps)
+  let start = text (writerBulletListMarker opts : ' ' : sps)
   -- remove trailing blank line if it is a tight list
   let contents' = case reverse items of
                        (BulletList xs:_) | isTightList xs ->


### PR DESCRIPTION
Markdown reader understands all of bullet list marker (`-`, `+` and `*` character). But Markdown writer cannot use `+` and `*` character to bullet list marker.

This pull-request adds `--bullet-list-marker` argument to resolve it.

---

Input file is:

```
yuya@yoshiyuki|20:18:19|0% cat /tmp/a.textile
* foo
* bar
* baz
```

No `--bullet-list-marker` argument:
(equivalent to `--bullet-list-marker=minus`)

```
yuya@yoshiyuki|20:21:01|0% ./dist/build/pandoc/pandoc -t markdown /tmp/a.textile
-   foo
-   bar
-   baz

```

`--bullet-list-marker=plus` argument:

```
yuya@yoshiyuki|20:21:45|0% ./dist/build/pandoc/pandoc -t markdown --bullet-list-marker=plus /tmp/a.textile
+   foo
+   bar
+   baz

```

`--bullet-list-marker=asterisk` argument:

```
yuya@yoshiyuki|20:22:13|0% ./dist/build/pandoc/pandoc -t markdown --bullet-list-marker=asterisk /tmp/a.textile
*   foo
*   bar
*   baz

```
