### PR TITLE
Allow digit as first character of a citation key.

### DIFF
--- a/README
+++ b/README
@@ -2616,7 +2616,7 @@ can be found at <https://github.com/citation-style-language/styles>.  See also
 Citations go inside square brackets and are separated by semicolons.
 Each citation must have a key, composed of '@' + the citation
 identifier from the database, and may optionally have a prefix,
-a locator, and a suffix.  The citation key must begin with a letter
+a locator, and a suffix.  The citation key must begin with a letter, digit,
 or `_`, and may contain alphanumerics, `_`, and internal punctuation
 characters (`:.#$%&-+?<>~/`).  Here are some examples:
 

--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -1212,7 +1212,7 @@ citeKey = try $ do
   guard =<< notAfterString
   suppress_author <- option False (char '-' *> return True)
   char '@'
-  firstChar <- letter <|> char '_'
+  firstChar <- alphaNum <|> char '_'
   let regchar = satisfy (\c -> isAlphaNum c || c == '_')
   let internal p = try $ p <* lookAhead regchar
   rest <- many $ regchar <|> internal (oneOf ":.#$%&-+?<>~/")

--- a/tests/Tests/Readers/Markdown.hs
+++ b/tests/Tests/Readers/Markdown.hs
@@ -289,4 +289,26 @@ tests = [ testGroup "inline code"
                          , plain "b"
                          , plain "c" <> bulletList [plain "d"] ]
           ]
+        , testGroup "citations"
+          [ "simple" =:
+            "@item1" =?> para (cite [
+                Citation{ citationId      = "item1"
+                        , citationPrefix  = []
+                        , citationSuffix  = []
+                        , citationMode    = AuthorInText
+                        , citationNoteNum = 0
+                        , citationHash    = 0
+                        }
+                ] "@item1")
+          , "key starts with digit" =:
+            "@1657:huyghens" =?> para (cite [
+                Citation{ citationId      = "1657:huyghens"
+                        , citationPrefix  = []
+                        , citationSuffix  = []
+                        , citationMode    = AuthorInText
+                        , citationNoteNum = 0
+                        , citationHash    = 0
+                        }
+                ] "@1657:huyghens")
+          ]
         ]


### PR DESCRIPTION
* Update parser to recognize citation keys starting with a digit.
* Update documentation accordingly.
* Test case added.

See https://github.com/jgm/pandoc-citeproc/issues/97