### PR TITLE
Better way to find the artifacts on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,8 @@ cache:
   - "c:\\sr" # stack root, short paths == fewer problems
   - '%LOCALAPPDATA%\Programs\stack' # even less to install...
 
-# build: off # this disables automatic builds
+# We don't do a normal C build, but build in test_script via stack
+build: off 
 
 install:
   - curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
@@ -27,11 +28,12 @@ before_test:
 test_script:
   # The ugly echo "" hack is to avoid complaints about 0 being an invalid file
   # descriptor
-  - echo "" | stack --no-terminal test
+  - echo "" | stack --no-terminal  test
+  - echo "" | stack --local-bin-path . install pandoc
 
 after_test:
-  - ps: |
-      7z a pandoc.zip $(.\stack.exe path --local-install-root)\bin\pandoc*.exe
+    # .\ in the stack commandline seems to be .\windows\ (where the stack-appveyor.yaml is)
+  - 7z a "pandoc.zip" windows\pandoc.exe"
 
 artifacts:
   - path: pandoc.zip


### PR DESCRIPTION
Also enable the build again (build: off just prevents a default msbuild based one)

See https://github.com/jgm/pandoc/pull/2910#issuecomment-218842826 for the problem with the artifacts.