### PR TITLE
Fix RST reference names with special characters

### DIFF
--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -779,7 +779,7 @@ simpleReferenceName' :: Parser [Char] st String
 simpleReferenceName' = do
   x <- alphaNum
   xs <- many $  alphaNum
-            <|> (try $ oneOf "-_:+." >> lookAhead alphaNum)
+            <|> (try $ oneOf "-_:+." <* lookAhead alphaNum)
   return (x:xs)
 
 simpleReferenceName :: Parser [Char] st Inlines

--- a/tests/Tests/Readers/RST.hs
+++ b/tests/Tests/Readers/RST.hs
@@ -68,6 +68,10 @@ tests = [ "line block with blank line" =:
                 link "http://foo.bar.baz" "" "http://foo.bar.baz" <> ". " <>
                 link "http://foo.bar/baz_(bam)" "" "http://foo.bar/baz_(bam)"
                 <> " (" <> link "http://foo.bar" "" "http://foo.bar" <> ")")
+        , "Reference names with special characters" =:
+		  ("A-1-B_2_C:3:D+4+E.5.F_\n\n" ++
+		   ".. _A-1-B_2_C:3:D+4+E.5.F: https://example.com\n") =?>
+		  para (link "https://example.com" "" "A-1-B_2_C:3:D+4+E.5.F")
         , testGroup "literal / line / code blocks"
           [ "indented literal block" =: unlines
             [ "::"


### PR DESCRIPTION
The reference ``A-B_`` had the name ``ABB`` prior to this change, because the result of ``lookAhead`` was used.