### PR TITLE
Docbook5 write support

### DIFF
--- a/src/Text/Pandoc.hs
+++ b/src/Text/Pandoc.hs
@@ -291,6 +291,8 @@ writers = [
      writeHtmlString o{ writerSlideVariant = RevealJsSlides
                       , writerHtml5 = True })
   ,("docbook"      , PureStringWriter writeDocbook)
+  ,("docbook5"     , PureStringWriter $ \o ->
+     writeDocbook o{ writerDocBook5 = True })
   ,("opml"         , PureStringWriter writeOPML)
   ,("opendocument" , PureStringWriter writeOpenDocument)
   ,("latex"        , PureStringWriter writeLaTeX)

--- a/src/Text/Pandoc.hs
+++ b/src/Text/Pandoc.hs
@@ -292,7 +292,7 @@ writers = [
                       , writerHtml5 = True })
   ,("docbook"      , PureStringWriter writeDocbook)
   ,("docbook5"     , PureStringWriter $ \o ->
-     writeDocbook o{ writerDocBook5 = True })
+     writeDocbook o{ writerDocbook5 = True })
   ,("opml"         , PureStringWriter writeOPML)
   ,("opendocument" , PureStringWriter writeOpenDocument)
   ,("latex"        , PureStringWriter writeLaTeX)

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -357,6 +357,7 @@ data WriterOptions = WriterOptions
   , writerSourceURL        :: Maybe String  -- ^ Absolute URL + directory of 1st source file
   , writerUserDataDir      :: Maybe FilePath -- ^ Path of user data directory
   , writerCiteMethod       :: CiteMethod -- ^ How to print cites
+  , writerDocBook5         :: Bool       -- ^ Produce DocBook5
   , writerHtml5            :: Bool       -- ^ Produce HTML5
   , writerHtmlQTags        :: Bool       -- ^ Use @<q>@ tags for quotes in HTML
   , writerBeamer           :: Bool       -- ^ Produce beamer LaTeX slide show
@@ -403,6 +404,7 @@ instance Default WriterOptions where
                       , writerSourceURL        = Nothing
                       , writerUserDataDir      = Nothing
                       , writerCiteMethod       = Citeproc
+                      , writerDocBook5         = False
                       , writerHtml5            = False
                       , writerHtmlQTags        = False
                       , writerBeamer           = False

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -357,7 +357,7 @@ data WriterOptions = WriterOptions
   , writerSourceURL        :: Maybe String  -- ^ Absolute URL + directory of 1st source file
   , writerUserDataDir      :: Maybe FilePath -- ^ Path of user data directory
   , writerCiteMethod       :: CiteMethod -- ^ How to print cites
-  , writerDocBook5         :: Bool       -- ^ Produce DocBook5
+  , writerDocbook5         :: Bool       -- ^ Produce DocBook5
   , writerHtml5            :: Bool       -- ^ Produce HTML5
   , writerHtmlQTags        :: Bool       -- ^ Use @<q>@ tags for quotes in HTML
   , writerBeamer           :: Bool       -- ^ Produce beamer LaTeX slide show
@@ -404,7 +404,7 @@ instance Default WriterOptions where
                       , writerSourceURL        = Nothing
                       , writerUserDataDir      = Nothing
                       , writerCiteMethod       = Citeproc
-                      , writerDocBook5         = False
+                      , writerDocbook5         = False
                       , writerHtml5            = False
                       , writerHtmlQTags        = False
                       , writerBeamer           = False

