### PR TITLE
update syntax for Images/Media files in MediaWiki

### DIFF
--- a/src/Text/Pandoc/Writers/MediaWiki.hs
+++ b/src/Text/Pandoc/Writers/MediaWiki.hs
@@ -107,7 +107,7 @@ blockToMediaWiki (Para [Image txt (src,'f':'i':'g':':':tit)]) = do
   let opt = if null txt
                then ""
                else "|alt=" ++ if null tit then capt else tit ++ capt
-  return $ "[[Image:" ++ src ++ "|frame|none" ++ opt ++ "]]\n"
+  return $ "[[File:" ++ src ++ "|frame|none" ++ opt ++ "]]\n"
 
 blockToMediaWiki (Para inlines) = do
   tags <- asks useTags
@@ -397,7 +397,7 @@ inlineToMediaWiki (Image alt (source, tit)) = do
                        then ""
                        else '|' : alt'
                else '|' : tit
-  return $ "[[Image:" ++ source ++ txt ++ "]]"
+  return $ "[[File:" ++ source ++ txt ++ "]]"
 
 inlineToMediaWiki (Note contents) = do
   contents' <- blockListToMediaWiki contents

--- a/tests/writer.mediawiki
+++ b/tests/writer.mediawiki
@@ -623,9 +623,9 @@ Auto-links should not occur here: <code>&lt;http://example.com/&gt;</code>
 
 From “Voyage dans la Lune” by Georges Melies (1902):
 
-[[Image:lalune.jpg|frame|none|alt=Voyage dans la Lune|caption lalune]]
+[[File:lalune.jpg|frame|none|alt=Voyage dans la Lune|caption lalune]]
 
-Here is a movie [[Image:movie.jpg|movie]] icon.
+Here is a movie [[File:movie.jpg|movie]] icon.
 
 
 -----


### PR DESCRIPTION
The preferred syntax for Images and other media is [[File:Foo.jpg]] in MediaWiki since v1.14 (6 years).  [[Image:Foo.jpg]] is deprecated but still works as an alias to the File namespace.  I don't think this would break any existing wikis since talk of switching the syntax/namespace for images started back in 2002 (https://phabricator.wikimedia.org/T2044).  NS_FILE became the new namespace for Files in v 1.14 in late 2008; released Feb 2009. (https://www.mediawiki.org/wiki/Release_notes/1.14)  There is still a namespace alias so '[[Image:]]' still works today.  It's just that MediaWiki supports other media as well, and so the name and syntax used in documentation (see https://www.mediawiki.org/wiki/Help:Images) has long been '[[File:foo.jpg]]'

This updates both the writer, and the test.  The reader already uses the "[[File: ]]" syntax.