### PR TITLE
Add support for alt text as short title in latex

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -353,11 +353,12 @@ blockToLaTeX (Para [Image txt (src,'f':'i':'g':':':tit)]) = do
   inNote <- gets stInNote
   capt <- inlineListToLaTeX txt
   img <- inlineToLaTeX (Image txt (src,tit))
+  short <- stringToLaTeX TextString tit
   return $ if inNote
               -- can't have figures in notes
               then "\\begin{center}" $$ img $+$ capt $$ "\\end{center}"
               else "\\begin{figure}[htbp]" $$ "\\centering" $$ img $$
-                      ("\\caption" <> braces capt) $$ "\\end{figure}"
+                      ("\\caption" <> brackets (text short) <> braces capt) $$ "\\end{figure}"
 -- . . . indicates pause in beamer slides
 blockToLaTeX (Para [Str ".",Space,Str ".",Space,Str "."]) = do
   beamer <- writerBeamer `fmap` gets stOptions

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -358,7 +358,9 @@ blockToLaTeX (Para [Image txt (src,'f':'i':'g':':':tit)]) = do
               -- can't have figures in notes
               then "\\begin{center}" $$ img $+$ capt $$ "\\end{center}"
               else "\\begin{figure}[htbp]" $$ "\\centering" $$ img $$
-                      ("\\caption" <> brackets (text short) <> braces capt) $$ "\\end{figure}"
+                      if null short
+                        then ("\\caption" <> braces capt) $$ "\\end{figure}"
+                        else ("\\caption" <> brackets (text short) <> braces capt) $$ "\\end{figure}"
 -- . . . indicates pause in beamer slides
 blockToLaTeX (Para [Str ".",Space,Str ".",Space,Str "."]) = do
   beamer <- writerBeamer `fmap` gets stOptions

--- a/tests/writer.latex
+++ b/tests/writer.latex
@@ -938,7 +938,7 @@ From ``Voyage dans la Lune'' by Georges Melies (1902):
 \begin{figure}[htbp]
 \centering
 \includegraphics{lalune.jpg}
-\caption{lalune}
+\caption[Voyage dans la Lune]{lalune}
 \end{figure}
 
 Here is a movie \includegraphics{movie.jpg} icon.


### PR DESCRIPTION
Use the images ~~alt text~~ title as a short caption for the list of figures in
latex documents.

```
![la lune](lalune.jpg "Voyage to the moon")
```

Should now result in:

```
\caption[Voyage to the moon]{la lune}
```

in latex figures.
