### PR TITLE
LaTeX writer: \textarabic fix

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -800,7 +800,7 @@ inlineToLaTeX (Span (id',classes,kvs) ils) = do
      (if rtl then inCmd "RL" else id) .
      (if ltr then inCmd "LR" else id) .
      (case lookup "lang" kvs of
-        Just lng -> let (l, o) = toPolyglossiaEnv lng
+        Just lng -> let (l, o) = toPolyglossia $ splitBy (=='-') lng
                         ops = if null o then "" else brackets (text o)
                     in  \c -> char '\\' <> "text" <> text l <> ops <> braces c
         Nothing  -> id)


### PR DESCRIPTION
Only the environment name should be capitalised (`\begin{Arabic} … \end{Arabic}`), but not the command, which has to be `\textarabic{…}`. 