### PR TITLE
ODT Writer: Figure captions

### DIFF
--- a/data/odt/styles.xml
+++ b/data/odt/styles.xml
@@ -133,6 +133,22 @@ xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2">
       style:font-size-complex="12pt"
       style:font-style-complex="italic" />
     </style:style>
+    <style:style style:name="TableCaption" style:family="paragraph"
+    style:parent-style-name="Caption" style:class="extra">
+    </style:style>
+    <style:style style:name="FigureCaption" style:family="paragraph"
+    style:parent-style-name="Caption" style:class="extra">
+    </style:style>
+    <style:style style:name="Figure" style:family="paragraph"
+    style:parent-style-name="Standard" style:class="extra">
+      <style:paragraph-properties text:number-lines="false"
+      text:line-number="0" />
+    </style:style>
+    <style:style style:name="FigureWithCaption" style:family="paragraph"
+    style:parent-style-name="Figure" style:class="extra">
+      <style:paragraph-properties text:number-lines="false"
+      text:line-number="0" fo:keep-with-next="always" />
+    </style:style>
     <style:style style:name="Index" style:family="paragraph"
     style:parent-style-name="Standard" style:class="index">
       <style:paragraph-properties text:number-lines="false"

--- a/src/Text/Pandoc/Writers/ODT.hs
+++ b/src/Text/Pandoc/Writers/ODT.hs
@@ -127,7 +127,7 @@ writeODT opts doc@(Pandoc meta _) = do
   return $ fromArchive archive''
 
 transformPicMath :: WriterOptions -> IORef [Entry] -> Inline -> IO Inline
-transformPicMath opts entriesRef (Image lab (src,_)) = do
+transformPicMath opts entriesRef (Image lab (src,t)) = do
   res <- fetchItem' (writerMediaBag opts) (writerSourceURL opts) src
   case res of
      Left (_ :: E.SomeException) -> do
@@ -145,7 +145,9 @@ transformPicMath opts entriesRef (Image lab (src,_)) = do
        epochtime <- floor `fmap` getPOSIXTime
        let entry = toEntry newsrc epochtime $ toLazy img
        modifyIORef entriesRef (entry:)
-       return $ Image lab (newsrc, tit')
+       let fig | "fig:" `isPrefixOf` t = "fig:"
+               | otherwise             = ""
+       return $ Image lab (newsrc, fig++tit')
 transformPicMath _ entriesRef (Math t math) = do
   entries <- readIORef entriesRef
   let dt = if t == InlineMath then DisplayInline else DisplayBlock

--- a/tests/tables.opendocument
+++ b/tests/tables.opendocument
@@ -63,7 +63,7 @@
     </table:table-cell>
   </table:table-row>
 </table:table>
-<text:p text:style-name="Caption">Demonstration of simple table
+<text:p text:style-name="TableCaption">Demonstration of simple table
 syntax.</text:p>
 <text:p text:style-name="First_20_paragraph">Simple table without
 caption:</text:p>
@@ -197,7 +197,7 @@ spaces:</text:p>
     </table:table-cell>
   </table:table-row>
 </table:table>
-<text:p text:style-name="Caption">Demonstration of simple table
+<text:p text:style-name="TableCaption">Demonstration of simple table
 syntax.</text:p>
 <text:p text:style-name="First_20_paragraph">Multiline table with
 caption:</text:p>
@@ -253,8 +253,8 @@ caption:</text:p>
     </table:table-cell>
   </table:table-row>
 </table:table>
-<text:p text:style-name="Caption">Here's the caption. It may span multiple
-lines.</text:p>
+<text:p text:style-name="TableCaption">Here's the caption. It may span
+multiple lines.</text:p>
 <text:p text:style-name="First_20_paragraph">Multiline table without
 caption:</text:p>
 <table:table table:name="Table5" table:style-name="Table5">

--- a/tests/writer.opendocument
+++ b/tests/writer.opendocument
@@ -1577,7 +1577,8 @@ link in pointy braces</text:span></text:a>.</text:p>
 <text:h text:style-name="Heading_20_1" text:outline-level="1">Images</text:h>
 <text:p text:style-name="First_20_paragraph">From “Voyage dans la Lune” by
 Georges Melies (1902):</text:p>
-<text:p text:style-name="Text_20_body"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureCaption">lalune</text:p>
 <text:p text:style-name="Text_20_body">Here is a movie
 <draw:frame draw:name="img2"><draw:image xlink:href="movie.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame>
 icon.</text:p>


### PR DESCRIPTION
Closes #376.

Works pretty much the same as Word writer.

Following styles are used for figures:

Figure -- for figure with empty caption
FigureWithCaption (based on Figure) -- for figure with caption
FigureCaption (based on Caption) -- for figure captions

Also, TableCaption (based on Caption) is used for table captions.

We need FigureWithCaption to set keepWithNext, in order to keep caption
with figure across pages.