### PR TITLE
LaTeX writer: Add missing languages.

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -1125,7 +1125,7 @@ toPolyglossiaEnv l =
 
 -- Takes a list of the constituents of a BCP 47 language code and
 -- converts it to a Polyglossia (language, options) tuple
--- http://mirrors.concertpass.com/tex-archive/macros/latex/contrib/polyglossia/polyglossia.pdf
+-- http://mirrors.ctan.org/macros/latex/contrib/polyglossia/polyglossia.pdf
 toPolyglossia :: [String] -> (String, String)
 toPolyglossia ("ar":"DZ":_)        = ("arabic", "locale=algeria")
 toPolyglossia ("ar":"IQ":_)        = ("arabic", "locale=mashriq")
@@ -1153,18 +1153,21 @@ toPolyglossia ("en":"UK":_)        = ("english", "variant=british")
 toPolyglossia ("en":"US":_)        = ("english", "variant=american")
 toPolyglossia ("grc":_)            = ("greek",   "variant=ancient")
 toPolyglossia ("hsb":_)            = ("usorbian", "")
-toPolyglossia ("la":"x-classic":_) = ("latin",   "variant=classic")
+toPolyglossia ("la":"x":"classic":_) = ("latin", "variant=classic")
 toPolyglossia ("sl":_)             = ("slovenian", "")
 toPolyglossia x                    = (commonFromBcp47 x, "")
 
 -- Takes a list of the constituents of a BCP 47 language code and
 -- converts it to a Babel language string.
--- http://mirrors.concertpass.com/tex-archive/macros/latex/required/babel/base/babel.pdf
--- Note that the PDF unfortunately does not contain a complete list of supported languages.
+-- http://mirrors.ctan.org/macros/latex/required/babel/base/babel.pdf
+-- List of supported languages (slightly outdated):
+-- http://tug.ctan.org/language/hyph-utf8/doc/generic/hyph-utf8/hyphenation.pdf
 toBabel :: [String] -> String
 toBabel ("de":"1901":_)      = "german"
 toBabel ("de":"AT":"1901":_) = "austrian"
 toBabel ("de":"AT":_)        = "naustrian"
+toBabel ("de":"CH":"1901":_) = "swissgerman"
+toBabel ("de":"CH":_)        = "nswissgerman"
 toBabel ("de":_)             = "ngerman"
 toBabel ("dsb":_)            = "lowersorbian"
 toBabel ("el":"polyton":_)   = "polutonikogreek"
@@ -1178,7 +1181,7 @@ toBabel ("fr":"CA":_)        = "canadien"
 toBabel ("fra":"aca":_)      = "acadian"
 toBabel ("grc":_)            = "polutonikogreek"
 toBabel ("hsb":_)            = "uppersorbian"
-toBabel ("la":"x-classic":_) = "classiclatin"
+toBabel ("la":"x":"classic":_) = "classiclatin"
 toBabel ("sl":_)             = "slovene"
 toBabel x                    = commonFromBcp47 x
 
@@ -1187,12 +1190,15 @@ toBabel x                    = commonFromBcp47 x
 -- https://tools.ietf.org/html/bcp47#section-2.1
 commonFromBcp47 :: [String] -> String
 commonFromBcp47 [] = ""
-commonFromBcp47 ("pt":"BR":_) = "brazilian"
+commonFromBcp47 ("pt":"BR":_)            = "brazilian"
+commonFromBcp47 ("sr":"Cyrl":_)          = "serbianc"
+commonFromBcp47 ("zh":"Latn":"pinyin":_) = "pinyin"
 commonFromBcp47 x = fromIso $ head x
   where
     fromIso "af"  = "afrikaans"
     fromIso "am"  = "amharic"
     fromIso "ar"  = "arabic"
+    fromIso "as"  = "assamese"
     fromIso "ast" = "asturian"
     fromIso "bg"  = "bulgarian"
     fromIso "bn"  = "bengali"
@@ -1216,12 +1222,13 @@ commonFromBcp47 x = fromIso $ head x
     fromIso "fur" = "friulan"
     fromIso "ga"  = "irish"
     fromIso "gd"  = "scottish"
+    fromIso "gez" = "ethiopic"
     fromIso "gl"  = "galician"
     fromIso "he"  = "hebrew"
     fromIso "hi"  = "hindi"
     fromIso "hr"  = "croatian"
-    fromIso "hy"  = "armenian"
     fromIso "hu"  = "magyar"
+    fromIso "hy"  = "armenian"
     fromIso "ia"  = "interlingua"
     fromIso "id"  = "indonesian"
     fromIso "ie"  = "interlingua"
@@ -1229,6 +1236,7 @@ commonFromBcp47 x = fromIso $ head x
     fromIso "it"  = "italian"
     fromIso "jp"  = "japanese"
     fromIso "km"  = "khmer"
+    fromIso "kmr" = "kurmanji"
     fromIso "kn"  = "kannada"
     fromIso "ko"  = "korean"
     fromIso "la"  = "latin"
@@ -1244,6 +1252,7 @@ commonFromBcp47 x = fromIso $ head x
     fromIso "no"  = "norsk"
     fromIso "nqo" = "nko"
     fromIso "oc"  = "occitan"
+    fromIso "pa"  = "panjabi"
     fromIso "pl"  = "polish"
     fromIso "pms" = "piedmontese"
     fromIso "pt"  = "portuguese"
@@ -1260,6 +1269,7 @@ commonFromBcp47 x = fromIso $ head x
     fromIso "ta"  = "tamil"
     fromIso "te"  = "telugu"
     fromIso "th"  = "thai"
+    fromIso "ti"  = "ethiopic"
     fromIso "tk"  = "turkmen"
     fromIso "tr"  = "turkish"
     fromIso "uk"  = "ukrainian"

--- a/tests/writers-lang-and-dir.latex
+++ b/tests/writers-lang-and-dir.latex
@@ -27,7 +27,7 @@
             breaklinks=true}
 \urlstyle{same}  % don't use monospace font for urls
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
-  \usepackage[shorthands=off,ngerman,british,ngerman,spanish,french,main=english]{babel}
+  \usepackage[shorthands=off,ngerman,british,nswissgerman,spanish,french,main=english]{babel}
   \newcommand{\textgerman}[2][]{\foreignlanguage{ngerman}{#2}}
   \newenvironment{german}[1]{\begin{otherlanguage}{ngerman}}{\end{otherlanguage}}
   \newcommand{\textenglish}[2][]{\foreignlanguage{british}{#2}}


### PR DESCRIPTION
Updates the list from the hyphenation files at <http://mirror.ctan.org/language/hyph-utf8/tex/generic/hyph-utf8/loadhyph/>.