### PR TITLE
Org reader: put header tags into empty spans

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -84,13 +84,21 @@ dropCommentTrees [] = []
 dropCommentTrees blks@(b:bs) =
   maybe blks (flip dropUntilHeaderAboveLevel bs) $ commentHeaderLevel b
 
--- | Return the level of a header starting a comment tree and Nothing
--- otherwise.
+-- | Return the level of a header starting a comment or :noexport: tree and
+--  Nothing otherwise.
 commentHeaderLevel :: Block -> Maybe Int
 commentHeaderLevel blk =
    case blk of
-     (Header level _ ((Str "COMMENT"):_)) -> Just level
-     _                                    -> Nothing
+     (Header level _ ((Str "COMMENT"):_))          -> Just level
+     (Header level _ title) | hasNoExportTag title -> Just level
+     _                                             -> Nothing
+ where
+   hasNoExportTag :: [Inline] -> Bool
+   hasNoExportTag = any isNoExportTag
+
+   isNoExportTag :: Inline -> Bool
+   isNoExportTag (Span ("", ["tag"], [("data-tag-name", "noexport")]) []) = True
+   isNoExportTag _ = False
 
 -- | Drop blocks until a header on or above the given level is seen
 dropUntilHeaderAboveLevel :: Int -> [Block] -> [Block]

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -524,6 +524,13 @@ tests =
           "* COMMENT Test" =?>
           (mempty::Blocks)
 
+      , "Tree with :noexport:" =:
+          unlines [ "* Should be ignored :archive:noexport:old:"
+                  , "** Old stuff"
+                  , "   This is not going to be exported"
+                  ] =?>
+          (mempty::Blocks)
+
       , "Paragraph starting with an asterisk" =:
           "*five" =?>
           para "*five"

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -497,6 +497,21 @@ tests =
                   , header 2 ("walk" <> space <> "dog")
                   ]
 
+      , "Tagged headers" =:
+          unlines [ "* Personal       :PERSONAL:"
+                  , "** Call Mom      :@PHONE:"
+                  , "** Call John     :@PHONE:JOHN: "
+                  ] =?>
+          let tagSpan t = spanWith ("", ["tag"], [("data-tag-name", t)]) mempty
+          in mconcat [ header 1 ("Personal" <> tagSpan "PERSONAL")
+                     , header 2 ("Call Mom" <> tagSpan "@PHONE")
+                     , header 2 ("Call John" <> tagSpan "@PHONE" <> tagSpan "JOHN")
+                     ]
+
+      , "Untagged header containing colons" =:
+          "* This: is not: tagged" =?>
+          header 1 "This: is not: tagged"
+
       , "Comment Trees" =:
           unlines [ "* COMMENT A comment tree"
                   , "  Not much going on here"
@@ -1164,19 +1179,19 @@ tests =
       [ test orgSmart "quote before ellipses"
         ("'...hi'"
          =?> para (singleQuoted "…hi"))
-        
+
       , test orgSmart "apostrophe before emph"
         ("D'oh! A l'/aide/!"
          =?> para ("D’oh! A l’" <> emph "aide" <> "!"))
-        
+
       , test orgSmart "apostrophe in French"
         ("À l'arrivée de la guerre, le thème de l'«impossibilité du socialisme»"
          =?> para "À l’arrivée de la guerre, le thème de l’«impossibilité du socialisme»")
-        
+
       , test orgSmart "Quotes cannot occur at the end of emphasized text"
         ("/say \"yes\"/" =?>
          para ("/say" <> space <> doubleQuoted "yes" <> "/"))
-        
+
       , test orgSmart "Dashes are allowed at the borders of emphasis'"
         ("/foo---/" =?>
          para (emph "foo—"))


### PR DESCRIPTION
Org mode allows headers to be tagged:

``` org-mode
* Headline         :TAG1:TAG2:
```

Instead of being interpreted as part of the headline, the tags are now
put into the attributes of empty spans.  Spans without textual content
won't be visible by default, but they are detectable by filters.  They
can also be styled using CSS when written as HTML.

This fixes #2160.