### PR TITLE
Interpret pauses correctly for all headers

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -308,11 +308,9 @@ elementToHtml slideLevel opts (Sec level num (id',classes,keyvals) title' elemen
                    $ if titleSlide
                         -- title slides have no content of their own
                         then filter isSec elements
-                        else if slide
-                                then case splitBy isPause elements of
-                                          []     -> []
-                                          (x:xs) -> x ++ concatMap inDiv xs
-                                else elements
+                        else case splitBy isPause elements of
+                                  []     -> []
+                                  (x:xs) -> x ++ concatMap inDiv xs
   let inNl x = mconcat $ nl opts : intersperse (nl opts) x ++ [nl opts]
   let classes' = ["titleslide" | titleSlide] ++ ["slide" | slide] ++
                   ["section" | (slide || writerSectionDivs opts) &&


### PR DESCRIPTION
Previously, when using headers below the slide level, pauses are left
uninterpreted into pauses. In my opinion, unexpected behavior but
intentional looking at the code.

Fixes #2530