--- a/src/Text/Pandoc/Writers/Docbook.hs
+++ b/src/Text/Pandoc/Writers/Docbook.hs
@@ -112,7 +112,9 @@ elementToDocbook opts lvl (Sec _ _num (id',_,_) title elements) =
                     else elements
       tag = case lvl of
                  n | n == 0           -> "chapter"
-                   | n >= 1 && n <= 5 -> "sect" ++ show n
+                   | n >= 1 && n <= 5 -> if writerDocBook5 opts
+                                              then "section"
+                                              else "sect" ++ show n
                    | otherwise        -> "simplesect"
   in  inTags True tag [("id", writerIdentifierPrefix opts ++ id') |
                        not (null id')] $
@@ -227,9 +229,11 @@ blockToDocbook opts (OrderedList (start, numstyle, _) (first:rest)) =
 blockToDocbook opts (DefinitionList lst) =
   let attribs = [("spacing", "compact") | isTightList $ concatMap snd lst]
   in  inTags True "variablelist" attribs $ deflistItemsToDocbook opts lst
-blockToDocbook _ (RawBlock f str)
+blockToDocbook opts (RawBlock f str)
   | f == "docbook" = text str -- raw XML block
-  | f == "html"    = text str -- allow html for backwards compatibility
+  | f == "html"    = if writerDocBook5 opts
+                        then empty -- No html in Docbook5
+                        else text str -- allow html for backwards compatibility
   | otherwise      = empty
 blockToDocbook _ HorizontalRule = empty -- not semantic
 blockToDocbook opts (Table caption aligns widths headers rows) =

--- a/src/Text/Pandoc/Writers/Docbook.hs
+++ b/src/Text/Pandoc/Writers/Docbook.hs
@@ -351,7 +351,9 @@ inlineToDocbook opts (Link attr txt (src, _))
   | otherwise =
       (if isPrefixOf "#" src
             then inTags False "link" $ ("linkend", drop 1 src) : idAndRole attr
-            else inTags False "ulink" $ ("url", src) : idAndRole attr ) $
+            else if writerDocbook5 opts
+                    then inTags False "link" $ ("xlink:href", src) : idAndRole attr
+                    else inTags False "ulink" $ ("url", src) : idAndRole attr ) $
         inlinesToDocbook opts txt
 inlineToDocbook opts (Image attr _ (src, tit)) =
   let titleDoc = if null tit

--- a/src/Text/Pandoc/Writers/Docbook.hs
+++ b/src/Text/Pandoc/Writers/Docbook.hs
@@ -112,12 +112,15 @@ elementToDocbook opts lvl (Sec _ _num (id',_,_) title elements) =
                     else elements
       tag = case lvl of
                  n | n == 0           -> "chapter"
-                   | n >= 1 && n <= 5 -> if writerDocBook5 opts
+                   | n >= 1 && n <= 5 -> if writerDocbook5 opts
                                               then "section"
                                               else "sect" ++ show n
                    | otherwise        -> "simplesect"
-  in  inTags True tag [("id", writerIdentifierPrefix opts ++ id') |
-                       not (null id')] $
+      idAttr = [("id", writerIdentifierPrefix opts ++ id') | not (null id')]
+      nsAttr = if writerDocbook5 opts && lvl == 0 then [("xmlns", "http://docbook.org/ns/docbook")]
+                                      else []
+      attribs = nsAttr ++ idAttr
+  in  inTags True tag attribs $
       inTagsSimple "title" (inlinesToDocbook opts title) $$
       vcat (map (elementToDocbook opts (lvl + 1)) elements')
 
@@ -231,7 +234,7 @@ blockToDocbook opts (DefinitionList lst) =
   in  inTags True "variablelist" attribs $ deflistItemsToDocbook opts lst
 blockToDocbook opts (RawBlock f str)
   | f == "docbook" = text str -- raw XML block
-  | f == "html"    = if writerDocBook5 opts
+  | f == "html"    = if writerDocbook5 opts
                         then empty -- No html in Docbook5
                         else text str -- allow html for backwards compatibility
   | otherwise      = empty

--- a/tests/Tests/Old.hs
+++ b/tests/Tests/Old.hs
@@ -108,6 +108,9 @@ tests = [ testGroup "markdown"
           , test "reader" ["-r", "docbook", "-w", "native", "-s"]
             "docbook-xref.docbook" "docbook-xref.native"
           ]
+        , testGroup "docbook5"
+          [ testGroup "writer" $ writerTests "docbook5"
+          ]
         , testGroup "native"
           [ testGroup "writer" $ writerTests "native"
           , test "reader" ["-r", "native", "-w", "native", "-s"]

--- a/tests/tables.docbook5
+++ b/tests/tables.docbook5
@@ -1,0 +1,432 @@
+<para>
+  Simple table with caption:
+</para>
+<table>
+  <title>
+    Demonstration of simple table syntax.
+  </title>
+  <tgroup cols="4">
+    <colspec align="right" />
+    <colspec align="left" />
+    <colspec align="center" />
+    <colspec align="left" />
+    <thead>
+      <row>
+        <entry>
+          Right
+        </entry>
+        <entry>
+          Left
+        </entry>
+        <entry>
+          Center
+        </entry>
+        <entry>
+          Default
+        </entry>
+      </row>
+    </thead>
+    <tbody>
+      <row>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+      </row>
+      <row>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+      </row>
+      <row>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</table>
+<para>
+  Simple table without caption:
+</para>
+<informaltable>
+  <tgroup cols="4">
+    <colspec align="right" />
+    <colspec align="left" />
+    <colspec align="center" />
+    <colspec align="left" />
+    <thead>
+      <row>
+        <entry>
+          Right
+        </entry>
+        <entry>
+          Left
+        </entry>
+        <entry>
+          Center
+        </entry>
+        <entry>
+          Default
+        </entry>
+      </row>
+    </thead>
+    <tbody>
+      <row>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+      </row>
+      <row>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+      </row>
+      <row>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</informaltable>
+<para>
+  Simple table indented two spaces:
+</para>
+<table>
+  <title>
+    Demonstration of simple table syntax.
+  </title>
+  <tgroup cols="4">
+    <colspec align="right" />
+    <colspec align="left" />
+    <colspec align="center" />
+    <colspec align="left" />
+    <thead>
+      <row>
+        <entry>
+          Right
+        </entry>
+        <entry>
+          Left
+        </entry>
+        <entry>
+          Center
+        </entry>
+        <entry>
+          Default
+        </entry>
+      </row>
+    </thead>
+    <tbody>
+      <row>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+      </row>
+      <row>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+      </row>
+      <row>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</table>
+<para>
+  Multiline table with caption:
+</para>
+<table>
+  <title>
+    Here's the caption. It may span multiple lines.
+  </title>
+  <tgroup cols="4">
+    <colspec colwidth="15*" align="center" />
+    <colspec colwidth="13*" align="left" />
+    <colspec colwidth="16*" align="right" />
+    <colspec colwidth="33*" align="left" />
+    <thead>
+      <row>
+        <entry>
+          Centered Header
+        </entry>
+        <entry>
+          Left Aligned
+        </entry>
+        <entry>
+          Right Aligned
+        </entry>
+        <entry>
+          Default aligned
+        </entry>
+      </row>
+    </thead>
+    <tbody>
+      <row>
+        <entry>
+          First
+        </entry>
+        <entry>
+          row
+        </entry>
+        <entry>
+          12.0
+        </entry>
+        <entry>
+          Example of a row that spans multiple lines.
+        </entry>
+      </row>
+      <row>
+        <entry>
+          Second
+        </entry>
+        <entry>
+          row
+        </entry>
+        <entry>
+          5.0
+        </entry>
+        <entry>
+          Here's another one. Note the blank line between rows.
+        </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</table>
+<para>
+  Multiline table without caption:
+</para>
+<informaltable>
+  <tgroup cols="4">
+    <colspec colwidth="15*" align="center" />
+    <colspec colwidth="13*" align="left" />
+    <colspec colwidth="16*" align="right" />
+    <colspec colwidth="33*" align="left" />
+    <thead>
+      <row>
+        <entry>
+          Centered Header
+        </entry>
+        <entry>
+          Left Aligned
+        </entry>
+        <entry>
+          Right Aligned
+        </entry>
+        <entry>
+          Default aligned
+        </entry>
+      </row>
+    </thead>
+    <tbody>
+      <row>
+        <entry>
+          First
+        </entry>
+        <entry>
+          row
+        </entry>
+        <entry>
+          12.0
+        </entry>
+        <entry>
+          Example of a row that spans multiple lines.
+        </entry>
+      </row>
+      <row>
+        <entry>
+          Second
+        </entry>
+        <entry>
+          row
+        </entry>
+        <entry>
+          5.0
+        </entry>
+        <entry>
+          Here's another one. Note the blank line between rows.
+        </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</informaltable>
+<para>
+  Table without column headers:
+</para>
+<informaltable>
+  <tgroup cols="4">
+    <colspec align="right" />
+    <colspec align="left" />
+    <colspec align="center" />
+    <colspec align="right" />
+    <tbody>
+      <row>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+        <entry>
+          12
+        </entry>
+      </row>
+      <row>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+        <entry>
+          123
+        </entry>
+      </row>
+      <row>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+        <entry>
+          1
+        </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</informaltable>
+<para>
+  Multiline table without column headers:
+</para>
+<informaltable>
+  <tgroup cols="4">
+    <colspec colwidth="15*" align="center" />
+    <colspec colwidth="13*" align="left" />
+    <colspec colwidth="16*" align="right" />
+    <colspec colwidth="33*" align="left" />
+    <tbody>
+      <row>
+        <entry>
+          First
+        </entry>
+        <entry>
+          row
+        </entry>
+        <entry>
+          12.0
+        </entry>
+        <entry>
+          Example of a row that spans multiple lines.
+        </entry>
+      </row>
+      <row>
+        <entry>
+          Second
+        </entry>
+        <entry>
+          row
+        </entry>
+        <entry>
+          5.0
+        </entry>
+        <entry>
+          Here's another one. Note the blank line between rows.
+        </entry>
+      </row>
+    </tbody>
+  </tgroup>
+</informaltable>

--- a/tests/writer.docbook5
+++ b/tests/writer.docbook5
@@ -1,0 +1,1394 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE article>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+  <info>
+    <title>Pandoc Test Suite</title>
+    <authorgroup>
+      <author>
+        <firstname>John</firstname>
+        <surname>MacFarlane</surname>
+      </author>
+      <author>
+        <firstname></firstname>
+        <surname>Anonymous</surname>
+      </author>
+    </authorgroup>
+    <date>July 17, 2006</date>
+  </info>
+<para>
+  This is a set of tests for pandoc. Most of them are adapted from John
+  Gruber’s markdown test suite.
+</para>
+<section id="headers">
+  <title>Headers</title>
+  <section id="level-2-with-an-embedded-link">
+    <title>Level 2 with an <ulink url="/url">embedded link</ulink></title>
+    <section id="level-3-with-emphasis">
+      <title>Level 3 with <emphasis>emphasis</emphasis></title>
+      <section id="level-4">
+        <title>Level 4</title>
+        <section id="level-5">
+          <title>Level 5</title>
+          <para>
+          </para>
+        </section>
+      </section>
+    </section>
+  </section>
+</section>
+<section id="level-1">
+  <title>Level 1</title>
+  <section id="level-2-with-emphasis">
+    <title>Level 2 with <emphasis>emphasis</emphasis></title>
+    <section id="level-3">
+      <title>Level 3</title>
+      <para>
+        with no blank line
+      </para>
+    </section>
+  </section>
+  <section id="level-2">
+    <title>Level 2</title>
+    <para>
+      with no blank line
+    </para>
+  </section>
+</section>
+<section id="paragraphs">
+  <title>Paragraphs</title>
+  <para>
+    Here’s a regular paragraph.
+  </para>
+  <para>
+    In Markdown 1.0.0 and earlier. Version 8. This line turns into a list
+    item. Because a hard-wrapped line in the middle of a paragraph looked like
+    a list item.
+  </para>
+  <para>
+    Here’s one with a bullet. * criminey.
+  </para>
+<literallayout>There should be a hard line break
+here.</literallayout>
+</section>
+<section id="block-quotes">
+  <title>Block Quotes</title>
+  <para>
+    E-mail style:
+  </para>
+  <blockquote>
+    <para>
+      This is a block quote. It is pretty short.
+    </para>
+  </blockquote>
+  <blockquote>
+    <para>
+      Code in a block quote:
+    </para>
+    <programlisting>
+sub status {
+    print &quot;working&quot;;
+}
+</programlisting>
+    <para>
+      A list:
+    </para>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          item one
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          item two
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      Nested block quotes:
+    </para>
+    <blockquote>
+      <para>
+        nested
+      </para>
+    </blockquote>
+    <blockquote>
+      <para>
+        nested
+      </para>
+    </blockquote>
+  </blockquote>
+  <para>
+    This should not be a block quote: 2 &gt; 1.
+  </para>
+  <para>
+    And a following paragraph.
+  </para>
+</section>
+<section id="code-blocks">
+  <title>Code Blocks</title>
+  <para>
+    Code:
+  </para>
+  <programlisting>
+---- (should be four hyphens)
+
+sub status {
+    print &quot;working&quot;;
+}
+
+this code block is indented by one tab
+</programlisting>
+  <para>
+    And:
+  </para>
+  <programlisting>
+    this code block is indented by two tabs
+
+These should not be escaped:  \$ \\ \&gt; \[ \{
+</programlisting>
+</section>
+<section id="lists">
+  <title>Lists</title>
+  <section id="unordered">
+    <title>Unordered</title>
+    <para>
+      Asterisks tight:
+    </para>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          asterisk 1
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          asterisk 2
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          asterisk 3
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Asterisks loose:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          asterisk 1
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          asterisk 2
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          asterisk 3
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Pluses tight:
+    </para>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Plus 1
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Plus 2
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Plus 3
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Pluses loose:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Plus 1
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Plus 2
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Plus 3
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Minuses tight:
+    </para>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Minus 1
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Minus 2
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Minus 3
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Minuses loose:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Minus 1
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Minus 2
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Minus 3
+        </para>
+      </listitem>
+    </itemizedlist>
+  </section>
+  <section id="ordered">
+    <title>Ordered</title>
+    <para>
+      Tight:
+    </para>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          First
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Second
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Third
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      and:
+    </para>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          One
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Two
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Three
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      Loose using tabs:
+    </para>
+    <orderedlist numeration="arabic">
+      <listitem>
+        <para>
+          First
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Second
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Third
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      and using spaces:
+    </para>
+    <orderedlist numeration="arabic">
+      <listitem>
+        <para>
+          One
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Two
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Three
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      Multiple paragraphs:
+    </para>
+    <orderedlist numeration="arabic">
+      <listitem>
+        <para>
+          Item 1, graf one.
+        </para>
+        <para>
+          Item 1. graf two. The quick brown fox jumped over the lazy dog’s
+          back.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Item 2.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Item 3.
+        </para>
+      </listitem>
+    </orderedlist>
+  </section>
+  <section id="nested">
+    <title>Nested</title>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Tab
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              Tab
+            </para>
+            <itemizedlist spacing="compact">
+              <listitem>
+                <para>
+                  Tab
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Here’s another:
+    </para>
+    <orderedlist numeration="arabic" spacing="compact">
+      <listitem>
+        <para>
+          First
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Second:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              Fee
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Fie
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Foe
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
+          Third
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      Same thing but with paragraphs:
+    </para>
+    <orderedlist numeration="arabic">
+      <listitem>
+        <para>
+          First
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Second:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              Fee
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Fie
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Foe
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
+          Third
+        </para>
+      </listitem>
+    </orderedlist>
+  </section>
+  <section id="tabs-and-spaces">
+    <title>Tabs and spaces</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          this is a list item indented with tabs
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          this is a list item indented with spaces
+        </para>
+        <itemizedlist>
+          <listitem>
+            <para>
+              this is an example list item indented with tabs
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              this is an example list item indented with spaces
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+    </itemizedlist>
+  </section>
+  <section id="fancy-list-markers">
+    <title>Fancy list markers</title>
+    <orderedlist numeration="arabic">
+      <listitem override="2">
+        <para>
+          begins with 2
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          and now 3
+        </para>
+        <para>
+          with a continuation
+        </para>
+        <orderedlist numeration="lowerroman" spacing="compact">
+          <listitem override="4">
+            <para>
+              sublist with roman numerals, starting with 4
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              more items
+            </para>
+            <orderedlist numeration="upperalpha" spacing="compact">
+              <listitem>
+                <para>
+                  a subsublist
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  a subsublist
+                </para>
+              </listitem>
+            </orderedlist>
+          </listitem>
+        </orderedlist>
+      </listitem>
+    </orderedlist>
+    <para>
+      Nesting:
+    </para>
+    <orderedlist numeration="upperalpha" spacing="compact">
+      <listitem>
+        <para>
+          Upper Alpha
+        </para>
+        <orderedlist numeration="upperroman" spacing="compact">
+          <listitem>
+            <para>
+              Upper Roman.
+            </para>
+            <orderedlist numeration="arabic" spacing="compact">
+              <listitem override="6">
+                <para>
+                  Decimal start with 6
+                </para>
+                <orderedlist numeration="loweralpha" spacing="compact">
+                  <listitem override="3">
+                    <para>
+                      Lower alpha with paren
+                    </para>
+                  </listitem>
+                </orderedlist>
+              </listitem>
+            </orderedlist>
+          </listitem>
+        </orderedlist>
+      </listitem>
+    </orderedlist>
+    <para>
+      Autonumbering:
+    </para>
+    <orderedlist spacing="compact">
+      <listitem>
+        <para>
+          Autonumber.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          More.
+        </para>
+        <orderedlist spacing="compact">
+          <listitem>
+            <para>
+              Nested.
+            </para>
+          </listitem>
+        </orderedlist>
+      </listitem>
+    </orderedlist>
+    <para>
+      Should not be a list item:
+    </para>
+    <para>
+      M.A. 2007
+    </para>
+    <para>
+      B. Williams
+    </para>
+  </section>
+</section>
+<section id="definition-lists">
+  <title>Definition Lists</title>
+  <para>
+    Tight using spaces:
+  </para>
+  <variablelist spacing="compact">
+    <varlistentry>
+      <term>
+        apple
+      </term>
+      <listitem>
+        <para>
+          red fruit
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        orange
+      </term>
+      <listitem>
+        <para>
+          orange fruit
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        banana
+      </term>
+      <listitem>
+        <para>
+          yellow fruit
+        </para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  <para>
+    Tight using tabs:
+  </para>
+  <variablelist spacing="compact">
+    <varlistentry>
+      <term>
+        apple
+      </term>
+      <listitem>
+        <para>
+          red fruit
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        orange
+      </term>
+      <listitem>
+        <para>
+          orange fruit
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        banana
+      </term>
+      <listitem>
+        <para>
+          yellow fruit
+        </para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  <para>
+    Loose:
+  </para>
+  <variablelist>
+    <varlistentry>
+      <term>
+        apple
+      </term>
+      <listitem>
+        <para>
+          red fruit
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        orange
+      </term>
+      <listitem>
+        <para>
+          orange fruit
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        banana
+      </term>
+      <listitem>
+        <para>
+          yellow fruit
+        </para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  <para>
+    Multiple blocks with italics:
+  </para>
+  <variablelist>
+    <varlistentry>
+      <term>
+        <emphasis>apple</emphasis>
+      </term>
+      <listitem>
+        <para>
+          red fruit
+        </para>
+        <para>
+          contains seeds, crisp, pleasant to taste
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        <emphasis>orange</emphasis>
+      </term>
+      <listitem>
+        <para>
+          orange fruit
+        </para>
+        <programlisting>
+{ orange code block }
+</programlisting>
+        <blockquote>
+          <para>
+            orange block quote
+          </para>
+        </blockquote>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  <para>
+    Multiple definitions, tight:
+  </para>
+  <variablelist spacing="compact">
+    <varlistentry>
+      <term>
+        apple
+      </term>
+      <listitem>
+        <para>
+          red fruit
+        </para>
+        <para>
+          computer
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        orange
+      </term>
+      <listitem>
+        <para>
+          orange fruit
+        </para>
+        <para>
+          bank
+        </para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  <para>
+    Multiple definitions, loose:
+  </para>
+  <variablelist>
+    <varlistentry>
+      <term>
+        apple
+      </term>
+      <listitem>
+        <para>
+          red fruit
+        </para>
+        <para>
+          computer
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        orange
+      </term>
+      <listitem>
+        <para>
+          orange fruit
+        </para>
+        <para>
+          bank
+        </para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  <para>
+    Blank line after term, indented marker, alternate markers:
+  </para>
+  <variablelist>
+    <varlistentry>
+      <term>
+        apple
+      </term>
+      <listitem>
+        <para>
+          red fruit
+        </para>
+        <para>
+          computer
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        orange
+      </term>
+      <listitem>
+        <para>
+          orange fruit
+        </para>
+        <orderedlist numeration="arabic" spacing="compact">
+          <listitem>
+            <para>
+              sublist
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              sublist
+            </para>
+          </listitem>
+        </orderedlist>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+</section>
+<section id="html-blocks">
+  <title>HTML Blocks</title>
+  <para>
+    Simple block on one line:
+  </para>
+  <para>
+    foo
+  </para>
+  <para>
+    And nested without indentation:
+  </para>
+  <para>
+    foo
+  </para>
+  <para>
+    bar
+  </para>
+  <para>
+    Interpreted markdown in a table:
+  </para>
+  This is <emphasis>emphasized</emphasis>
+  And this is <emphasis role="strong">strong</emphasis>
+  <para>
+    Here’s a simple block:
+  </para>
+  <para>
+    foo
+  </para>
+  <para>
+    This should be a code block, though:
+  </para>
+  <programlisting>
+&lt;div&gt;
+    foo
+&lt;/div&gt;
+</programlisting>
+  <para>
+    As should this:
+  </para>
+  <programlisting>
+&lt;div&gt;foo&lt;/div&gt;
+</programlisting>
+  <para>
+    Now, nested:
+  </para>
+  <para>
+    foo
+  </para>
+  <para>
+    This should just be an HTML comment:
+  </para>
+  <para>
+    Multiline:
+  </para>
+  <para>
+    Code block:
+  </para>
+  <programlisting>
+&lt;!-- Comment --&gt;
+</programlisting>
+  <para>
+    Just plain comment, with trailing spaces on the line:
+  </para>
+  <para>
+    Code:
+  </para>
+  <programlisting>
+&lt;hr /&gt;
+</programlisting>
+  <para>
+    Hr’s:
+  </para>
+</section>
+<section id="inline-markup">
+  <title>Inline Markup</title>
+  <para>
+    This is <emphasis>emphasized</emphasis>, and so <emphasis>is
+    this</emphasis>.
+  </para>
+  <para>
+    This is <emphasis role="strong">strong</emphasis>, and so
+    <emphasis role="strong">is this</emphasis>.
+  </para>
+  <para>
+    An <emphasis><ulink url="/url">emphasized link</ulink></emphasis>.
+  </para>
+  <para>
+    <emphasis role="strong"><emphasis>This is strong and
+    em.</emphasis></emphasis>
+  </para>
+  <para>
+    So is <emphasis role="strong"><emphasis>this</emphasis></emphasis> word.
+  </para>
+  <para>
+    <emphasis role="strong"><emphasis>This is strong and
+    em.</emphasis></emphasis>
+  </para>
+  <para>
+    So is <emphasis role="strong"><emphasis>this</emphasis></emphasis> word.
+  </para>
+  <para>
+    This is code: <literal>&gt;</literal>, <literal>$</literal>,
+    <literal>\</literal>, <literal>\$</literal>,
+    <literal>&lt;html&gt;</literal>.
+  </para>
+  <para>
+    <emphasis role="strikethrough">This is
+    <emphasis>strikeout</emphasis>.</emphasis>
+  </para>
+  <para>
+    Superscripts: a<superscript>bc</superscript>d
+    a<superscript><emphasis>hello</emphasis></superscript>
+    a<superscript>hello there</superscript>.
+  </para>
+  <para>
+    Subscripts: H<subscript>2</subscript>O, H<subscript>23</subscript>O,
+    H<subscript>many of them</subscript>O.
+  </para>
+  <para>
+    These should not be superscripts or subscripts, because of the unescaped
+    spaces: a^b c^d, a~b c~d.
+  </para>
+</section>
+<section id="smart-quotes-ellipses-dashes">
+  <title>Smart quotes, ellipses, dashes</title>
+  <para>
+    <quote>Hello,</quote> said the spider. <quote><quote>Shelob</quote> is my
+    name.</quote>
+  </para>
+  <para>
+    <quote>A</quote>, <quote>B</quote>, and <quote>C</quote> are letters.
+  </para>
+  <para>
+    <quote>Oak,</quote> <quote>elm,</quote> and <quote>beech</quote> are names
+    of trees. So is <quote>pine.</quote>
+  </para>
+  <para>
+    <quote>He said, <quote>I want to go.</quote></quote> Were you alive in the
+    70’s?
+  </para>
+  <para>
+    Here is some quoted <quote><literal>code</literal></quote> and a
+    <quote><ulink url="http://example.com/?foo=1&amp;bar=2">quoted
+    link</ulink></quote>.
+  </para>
+  <para>
+    Some dashes: one—two — three—four — five.
+  </para>
+  <para>
+    Dashes between numbers: 5–7, 255–66, 1987–1999.
+  </para>
+  <para>
+    Ellipses…and…and….
+  </para>
+</section>
+<section id="latex">
+  <title>LaTeX</title>
+  <itemizedlist spacing="compact">
+    <listitem>
+      <para>
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        2 + 2 = 4
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <emphasis>x</emphasis> ∈ <emphasis>y</emphasis>
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <emphasis>α</emphasis> ∧ <emphasis>ω</emphasis>
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        223
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <emphasis>p</emphasis>-Tree
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Here’s some display math:
+        $$\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}$$
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Here’s one that has a line break in it:
+        <emphasis>α</emphasis> + <emphasis>ω</emphasis> × <emphasis>x</emphasis><superscript>2</superscript>.
+      </para>
+    </listitem>
+  </itemizedlist>
+  <para>
+    These shouldn’t be math:
+  </para>
+  <itemizedlist spacing="compact">
+    <listitem>
+      <para>
+        To get the famous equation, write <literal>$e = mc^2$</literal>.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        $22,000 is a <emphasis>lot</emphasis> of money. So is $34,000. (It
+        worked if <quote>lot</quote> is emphasized.)
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Shoes ($20) and socks ($5).
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Escaped <literal>$</literal>: $73 <emphasis>this should be
+        emphasized</emphasis> 23$.
+      </para>
+    </listitem>
+  </itemizedlist>
+  <para>
+    Here’s a LaTeX table:
+  </para>
+</section>
+<section id="special-characters">
+  <title>Special Characters</title>
+  <para>
+    Here is some unicode:
+  </para>
+  <itemizedlist spacing="compact">
+    <listitem>
+      <para>
+        I hat: Î
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        o umlaut: ö
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        section: §
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        set membership: ∈
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        copyright: ©
+      </para>
+    </listitem>
+  </itemizedlist>
+  <para>
+    AT&amp;T has an ampersand in their name.
+  </para>
+  <para>
+    AT&amp;T is another way to write it.
+  </para>
+  <para>
+    This &amp; that.
+  </para>
+  <para>
+    4 &lt; 5.
+  </para>
+  <para>
+    6 &gt; 5.
+  </para>
+  <para>
+    Backslash: \
+  </para>
+  <para>
+    Backtick: `
+  </para>
+  <para>
+    Asterisk: *
+  </para>
+  <para>
+    Underscore: _
+  </para>
+  <para>
+    Left brace: {
+  </para>
+  <para>
+    Right brace: }
+  </para>
+  <para>
+    Left bracket: [
+  </para>
+  <para>
+    Right bracket: ]
+  </para>
+  <para>
+    Left paren: (
+  </para>
+  <para>
+    Right paren: )
+  </para>
+  <para>
+    Greater-than: &gt;
+  </para>
+  <para>
+    Hash: #
+  </para>
+  <para>
+    Period: .
+  </para>
+  <para>
+    Bang: !
+  </para>
+  <para>
+    Plus: +
+  </para>
+  <para>
+    Minus: -
+  </para>
+</section>
+<section id="links">
+  <title>Links</title>
+  <section id="explicit">
+    <title>Explicit</title>
+    <para>
+      Just a <ulink url="/url/">URL</ulink>.
+    </para>
+    <para>
+      <ulink url="/url/">URL and title</ulink>.
+    </para>
+    <para>
+      <ulink url="/url/">URL and title</ulink>.
+    </para>
+    <para>
+      <ulink url="/url/">URL and title</ulink>.
+    </para>
+    <para>
+      <ulink url="/url/">URL and title</ulink>
+    </para>
+    <para>
+      <ulink url="/url/">URL and title</ulink>
+    </para>
+    <para>
+      <ulink url="/url/with_underscore">with_underscore</ulink>
+    </para>
+    <para>
+      Email link (<email>nobody@nowhere.net</email>)
+    </para>
+    <para>
+      <ulink url="">Empty</ulink>.
+    </para>
+  </section>
+  <section id="reference">
+    <title>Reference</title>
+    <para>
+      Foo <ulink url="/url/">bar</ulink>.
+    </para>
+    <para>
+      Foo <ulink url="/url/">bar</ulink>.
+    </para>
+    <para>
+      Foo <ulink url="/url/">bar</ulink>.
+    </para>
+    <para>
+      With <ulink url="/url/">embedded [brackets]</ulink>.
+    </para>
+    <para>
+      <ulink url="/url/">b</ulink> by itself should be a link.
+    </para>
+    <para>
+      Indented <ulink url="/url">once</ulink>.
+    </para>
+    <para>
+      Indented <ulink url="/url">twice</ulink>.
+    </para>
+    <para>
+      Indented <ulink url="/url">thrice</ulink>.
+    </para>
+    <para>
+      This should [not][] be a link.
+    </para>
+    <programlisting>
+[not]: /url
+</programlisting>
+    <para>
+      Foo <ulink url="/url/">bar</ulink>.
+    </para>
+    <para>
+      Foo <ulink url="/url/">biz</ulink>.
+    </para>
+  </section>
+  <section id="with-ampersands">
+    <title>With ampersands</title>
+    <para>
+      Here’s a <ulink url="http://example.com/?foo=1&amp;bar=2">link with an
+      ampersand in the URL</ulink>.
+    </para>
+    <para>
+      Here’s a link with an amersand in the link text:
+      <ulink url="http://att.com/">AT&amp;T</ulink>.
+    </para>
+    <para>
+      Here’s an <ulink url="/script?foo=1&amp;bar=2">inline link</ulink>.
+    </para>
+    <para>
+      Here’s an <ulink url="/script?foo=1&amp;bar=2">inline link in pointy
+      braces</ulink>.
+    </para>
+  </section>
+  <section id="autolinks">
+    <title>Autolinks</title>
+    <para>
+      With an ampersand:
+      <ulink url="http://example.com/?foo=1&amp;bar=2">http://example.com/?foo=1&amp;bar=2</ulink>
+    </para>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          In a list?
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <ulink url="http://example.com/">http://example.com/</ulink>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          It should.
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      An e-mail address: <email>nobody@nowhere.net</email>
+    </para>
+    <blockquote>
+      <para>
+        Blockquoted:
+        <ulink url="http://example.com/">http://example.com/</ulink>
+      </para>
+    </blockquote>
+    <para>
+      Auto-links should not occur here:
+      <literal>&lt;http://example.com/&gt;</literal>
+    </para>
+    <programlisting>
+or here: &lt;http://example.com/&gt;
+</programlisting>
+  </section>
+</section>
+<section id="images">
+  <title>Images</title>
+  <para>
+    From <quote>Voyage dans la Lune</quote> by Georges Melies (1902):
+  </para>
+  <figure>
+    <title>lalune</title>
+    <mediaobject>
+      <imageobject>
+        <imagedata fileref="lalune.jpg" />
+      </imageobject>
+      <textobject><phrase>lalune</phrase></textobject>
+    </mediaobject>
+  </figure>
+  <para>
+    Here is a movie <inlinemediaobject>
+      <imageobject>
+        <imagedata fileref="movie.jpg" />
+      </imageobject>
+    </inlinemediaobject> icon.
+  </para>
+</section>
+<section id="footnotes">
+  <title>Footnotes</title>
+  <para>
+    Here is a footnote reference,<footnote>
+      <para>
+        Here is the footnote. It can go anywhere after the footnote reference.
+        It need not be placed at the end of the document.
+      </para>
+    </footnote> and another.<footnote>
+      <para>
+        Here’s the long note. This one contains multiple blocks.
+      </para>
+      <para>
+        Subsequent blocks are indented to show that they belong to the
+        footnote (as with list items).
+      </para>
+      <programlisting>
+  { &lt;code&gt; }
+</programlisting>
+      <para>
+        If you want, you can indent every line, but you can also be lazy and
+        just indent the first line of each block.
+      </para>
+    </footnote> This should <emphasis>not</emphasis> be a footnote reference,
+    because it contains a space.[^my note] Here is an inline note.<footnote>
+      <para>
+        This is <emphasis>easier</emphasis> to type. Inline notes may contain
+        <ulink url="http://google.com">links</ulink> and <literal>]</literal>
+        verbatim characters, as well as [bracketed text].
+      </para>
+    </footnote>
+  </para>
+  <blockquote>
+    <para>
+      Notes can go in quotes.<footnote>
+        <para>
+          In quote.
+        </para>
+      </footnote>
+    </para>
+  </blockquote>
+  <orderedlist numeration="arabic" spacing="compact">
+    <listitem>
+      <para>
+        And in list items.<footnote>
+          <para>
+            In list.
+          </para>
+        </footnote>
+      </para>
+    </listitem>
+  </orderedlist>
+  <para>
+    This paragraph should not be part of the note, as it is not indented.
+  </para>
+</section>
+</article>

--- a/tests/writer.docbook5
+++ b/tests/writer.docbook5
@@ -22,7 +22,8 @@
 <section id="headers">
   <title>Headers</title>
   <section id="level-2-with-an-embedded-link">
-    <title>Level 2 with an <ulink url="/url">embedded link</ulink></title>
+    <title>Level 2 with an <link xlink:href="/url">embedded
+    link</link></title>
     <section id="level-3-with-emphasis">
       <title>Level 3 with <emphasis>emphasis</emphasis></title>
       <section id="level-4">
@@ -940,7 +941,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
     <emphasis role="strong">is this</emphasis>.
   </para>
   <para>
-    An <emphasis><ulink url="/url">emphasized link</ulink></emphasis>.
+    An <emphasis><link xlink:href="/url">emphasized link</link></emphasis>.
   </para>
   <para>
     <emphasis role="strong"><emphasis>This is strong and
@@ -998,8 +999,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
   </para>
   <para>
     Here is some quoted <quote><literal>code</literal></quote> and a
-    <quote><ulink url="http://example.com/?foo=1&amp;bar=2">quoted
-    link</ulink></quote>.
+    <quote><link xlink:href="http://example.com/?foo=1&amp;bar=2">quoted
+    link</link></quote>.
   </para>
   <para>
     Some dashes: one—two — three—four — five.
@@ -1188,58 +1189,58 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
   <section id="explicit">
     <title>Explicit</title>
     <para>
-      Just a <ulink url="/url/">URL</ulink>.
+      Just a <link xlink:href="/url/">URL</link>.
     </para>
     <para>
-      <ulink url="/url/">URL and title</ulink>.
+      <link xlink:href="/url/">URL and title</link>.
     </para>
     <para>
-      <ulink url="/url/">URL and title</ulink>.
+      <link xlink:href="/url/">URL and title</link>.
     </para>
     <para>
-      <ulink url="/url/">URL and title</ulink>.
+      <link xlink:href="/url/">URL and title</link>.
     </para>
     <para>
-      <ulink url="/url/">URL and title</ulink>
+      <link xlink:href="/url/">URL and title</link>
     </para>
     <para>
-      <ulink url="/url/">URL and title</ulink>
+      <link xlink:href="/url/">URL and title</link>
     </para>
     <para>
-      <ulink url="/url/with_underscore">with_underscore</ulink>
+      <link xlink:href="/url/with_underscore">with_underscore</link>
     </para>
     <para>
       Email link (<email>nobody@nowhere.net</email>)
     </para>
     <para>
-      <ulink url="">Empty</ulink>.
+      <link xlink:href="">Empty</link>.
     </para>
   </section>
   <section id="reference">
     <title>Reference</title>
     <para>
-      Foo <ulink url="/url/">bar</ulink>.
+      Foo <link xlink:href="/url/">bar</link>.
     </para>
     <para>
-      Foo <ulink url="/url/">bar</ulink>.
+      Foo <link xlink:href="/url/">bar</link>.
     </para>
     <para>
-      Foo <ulink url="/url/">bar</ulink>.
+      Foo <link xlink:href="/url/">bar</link>.
     </para>
     <para>
-      With <ulink url="/url/">embedded [brackets]</ulink>.
+      With <link xlink:href="/url/">embedded [brackets]</link>.
     </para>
     <para>
-      <ulink url="/url/">b</ulink> by itself should be a link.
+      <link xlink:href="/url/">b</link> by itself should be a link.
     </para>
     <para>
-      Indented <ulink url="/url">once</ulink>.
+      Indented <link xlink:href="/url">once</link>.
     </para>
     <para>
-      Indented <ulink url="/url">twice</ulink>.
+      Indented <link xlink:href="/url">twice</link>.
     </para>
     <para>
-      Indented <ulink url="/url">thrice</ulink>.
+      Indented <link xlink:href="/url">thrice</link>.
     </para>
     <para>
       This should [not][] be a link.
@@ -1248,35 +1249,35 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
 [not]: /url
 </programlisting>
     <para>
-      Foo <ulink url="/url/">bar</ulink>.
+      Foo <link xlink:href="/url/">bar</link>.
     </para>
     <para>
-      Foo <ulink url="/url/">biz</ulink>.
+      Foo <link xlink:href="/url/">biz</link>.
     </para>
   </section>
   <section id="with-ampersands">
     <title>With ampersands</title>
     <para>
-      Here’s a <ulink url="http://example.com/?foo=1&amp;bar=2">link with an
-      ampersand in the URL</ulink>.
+      Here’s a <link xlink:href="http://example.com/?foo=1&amp;bar=2">link
+      with an ampersand in the URL</link>.
     </para>
     <para>
       Here’s a link with an amersand in the link text:
-      <ulink url="http://att.com/">AT&amp;T</ulink>.
+      <link xlink:href="http://att.com/">AT&amp;T</link>.
     </para>
     <para>
-      Here’s an <ulink url="/script?foo=1&amp;bar=2">inline link</ulink>.
+      Here’s an <link xlink:href="/script?foo=1&amp;bar=2">inline link</link>.
     </para>
     <para>
-      Here’s an <ulink url="/script?foo=1&amp;bar=2">inline link in pointy
-      braces</ulink>.
+      Here’s an <link xlink:href="/script?foo=1&amp;bar=2">inline link in
+      pointy braces</link>.
     </para>
   </section>
   <section id="autolinks">
     <title>Autolinks</title>
     <para>
       With an ampersand:
-      <ulink url="http://example.com/?foo=1&amp;bar=2">http://example.com/?foo=1&amp;bar=2</ulink>
+      <link xlink:href="http://example.com/?foo=1&amp;bar=2">http://example.com/?foo=1&amp;bar=2</link>
     </para>
     <itemizedlist spacing="compact">
       <listitem>
@@ -1286,7 +1287,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
       </listitem>
       <listitem>
         <para>
-          <ulink url="http://example.com/">http://example.com/</ulink>
+          <link xlink:href="http://example.com/">http://example.com/</link>
         </para>
       </listitem>
       <listitem>
@@ -1301,7 +1302,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
     <blockquote>
       <para>
         Blockquoted:
-        <ulink url="http://example.com/">http://example.com/</ulink>
+        <link xlink:href="http://example.com/">http://example.com/</link>
       </para>
     </blockquote>
     <para>
@@ -1362,8 +1363,8 @@ or here: &lt;http://example.com/&gt;
     because it contains a space.[^my note] Here is an inline note.<footnote>
       <para>
         This is <emphasis>easier</emphasis> to type. Inline notes may contain
-        <ulink url="http://google.com">links</ulink> and <literal>]</literal>
-        verbatim characters, as well as [bracketed text].
+        <link xlink:href="http://google.com">links</link> and
+        <literal>]</literal> verbatim characters, as well as [bracketed text].
       </para>
     </footnote>
   </para>


### PR DESCRIPTION
- Extends docbook writer to add support for DocBook 5
- Avoids having to post-process DocBook 4.5 output with db4-upgrade.xsl
- Includes namespace in top-level element
- Use link with xlink:href attribute instead of ulink

Partially addresses feature request https://github.com/jgm/pandoc/issues/2164