### PR TITLE
Drawer capability for the Org Writer

### DIFF
--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -107,6 +107,19 @@ escapeString = escapeStringUsing $
 blockToOrg :: Block         -- ^ Block element
            -> State WriterState Doc
 blockToOrg Null = return empty
+blockToOrg (Div ("Drawer",drawer,kvs) bs) = do
+  contents <- blockListToOrg bs
+  let drawerNameTag = if null drawer
+                      then text ":PROPERTIES:"
+                      else ":" <> text (head drawer) <> ":"
+  let keys = vcat $ map (\(k,v) ->
+                       ":" <> text k <> ":"
+                       <> space <> text v) kvs
+  let drawerEndTag = text ":END:"
+  return $ drawerNameTag $$ cr $$ keys $$
+           blankline $$ contents $$
+           blankline $$ drawerEndTag $$
+           blankline
 blockToOrg (Div attrs bs) = do
   contents <- blockListToOrg bs
   let startTag = tagWithAttrs "div" attrs


### PR DESCRIPTION
  For the implementation of the Drawer element in the Org Writer, we
  make use of a Generic Block container with attributes. Where the first
  element of the attributes defines that the Div constructor is a
  Drawer. The first element of the list in the attributes, defines the
  Drawer name to use. The key-value list in the attributes defines the
  keys to add inside the Drawer. Lastly, the list of Block elements
  contains miscellaneous blocks elements to add inside of the Drawer.

  If the Div element does not contain a Drawer name, it will default
  to the standard :PROPERTIES: tag. If given a name, it's automatically
  decorated to be a valid Org tag.