### PR TITLE
HTML Reader: Correctly parse inline list-style(-type) for <ol>

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -275,7 +275,8 @@ Library
                  deepseq-generics >= 0.1 && < 0.2,
                  JuicyPixels >= 3.1.6.1 && < 3.3,
                  filemanip >= 0.3 && < 0.4,
-                 cmark >= 0.4.0.1 && < 0.5
+                 cmark >= 0.4.0.1 && < 0.5,
+                 css-text >= 0.1.2 && < 0.1.3
   if flag(old-locale)
      Build-Depends: old-locale >= 1 && < 1.1,
                     time >= 1.2 && < 1.5

--- a/tests/html-reader.html
+++ b/tests/html-reader.html
@@ -185,6 +185,13 @@ These should not be escaped:  \$ \\ \> \[ \{
 <li><p>Item 3.</p>
 </li>
 </ol>
+<p>List styles:</p>
+<ol></ol>
+<ol type="i"></ol>
+<ol class="lower-roman"></ol>
+<ol style="lower-roman"></ol>
+<ol style="list-style: lower-roman;"></ol>
+<ol style="list-style-type: lower-roman;"></ol>
 <h2>Nested</h2>
 <ul>
 <li>Tab<ul>

--- a/tests/html-reader.native
+++ b/tests/html-reader.native
@@ -116,6 +116,19 @@ Pandoc (Meta {unMeta = fromList [("generator",MetaInlines [Str "pandoc"]),("titl
   ,Para [Str "Item",Space,Str "1.",Space,Str "graf",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",Space,Str "dog's",Space,Str "back."]]
  ,[Para [Str "Item",Space,Str "2."]]
  ,[Para [Str "Item",Space,Str "3."]]]
+,Para [Str "List",Space,Str "styles:"]
+,OrderedList (1,DefaultStyle,DefaultDelim)
+ []
+,OrderedList (1,LowerRoman,DefaultDelim)
+ []
+,OrderedList (1,LowerRoman,DefaultDelim)
+ []
+,OrderedList (1,DefaultStyle,DefaultDelim)
+ []
+,OrderedList (1,LowerRoman,DefaultDelim)
+ []
+,OrderedList (1,LowerRoman,DefaultDelim)
+ []
 ,Header 2 ("",[],[]) [Str "Nested"]
 ,BulletList
  [[Plain [Str "Tab"]


### PR DESCRIPTION
Fixes #2313.

As you can tell, I don't really know what I'm doing :innocent: 