### PR TITLE
Adding SVG support for PDF & DOCX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
  - cabal-$CABALVER update
 # - git clone https://github.com/jgm/pandoc-types && cd pandoc-types && cabal-1.18 install && cd ..
  - cabal-$CABALVER install "Cabal >= 1.18" # -v2 provides useful information for debugging
+ - cabal-$CABALVER sandbox init --sandbox=tsandbox
  - cabal-$CABALVER install $JOPTS --only-dependencies --enable-tests
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
@@ -32,6 +33,7 @@ script:
       cabal-$CABALVER sdist --output-directory=build
       cd build
    fi
+ - cabal-$CABALVER sandbox init --sandbox=../tsandbox
  - cabal-$CABALVER install "Cabal >= 1.18" -v2  # -v2 provides useful information for debugging
  - cabal-$CABALVER configure --enable-tests -v2  # -v2 provides useful information for debugging
  - cabal-$CABALVER build $JOPTS --ghc-options=$GHCOPTS # this builds all libraries and executables (including tests/benchmarks)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: false
 # The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
 matrix:
  include:
-  - env: CABALVER=1.16 GHCVER=7.4.2 GHCOPTS="-Werror" JOPTS=""
-    addons: {apt: {packages: [cabal-install-1.16, ghc-7.4.2], sources: [hvr-ghc]}}
   - env: CABALVER=1.18 GHCVER=7.6.3 GHCOPTS="-Werror" JOPTS="-j2"
     addons: {apt: {packages: [cabal-install-1.18, ghc-7.6.3], sources: [hvr-ghc]}}
   - env: CABALVER=1.18 GHCVER=7.8.4 GHCOPTS="-Werror" JOPTS="-j2"
@@ -24,6 +22,7 @@ before_install:
 install:
  - cabal-$CABALVER update
 # - git clone https://github.com/jgm/pandoc-types && cd pandoc-types && cabal-1.18 install && cd ..
+ - cabal-$CABALVER install "Cabal >= 1.18" # -v2 provides useful information for debugging
  - cabal-$CABALVER install $JOPTS --only-dependencies --enable-tests
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
@@ -33,6 +32,7 @@ script:
       cabal-$CABALVER sdist --output-directory=build
       cd build
    fi
+ - cabal-$CABALVER install "Cabal >= 1.18" -v2  # -v2 provides useful information for debugging
  - cabal-$CABALVER configure --enable-tests -v2  # -v2 provides useful information for debugging
  - cabal-$CABALVER build $JOPTS --ghc-options=$GHCOPTS # this builds all libraries and executables (including tests/benchmarks)
  - cabal-$CABALVER test

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -278,7 +278,7 @@ Library
                  haddock-library >= 1.1 && < 1.3,
                  old-time,
                  deepseq-generics >= 0.1 && < 0.2,
-                 JuicyPixels >= 3.2.5.2 && < 3.3,
+                 JuicyPixels >= 3.2.6 && < 3.3,
                  filemanip >= 0.3 && < 0.4,
                  cmark >= 0.4.0.1 && < 0.5,
                  rasterific-svg >= 0.2.3 && < 0.3,

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -1,6 +1,6 @@
 Name:            pandoc
 Version:         1.15.1
-Cabal-Version:   >= 1.10
+Cabal-Version:   >= 1.18
 Build-Type:      Custom
 License:         GPL
 License-File:    COPYING

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -280,7 +280,9 @@ Library
                  deepseq-generics >= 0.1 && < 0.2,
                  JuicyPixels >= 3.2.5.2 && < 3.3,
                  filemanip >= 0.3 && < 0.4,
-                 cmark >= 0.4.0.1 && < 0.5
+                 cmark >= 0.4.0.1 && < 0.5,
+                 rasterific-svg >= 0.2.3 && < 0.3,
+                 svg-tree >= 0.3.1 && < 0.4
   if flag(old-locale)
      Build-Depends: old-locale >= 1 && < 1.1,
                     time >= 1.2 && < 1.5

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -278,7 +278,7 @@ Library
                  haddock-library >= 1.1 && < 1.3,
                  old-time,
                  deepseq-generics >= 0.1 && < 0.2,
