### PR TITLE
Org fixes (reader and writer)

### DIFF
--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -170,7 +170,7 @@ blockToOrg (Table caption' _ _ headers rows) =  do
        map ((+2) . numChars) $ transpose (headers' : rawRows)
   -- FIXME: Org doesn't allow blocks with height more than 1.
   let hpipeBlocks blocks = hcat [beg, middle, end]
-        where h      = maximum (map height blocks)
+        where h      = maximum (1 : map height blocks)
               sep'   = lblock 3 $ vcat (map text $ replicate h " | ")
               beg    = lblock 2 $ vcat (map text $ replicate h "| ")
               end    = lblock 2 $ vcat (map text $ replicate h " |")

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -308,6 +308,10 @@ tests =
           "\\textit{Emphasised}" =?>
           para (emph "Emphasised")
 
+      , "Inline LaTeX command with spaces" =:
+          "\\emph{Emphasis mine}" =?>
+          para (emph "Emphasis mine")
+
       , "Inline LaTeX math symbol" =:
           "\\tau" =?>
           para (emph "τ")


### PR DESCRIPTION
- Fix reader regression introduced in the previous fix.
- Include empty table rows in org-mode output.