### PR TITLE
Org reader: Require whitespace around def list markers

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -994,13 +994,16 @@ definitionListItem :: OrgParser Int
                    -> OrgParser (F (Inlines, [Blocks]))
 definitionListItem parseMarkerGetLength = try $ do
   markerLength <- parseMarkerGetLength
-  term <- manyTill (noneOf "\n\r") (try $ string "::")
+  term <- manyTill (noneOf "\n\r") (try definitionMarker)
   line1 <- anyLineNewline
   blank <- option "" ("\n" <$ blankline)
   cont <- concat <$> many (listContinuation markerLength)
   term' <- parseFromString parseInlines term
   contents' <- parseFromString parseBlocks $ line1 ++ blank ++ cont
   return $ (,) <$> term' <*> fmap (:[]) contents'
+ where
+   definitionMarker =
+     spaceChar *> string "::" <* (spaceChar <|> lookAhead P.newline)
 
 
 -- parse raw text for one list item, excluding start marker and continuations

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -841,7 +841,7 @@ tests =
           unlines [ "- PLL :: phase-locked loop"
                   , "- TTL ::"
                   , "  transistor-transistor logic"
-                  , "- PSK::phase-shift keying"
+                  , "- PSK :: phase-shift keying"
                   , ""
                   , "  a digital modulation scheme"
                   ] =?>
@@ -879,6 +879,10 @@ tests =
                                    ]
                   , headerWith ("header", [], []) 1 "header"
                   ]
+
+      , "Definition lists double-colon markers must be surrounded by whitespace" =:
+          "- std::cout" =?>
+          bulletList [ plain "std::cout" ]
 
       , "Loose bullet list" =:
           unlines [ "- apple"


### PR DESCRIPTION
Definition list markers (i.e. double colons `::`) must be surrounded by
whitespace to start a definition item.  This rule was not checked
before, resulting in bugs with footnotes and some link types.

Thanks to @conklech for noticing and reporting this issue.

This fixes #2518.