### PR TITLE
Org reader: Allow image links with non-image targets

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -1106,7 +1106,7 @@ explicitOrImageLink = try $ do
   char ']'
   return $ do
     src <- srcF
-    if isImageFilename src && isImageFilename title
+    if isImageFilename title
       then pure $ B.link src "" $ B.image title mempty mempty
       else linkToInlinesF src =<< title'
 

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -212,6 +212,10 @@ tests =
           "[[sunset.png][dusk.svg]]" =?>
           (para $ link "sunset.png" "" (image "dusk.svg" "" ""))
 
+      , "Image link with non-image target" =:
+          "[[http://example.com][logo.png]]" =?>
+          (para $ link "http://example.com" "" (image "logo.png" "" ""))
+
       , "Plain link" =:
           "Posts on http://zeitlens.com/ can be funny at times." =?>
           (para $ spcSep [ "Posts", "on"


### PR DESCRIPTION
Org-Mode's own html exporter converts the following org link:

    [[http://example.com][https://www.haskell.org/static/img/logo.png]]

to

    <a href="http://example.com">
    <img src="https://www.haskell.org/static/img/logo.png" alt="logo.png" />
    </a>

but pandoc generates:

    <a href="http://example.com">
    <a href="https://www.haskell.org/static/img/logo.png" class="uri">
     https://www.haskell.org/static/img/logo.png
    </a>
    </a>

which is useless. With this patch, it generates:

    <a href="http://example.com">
    <img src="https://www.haskell.org/static/img/logo.png" alt="" />
    </a>