### PR TITLE
set font-style to normal in emphasized emphasis (epub.css)

### DIFF
--- a/data/epub.css
+++ b/data/epub.css
@@ -13,3 +13,4 @@ h3.date { }
 ol.toc { padding: 0; margin-left: 1em; }
 ol.toc li { list-style-type: none; margin: 0; padding: 0; }
 a.footnoteRef { vertical-align: super; }
+em em { font-style: normal; }


### PR DESCRIPTION
@jgm, I think it would be interesting to add the following line to `data/epub.css`:

``` css
em em { font-style: normal; }
```

So emphasis inside emphasis gets normal, as it is the standard practice ([sample](http://pandoc.org/try/?text=_emphasis+*emphasized+again*+should+be+upright%2C+not+in+italics_&from=markdown&to=html)).

