### PR TITLE
CommonMark Writer: Correct tags used for superscript/subscript

### DIFF
--- a/src/Text/Pandoc/Writers/CommonMark.hs
+++ b/src/Text/Pandoc/Writers/CommonMark.hs
@@ -144,11 +144,11 @@ inlineToNodes (Strikeout xs) =
   ((node (INLINE_HTML (T.pack "<s>")) [] : inlinesToNodes xs ++
    [node (INLINE_HTML (T.pack "</s>")) []]) ++ )
 inlineToNodes (Superscript xs) =
-  ((node (INLINE_HTML (T.pack "<sub>")) [] : inlinesToNodes xs ++
-   [node (INLINE_HTML (T.pack "</sub>")) []]) ++ )
-inlineToNodes (Subscript xs) =
   ((node (INLINE_HTML (T.pack "<sup>")) [] : inlinesToNodes xs ++
    [node (INLINE_HTML (T.pack "</sup>")) []]) ++ )
+inlineToNodes (Subscript xs) =
+  ((node (INLINE_HTML (T.pack "<sub>")) [] : inlinesToNodes xs ++
+   [node (INLINE_HTML (T.pack "</sub>")) []]) ++ )
 inlineToNodes (SmallCaps xs) =
   ((node (INLINE_HTML (T.pack "<span style=\"font-variant:small-caps;\">")) []
     : inlinesToNodes xs ++


### PR DESCRIPTION
Switches the `<sup>` and `<sub>` tags.

This corrects the results of the following:

```shell
pandoc -t commonmark << EOT
^1^ ~2~
EOT
```

Previous output:

```html
<sub>1</sub> <sup>2</sup>
```

New output:

```html
<sup>1</sup> <sub>2</sub>
```