-                 JuicyPixels >= 3.1.6.1 && < 3.3,
+                 JuicyPixels >= 3.2.5.2 && < 3.3,
                  filemanip >= 0.3 && < 0.4,
                  cmark >= 0.4.0.1 && < 0.5
   if flag(old-locale)

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -251,7 +251,7 @@ Library
                  filepath >= 1.1 && < 1.5,
                  process >= 1 && < 1.3,
                  directory >= 1 && < 1.3,
-                 bytestring >= 0.9 && < 0.11,
+                 bytestring >= 0.10.2 && < 0.11,
                  text >= 0.11 && < 1.3,
                  zip-archive >= 0.2.3.4 && < 0.3,
                  HTTP >= 4000.0.5 && < 4000.3,

--- a/src/Text/Pandoc/ImageSize.hs
+++ b/src/Text/Pandoc/ImageSize.hs
@@ -31,19 +31,12 @@ Functions for determining the size of a PNG, JPEG, or GIF image.
 -}
 module Text.Pandoc.ImageSize ( ImageType(..), imageType, imageSize,
                     sizeInPixels, sizeInPoints ) where
-import Data.ByteString (ByteString, unpack)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
-import qualified Data.ByteString.Lazy as BL
-import Control.Applicative
 import Control.Monad
-import Data.Bits
-import Data.Binary
-import Data.Binary.Get
-import Text.Pandoc.Shared (safeRead, hush)
-import qualified Data.Map as M
-import Text.Pandoc.Compat.Except
-import Control.Monad.Trans
-import Data.Maybe (fromMaybe)
+import Text.Pandoc.Shared (safeRead)
+import qualified Codec.Picture.Metadata as JM
+import Codec.Picture( decodeImageWithMetadata )
 
 -- quick and dirty functions to get image sizes
 -- algorithms borrowed from wwwis.pl
@@ -60,30 +53,30 @@ data ImageSize = ImageSize{
 
 imageType :: ByteString -> Maybe ImageType
 imageType img = case B.take 4 img of
-                     "\x89\x50\x4e\x47" -> return Png
-                     "\x47\x49\x46\x38" -> return Gif
-                     "\xff\xd8\xff\xe0" -> return Jpeg  -- JFIF
-                     "\xff\xd8\xff\xe1" -> return Jpeg  -- Exif
-                     "%PDF"             -> return Pdf
-                     "%!PS"
-                       | (B.take 4 $ B.drop 1 $ B.dropWhile (/=' ') img) == "EPSF"
-                                        -> return Eps
-                     _                  -> mzero
+  "\xff\xd8\xff\xe0" -> return Jpeg  -- JFIF
+  "\xff\xd8\xff\xe1" -> return Jpeg  -- Exif
+  "%PDF"             -> return Pdf
+  "%!PS"
+    | (B.take 4 $ B.drop 1 $ B.dropWhile (/=' ') img) == "EPSF"
+                     -> return Eps
+  _                  -> mzero
 
 imageSize :: ByteString -> Either String ImageSize
-imageSize img =
-  case imageType img of
-       Just Png  -> mbToEither "could not determine PNG size" $ pngSize img
-       Just Gif  -> mbToEither "could not determine GIF size" $ gifSize img
-       Just Jpeg -> jpegSize img
-       Just Eps  -> mbToEither "could not determine EPS size" $ epsSize img
-       Just Pdf  -> Left "could not determine PDF size" -- TODO
-       Nothing   -> Left "could not determine image type"
-  where mbToEither msg Nothing  = Left msg
-        mbToEither _   (Just x) = Right x
-
-defaultSize :: (Integer, Integer)
-defaultSize = (72, 72)
+imageSize img = case (imageType img, decodeImageWithMetadata img) of
+  (Just Pdf, _) -> maybe (Left "can't find EPS size") Right $ epsSize img
+  (_, Left _err) -> Left "could not determine image size."
+  (_, Right (_, metadatas)) -> Right $ ImageSize
+      { pxX = extractSize metadatas JM.Width
+      , pxY = extractSize metadatas JM.Height
+      , dpiX = extractDpi metadatas JM.DpiX
+      , dpiY = extractDpi metadatas JM.DpiY
+      }
+  where
+    defaultDpi = 72
+    extractDpi metas k =
+      maybe defaultDpi fromIntegral $ JM.lookup k metas
+    extractSize metas k =
+      maybe 0 fromIntegral $ JM.lookup k metas
 
 sizeInPixels :: ImageSize -> (Integer, Integer)
 sizeInPixels s = (pxX s, pxY s)
@@ -108,320 +101,3 @@ epsSize img = do
                           , dpiY = 72 }
                      _ -> mzero
 
