### PR TITLE
Fixed auto_identifiers examples

### DIFF
--- a/README
+++ b/README
@@ -1418,11 +1418,11 @@ Thus, for example,
 
   Header                            Identifier
   -------------------------------   ----------------------------
-  Header identifiers in HTML        `header-identifiers-in-html`
-  *Dogs*?--in *my* house?           `dogs--in-my-house`
-  [HTML], [S5], or [RTF]?           `html-s5-or-rtf`
-  3. Applications                   `applications`
-  33                                `section`
+  `Header identifiers in HTML`      `header-identifiers-in-html`
+  `*Dogs*?--in *my* house?`         `dogs--in-my-house`
+  `[HTML], [S5], or [RTF]?`         `html-s5-or-rtf`
+  `3. Applications`                 `applications`
+  `33`                              `section`
 
 These rules should, in most cases, allow one to determine the identifier
 from the header text. The exception is when several headers have the


### PR DESCRIPTION
I was trying to figure out how could `Dogs?–in my house?` become `dogs--in-my-house` in the documentation page...