### PR TITLE
Replace occurrences of 'Github' with 'GitHub'

### DIFF
--- a/README
+++ b/README
@@ -2810,7 +2810,7 @@ variants are supported:
     `fenced_code_blocks`, `definition_lists`, `intraword_underscores`,
     `header_attributes`, `abbreviations`.
 
-`markdown_github` (Github-flavored Markdown)
+`markdown_github` (GitHub-flavored Markdown)
 :   `pipe_tables`, `raw_html`, `tex_math_single_backslash`,
     `fenced_code_blocks`, `auto_identifiers`,
     `ascii_identifiers`, `backtick_code_blocks`, `autolink_bare_uris`,

--- a/changelog
+++ b/changelog
@@ -3975,7 +3975,7 @@ pandoc (1.9)
 
     These constructions are now supported now by `rst2latex.py`.
 
-  * Github syntax for fenced code blocks is supported in pandoc's
+  * GitHub syntax for fenced code blocks is supported in pandoc's
     markdown.  You can now write
 
         ```ruby

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -74,7 +74,7 @@ data Extension =
     | Ext_latex_macros        -- ^ Parse LaTeX macro definitions (for math only)
     | Ext_fenced_code_blocks  -- ^ Parse fenced code blocks
     | Ext_fenced_code_attributes  -- ^ Allow attributes on fenced code blocks
-    | Ext_backtick_code_blocks    -- ^ Github style ``` code blocks
+    | Ext_backtick_code_blocks    -- ^ GitHub style ``` code blocks
     | Ext_inline_code_attributes  -- ^ Allow attributes on inline code
     | Ext_markdown_in_html_blocks -- ^ Interpret as markdown inside HTML blocks
     | Ext_native_divs             -- ^ Use Div blocks for contents of <div> tags

--- a/trypandoc/index.html
+++ b/trypandoc/index.html
@@ -73,7 +73,7 @@ $(document).ready(function() {
         <option value="markdown" selected>Markdown</option>
         <option value="markdown_strict">Markdown/strict</option>
         <option value="markdown_phpextra">PHP Markdown Extra</option>
-        <option value="markdown_github">Github Markdown</option>
+        <option value="markdown_github">GitHub Markdown</option>
         <option value="markdown_mmd">MultiMarkdown</option>
         <option value="rst">reStructuredText</option>
         <option value="textile">Textile</option>
@@ -99,7 +99,7 @@ $(document).ready(function() {
         <option value="markdown">Markdown</option>
         <option value="markdown_strict">Markdown/strict</option>
         <option value="markdown_phpextra">PHP Markdown Extra</option>
-        <option value="markdown_github">Github Markdown</option>
+        <option value="markdown_github">GitHub Markdown</option>
         <option value="markdown_mmd">MultiMarkdown</option>
         <option value="rst">reStructuredText</option>
         <option value="asciidoc">AsciiDoc</option>


### PR DESCRIPTION
The website is called 'GitHub' afterall.