### PR TITLE
Org reader: allow toggling header args

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -513,10 +513,16 @@ rundocBlockClass :: String
 rundocBlockClass = rundocPrefix ++ "block"
 
 blockOption :: OrgParser (String, String)
-blockOption = try $ (,) <$> orgArgKey <*> orgParamValue
+blockOption = try $ do
+  argKey <- orgArgKey
+  paramValue <- option "yes" orgParamValue
+  return (argKey, paramValue)
 
 inlineBlockOption :: OrgParser (String, String)
-inlineBlockOption = try $ (,) <$> orgArgKey <*> orgInlineParamValue
+inlineBlockOption = try $ do
+  argKey <- orgArgKey
+  paramValue <- option "yes" orgInlineParamValue
+  return (argKey, paramValue)
 
 orgArgKey :: OrgParser String
 orgArgKey = try $
@@ -525,11 +531,17 @@ orgArgKey = try $
 
 orgParamValue :: OrgParser String
 orgParamValue = try $
-  skipSpaces *> many1 (noneOf "\t\n\r ") <* skipSpaces
+  skipSpaces
+    *> notFollowedBy (char ':' )
+    *> many1 (noneOf "\t\n\r ")
+    <* skipSpaces
 
 orgInlineParamValue :: OrgParser String
 orgInlineParamValue = try $
-  skipSpaces *> many1 (noneOf "\t\n\r ]") <* skipSpaces
+  skipSpaces
+    *> notFollowedBy (char ':')
+    *> many1 (noneOf "\t\n\r ]")
+    <* skipSpaces
 
 orgArgWordChar :: OrgParser Char
 orgArgWordChar = alphaNum <|> oneOf "-_"

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -264,6 +264,16 @@ tests =
                            )
                            "echo 'Hello, World'")
 
+      , "Inline code block with toggle" =:
+          "src_sh[:toggle]{echo $HOME}" =?>
+          (para $ codeWith ( ""
+                           , [ "bash", "rundoc-block" ]
+                           , [ ("rundoc-language", "sh")
+                             , ("rundoc-toggle", "yes")
+                             ]
+                           )
+                           "echo $HOME")
+
       , "Citation" =:
           "[@nonexistent]" =?>
           let citation = Citation
@@ -1093,6 +1103,15 @@ tests =
                    , "#+RESULTS:"
                    , ": 65" ] =?>
            rawBlock "html" ""
+
+      , "Source block with toggling header arguments" =:
+        unlines [ "#+BEGIN_SRC sh :noeval"
+                , "echo $HOME"
+                , "#+END_SRC"
+                ] =?>
+        let classes = [ "bash", "rundoc-block" ]
+            params = [ ("rundoc-language", "sh"), ("rundoc-noeval", "yes") ]
+        in codeBlockWith ("", classes, params) "echo $HOME\n"
 
       , "Example block" =:
            unlines [ "#+begin_example"


### PR DESCRIPTION
Org-mode allows to skip the argument of a code block header argument if
it's toggling a value.  Argument-less headers are now recognized,
avoiding weird parsing errors.

The fixes are not exactly pretty, but neither is the code that was
fixed.  So I guess it's about par for the course.  However, a rewrite of
the header parsing code wouldn't hurt in the long run.

Thanks to @jo-tham for filing the bug report.

This fixes #2269.