### PR TITLE
Org reader: fix spacing after LaTeX-style symbols

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -328,6 +328,10 @@ tests =
           "\\copy" =?>
           para "©"
 
+      , "MathML symbols, space separated" =:
+          "\\ForAll \\Auml" =?>
+          para "∀ Ä"
+
       , "LaTeX citation" =:
           "\\cite{Coffee}" =?>
           let citation = Citation


### PR DESCRIPTION
The org-reader was droping space after unescaped LaTeX-style symbol
commands: `\ForAll \Auml` resulted in `∀Ä` but should give `∀ Ä`
instead.  This seems to be because the LaTeX-reader treats the
command-terminating space as part of the command.  Dropping the trailing
space from the symbol-command fixes this issue.