### PR TITLE
Fix typo in stack build files

### DIFF
--- a/stack.full.yaml
+++ b/stack.full.yaml
@@ -15,5 +15,5 @@ packages:
 extra-deps:
 - 'cmark-0.5.0'
 # Use older aeson to avoid excessive memory use in compilation:
-- 'aeson-0.8.0.2
+- 'aeson-0.8.0.2'
 resolver: lts-4.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,5 +12,5 @@ extra-deps:
 - 'pandoc-citeproc-0.9'
 - 'pandoc-types-1.16.0.1'
 # Use older aeson to avoid excessive memory use in compilation:
-- 'aeson-0.8.0.2
+- 'aeson-0.8.0.2'
 resolver: lts-4.0


### PR DESCRIPTION
Missing end-quote in the stack yaml files makes them unparseable.