### PR TITLE
Update LaTeX writer to align images

### DIFF
--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -39,7 +39,7 @@ import Text.Pandoc.Shared
 import Text.Pandoc.Parsing
 import Text.Pandoc.Options
 import Control.Monad ( when, liftM, guard, mzero )
-import Data.List ( findIndex, intersperse, intercalate,
+import Data.List ( find, findIndex, intersperse, intercalate,
                    transpose, sort, deleteFirstsBy, isSuffixOf , nub, union)
 import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
@@ -541,12 +541,16 @@ directive' = do
   body <- option "" $ try $ blanklines >> indentedBlock
   optional blanklines
   let body' = body ++ "\n\n"
-      imgAttr cl = ("", classes, getAtt "width" ++ getAtt "height")
+      imgAttr cl = ("", classes, getAtt "width" ++ getAtt "height" ++ align)
         where
           classes = words $ maybe "" trim $ lookup cl fields
           getAtt k = case lookup k fields of
                        Just v  -> [(k, filter (not . isSpace) v)]
                        Nothing -> []
+          align =
+            let mv = lookup "align" fields
+                     >>= find (`elem` ["center", "right", "left"]) . words
+            in maybe [] (\s -> [("align", s)]) mv
   case label of
         "raw" -> return $ B.rawBlock (trim top) (stripTrailingNewlines body)
         "role" -> addNewRole top $ map (\(k,v) -> (k, trim v)) fields

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -320,6 +320,20 @@ toLabel z = go `fmap` stringToLaTeX URLString z
 inCmd :: String -> Doc -> Doc
 inCmd cmd contents = char '\\' <> text cmd <> braces contents
 
+-- | Put the given 'Doc' into the named environment
+--
+inEnv :: Doc -> Doc -> Doc
+inEnv name doc = inCmd "begin" name $$ doc $$ inCmd "end" name
+
+-- | Put the given 'Doc' in a suitable alignment environment
+--
+alignEnv :: Alignment -> Doc -> Doc
+alignEnv align doc = case align of
+  AlignLeft    -> inEnv "flushleft" doc
+  AlignRight   -> inEnv "flushright" doc
+  AlignCenter  -> inEnv "center" doc
+  AlignDefault -> doc
+
 toSlides :: [Block] -> State WriterState [Block]
 toSlides bs = do
   opts <- gets stOptions
@@ -938,7 +952,7 @@ inlineToLaTeX (Link _ txt (src, _)) =
                 src' <- stringToLaTeX URLString (escapeURI src)
                 return $ text ("\\href{" ++ src' ++ "}{") <>
                          contents <> char '}'
-inlineToLaTeX (Image attr _ (source, _)) = do
+inlineToLaTeX (Image attr@(_, _, kvs) _ (source, _)) = do
   modify $ \s -> s{ stGraphics = True }
   opts <- gets stOptions
   let showDim dir = let d = text (show dir) <> "="
@@ -958,11 +972,16 @@ inlineToLaTeX (Image attr _ (source, _)) = do
       source' = if isURI source
                    then source
                    else unEscapeString source
+      align = case lookup "align" kvs of
+        Just "left"   -> AlignLeft
+        Just "center" -> AlignCenter
+        Just "right"  -> AlignRight
+        _             -> AlignDefault
   source'' <- stringToLaTeX URLString (escapeURI source')
   inHeading <- gets stInHeading
-  return $
-    (if inHeading then "\\protect\\includegraphics" else "\\includegraphics") <>
-    dims <> braces (text source'')
+  let img = (if inHeading then "\\protect\\includegraphics" else "\\includegraphics") <>
+            dims <> braces (text source'')
+  return $ alignEnv align img
 inlineToLaTeX (Note contents) = do
   inMinipage <- gets stInMinipage
   modify (\s -> s{stInNote = True})


### PR DESCRIPTION
Update the LaTeX writer to align images that have an "align"
attribute whose value is "left", "right" or "center".  If the
attribute is absent or has an unrecognised values, the image is left
alone.

Also update the RST reader to read these horizonal alignment values
from the image directive (the first encountered value applies). See
http://docutils.sourceforge.net/docs/ref/rst/directives.html#image
for details.
