### PR TITLE
Retake on strut with \minipage inside tables

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -675,7 +675,8 @@ tableCellToLaTeX header (width, align, blocks) = do
                AlignDefault -> "\\raggedright"
   return $ ("\\begin{minipage}" <> valign <>
             braces (text (printf "%.2f\\columnwidth" width)) <>
-            (halign <> cr <> cellContents <> cr) <> "\\end{minipage}") $$
+            (halign <> "\\strut" <> cr <> cellContents <> "\\strut" <> cr) <>
+            "\\end{minipage}") $$
             notesToLaTeX notes
 
 notesToLaTeX :: [Doc] -> Doc
@@ -1306,4 +1307,3 @@ pDocumentClass =
        else do P.skipMany (P.satisfy (/='{'))
                P.char '{'
                P.manyTill P.letter (P.char '}')
-                                   

--- a/tests/tables.latex
+++ b/tests/tables.latex
@@ -52,46 +52,46 @@ Multiline table with caption:
 \begin{longtable}[]{@{}clrl@{}}
 \caption{Here's the caption. It may span multiple lines.}\tabularnewline
 \toprule
-\begin{minipage}[b]{0.13\columnwidth}\centering
-Centered Header
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\raggedright
-Left Aligned
-\end{minipage} & \begin{minipage}[b]{0.14\columnwidth}\raggedleft
-Right Aligned
-\end{minipage} & \begin{minipage}[b]{0.30\columnwidth}\raggedright
-Default aligned
+\begin{minipage}[b]{0.13\columnwidth}\centering\strut
+Centered Header\strut
+\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\raggedright\strut
+Left Aligned\strut
+\end{minipage} & \begin{minipage}[b]{0.14\columnwidth}\raggedleft\strut
+Right Aligned\strut
+\end{minipage} & \begin{minipage}[b]{0.30\columnwidth}\raggedright\strut
+Default aligned\strut
 \end{minipage}\tabularnewline
 \midrule
 \endfirsthead
 \toprule
-\begin{minipage}[b]{0.13\columnwidth}\centering
-Centered Header
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\raggedright
-Left Aligned
-\end{minipage} & \begin{minipage}[b]{0.14\columnwidth}\raggedleft
-Right Aligned
-\end{minipage} & \begin{minipage}[b]{0.30\columnwidth}\raggedright
-Default aligned
+\begin{minipage}[b]{0.13\columnwidth}\centering\strut
+Centered Header\strut
+\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\raggedright\strut
+Left Aligned\strut
+\end{minipage} & \begin{minipage}[b]{0.14\columnwidth}\raggedleft\strut
+Right Aligned\strut
+\end{minipage} & \begin{minipage}[b]{0.30\columnwidth}\raggedright\strut
+Default aligned\strut
 \end{minipage}\tabularnewline
 \midrule
 \endhead
-\begin{minipage}[t]{0.13\columnwidth}\centering
-First
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright
-row
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft
-12.0
-\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright
-Example of a row that spans multiple lines.
+\begin{minipage}[t]{0.13\columnwidth}\centering\strut
+First\strut
+\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright\strut
+row\strut
+\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft\strut
+12.0\strut
+\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright\strut
+Example of a row that spans multiple lines.\strut
 \end{minipage}\tabularnewline
-\begin{minipage}[t]{0.13\columnwidth}\centering
-Second
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright
-row
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft
-5.0
-\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright
-Here's another one. Note the blank line between rows.
+\begin{minipage}[t]{0.13\columnwidth}\centering\strut
+Second\strut
+\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright\strut
+row\strut
+\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft\strut
+5.0\strut
+\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright\strut
+Here's another one. Note the blank line between rows.\strut
 \end{minipage}\tabularnewline
 \bottomrule
 \end{longtable}
@@ -100,34 +100,34 @@ Multiline table without caption:
 
 \begin{longtable}[]{@{}clrl@{}}
 \toprule
-\begin{minipage}[b]{0.13\columnwidth}\centering
-Centered Header
-\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\raggedright
-Left Aligned
-\end{minipage} & \begin{minipage}[b]{0.14\columnwidth}\raggedleft
-Right Aligned
-\end{minipage} & \begin{minipage}[b]{0.30\columnwidth}\raggedright
-Default aligned
+\begin{minipage}[b]{0.13\columnwidth}\centering\strut
+Centered Header\strut
+\end{minipage} & \begin{minipage}[b]{0.12\columnwidth}\raggedright\strut
+Left Aligned\strut
+\end{minipage} & \begin{minipage}[b]{0.14\columnwidth}\raggedleft\strut
+Right Aligned\strut
+\end{minipage} & \begin{minipage}[b]{0.30\columnwidth}\raggedright\strut
+Default aligned\strut
 \end{minipage}\tabularnewline
 \midrule
 \endhead
-\begin{minipage}[t]{0.13\columnwidth}\centering
-First
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright
-row
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft
-12.0
-\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright
-Example of a row that spans multiple lines.
+\begin{minipage}[t]{0.13\columnwidth}\centering\strut
+First\strut
+\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright\strut
+row\strut
+\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft\strut
+12.0\strut
+\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright\strut
+Example of a row that spans multiple lines.\strut
 \end{minipage}\tabularnewline
-\begin{minipage}[t]{0.13\columnwidth}\centering
-Second
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright
-row
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft
-5.0
-\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright
-Here's another one. Note the blank line between rows.
+\begin{minipage}[t]{0.13\columnwidth}\centering\strut
+Second\strut
+\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright\strut
+row\strut
+\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft\strut
+5.0\strut
+\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright\strut
+Here's another one. Note the blank line between rows.\strut
 \end{minipage}\tabularnewline
 \bottomrule
 \end{longtable}
@@ -146,23 +146,23 @@ Multiline table without column headers:
 
 \begin{longtable}[]{@{}clrl@{}}
 \toprule
-\begin{minipage}[t]{0.13\columnwidth}\centering
-First
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright
-row
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft
-12.0
-\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright
-Example of a row that spans multiple lines.
+\begin{minipage}[t]{0.13\columnwidth}\centering\strut
+First\strut
+\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright\strut
+row\strut
+\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft\strut
+12.0\strut
+\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright\strut
+Example of a row that spans multiple lines.\strut
 \end{minipage}\tabularnewline
-\begin{minipage}[t]{0.13\columnwidth}\centering
-Second
-\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright
-row
-\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft
-5.0
-\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright
-Here's another one. Note the blank line between rows.
+\begin{minipage}[t]{0.13\columnwidth}\centering\strut
+Second\strut
+\end{minipage} & \begin{minipage}[t]{0.12\columnwidth}\raggedright\strut
+row\strut
+\end{minipage} & \begin{minipage}[t]{0.14\columnwidth}\raggedleft\strut
+5.0\strut
+\end{minipage} & \begin{minipage}[t]{0.30\columnwidth}\raggedright\strut
+Here's another one. Note the blank line between rows.\strut
 \end{minipage}\tabularnewline
 \bottomrule
 \end{longtable}


### PR DESCRIPTION
Reimplement on 4c684561ee0665b014e887ae559b7020e4e9f2d3

The problem with 4c68456 was a space between the cell contents and the `\strut` that affected the alignment.
