### PR TITLE
LaTeX Reader: Code cleanup

### DIFF
--- a/tests/Tests/Readers/LaTeX.hs
+++ b/tests/Tests/Readers/LaTeX.hs
@@ -106,6 +106,16 @@ tests = [ testGroup "basic"
           [ natbibCitations
           , biblatexCitations
           ]
+
+        , let hex = ['0'..'9']++['a'..'f'] in
+          testGroup "Character Escapes"
+          [ "Two-character escapes" =:
+            concat ["^^"++[i,j] | i <- hex, j <- hex] =?>
+            para (str ['\0'..'\255'])
+          , "One-character escapes" =:
+            concat ["^^"++[i] | i <- hex] =?>
+            para (str $ ['p'..'y']++['!'..'&'])
+          ]
         ]
 
 baseCitation :: Citation


### PR DESCRIPTION
Something I wanted to do for a little while.

Removed redundant brackets and `$`s, consolidated imports, replaced some more obvious things with library functions, simplified nested `case` expressions, and changed `[Char]`s to `String`s.

I also accidentally stumbled on a little bug, that prevented `tildeEscape` parser from ever working. Fixed that as well (line 203 in new source). Should I also add a test, while I'm at it?

Behavior shouldn't be in any way changed, except for that bug thing, but wait for Travis just in case.