### PR TITLE
Make sure verse blocks can contain empty lines

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -409,7 +409,7 @@ verseBlock blkProp = try $ do
   ignHeaders
   content <- rawBlockContent blkProp
   fmap B.para . mconcat . intersperse (pure B.linebreak)
-    <$> mapM (parseFromString parseInlines) (lines content)
+    <$> mapM (parseFromString parseInlines) (map (++ "\n") . lines $ content)
 
 exportsCode :: [(String, String)] -> Bool
 exportsCode attrs = not (("rundoc-exports", "none") `elem` attrs

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -1143,6 +1143,15 @@ tests =
               ]
           ]
 
+      , "Verse block with newlines" =:
+          unlines [ "#+BEGIN_VERSE"
+                  , "foo"
+                  , ""
+                  , "bar"
+                  , "#+END_VERSE"
+                  ] =?>
+          para ("foo" <> linebreak <> linebreak <> "bar")
+
       , "LaTeX fragment" =:
           unlines [ "\\begin{equation}"
                   , "X_i = \\begin{cases}"


### PR DESCRIPTION
The previous verse parsing code made the faulty assumption that empty
strings are valid (and empty) inlines.  This isn't the case, so lines
are changed to contain at least a newline.

It would generally be nicer and faster to keep the newlines while
splitting the string.  However, this would require more code, which
seems unjustified for a simple (and fairly rare) block as *verse*.

This fixes #2402.