### PR TITLE
LaTeX writer: Allow more flexible table alignment

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -591,7 +591,7 @@ blockToLaTeX (Table caption aligns widths heads rows) = do
   rows' <- mapM (tableRowToLaTeX False aligns widths) rows
   let colDescriptors = text $ concat $ map toColDescriptor aligns
   modify $ \s -> s{ stTable = True }
-  return $ "\\begin{longtable}[c]" <>
+  return $ "\\begin{longtable}[]" <>
               braces ("@{}" <> colDescriptors <> "@{}")
               -- the @{} removes extra space at beginning and end
          $$ capt


### PR DESCRIPTION
Removing the centering option `[c]` to the `longtable` environment allows LaTeX templates to control the overall table alignment in a document by setting the `longtable` length variables `LTleft` and `LTright`.

Example:

```latex
\setlength\LTleft\parindent
\setlength\LTright\fill
```

results in left aligned tables that respect paragraph indentation.

This patch will not change the default behavior of pandoc because `centering` is the default for tables even if `[c]` is not specified.