### PR TITLE
Bump zlib upper version bounds

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -262,7 +262,7 @@ Library
                  aeson >= 0.7 && < 0.9,
                  tagsoup >= 0.13.1 && < 0.14,
                  base64-bytestring >= 0.1 && < 1.1,
-                 zlib >= 0.5 && < 0.6,
+                 zlib >= 0.5 && < 0.7,
                  highlighting-kate >= 0.5.14 && < 0.6,
                  data-default >= 0.4 && < 0.6,
                  temporary >= 1.1 && < 1.3,


### PR DESCRIPTION
Allow `pandoc` to build with the latest version of `zlib`.