### PR TITLE
Fix #2254 : OpenDocument writer adds space with hard line break

### DIFF
--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -378,7 +378,7 @@ inlineToOpenDocument :: WriterOptions -> Inline -> State WriterState Doc
 inlineToOpenDocument o ils
     | Space         <- ils = inTextStyle space
     | Span _ xs     <- ils = inlinesToOpenDocument o xs
-    | LineBreak     <- ils = return $ selfClosingTag "text:line-break" [] <> cr
+    | LineBreak     <- ils = return $ selfClosingTag "text:line-break" []
     | Str         s <- ils = inTextStyle $ handleSpaces $ escapeStringForXML s
     | Emph        l <- ils = withTextStyle Italic $ inlinesToOpenDocument o l
     | Strong      l <- ils = withTextStyle Bold   $ inlinesToOpenDocument o l

--- a/tests/writer.opendocument
+++ b/tests/writer.opendocument
@@ -896,8 +896,7 @@ of a paragraph looked like a list item.</text:p>
 <text:p text:style-name="Text_20_body">Here’s one with a bullet. *
 criminey.</text:p>
 <text:p text:style-name="Text_20_body">There should be a hard line
-break<text:line-break />
-here.</text:p>
+break<text:line-break />here.</text:p>
 <text:p text:style-name="Horizontal_20_Line" />
 <text:h text:style-name="Heading_20_1" text:outline-level="1">Block
 Quotes</text:h>


### PR DESCRIPTION
Fixes #2254 Removes the carriage return after a hard line break that causes the ODT writer to add a space at the beginning of the new line. Also changed the test, `tests/writer.opendocument`, to reflect this change.