### PR TITLE
Added woff2 to MIME types

### DIFF
--- a/src/Text/Pandoc/MIME.hs
+++ b/src/Text/Pandoc/MIME.hs
@@ -497,6 +497,7 @@ mimeTypesList = -- List borrowed from happstack-server.
            ,("wmx","video/x-ms-wmx")
            ,("wmz","application/x-ms-wmz")
            ,("woff","application/x-font-woff")
+           ,("woff2","application/x-font-woff2")
            ,("wp5","application/wordperfect5.1")
            ,("wpd","application/wordperfect")
            ,("wrl","model/vrml")


### PR DESCRIPTION
I was getting a MIME type not defined error when generating HTML from RMarkdown, saying that it did not recognize woff2.  I am using a bootstrap css theme that references a woff2 file.