### PR TITLE
Remove stray line from stack.full.yaml

### DIFF
--- a/stack.full.yaml
+++ b/stack.full.yaml
@@ -12,5 +12,4 @@ packages:
 - '../pandoc-citeproc'
 - '../pandoc-types'
 - '../texmath'
-extra-deps:
 resolver: lts-5.2


### PR DESCRIPTION
The line causes an error with stack 1.0.2:

```
Could not parse '/pandoc-build/pandoc/stack.full.yaml':
AesonException "Error in $.extra-deps: failed to parse field 'extra-deps': failed to parse field extra-deps: expected [a], encountered Null"
See http://docs.haskellstack.org/en/stable/yaml_configuration.html.
```