### PR TITLE
Better man writer (revised)

### DIFF
--- a/pandoc.hs
+++ b/pandoc.hs
@@ -37,7 +37,7 @@ import Text.Pandoc.Walk (walk)
 import Text.Pandoc.Readers.LaTeX (handleIncludes)
 import Text.Pandoc.Shared ( tabFilter, readDataFileUTF8, readDataFile,
                             safeRead, headerShift, normalize, err, warn,
-                            openURL )
+                            openURL, pandocVersion )
 import Text.Pandoc.MediaBag ( mediaDirectory, extractMediaBag, MediaBag )
 import Text.Pandoc.XML ( toEntities )
 import Text.Pandoc.SelfContained ( makeSelfContained )

--- a/src/Text/Pandoc.hs
+++ b/src/Text/Pandoc.hs
@@ -117,8 +117,6 @@ module Text.Pandoc
                , writeCustom
                -- * Rendering templates and default templates
                , module Text.Pandoc.Templates
-               -- * Version
-               , pandocVersion
                -- * Miscellaneous
                , getReader
                , getWriter
@@ -178,17 +176,11 @@ import Text.Pandoc.Error
 import Data.Aeson
 import qualified Data.ByteString.Lazy as BL
 import Data.List (intercalate)
-import Data.Version (showVersion)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Text.Parsec
 import Text.Parsec.Error
 import qualified Text.Pandoc.UTF8 as UTF8
-import Paths_pandoc (version)
-
--- | Version number of pandoc library.
-pandocVersion :: String
-pandocVersion = showVersion version
 
 parseFormatSpec :: String
                 -> Either ParseError (String, Set Extension -> Set Extension)

--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -92,7 +92,9 @@ module Text.Pandoc.Shared (
                      -- * Safe read
                      safeRead,
                      -- * Temp directory
-                     withTempDir
+                     withTempDir,
+                     -- * Version
+                     pandocVersion
                     ) where
 
 import Text.Pandoc.Definition
@@ -106,6 +108,7 @@ import System.Exit (exitWith, ExitCode(..))
 import Data.Char ( toLower, isLower, isUpper, isAlpha,
                    isLetter, isDigit, isSpace )
 import Data.List ( find, stripPrefix, intercalate )
+import Data.Version ( showVersion )
 import qualified Data.Map as M
 import Network.URI ( escapeURIString, isURI, nonStrictRelativeTo,
                      unEscapeString, parseURIReference, isAllowedInURI )
@@ -136,6 +139,7 @@ import Data.Sequence (ViewR(..), ViewL(..), viewl, viewr)
 import qualified Data.Text as T (toUpper, pack, unpack)
 import Data.ByteString.Lazy (toChunks, fromChunks)
 import qualified Data.ByteString.Lazy as BL
+import Paths_pandoc (version)
 
 import Codec.Archive.Zip
 
@@ -164,6 +168,10 @@ import Network.HTTP (findHeader, rspBody,
                      RequestMethod(..), HeaderName(..), mkRequest)
 import Network.Browser (browse, setAllowRedirects, setOutHandler, request)
 #endif
+
+-- | Version number of pandoc library.
+pandocVersion :: String
+pandocVersion = showVersion version
 
 --
 -- List processing

--- a/src/Text/Pandoc/Writers/Man.hs
+++ b/src/Text/Pandoc/Writers/Man.hs
@@ -86,6 +86,7 @@ pandocToMan opts (Pandoc meta blocks) = do
               $ setFieldsFromTitle
               $ defField "has-tables" hasTables
               $ defField "hyphenate" True
+              $ defField "pandoc-version" pandocVersion
               $ metadata
   if writerStandalone opts
      then return $ renderTemplate' (writerTemplate opts) context

--- a/src/Text/Pandoc/Writers/Man.hs
+++ b/src/Text/Pandoc/Writers/Man.hs
@@ -85,6 +85,7 @@ pandocToMan opts (Pandoc meta blocks) = do
   let context = defField "body" main
               $ setFieldsFromTitle
               $ defField "has-tables" hasTables
+              $ defField "hyphenate" True
               $ metadata
   if writerStandalone opts
      then return $ renderTemplate' (writerTemplate opts) context


### PR DESCRIPTION
1. To allow the variable **pandocVersion** to be accessed by all writers, **pandocVersion** is being moved from `src/Text/Pandoc.hs` to  `src/Text/Pandoc/Shared.hs` to avoid circular import. (Since if writers were to access **pandocVersion**, it would need to import `src/Text/Pandoc.hs`, but we know writers are imported by `src/Text/Pandoc.hs`, causing circular import.)
2. Export **pandocVersion** as **pandoc-version** template variable.
3. Set **hyphenate** to be **true** by default.

This PR is required to implement https://github.com/jgm/pandoc-templates/issues/117.