### PR TITLE
DokuWiki: write $..$ instead of <math>..</math>

### DIFF
--- a/src/Text/Pandoc/Writers/DokuWiki.hs
+++ b/src/Text/Pandoc/Writers/DokuWiki.hs
@@ -451,7 +451,7 @@ inlineToDokuWiki _ (Code _ str) =
 
 inlineToDokuWiki _ (Str str) = return $ escapeString str
 
-inlineToDokuWiki _ (Math _ str) = return $ "<math>" ++ str ++ "</math>"
+inlineToDokuWiki _ (Math _ str) = return $ "$" ++ str ++ "$"
                                  -- note:  str should NOT be escaped
 
 inlineToDokuWiki _ (RawInline f str)

--- a/tests/writer.dokuwiki
+++ b/tests/writer.dokuwiki
@@ -454,13 +454,13 @@ Ellipses…and…and….
 ====== LaTeX ======
 
   * 
-  * <math>2+2=4</math>
-  * <math>x \in y</math>
-  * <math>\alpha \wedge \omega</math>
-  * <math>223</math>
-  * <math>p</math>-Tree
-  * Here’s some display math: <math>\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}</math>
-  * Here’s one that has a line break in it: <math>\alpha + \omega \times x^2</math>.
+  * $2+2=4$
+  * $x \in y$
+  * $\alpha \wedge \omega$
+  * $223$
+  * $p$-Tree
+  * Here’s some display math: $\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}$
+  * Here’s one that has a line break in it: $\alpha + \omega \times x^2$.
 
 These shouldn’t be math:
 


### PR DESCRIPTION
MathJax seems currently to be the only maintained math rendering
extension for DokuWiki and it uses $..$ instead of <math>..</math>.