### PR TITLE
Fix implicit header refs for headers with extra spaces

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -521,6 +521,7 @@ atxClosing :: MarkdownParser Attr
 atxClosing = try $ do
   attr' <- option nullAttr
              (guardEnabled Ext_mmd_header_identifiers >> mmdHeaderIdentifier)
+  skipSpaces
   skipMany (char '#')
   skipSpaces
   attr <- option attr'
@@ -547,6 +548,7 @@ setextHeader = try $ do
   -- This lookahead prevents us from wasting time parsing Inlines
   -- unless necessary -- it gives a significant performance boost.
   lookAhead $ anyLine >> many1 (oneOf setextHChars) >> blankline
+  skipSpaces
   (text, raw) <- withRaw $
        trimInlinesF . mconcat <$> many1 (notFollowedBy setextHeaderEnd >> inline)
   attr <- setextHeaderEnd

--- a/tests/Tests/Readers/Markdown.hs
+++ b/tests/Tests/Readers/Markdown.hs
@@ -224,6 +224,16 @@ tests = [ testGroup "inline code"
           , "bracketed text (#2062)" =:
             "# [hi]\n"
             =?> headerWith ("hi",[],[]) 1 "[hi]"
+          , "ATX header without trailing #s" =:
+            "# Foo bar\n\n" =?>
+            headerWith ("foo-bar",[],[]) 1 "Foo bar"
+          , "ATX header without trailing #s" =:
+            "# Foo bar with # #" =?>
+            headerWith ("foo-bar-with",[],[]) 1 "Foo bar with #"
+          , "setext header" =:
+            "Foo bar\n=\n\n Foo bar 2 \n=" =?>
+            headerWith ("foo-bar",[],[]) 1 "Foo bar"
+            <> headerWith ("foo-bar-2",[],[]) 1 "Foo bar 2"
           ]
         , testGroup "Implicit header references"
           [ "ATX header without trailing #s" =:

--- a/tests/Tests/Readers/Markdown.hs
+++ b/tests/Tests/Readers/Markdown.hs
@@ -225,6 +225,26 @@ tests = [ testGroup "inline code"
             "# [hi]\n"
             =?> headerWith ("hi",[],[]) 1 "[hi]"
           ]
+        , testGroup "Implicit header references"
+          [ "ATX header without trailing #s" =:
+            "# Header\n[header]\n\n[header ]\n\n[ header]" =?>
+            headerWith ("header",[],[]) 1 "Header"
+            <> para (link "#header" "" (text "header"))
+            <> para (text "[header" <> space <> text "]")
+            <> para (text "[" <> space <> text "header]")
+          , "ATX header with trailing #s" =:
+            "# Foo bar #\n[foo bar]\n\n[foo bar ]\n\n[ foo bar]" =?>
+            headerWith ("foo-bar",[],[]) 1 "Foo bar"
+            <> para (link "#foo-bar" "" (text "foo bar"))
+            <> para (text "[foo bar" <> space <> text "]")
+            <> para (text "[" <> space <> text "foo bar]")
+          , "setext header" =:
+            " Header \n=\n\n[header]\n\n[header ]\n\n[ header]" =?>
+            headerWith ("header",[],[]) 1 "Header"
+            <> para (link "#header" "" (text "header"))
+            <> para (text "[header" <> space <> text "]")
+            <> para (text "[" <> space <> text "header]")
+          ]
         , testGroup "smart punctuation"
           [ test markdownSmart "quote before ellipses"
             ("'...hi'"


### PR DESCRIPTION
Fixes #2321, which affects setext headers and atx headers with trailing `#`s.

I’m not confident this is the best solution. (For example, would `skipSpaces` make certain code blocks get parsed as headers instead?) I should probably also write more tests.