### PR TITLE
Add --docx-note-tab flag to replace the initial space in footnotes with a tab.

### DIFF
--- a/README
+++ b/README
@@ -744,6 +744,17 @@ Options affecting specific writers
     [character] Default Paragraph Font, Body Text Char, Verbatim Char,
     Footnote Reference, Hyperlink; [table] Normal Table.
 
+`--docx-note-tab`
+
+:   When producing footnotes in docx files, place a tab character rather than a
+    space between the footnote reference (i.e. the footnote number) and the text
+    of the footnote.  If the Footnote Text style in the reference docx has a 
+    hanging indent, this will produce typographically aligned footnotes: the 
+    text will be uniformly aligned, with all footnote references to the left, 
+    as in a well-typeset book.  Correct alignment may also be ensured by 
+    manually modifying the Footnote Text style in the output file to have a
+    small hanging indent. 
+
 `--epub-stylesheet=`*FILE*
 
 :   Use the specified CSS file to style the EPUB.  If no stylesheet

--- a/pandoc.hs
+++ b/pandoc.hs
@@ -187,6 +187,7 @@ data Opt = Opt
     , optHTMLMathMethod    :: HTMLMathMethod -- ^ Method to print HTML math
     , optReferenceODT      :: Maybe FilePath -- ^ Path of reference.odt
     , optReferenceDocx     :: Maybe FilePath -- ^ Path of reference.docx
+    , optDocxNoteTab       :: Bool    -- ^ Insert tab rather than space after DOCX footnote reference
     , optEpubStylesheet    :: Maybe String   -- ^ EPUB stylesheet
     , optEpubMetadata      :: String  -- ^ EPUB metadata
     , optEpubFonts         :: [FilePath] -- ^ EPUB fonts to embed
@@ -249,6 +250,7 @@ defaultOpts = Opt
     , optHTMLMathMethod        = PlainMath
     , optReferenceODT          = Nothing
     , optReferenceDocx         = Nothing
+    , optDocxNoteTab           = False
     , optEpubStylesheet        = Nothing
     , optEpubMetadata          = ""
     , optEpubFonts             = []
@@ -692,6 +694,11 @@ options =
                   "FILENAME")
                  "" -- "Path of custom reference.docx"
 
+    , Option "" ["docx-note-tab"]
+                 (NoArg
+                  (\opt -> return opt { optDocxNoteTab = True }))
+                 "" -- "Insert tab rather than space after DOCX footnote reference"
+
     , Option "" ["epub-stylesheet"]
                  (ReqArg
                   (\arg opt -> do
@@ -1094,6 +1101,7 @@ main = do
               , optHTMLMathMethod        = mathMethod'
               , optReferenceODT          = referenceODT
               , optReferenceDocx         = referenceDocx
+              , optDocxNoteTab           = docxNoteTab
               , optEpubStylesheet        = epubStylesheet
               , optEpubMetadata          = epubMetadata
               , optEpubFonts             = epubFonts
@@ -1344,6 +1352,7 @@ main = do
                             writerTOCDepth         = epubTOCDepth,
                             writerReferenceODT     = referenceODT,
                             writerReferenceDocx    = referenceDocx,
+                            writerDocxNoteTab      = docxNoteTab,
                             writerMediaBag         = media,
                             writerVerbose          = verbose,
                             writerLaTeXArgs        = latexEngineArgs

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -364,6 +364,7 @@ data WriterOptions = WriterOptions
   , writerMediaBag         :: MediaBag       -- ^ Media collected by docx or epub reader
   , writerVerbose          :: Bool           -- ^ Verbose debugging output
   , writerLaTeXArgs        :: [String]       -- ^ Flags to pass to latex-engine
+  , writerDocxNoteTab      :: Bool           -- ^ Insert tab rather than space after DOCX footnote reference
   } deriving (Show, Data, Typeable, Generic)
 
 instance Default WriterOptions where
@@ -409,6 +410,7 @@ instance Default WriterOptions where
                       , writerMediaBag         = mempty
                       , writerVerbose          = False
                       , writerLaTeXArgs        = []
+                      , writerDocxNoteTab      = False
                       }
 
 -- | Returns True if the given extension is enabled.

--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -1070,8 +1070,14 @@ inlineToOpenXML opts (Note bs) = do
                    [ mknode "w:rPr" [] footnoteStyle
                    , mknode "w:footnoteRef" [] () ]
   let notemarkerXml = RawInline (Format "openxml") $ ppElement notemarker
-  let insertNoteRef (Plain ils : xs) = Plain (notemarkerXml : Space : ils) : xs
-      insertNoteRef (Para ils  : xs) = Para  (notemarkerXml : Space : ils) : xs
+  let tab = mknode "w:r" [] 
+            [ mknode "w:tab" [] () ]
+  let tabXml = RawInline (Format "openxml") $ ppElement tab
+  let separator = case writerDocxNoteTab opts of
+                  False -> Space
+                  True  -> tabXml
+  let insertNoteRef (Plain ils : xs) = Plain (notemarkerXml : separator : ils) : xs
+      insertNoteRef (Para ils  : xs) = Para  (notemarkerXml : separator : ils) : xs
       insertNoteRef xs               = Para [notemarkerXml] : xs
   oldListLevel <- gets stListLevel
   oldParaProperties <- gets stParaProperties


### PR DESCRIPTION
This only applies to the docx writer, and implements the alternative behavior from #2527.

I'm open to bikeshedding over the flag name. "footnote" rather than "note" might be better for the user-exposed name. I didn't want to reformat all of `Options.hs`, hence the shorter form.

I updated the README; this should probably be documented elsewhere.

This is what footnotes look like with `--docx-note-tab` and the default template altered to have 0.25" hanging indent:

![image](https://cloud.githubusercontent.com/assets/573035/11171918/f1806b22-8bb0-11e5-9295-fdb7b759a2f9.png)

A smaller hanging indent would look nicer for documents without triple-digit footnotes.

Adding that hanging tab to the reference docx's `styles.xml` involves adding this  to the end of the `FootnoteText` style tag:

```
    <w:pPr>
      <w:ind w:left="360" w:hanging="360"/>
    </w:pPr>
```

But note that this style looks terrible with the default spaces, so it shouldn't be the default.