### PR TITLE
Docx Writer/Reference: Add keepNext to objects w/ captions

### DIFF
--- a/README
+++ b/README
@@ -625,10 +625,11 @@ Options affecting specific writers
     `--data-dir`). If this is not found either, sensible defaults will be
     used. The following styles are used by pandoc: [paragraph]
     Normal, Compact, Title, Subtitle, Authors, Date, Abstract, Heading 1,
-    Heading 2, Heading 3, Heading 4, Heading 5, Block Quote, Definition Term,
-    Definition, Bibliography, Body Text, Table Caption, Image Caption;
+    Heading 2, Heading 3, Heading 4, Heading 5, Block Text, Definition Term,
+    Definition, Bibliography, Body Text, Table Caption, Image Caption,
+    Figure, FigureWithCaption;
     [character] Default Paragraph Font, Body Text Char, Verbatim Char,
-    Footnote Ref, Link.
+    Footnote Reference, Hyperlink.
 
 `--epub-stylesheet=`*FILE*
 

--- a/data/docx/word/styles.xml
+++ b/data/docx/word/styles.xml
@@ -308,6 +308,9 @@
   <w:style w:type="paragraph" w:customStyle="1" w:styleId="TableCaption">
     <w:name w:val="Table Caption" />
     <w:basedOn w:val="Caption" />
+    <w:pPr>
+      <w:keepNext />
+    </w:pPr>
   </w:style>
   <w:style w:type="paragraph" w:customStyle="1" w:styleId="ImageCaption">
     <w:name w:val="Image Caption" />

--- a/data/docx/word/styles.xml
+++ b/data/docx/word/styles.xml
@@ -313,6 +313,17 @@
     <w:name w:val="Image Caption" />
     <w:basedOn w:val="Caption" />
   </w:style>
+  <w:style w:type="paragraph" w:customStyle="1" w:styleId="Figure">
+    <w:name w:val="Figure" />
+    <w:basedOn w:val="Normal" />
+  </w:style>
+  <w:style w:type="paragraph" w:customStyle="1" w:styleId="FigureWithCaption">
+    <w:name w:val="Figure with Caption" />
+    <w:basedOn w:val="Figure" />
+    <w:pPr>
+      <w:keepNext />
+    </w:pPr>
+  </w:style>
   <w:style w:type="character" w:customStyle="1" w:styleId="BodyTextChar">
     <w:name w:val="Body Text Char" />
     <w:basedOn w:val="DefaultParagraphFont" />

--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -673,7 +673,12 @@ blockToOpenXML opts (Plain lst) = withParaProp (pCustomStyle "Compact")
 -- title beginning with fig: indicates that the image is a figure
 blockToOpenXML opts (Para [Image alt (src,'f':'i':'g':':':tit)]) = do
   setFirstPara
+  pushParaProp $ pCustomStyle $
+    if null alt
+      then "Figure"
+      else "FigureWithCaption"
   paraProps <- getParaProps False
+  popParaProp
   contents <- inlinesToOpenXML opts [Image alt (src,tit)]
   captionNode <- withParaProp (pCustomStyle "ImageCaption")
                  $ blockToOpenXML opts (Para alt)


### PR DESCRIPTION
This changes `TableCaption` style, adding `w:keepNext` option, and adds `Figure` style to figure images and `FigureWithCaption` to figures with nonempty captions, which is based on `Figure`, and additionally has `w:keepNext` set as well

With this, caption and table/figure are not separated at page boundaries, as per #2031.