### PR TITLE
Wrap code block HTML table in a div element

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -480,7 +480,8 @@ blockToHtml opts (CodeBlock (id',classes,keyvals) rawCode) = do
          Nothing -> return $ addAttrs opts (id',classes,keyvals)
                            $ H.pre $ H.code $ toHtml adjCode
          Just  h -> modify (\st -> st{ stHighlighting = True }) >>
-                    return (addAttrs opts (id',[],keyvals) h)
+                    return (addAttrs opts (id',[],keyvals) 
+                            $ H.div ! A.class_ "sourceCode" $ h)
 blockToHtml opts (BlockQuote blocks) =
   -- in S5, treat list in blockquote specially
   -- if default is incremental, make it nonincremental;

--- a/tests/lhs-test.html
+++ b/tests/lhs-test.html
@@ -29,9 +29,9 @@ code > span.er { color: #ff0000; font-weight: bold; }
 <body>
 <h1 id="lhs-test">lhs test</h1>
 <p><code>unsplit</code> is an arrow that takes a pair of values and combines them to return a single value:</p>
-<pre class="sourceCode literate haskell"><code class="sourceCode haskell"><span class="ot">unsplit ::</span> (<span class="dt">Arrow</span> a) <span class="ot">=&gt;</span> (b <span class="ot">-&gt;</span> c <span class="ot">-&gt;</span> d) <span class="ot">-&gt;</span> a (b, c) d
+<div class="sourceCode"><pre class="sourceCode literate haskell"><code class="sourceCode haskell"><span class="ot">unsplit ::</span> (<span class="dt">Arrow</span> a) <span class="ot">=&gt;</span> (b <span class="ot">-&gt;</span> c <span class="ot">-&gt;</span> d) <span class="ot">-&gt;</span> a (b, c) d
 unsplit <span class="fu">=</span> arr <span class="fu">.</span> uncurry
-          <span class="co">-- arr (\op (x,y) -&gt; x `op` y)</span></code></pre>
+          <span class="co">-- arr (\op (x,y) -&gt; x `op` y)</span></code></pre></div>
 <p><code>(***)</code> combines two arrows into a new arrow by running the two arrows on a pair of values (one arrow on the first item of the pair and one arrow on the second item of the pair).</p>
 <pre><code>f *** g = first f &gt;&gt;&gt; second g</code></pre>
 <p>Block quote:</p>

--- a/tests/lhs-test.html+lhs
+++ b/tests/lhs-test.html+lhs
@@ -29,9 +29,9 @@ code > span.er { color: #ff0000; font-weight: bold; }
 <body>
 <h1 id="lhs-test">lhs test</h1>
 <p><code>unsplit</code> is an arrow that takes a pair of values and combines them to return a single value:</p>
-<pre class="sourceCode literate literatehaskell"><code class="sourceCode literatehaskell"><span class="ot">&gt; unsplit ::</span> (<span class="dt">Arrow</span> a) <span class="ot">=&gt;</span> (b <span class="ot">-&gt;</span> c <span class="ot">-&gt;</span> d) <span class="ot">-&gt;</span> a (b, c) d
+<div class="sourceCode"><pre class="sourceCode literate literatehaskell"><code class="sourceCode literatehaskell"><span class="ot">&gt; unsplit ::</span> (<span class="dt">Arrow</span> a) <span class="ot">=&gt;</span> (b <span class="ot">-&gt;</span> c <span class="ot">-&gt;</span> d) <span class="ot">-&gt;</span> a (b, c) d
 <span class="ot">&gt;</span> unsplit <span class="fu">=</span> arr <span class="fu">.</span> uncurry
-<span class="ot">&gt;</span>           <span class="co">-- arr (\op (x,y) -&gt; x `op` y)</span></code></pre>
+<span class="ot">&gt;</span>           <span class="co">-- arr (\op (x,y) -&gt; x `op` y)</span></code></pre></div>
 <p><code>(***)</code> combines two arrows into a new arrow by running the two arrows on a pair of values (one arrow on the first item of the pair and one arrow on the second item of the pair).</p>
 <pre><code>f *** g = first f &gt;&gt;&gt; second g</code></pre>
 <p>Block quote:</p>


### PR DESCRIPTION
Syntax highlighted code blocks are written out as HTML tables which are
impossible to format via styles for different screen widths. This means
that pandoc generated pages with code blocks must have a fixed minimal
width, making them hard to read on narrower screens.

Wrapping the table in a `<div>` allows formating a code block that will
have a horizontal scroll bar if the content doesn't fit the screen
width, by adding the following style:

    div.sourceCode {
        overflow-x: auto;
    }

This enables pandoc to generate responsive HTML pages.