### PR TITLE
LaTeX Writer: fix polyglossia to babel env mapping

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -223,7 +223,7 @@ pandocToLaTeX options (Pandoc meta blocks) = do
                       ++ poly ++ "}{##2}}}\n"
                else "\\newcommand{\\text" ++ poly ++ "}[2][]{\\foreignlanguage{"
                       ++ babel ++ "}{#2}}\n" ++
-                    "\\newenvironment{" ++ poly ++ "}[1]{\\begin{otherlanguage}{"
+                    "\\newenvironment{" ++ poly ++ "}[2][]{\\begin{otherlanguage}{"
                       ++ babel ++ "}}{\\end{otherlanguage}}\n"
             )
             -- eliminate duplicates that have same polyglossia name

--- a/tests/writers-lang-and-dir.latex
+++ b/tests/writers-lang-and-dir.latex
@@ -29,14 +29,14 @@
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[shorthands=off,ngerman,british,ngerman,spanish,french,main=english]{babel}
   \newcommand{\textgerman}[2][]{\foreignlanguage{ngerman}{#2}}
-  \newenvironment{german}[1]{\begin{otherlanguage}{ngerman}}{\end{otherlanguage}}
+  \newenvironment{german}[2][]{\begin{otherlanguage}{ngerman}}{\end{otherlanguage}}
   \newcommand{\textenglish}[2][]{\foreignlanguage{british}{#2}}
-  \newenvironment{english}[1]{\begin{otherlanguage}{british}}{\end{otherlanguage}}
+  \newenvironment{english}[2][]{\begin{otherlanguage}{british}}{\end{otherlanguage}}
   \let\oritextspanish\textspanish
   \AddBabelHook{spanish}{beforeextras}{\renewcommand{\textspanish}{\oritextspanish}}
   \AddBabelHook{spanish}{afterextras}{\renewcommand{\textspanish}[2][]{\foreignlanguage{spanish}{##2}}}
   \newcommand{\textfrench}[2][]{\foreignlanguage{french}{#2}}
-  \newenvironment{french}[1]{\begin{otherlanguage}{french}}{\end{otherlanguage}}
+  \newenvironment{french}[2][]{\begin{otherlanguage}{french}}{\end{otherlanguage}}
 \else
   \usepackage{polyglossia}
   \setmainlanguage[]{english}


### PR DESCRIPTION
allow for optional argument in square brackets, closes #2728