### PR TITLE
Append newline to the LineBreak of various writers

### DIFF
--- a/src/Text/Pandoc/Writers/DokuWiki.hs
+++ b/src/Text/Pandoc/Writers/DokuWiki.hs
@@ -459,7 +459,7 @@ inlineToDokuWiki _ (RawInline f str)
   | f == Format "html"     = return $ "<html>" ++ str ++ "</html>"
   | otherwise              = return ""
 
-inlineToDokuWiki _ (LineBreak) = return "\\\\ "
+inlineToDokuWiki _ (LineBreak) = return "\\\\\n"
 
 inlineToDokuWiki _ Space = return " "
 

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -656,7 +656,8 @@ inlineToHtml opts inline =
   case inline of
     (Str str)        -> return $ strToHtml str
     (Space)          -> return $ strToHtml " "
-    (LineBreak)      -> return $ if writerHtml5 opts then H5.br else H.br
+    (LineBreak)      -> return $ (if writerHtml5 opts then H5.br else H.br)
+                                 <> strToHtml "\n"
     (Span (id',classes,kvs) ils)
                      -> inlineListToHtml opts ils >>=
                            return . addAttrs opts attr' . H.span

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -802,7 +802,7 @@ inlineToLaTeX (RawInline f str)
   | f == Format "latex" || f == Format "tex"
                         = return $ text str
   | otherwise           = return empty
-inlineToLaTeX (LineBreak) = return "\\\\"
+inlineToLaTeX (LineBreak) = return $ "\\\\" <> cr
 inlineToLaTeX Space = return space
 inlineToLaTeX (Link txt ('#':ident, _)) = do
   contents <- inlineListToLaTeX txt

--- a/src/Text/Pandoc/Writers/MediaWiki.hs
+++ b/src/Text/Pandoc/Writers/MediaWiki.hs
@@ -375,7 +375,7 @@ inlineToMediaWiki (RawInline f str)
   | f == Format "html"      = return str
   | otherwise               = return ""
 
-inlineToMediaWiki (LineBreak) = return "<br />"
+inlineToMediaWiki (LineBreak) = return "<br />\n"
 
 inlineToMediaWiki Space = return " "
 

--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -370,7 +370,7 @@ inlineToOpenDocument :: WriterOptions -> Inline -> State WriterState Doc
 inlineToOpenDocument o ils
     | Space         <- ils = inTextStyle space
     | Span _ xs     <- ils = inlinesToOpenDocument o xs
-    | LineBreak     <- ils = return $ selfClosingTag "text:line-break" []
+    | LineBreak     <- ils = return $ selfClosingTag "text:line-break" [] <> cr
     | Str         s <- ils = inTextStyle $ handleSpaces $ escapeStringForXML s
     | Emph        l <- ils = withTextStyle Italic $ inlinesToOpenDocument o l
     | Strong      l <- ils = withTextStyle Bold   $ inlinesToOpenDocument o l

--- a/src/Text/Pandoc/Writers/Texinfo.hs
+++ b/src/Text/Pandoc/Writers/Texinfo.hs
@@ -421,7 +421,7 @@ inlineToTexinfo (RawInline f str)
                       return $ text "@tex" $$ text str $$ text "@end tex"
   | f == "texinfo" =  return $ text str
   | otherwise      =  return empty
-inlineToTexinfo (LineBreak) = return $ text "@*"
+inlineToTexinfo (LineBreak) = return $ text "@*" <> cr
 inlineToTexinfo Space = return $ char ' '
 
 inlineToTexinfo (Link txt (src@('#':_), _)) = do

--- a/tests/dokuwiki_inline_formatting.dokuwiki
+++ b/tests/dokuwiki_inline_formatting.dokuwiki
@@ -6,7 +6,8 @@ Some people use single underlines for //emphasis//.
 
 Above the line is <sup>superscript</sup> and below the line is <sub>subscript</sub>.
 
-A line\\ break.
+A line\\
+break.
 
 hello %%//%% world %%**%% from %%__%% me
 

--- a/tests/writer.dokuwiki
+++ b/tests/writer.dokuwiki
@@ -36,7 +36,8 @@ In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item. Beca
 
 Here’s one with a bullet. * criminey.
 
-There should be a hard line break\\ here.
+There should be a hard line break\\
+here.
 
 
 ----

--- a/tests/writer.html
+++ b/tests/writer.html
@@ -35,7 +35,8 @@
 <p>Here’s a regular paragraph.</p>
 <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item. Because a hard-wrapped line in the middle of a paragraph looked like a list item.</p>
 <p>Here’s one with a bullet. * criminey.</p>
-<p>There should be a hard line break<br />here.</p>
+<p>There should be a hard line break<br />
+here.</p>
 <hr />
 <h1 id="block-quotes">Block Quotes</h1>
 <p>E-mail style:</p>

--- a/tests/writer.latex
+++ b/tests/writer.latex
@@ -109,7 +109,8 @@ item.
 
 Here's one with a bullet. * criminey.
 
-There should be a hard line break\\here.
+There should be a hard line break\\
+here.
 
 \begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
 

--- a/tests/writer.mediawiki
+++ b/tests/writer.mediawiki
@@ -36,7 +36,8 @@ In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item. Beca
 
 Here’s one with a bullet. * criminey.
 
-There should be a hard line break<br />here.
+There should be a hard line break<br />
+here.
 
 
 -----

--- a/tests/writer.opendocument
+++ b/tests/writer.opendocument
@@ -896,7 +896,8 @@ of a paragraph looked like a list item.</text:p>
 <text:p text:style-name="Text_20_body">Here’s one with a bullet. *
 criminey.</text:p>
 <text:p text:style-name="Text_20_body">There should be a hard line
-break<text:line-break />here.</text:p>
+break<text:line-break />
+here.</text:p>
 <text:p text:style-name="Horizontal_20_Line" />
 <text:h text:style-name="Heading_20_1" text:outline-level="1">Block
 Quotes</text:h>

--- a/tests/writer.texinfo
+++ b/tests/writer.texinfo
@@ -129,7 +129,8 @@ In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item. Beca
 
 Here's one with a bullet. * criminey.
 
-There should be a hard line break@*here.
+There should be a hard line break@*
+here.
 
 @iftex
 @bigskip@hrule@bigskip


### PR DESCRIPTION
This change improves output formatting of content with a large amount of force line breaks, such as line-blocks. The following writers are affected:

* Dokuwiki
* HTML
* EPUB (via HTML)
* LaTeX
* MediaWiki
* OpenDocument
* Texinfo

This commit resolves #1924