### PR TITLE
LaTeX reader: minor table parsing improvements

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1314,7 +1314,7 @@ parseTableRow cols = try $ do
 simpTable :: Bool -> LP Blocks
 simpTable hasWidthParameter = try $ do
   when hasWidthParameter $ () <$ (spaces >> tok)
-  spaces
+  skipopts
   aligns <- parseAligns
   let cols = length aligns
   optional hline

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1275,7 +1275,7 @@ complexNatbibCitation mode = try $ do
 parseAligns :: LP [Alignment]
 parseAligns = try $ do
   char '{'
-  let maybeBar = skipMany $ sp <|> () <$ char '|' <|> () <$ try (string "@{}")
+  let maybeBar = skipMany $ sp <|> () <$ char '|' <|> () <$ (char '@' >> braced)
   maybeBar
   let cAlign = AlignCenter <$ char 'c'
   let lAlign = AlignLeft <$ char 'l'

--- a/tests/Tests/Readers/LaTeX.hs
+++ b/tests/Tests/Readers/LaTeX.hs
@@ -91,6 +91,9 @@ tests = [ testGroup "basic"
           , "Table with empty column separators" =:
             "\\begin{tabular}{@{}r@{}l}One & Two\\\\ \\end{tabular}" =?>
             simpleTable' [AlignRight,AlignLeft] [[plain "One", plain "Two"]]
+          , "Table with vertical alignment argument" =:
+            "\\begin{tabular}[t]{r|r}One & Two\\\\ \\end{tabular}" =?>
+            simpleTable' [AlignRight,AlignRight] [[plain "One", plain "Two"]]
           ]
 
         , testGroup "citations"

--- a/tests/Tests/Readers/LaTeX.hs
+++ b/tests/Tests/Readers/LaTeX.hs
@@ -91,6 +91,11 @@ tests = [ testGroup "basic"
           , "Table with empty column separators" =:
             "\\begin{tabular}{@{}r@{}l}One & Two\\\\ \\end{tabular}" =?>
             simpleTable' [AlignRight,AlignLeft] [[plain "One", plain "Two"]]
+          , "Table with custom column separators" =:
+            unlines [ "\\begin{tabular}{@{($\\to$)}r@{\\hspace{2cm}}l}"
+                    , "One&Two\\\\"
+                    , "\\end{tabular}" ] =?>
+            simpleTable' [AlignRight,AlignLeft] [[plain "One", plain "Two"]]
           , "Table with vertical alignment argument" =:
             "\\begin{tabular}[t]{r|r}One & Two\\\\ \\end{tabular}" =?>
             simpleTable' [AlignRight,AlignRight] [[plain "One", plain "Two"]]


### PR DESCRIPTION
This enables pandoc to parse `tabular` environments with optional arguments and non-empty column separators (which should be fairly common in real world LaTeX documents).

Basic test cases for simple tables are also included, modeled roughly after the test cases for the Org reader.
