### PR TITLE
Markdown writer: Use hyphens for yaml metadata block bottom line

### DIFF
--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -116,7 +116,7 @@ plainTitleBlock tit auths dat =
   dat <> cr
 
 yamlMetadataBlock :: Value -> Doc
-yamlMetadataBlock v = "---" $$ (jsonToYaml v) $$ "..."
+yamlMetadataBlock v = "---" $$ (jsonToYaml v) $$ "---"
 
 jsonToYaml :: Value -> Doc
 jsonToYaml (Object hashmap) =

--- a/tests/writer.markdown
+++ b/tests/writer.markdown
@@ -4,7 +4,7 @@ author:
 - Anonymous
 date: 'July 17, 2006'
 title: Pandoc Test Suite
-...
+---
 
 This is a set of tests for pandoc. Most of them are adapted from John Gruber’s
 markdown test suite.


### PR DESCRIPTION
I use pandoc as a formatter and pretty pretty-printer for markdown documents. Many markdown tools in my pipeline accept YAML metadata blocks delimited top and bottom by three hyphens `---` (for example: [jekyll](http://jekyllrb.com), [mustache](https://mustache.github.io) or [hugo](https://gohugo.io)). Pandoc generated markdown uses three dots `...` to mark the bottom of a metadata block which breaks these tools.
 
This patch changes the markdown writer to use three hyphens to mark the end of a metadata block. 

Some notes:

- The reader remains untouched and will still accept dots as well
- Other tools that rely on the dots may break
- The YAML spec suggests `...` to mark the end of a document in a stream of YAML documents
- This time I did not forget to update the tests