### PR TITLE
Fix function dropping subtrees tagged :noexport:

### DIFF
--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -87,8 +87,10 @@ parseOrg = do
 -- | Drop COMMENT headers and the document tree below those headers.
 dropCommentTrees :: [Block] -> [Block]
 dropCommentTrees [] = []
-dropCommentTrees blks@(b:bs) =
-  maybe blks (flip dropUntilHeaderAboveLevel bs) $ commentHeaderLevel b
+dropCommentTrees (b:bs) =
+  maybe (b:dropCommentTrees bs)
+        (dropCommentTrees . flip dropUntilHeaderAboveLevel bs)
+        (commentHeaderLevel b)
 
 -- | Return the level of a header starting a comment or :noexport: tree and
 --  Nothing otherwise.

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -569,6 +569,16 @@ tests =
                   ] =?>
           (mempty::Blocks)
 
+      , "Subtree with :noexport:" =:
+          unlines [ "* Exported"
+                  , "** This isn't exported :noexport:"
+                  , "*** This neither"
+                  , "** But this is"
+                  ] =?>
+          mconcat [ headerWith ("exported", [], []) 1 "Exported"
+                  , headerWith ("but-this-is", [], []) 2 "But this is"
+                  ]
+
       , "Paragraph starting with an asterisk" =:
           "*five" =?>
           para "*five"


### PR DESCRIPTION
Continue scanning for comment subtrees beyond only the first block.

Note to self: when writing an recursive function, don't forget to, you
know, actually recurse.

Shout to @mrvdb for noticing this.

This fixes #2628.