### PR TITLE
Wrap code block HTML table in a div element

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -480,7 +480,7 @@ blockToHtml opts (CodeBlock (id',classes,keyvals) rawCode) = do
          Nothing -> return $ addAttrs opts (id',classes,keyvals)
                            $ H.pre $ H.code $ toHtml adjCode
          Just  h -> modify (\st -> st{ stHighlighting = True }) >>
-                    return (addAttrs opts (id',[],keyvals) h)
+                    return (addAttrs opts (id',[],keyvals) $ H.div ! A.class_ "sourceCode" $ h)
 blockToHtml opts (BlockQuote blocks) =
   -- in S5, treat list in blockquote specially
   -- if default is incremental, make it nonincremental;


### PR DESCRIPTION
Syntax highlighted code blocks are written out as HTML tables which are
impossible to format via styles for different screen widths. This means
that pandoc generated pages with code blocks must have a fixed minimal
width, making them hard to read on narrower screens.

Wrapping the table in a `<div>` allows formating a code block that will
have a horizontal scroll bar if the content doesn't fit the screen
width, by adding the following style:

    div.sourceCode {
        overflow-x: auto;
    }

This enables pandoc to generate responsive HTML pages.