### PR TITLE
Open Document writer: set first level of blockquotes to not use indent

### DIFF
--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -106,7 +106,7 @@ increaseIndent :: State WriterState ()
 increaseIndent = modify $ \s -> s { stIndentPara = 1 + stIndentPara s }
 
 resetIndent :: State WriterState ()
-resetIndent = modify $ \s -> s { stIndentPara = (stIndentPara s) - 1 }
+resetIndent = modify $ \s -> s { stIndentPara = maximum [(stIndentPara s) - 1, 0] }
 
 inTightList :: State WriterState a -> State WriterState a
 inTightList  f = modify (\s -> s { stTight = True  }) >> f >>= \r ->
@@ -313,8 +313,7 @@ blockToOpenDocument o bs
                            setInDefinitionList False
                            return r
       preformatted  s = (flush . vcat) <$> mapM (inPreformattedTags . escapeStringForXML) (lines s)
-      mkBlockQuote  b = do increaseIndent
-                           i <- paraStyle "Quotations" []
+      mkBlockQuote  b = do i <- paraStyle "Quotations" []
                            inBlockQuote o i (map plainToPara b)
       orderedList a b = do (ln,pn) <- newOrderedListStyle (isTightList b) a
                            inTags True "text:list" [ ("text:style-name", "L" ++ show ln)]

--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -106,7 +106,7 @@ increaseIndent :: State WriterState ()
 increaseIndent = modify $ \s -> s { stIndentPara = 1 + stIndentPara s }
 
 resetIndent :: State WriterState ()
-resetIndent = modify $ \s -> s { stIndentPara = maximum [(stIndentPara s) - 1, 0] }
+resetIndent = modify $ \s -> s { stIndentPara = max (stIndentPara s - 1) 0 }
 
 inTightList :: State WriterState a -> State WriterState a
 inTightList  f = modify (\s -> s { stTight = True  }) >> f >>= \r ->


### PR DESCRIPTION
Nested blockquotes start using indents like before. Quotation style is still in use, so the style's indent settings take effect on the first level of blockquotes. This is to fix #2747. Some mechanism to set a starting indent for the second level block quotes and a delta for increasing levels might be useful, but that is beyond my capabilities in Haskell.