-pngSize :: ByteString -> Maybe ImageSize
-pngSize img = do
-  let (h, rest) = B.splitAt 8 img
-  guard $ h == "\x8a\x4d\x4e\x47\x0d\x0a\x1a\x0a" ||
-          h == "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"
-  let (i, rest') = B.splitAt 4 $ B.drop 4 rest
-  guard $ i == "MHDR" || i == "IHDR"
-  let (sizes, rest'') = B.splitAt 8 rest'
-  (x,y) <- case map fromIntegral $ unpack $ sizes of
-                ([w1,w2,w3,w4,h1,h2,h3,h4] :: [Integer]) -> return
-                    ((shift w1 24) + (shift w2 16) + (shift w3 8) + w4,
-                     (shift h1 24) + (shift h2 16) + (shift h3 8) + h4)
-                _ -> (hush . Left) "PNG parse error"
-  let (dpix, dpiy) = findpHYs rest''
-  return $ ImageSize { pxX  = x, pxY = y, dpiX = dpix, dpiY = dpiy }
-
-findpHYs :: ByteString -> (Integer, Integer)
-findpHYs x =
-  if B.null x || "IDAT" `B.isPrefixOf` x
-     then (72,72) -- default, no pHYs
-     else if "pHYs" `B.isPrefixOf` x
-          then let [x1,x2,x3,x4,y1,y2,y3,y4,u] = map fromIntegral
-                                               $ unpack $ B.take 9 $ B.drop 4 x
-                   factor = if u == 1 -- dots per meter
-                               then \z -> z * 254 `div` 10000
-                               else const 72
-               in  ( factor $ (shift x1 24) + (shift x2 16) + (shift x3 8) + x4,
-                     factor $ (shift y1 24) + (shift y2 16) + (shift y3 8) + y4 )
-          else findpHYs $ B.drop 1 x  -- read another byte
-
-gifSize :: ByteString -> Maybe ImageSize
-gifSize img = do
-  let (h, rest) = B.splitAt 6 img
-  guard $ h == "GIF87a" || h == "GIF89a"
-  case map fromIntegral $ unpack $ B.take 4 rest of
-       [w2,w1,h2,h1] -> return ImageSize {
-                          pxX  = shift w1 8 + w2,
-                          pxY  = shift h1 8 + h2,
-                          dpiX = 72,
-                          dpiY = 72
-                          }
-       _             -> (hush . Left) "GIF parse error"
-
-jpegSize :: ByteString -> Either String ImageSize
-jpegSize img =
-  let (hdr, rest) = B.splitAt 4 img
-  in if B.length rest < 14
-        then Left "unable to determine JPEG size"
-        else case hdr of
-               "\xff\xd8\xff\xe0" -> jfifSize rest
-               "\xff\xd8\xff\xe1" -> exifSize rest
-               _                  -> Left "unable to determine JPEG size"
-
-jfifSize :: ByteString -> Either String ImageSize
-jfifSize rest =
-  let [dpiDensity,dpix1,dpix2,dpiy1,dpiy2] = map fromIntegral
-                                           $ unpack $ B.take 5 $ B.drop 9 $ rest
-      factor = case dpiDensity of
-                    1 -> id
-                    2 -> \x -> (x * 254 `div` 10)
-                    _ -> const 72
-      dpix = factor (shift dpix1 8 + dpix2)
-      dpiy = factor (shift dpiy1 8 + dpiy2)
-  in case findJfifSize rest of
-       Left msg    -> Left msg
-       Right (w,h) -> Right $ ImageSize { pxX = w
-                                        , pxY = h
-                                        , dpiX = dpix
-                                        , dpiY = dpiy }
-
-findJfifSize :: ByteString -> Either String (Integer,Integer)
-findJfifSize bs =
-  let bs' = B.dropWhile (=='\xff') $ B.dropWhile (/='\xff') bs
-  in case B.uncons bs' of
-       Just (c,bs'') | c >= '\xc0' && c <= '\xc3' ->
-         case map fromIntegral $ unpack $ B.take 4 $ B.drop 3 bs'' of
-              [h1,h2,w1,w2] -> Right (shift w1 8 + w2, shift h1 8 + h2)
-              _             -> Left "JFIF parse error"
-       Just (_,bs'') ->
-         case map fromIntegral $ unpack $ B.take 2 bs'' of
-              [c1,c2] ->
-                let len = shift c1 8 + c2
-                -- skip variables
-                in  findJfifSize $ B.drop len bs''
-              _       -> Left "JFIF parse error"
-       Nothing -> Left "Did not find JFIF length record"
-
-runGet' :: Get (Either String a) -> BL.ByteString -> Either String a
-runGet' p bl =
-#if MIN_VERSION_binary(0,7,0)
-  case runGetOrFail p bl of
-       Left (_,_,msg) -> Left msg
-       Right (_,_,x)  -> x
-#else
-  runGet p bl
-#endif
-
-
-exifSize :: ByteString -> Either String ImageSize
-exifSize bs = runGet' header $ bl
-  where bl = BL.fromChunks [bs]
-        header = runExceptT $ exifHeader bl
--- NOTE:  It would be nicer to do
--- runGet ((Just <$> exifHeader) <|> return Nothing)
--- which would prevent pandoc from raising an error when an exif header can't
--- be parsed.  But we only get an Alternative instance for Get in binary 0.6,
--- and binary 0.5 ships with ghc 7.6.
-
-exifHeader :: BL.ByteString -> ExceptT String Get ImageSize
-exifHeader hdr = do
-  _app1DataSize <- lift getWord16be
-  exifHdr <- lift getWord32be
-  unless (exifHdr == 0x45786966) $ throwError "Did not find exif header"
-  zeros <- lift getWord16be
-  unless (zeros == 0) $ throwError "Expected zeros after exif header"
-  -- beginning of tiff header -- we read whole thing to use
-  -- in getting data from offsets:
-  let tiffHeader = BL.drop 8 hdr
-  byteAlign <- lift getWord16be
-  let bigEndian = byteAlign == 0x4d4d
-  let (getWord16, getWord32, getWord64) =
-        if bigEndian
-           then (getWord16be, getWord32be, getWord64be)
-           else (getWord16le, getWord32le, getWord64le)
-  let getRational = do
-        num <- getWord32
-        den <- getWord32
-        return $ fromIntegral num / fromIntegral den
-  tagmark <- lift getWord16
-  unless (tagmark == 0x002a) $ throwError "Failed alignment sanity check"
-  ifdOffset <- lift getWord32
-  lift $ skip (fromIntegral ifdOffset - 8) -- skip to IDF
-  numentries <- lift  getWord16
-  let ifdEntry :: ExceptT String Get (TagType, DataFormat)
-      ifdEntry = do
-       tag <- fromMaybe UnknownTagType . flip M.lookup tagTypeTable
-                <$> lift getWord16
-       dataFormat <- lift getWord16
-       numComponents <- lift getWord32
-       (fmt, bytesPerComponent) <-
-             case dataFormat of
-                  1  -> return (UnsignedByte <$> getWord8, 1)
-                  2  -> return (AsciiString <$>
-                                getLazyByteString
-                                (fromIntegral numComponents), 1)
-                  3  -> return (UnsignedShort <$> getWord16, 2)
-                  4  -> return (UnsignedLong <$> getWord32, 4)
-                  5  -> return (UnsignedRational <$> getRational, 8)
-                  6  -> return (SignedByte <$> getWord8, 1)
-                  7  -> return (Undefined <$> getLazyByteString
-                                (fromIntegral numComponents), 1)
-                  8  -> return (SignedShort <$> getWord16, 2)
-                  9  -> return (SignedLong <$> getWord32, 4)
-                  10 -> return (SignedRational <$> getRational, 8)
-                  11 -> return (SingleFloat <$> getWord32 {- TODO -}, 4)
-                  12 -> return (DoubleFloat <$> getWord64 {- TODO -}, 8)
-                  _  -> throwError $ "Unknown data format " ++ show dataFormat
-       let totalBytes = fromIntegral $ numComponents * bytesPerComponent
-       payload <- if totalBytes <= 4 -- data is right here
-                     then lift $ fmt <* skip (4 - totalBytes)
-                     else do  -- get data from offset
-                          offs <- lift getWord32
-                          let bytesAtOffset =
-                                 BL.take (fromIntegral totalBytes)
-                                 $ BL.drop (fromIntegral offs) tiffHeader
-                          case runGet' (Right <$> fmt) bytesAtOffset of
-                               Left msg -> throwError msg
-                               Right x  -> return x
-       return (tag, payload)
-  entries <- sequence $ replicate (fromIntegral numentries) ifdEntry
-  subentries <- case lookup ExifOffset entries of
-                      Just (UnsignedLong offset) -> do
-                        pos <- lift bytesRead
-                        lift $ skip (fromIntegral offset - (fromIntegral pos - 8))
-                        numsubentries <- lift getWord16
-                        sequence $
-                           replicate (fromIntegral numsubentries) ifdEntry
-                      _ -> return []
-  let allentries = entries ++ subentries
-  (width, height) <- case (lookup ExifImageWidth allentries,
-                           lookup ExifImageHeight allentries) of
-                          (Just (UnsignedLong w), Just (UnsignedLong h)) ->
-                            return (fromIntegral w, fromIntegral h)
-                          _ -> return defaultSize
-                               -- we return a default width and height when
-                               -- the exif header doesn't contain these
-  let resfactor = case lookup ResolutionUnit allentries of
-                        Just (UnsignedShort 1) -> (100 / 254)
-                        _ -> 1
-  let xres = maybe 72 (\(UnsignedRational x) -> floor $ x * resfactor)
-             $ lookup XResolution allentries
-  let yres = maybe 72 (\(UnsignedRational x) -> floor $ x * resfactor)
-             $ lookup YResolution allentries
-  return $ ImageSize{
-                    pxX  = width
-                  , pxY  = height
-                  , dpiX = xres
-                  , dpiY = yres }
-
-data DataFormat = UnsignedByte Word8
-                | AsciiString BL.ByteString
-                | UnsignedShort Word16
-                | UnsignedLong Word32
-                | UnsignedRational Rational
-                | SignedByte Word8
-                | Undefined BL.ByteString
-                | SignedShort Word16
-                | SignedLong Word32
-                | SignedRational Rational
-                | SingleFloat Word32
-                | DoubleFloat Word64
-                deriving (Show)
-
-data TagType = ImageDescription
-             | Make
-             | Model
-             | Orientation
-             | XResolution
-             | YResolution
-             | ResolutionUnit
-             | Software
-             | DateTime
-             | WhitePoint
-             | PrimaryChromaticities
-             | YCbCrCoefficients
-             | YCbCrPositioning
-             | ReferenceBlackWhite
-             | Copyright
-             | ExifOffset
-             | ExposureTime
-             | FNumber
-             | ExposureProgram
-             | ISOSpeedRatings
-             | ExifVersion
-             | DateTimeOriginal
-             | DateTimeDigitized
-             | ComponentConfiguration
-             | CompressedBitsPerPixel
-             | ShutterSpeedValue
-             | ApertureValue
-             | BrightnessValue
-             | ExposureBiasValue
-             | MaxApertureValue
-             | SubjectDistance
-             | MeteringMode
-             | LightSource
-             | Flash
-             | FocalLength
-             | MakerNote
-             | UserComment
-             | FlashPixVersion
-             | ColorSpace
-             | ExifImageWidth
-             | ExifImageHeight
-             | RelatedSoundFile
-             | ExifInteroperabilityOffset
-             | FocalPlaneXResolution
-             | FocalPlaneYResolution
-             | FocalPlaneResolutionUnit
-             | SensingMethod
-             | FileSource
-             | SceneType
-             | UnknownTagType
-             deriving (Show, Eq, Ord)
-
-tagTypeTable :: M.Map Word16 TagType
-tagTypeTable = M.fromList
-  [ (0x010e, ImageDescription)
-  , (0x010f, Make)
-  , (0x0110, Model)
-  , (0x0112, Orientation)
-  , (0x011a, XResolution)
-  , (0x011b, YResolution)
-  , (0x0128, ResolutionUnit)
-  , (0x0131, Software)
-  , (0x0132, DateTime)
-  , (0x013e, WhitePoint)
-  , (0x013f, PrimaryChromaticities)
-  , (0x0211, YCbCrCoefficients)
-  , (0x0213, YCbCrPositioning)
-  , (0x0214, ReferenceBlackWhite)
-  , (0x8298, Copyright)
-  , (0x8769, ExifOffset)
-  , (0x829a, ExposureTime)
-  , (0x829d, FNumber)
-  , (0x8822, ExposureProgram)
-  , (0x8827, ISOSpeedRatings)
-  , (0x9000, ExifVersion)
-  , (0x9003, DateTimeOriginal)
-  , (0x9004, DateTimeDigitized)
-  , (0x9101, ComponentConfiguration)
-  , (0x9102, CompressedBitsPerPixel)
-  , (0x9201, ShutterSpeedValue)
-  , (0x9202, ApertureValue)
-  , (0x9203, BrightnessValue)
-  , (0x9204, ExposureBiasValue)
-  , (0x9205, MaxApertureValue)
-  , (0x9206, SubjectDistance)
-  , (0x9207, MeteringMode)
-  , (0x9208, LightSource)
-  , (0x9209, Flash)
-  , (0x920a, FocalLength)
-  , (0x927c, MakerNote)
-  , (0x9286, UserComment)
-  , (0xa000, FlashPixVersion)
-  , (0xa001, ColorSpace)
-  , (0xa002, ExifImageWidth)
-  , (0xa003, ExifImageHeight)
-  , (0xa004, RelatedSoundFile)
-  , (0xa005, ExifInteroperabilityOffset)
-  , (0xa20e, FocalPlaneXResolution)
-  , (0xa20f, FocalPlaneYResolution)
-  , (0xa210, FocalPlaneResolutionUnit)
-  , (0xa217, SensingMethod)
-  , (0xa300, FileSource)
-  , (0xa301, SceneType)
-  ]


### PR DESCRIPTION
This pull request adds the following features:
- Convert SVG to PDF for PDF LaTeX output
- Convert SVG to PNG for Docx output
- Retrieve DPI information from Juicy.Pixels

Introduced dependencies:
- rasterific-svg (rendering module)
- svg-tree svg description types

By transitivity, Lens is required by svg-tree.
