### PR TITLE
Set the template variable $hyphenate$ to true by default

### DIFF
--- a/src/Text/Pandoc/Writers/Man.hs
+++ b/src/Text/Pandoc/Writers/Man.hs
@@ -85,6 +85,7 @@ pandocToMan opts (Pandoc meta blocks) = do
   let context = defField "body" main
               $ setFieldsFromTitle
               $ defField "has-tables" hasTables
+              $ defField "hyphenate" True
               $ metadata
   if writerStandalone opts
      then return $ renderTemplate' (writerTemplate opts) context


### PR DESCRIPTION
* src/Text/Pandoc/Writers/Man.hs: Set $hyphenate$ to be true.

This PR supplements https://github.com/jgm/pandoc-templates/pull/119 since https://github.com/jgm/pandoc-templates/pull/119 introduces template variable $hyphenate$.
