### PR TITLE
Expanded description of description metadata field

### DIFF
--- a/README
+++ b/README
@@ -3257,7 +3257,9 @@ The following fields are recognized:
   ~ A string value.
 
 `coverage`
-  ~ A string value.
+  ~ A string value which may include but is not limited to: an abstract, a 
+table of contents, a graphical representation, or a free-text account of 
+the resource. The character limit for the string is 282 characters.
 
 `rights`
   ~ A string value.
@@ -3410,7 +3412,7 @@ Hans-Peter Deifel,
 Henry de Valence,
 Ilya V. Portnov,
 infinity0x,
-Jaime Marquínez Ferrándiz,
+Jaime Marquínez Ferrándiz,
 James Aspnes,
 Jamie F. Olson,
 Jason Ronallo,


### PR DESCRIPTION
Added the description of the description metadata field from Dublin Core Metadata Element Set, Version 1.1. Also added details about the character limit of the string (282 characters).