### PR TITLE
Org reader: fix markup parsing in headers

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -730,7 +730,7 @@ headerTags = try $
 
 headerStart :: OrgParser Int
 headerStart = try $
-  (length <$> many1 (char '*')) <* many1 (char ' ')
+  (length <$> many1 (char '*')) <* many1 (char ' ') <* updateLastPreCharPos
 
 
 -- Don't use (or need) the reader wrapper here, we want hline to be

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -539,6 +539,17 @@ tests =
           "* This: is not: tagged" =?>
           headerWith ("this-is-not-tagged", [], []) 1 "This: is not: tagged"
 
+      , "Header starting with strokeout text" =:
+          unlines [ "foo"
+                  , ""
+                  , "* +thing+ other thing"
+                  ] =?>
+          mconcat [ para "foo"
+                  , headerWith ("thing-other-thing", [], [])
+                               1
+                               ((strikeout "thing") <> " other thing")
+                  ]
+
       , "Comment Trees" =:
           unlines [ "* COMMENT A comment tree"
                   , "  Not much going on here"


### PR DESCRIPTION
Markup as the very first item in a header wasn't recognized.  This was
caused by an incorrect parser state: positions at which inline markup
can start need to be marked explicitly by changing the parser state.
This wasn't done for headers.  The proper function to update the state
is now called at the beginning of the header parser, fixing this issue.

This fixes #2504.