### PR TITLE
LaTeX Reader: check for block-level newcommand aliases in blockCommand

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -253,10 +253,9 @@ blockCommand = try $ do
   let raw = do
         rawcommand <- getRawCommand name'
         transformed <- applyMacros' rawcommand
+        guard $ transformed /= rawcommand
         notFollowedBy $ parseFromString inlines transformed
-        if transformed /= rawcommand
-           then parseFromString blocks transformed
-           else mzero
+        parseFromString blocks transformed
   case M.lookup name' blockCommands of
        Just p      -> p
        Nothing     -> case M.lookup name blockCommands of

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -253,6 +253,7 @@ blockCommand = try $ do
   let raw = do
         rawcommand <- getRawCommand name'
         transformed <- applyMacros' rawcommand
+        notFollowedBy $ parseFromString inlines transformed
         if transformed /= rawcommand
            then parseFromString blocks transformed
            else mzero

--- a/tests/latex-reader.latex
+++ b/tests/latex-reader.latex
@@ -864,4 +864,8 @@ See e.g. issues #1866, #1835
 
 \FIG{lalune.jpg}{0.5}{Test caption}
 
+\newcommand{\wbal}{The Wikibook about \LaTeX}
+
+\wbal is a good resource for learning \LaTeX.
+
 \end{document}

--- a/tests/latex-reader.latex
+++ b/tests/latex-reader.latex
@@ -845,4 +845,23 @@ indented.
 
 \$ \% \& \# \_ \{ \}
 
+\section{Block newcommands}
+
+See e.g. issues #1866, #1835
+
+\newcommand{\FIG}[3]{
+        \begin{figure}[h!]
+                \centering
+                \includegraphics[width=#2\columnwidth,angle=0]{#1}
+                \caption{#3}
+                \label{fig:#1}
+        \end{figure}
+}
+
+\newcommand{\separator}{\vspace{4em}}
+
+\separator
+
+\FIG{lalune.jpg}{0.5}{Test caption}
+
 \end{document}

--- a/tests/latex-reader.latex
+++ b/tests/latex-reader.latex
@@ -868,4 +868,8 @@ See e.g. issues #1866, #1835
 
 \wbal is a good resource for learning \LaTeX.
 
+\separator with trailing inlines
+
+\FIG{lalune.jpg}{0.5}{Test caption} with trailing inlines
+
 \end{document}

--- a/tests/latex-reader.native
+++ b/tests/latex-reader.native
@@ -377,4 +377,8 @@ Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Spa
 ,Para [Str "See",Space,Str "e.g.",Space,Str "issues",Space,Str "#1866,",Space,Str "#1835"]
 ,RawBlock (Format "latex") "\\vspace{4em}"
 ,Para [RawInline (Format "latex") "\\centering",Image [Str "Test",Space,Str "caption",Span ("",[],[("data-label","fig:lalune.jpg")]) []] ("lalune.jpg","fig:")]
-,Para [Span ("",[],[]) [Str "The",Space,Str "Wikibook",Space,Str "about",Space,Str "LaTeX"],Str "is",Space,Str "a",Space,Str "good",Space,Str "resource",Space,Str "for",Space,Str "learning",Space,Str "LaTeX."]]
+,Para [Span ("",[],[]) [Str "The",Space,Str "Wikibook",Space,Str "about",Space,Str "LaTeX"],Str "is",Space,Str "a",Space,Str "good",Space,Str "resource",Space,Str "for",Space,Str "learning",Space,Str "LaTeX."]
+,RawBlock (Format "latex") "\\vspace{4em}"
+,Para [Str "with",Space,Str "trailing",Space,Str "inlines"]
+,Para [RawInline (Format "latex") "\\centering",Image [Str "Test",Space,Str "caption",Span ("",[],[("data-label","fig:lalune.jpg")]) []] ("lalune.jpg","fig:")]
+,Para [Str "with",Space,Str "trailing",Space,Str "inlines"]]

--- a/tests/latex-reader.native
+++ b/tests/latex-reader.native
@@ -372,4 +372,8 @@ Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Spa
  [[Para [Str "And",Space,Str "in",Space,Str "list",Space,Str "items.",Note [Para [Str "In",Space,Str "list."]]]]]
 ,Para [Str "This",Space,Str "paragraph",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "part",Space,Str "of",Space,Str "the",Space,Str "note,",Space,Str "as",Space,Str "it",Space,Str "is",Space,Str "not",Space,Str "indented."]
 ,Header 1 ("escaped-characters",[],[]) [Str "Escaped",Space,Str "characters"]
-,Para [Str "$",Space,Str "%",Space,Str "&",Space,Str "#",Space,Str "_",Space,Str "{",Space,Str "}"]]
+,Para [Str "$",Space,Str "%",Space,Str "&",Space,Str "#",Space,Str "_",Space,Str "{",Space,Str "}"]
+,Header 1 ("block-newcommands",[],[]) [Str "Block",Space,Str "newcommands"]
+,Para [Str "See",Space,Str "e.g.",Space,Str "issues",Space,Str "#1866,",Space,Str "#1835"]
+,RawBlock (Format "latex") "\\vspace{4em}"
+,Para [RawInline (Format "latex") "\\centering",Image [Str "Test",Space,Str "caption",Span ("",[],[("data-label","fig:lalune.jpg")]) []] ("lalune.jpg","fig:")]]

--- a/tests/latex-reader.native
+++ b/tests/latex-reader.native
@@ -376,4 +376,5 @@ Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Spa
 ,Header 1 ("block-newcommands",[],[]) [Str "Block",Space,Str "newcommands"]
 ,Para [Str "See",Space,Str "e.g.",Space,Str "issues",Space,Str "#1866,",Space,Str "#1835"]
 ,RawBlock (Format "latex") "\\vspace{4em}"
-,Para [RawInline (Format "latex") "\\centering",Image [Str "Test",Space,Str "caption",Span ("",[],[("data-label","fig:lalune.jpg")]) []] ("lalune.jpg","fig:")]]
+,Para [RawInline (Format "latex") "\\centering",Image [Str "Test",Space,Str "caption",Span ("",[],[("data-label","fig:lalune.jpg")]) []] ("lalune.jpg","fig:")]
+,Para [Span ("",[],[]) [Str "The",Space,Str "Wikibook",Space,Str "about",Space,Str "LaTeX"],Str "is",Space,Str "a",Space,Str "good",Space,Str "resource",Space,Str "for",Space,Str "learning",Space,Str "LaTeX."]]


### PR DESCRIPTION
This came to be in response to #1866. I'm creating a pull request to facilitate the process somewhat.

Comments are welcome.