### PR TITLE
Org reader: fix paragraph/list interaction

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -870,6 +870,14 @@ tests =
                      , para "orange"
                      , para "peach"
                      ]
+
+      , "Recognize preceding paragraphs in non-list contexts" =:
+          unlines [ "CLOSED: [2015-10-19 Mon 15:03]"
+                  , "- Note taken on [2015-10-19 Mon 13:24]"
+                  ] =?>
+          mconcat [ para "CLOSED: [2015-10-19 Mon 15:03]"
+                  , bulletList [ plain "Note taken on [2015-10-19 Mon 13:24]" ]
+                  ]
       ]
 
   , testGroup "Tables"


### PR DESCRIPTION
Paragraphs can be followed by lists, even if there is no blank line
between the two blocks.  However, this should only be true if the
paragraph is not within a list, were the preceding block should be
parsed as a plain instead of paragraph (to allow for compact lists).

Thanks to @rgaiacs for bringing this up.

This fixes #2464.