### PR TITLE
Allow .adoc file extension for AsciiDoc.

### DIFF
--- a/pandoc.hs
+++ b/pandoc.hs
@@ -1010,6 +1010,7 @@ defaultWriterName x =
     ".epub"     -> "epub"
     ".org"      -> "org"
     ".asciidoc" -> "asciidoc"
+    ".adoc"     -> "asciidoc"
     ".pdf"      -> "latex"
     ".fb2"      -> "fb2"
     ".opml"     -> "opml"


### PR DESCRIPTION
`.adoc` is the extension recommended at <http://asciidoctor.org/docs/asciidoc-writers-guide/>.