### PR TITLE
Update KaTeX JS and CSS versions.

### DIFF
--- a/pandoc.hs
+++ b/pandoc.hs
@@ -845,7 +845,7 @@ options =
                   (\arg opt ->
                       return opt
                         { optKaTeXJS =
-                           arg <|> Just "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.1.0/katex.min.js"})
+                           arg <|> Just "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.js"})
                   "URL")
                   "" -- Use KaTeX for HTML Math
 
@@ -1132,7 +1132,7 @@ main = do
        mapM_ (\arg -> UTF8.hPutStrLn stdout arg) args
        exitWith ExitSuccess
 
-  let csscdn = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.1.0/katex.min.css"
+  let csscdn = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.css"
   let mathMethod =
         case (katexJS, katexStylesheet) of
             (Nothing, _) -> mathMethod'


### PR DESCRIPTION
Update the default KaTeX JS/CSS links to the current version. KaTeX v0.5.1 has far more functions and symbols than v0.1.0, so it seems like a better default. I think technically this might break compatibility because we released a breaking change due to the greediness of the `\color` function, but this probably has very little impact.

I have not tested or linted this, but it shouldn't affect the build. I'm not sure if the tests will be affected by this change, I can run them if that is necessary.