### PR TITLE
Add .stack-work to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ man/man?/*.html
 windows/*.wixobj
 data/reference.docx
 data/reference.odt
+.stack-work


### PR DESCRIPTION
The .stack-work directory is analogous to a cabal sandbox;
it comprises temporary build artifacts.