### PR TITLE
Texinfo writer: fix wrapping by using breakable spaces

### DIFF
--- a/src/Text/Pandoc/Writers/Texinfo.hs
+++ b/src/Text/Pandoc/Writers/Texinfo.hs
@@ -422,7 +422,7 @@ inlineToTexinfo (RawInline f str)
   | f == "texinfo" =  return $ text str
   | otherwise      =  return empty
 inlineToTexinfo (LineBreak) = return $ text "@*"
-inlineToTexinfo Space = return $ char ' '
+inlineToTexinfo Space = return $ space
 
 inlineToTexinfo (Link txt (src@('#':_), _)) = do
   contents <- escapeCommas $ inlineListToTexinfo txt

--- a/tests/writer.texinfo
+++ b/tests/writer.texinfo
@@ -36,7 +36,8 @@ July 17, 2006
 @node Top
 @top Pandoc Test Suite
 
-This is a set of tests for pandoc. Most of them are adapted from John Gruber's markdown test suite.
+This is a set of tests for pandoc. Most of them are adapted from John Gruber's
+markdown test suite.
 
 @iftex
 @bigskip@hrule@bigskip
@@ -125,7 +126,9 @@ with no blank line
 @anchor{#paragraphs}
 Here's a regular paragraph.
 
-In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item. Because a hard-wrapped line in the middle of a paragraph looked like a list item.
+In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item.
+Because a hard-wrapped line in the middle of a paragraph looked like a list
+item.
 
 Here's one with a bullet. * criminey.
 
@@ -734,11 +737,14 @@ This is code: @code{>}, @code{$}, @code{\}, @code{\$}, @code{<html>}.
 
 @textstrikeout{This is @emph{strikeout}.}
 
-Superscripts: a@textsuperscript{bc}d a@textsuperscript{@emph{hello}} a@textsuperscript{hello@ there}.
+Superscripts: a@textsuperscript{bc}d a@textsuperscript{@emph{hello}}
+a@textsuperscript{hello@ there}.
 
-Subscripts: H@textsubscript{2}O, H@textsubscript{23}O, H@textsubscript{many@ of@ them}O.
+Subscripts: H@textsubscript{2}O, H@textsubscript{23}O,
+H@textsubscript{many@ of@ them}O.
 
-These should not be superscripts or subscripts, because of the unescaped spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped
+spaces: a^b c^d, a~b c~d.
 
 @iftex
 @bigskip@hrule@bigskip
@@ -758,7 +764,8 @@ These should not be superscripts or subscripts, because of the unescaped spaces:
 
 `He said, ``I want to go.''' Were you alive in the 70's?
 
-Here is some quoted `@code{code}' and a ``@uref{http://example.com/?foo=1&bar=2,quoted link}''.
+Here is some quoted `@code{code}' and a
+``@uref{http://example.com/?foo=1&bar=2,quoted link}''.
 
 Some dashes: one---two --- three---four --- five.
 
@@ -792,7 +799,8 @@ Ellipses@dots{}and@dots{}and@dots{}.
 @item
 @math{p}-Tree
 @item
-Here's some display math: @math{\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}}
+Here's some display math:
+@math{\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}}
 @item
 Here's one that has a line break in it: @math{\alpha + \omega \times x^2}.
 @end itemize
@@ -803,7 +811,8 @@ These shouldn't be math:
 @item
 To get the famous equation, write @code{$e = mc^2$}.
 @item
-$22,000 is a @emph{lot} of money. So is $34,000. (It worked if ``lot'' is emphasized.)
+$22,000 is a @emph{lot} of money. So is $34,000. (It worked if ``lot'' is
+emphasized.)
 @item
 Shoes ($20) and socks ($5).
 @item
@@ -956,7 +965,8 @@ Foo @uref{/url/,biz}.
 @node With ampersands
 @section With ampersands
 @anchor{#with-ampersands}
-Here's a @uref{http://example.com/?foo=1&bar=2,link with an ampersand in the URL}.
+Here's a @uref{http://example.com/?foo=1&bar=2,link with an ampersand in the
+URL}.
 
 Here's a link with an amersand in the link text: @uref{http://att.com/,AT&T}.
 
@@ -1018,15 +1028,24 @@ Here is a movie @image{movie,,,movie,jpg} icon.
 @node Footnotes
 @chapter Footnotes
 @anchor{#footnotes}
-Here is a footnote reference,@footnote{Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.} and another.@footnote{Here's the long note. This one contains multiple blocks.
+Here is a footnote reference,@footnote{Here is the footnote. It can go
+anywhere after the footnote reference. It need not be placed at the end of the
+document.} and another.@footnote{Here's the long note. This one contains
+multiple blocks.
 
-Subsequent blocks are indented to show that they belong to the footnote (as with list items).
+Subsequent blocks are indented to show that they belong to the footnote (as
+with list items).
 
 @verbatim
   { <code> }
 @end verbatim
 
-If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.} This should @emph{not} be a footnote reference, because it contains a space.[^my note] Here is an inline note.@footnote{This is @emph{easier} to type. Inline notes may contain @uref{http://google.com,links} and @code{]} verbatim characters, as well as [bracketed text].}
+If you want, you can indent every line, but you can also be lazy and just
+indent the first line of each block.} This should @emph{not} be a footnote
+reference, because it contains a space.[^my note] Here is an inline
+note.@footnote{This is @emph{easier} to type. Inline notes may contain
+@uref{http://google.com,links} and @code{]} verbatim characters, as well as
+[bracketed text].}
 
 @quotation
 Notes can go in quotes.@footnote{In quote.}


### PR DESCRIPTION
The Texinfo writer currently uses Pandoc.Pretty Doc combinator to format output, but converts a `Space` to `sp` literals instead of calling the `space` constructor which inserts a breakable space. I'm assuming this is not intended. Because of this, Texinfo writer output currently does not wrap properly.

Discovered while preparing pull request jgm/pandoc#1925

