### PR TITLE
Recognize `la-x-classic` as Classical Latin.

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -1153,6 +1153,7 @@ toPolyglossia ("en":"UK":_)        = ("english", "variant=british")
 toPolyglossia ("en":"US":_)        = ("english", "variant=american")
 toPolyglossia ("grc":_)            = ("greek",   "variant=ancient")
 toPolyglossia ("hsb":_)            = ("usorbian", "")
+toPolyglossia ("la":"x-classic":_) = ("latin",   "variant=classic")
 toPolyglossia ("sl":_)             = ("slovenian", "")
 toPolyglossia x                    = (commonFromBcp47 x, "")
 
@@ -1177,6 +1178,7 @@ toBabel ("fr":"CA":_)        = "canadien"
 toBabel ("fra":"aca":_)      = "acadian"
 toBabel ("grc":_)            = "polutonikogreek"
 toBabel ("hsb":_)            = "uppersorbian"
+toBabel ("la":"x-classic":_) = "classiclatin"
 toBabel ("sl":_)             = "slovene"
 toBabel x                    = commonFromBcp47 x
 


### PR DESCRIPTION
This allows one to access the hyphenation patterns at <http://mirrors.ctan.org/language/hyph-utf8/tex/generic/hyph-utf8/patterns/tex/hyph-la-x-classic.tex>, using its private language tag.