### PR TITLE
Remove redundant `center` variable for reveal.js.

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -193,9 +193,6 @@ pandocToHtml opts (Pandoc meta blocks) = do
                   defField "revealjs-url" ("reveal.js" :: String) $
                   defField "s5-url" ("s5/default" :: String) $
                   defField "html5" (writerHtml5 opts) $
-                  defField "center" (case lookupMeta "center" meta of
-                                          Just (MetaBool False) -> False
-                                          _                     -> True) $
                   metadata
   return (thebody, context)
 


### PR DESCRIPTION
This is no longer needed with the updates to the template in https://github.com/jgm/pandoc-templates/commit/da139313d2e2ba99f4d31be6ea376dabf8c877ff