### PR TITLE
Org properties drawer

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -412,17 +412,17 @@ tests =
                   ] =?>
           para "Before" <> para "After"
 
-      , "Drawer start is the only text in first line of a drawer" =:
+      , "Drawer markers must be the only text in the line" =:
           unlines [ "  :LOGBOOK: foo"
-                  , "  :END:"
+                  , "  :END: bar"
                   ] =?>
-          para (":LOGBOOK:" <> space <> "foo" <> softbreak <> ":END:")
+          para (":LOGBOOK: foo" <> softbreak <> ":END: bar")
 
-      , "Drawers with unknown names are just text" =:
+      , "Drawers can be arbitrary" =:
           unlines [ ":FOO:"
                   , ":END:"
                   ] =?>
-          para (":FOO:" <> softbreak <> ":END:")
+          (mempty::Blocks)
 
       , "Anchor reference" =:
           unlines [ "<<link-here>> Target."
@@ -596,6 +596,15 @@ tests =
           mconcat [ headerWith ("exported", [], []) 1 "Exported"
                   , headerWith ("but-this-is", [], []) 2 "But this is"
                   ]
+
+      , "Preferences are treated as header attributes" =:
+          unlines [ "* foo"
+                  , "  :PROPERTIES:"
+                  , "  :id: fubar"
+                  , "  :bar: baz"
+                  , "  :END:"
+                  ] =?>
+          headerWith ("fubar", [], [("bar", "baz")]) 1 "foo"
 
       , "Paragraph starting with an asterisk" =:
           "*five" =?>

--- a/tests/writer.org
+++ b/tests/writer.org
@@ -9,30 +9,60 @@ markdown test suite.
 --------------
 
 * Headers
+  :PROPERTIES:
+  :id: headers
+  :END:
 
 ** Level 2 with an [[/url][embedded link]]
+   :PROPERTIES:
+   :id: level-2-with-an-embedded-link
+   :END:
 
 *** Level 3 with /emphasis/
+    :PROPERTIES:
+    :id: level-3-with-emphasis
+    :END:
 
 **** Level 4
+     :PROPERTIES:
+     :id: level-4
+     :END:
 
 ***** Level 5
+      :PROPERTIES:
+      :id: level-5
+      :END:
 
 * Level 1
+  :PROPERTIES:
+  :id: level-1
+  :END:
 
 ** Level 2 with /emphasis/
+   :PROPERTIES:
+   :id: level-2-with-emphasis
+   :END:
 
 *** Level 3
+    :PROPERTIES:
+    :id: level-3
+    :END:
 
 with no blank line
 
 ** Level 2
+   :PROPERTIES:
+   :id: level-2
+   :END:
 
 with no blank line
 
 --------------
 
 * Paragraphs
+  :PROPERTIES:
+  :id: paragraphs
+  :END:
 
 Here's a regular paragraph.
 
@@ -48,6 +78,9 @@ here.
 --------------
 
 * Block Quotes
+  :PROPERTIES:
+  :id: block-quotes
+  :END:
 
 E-mail style:
 
@@ -87,6 +120,9 @@ And a following paragraph.
 --------------
 
 * Code Blocks
+  :PROPERTIES:
+  :id: code-blocks
+  :END:
 
 Code:
 
@@ -111,8 +147,14 @@ And:
 --------------
 
 * Lists
+  :PROPERTIES:
+  :id: lists
+  :END:
 
 ** Unordered
+   :PROPERTIES:
+   :id: unordered
+   :END:
 
 Asterisks tight:
 
@@ -157,6 +199,9 @@ Minuses loose:
 -  Minus 3
 
 ** Ordered
+   :PROPERTIES:
+   :id: ordered
+   :END:
 
 Tight:
 
@@ -197,6 +242,9 @@ Multiple paragraphs:
 3. Item 3.
 
 ** Nested
+   :PROPERTIES:
+   :id: nested
+   :END:
 
 -  Tab
 
@@ -228,6 +276,9 @@ Same thing but with paragraphs:
 3. Third
 
 ** Tabs and spaces
+   :PROPERTIES:
+   :id: tabs-and-spaces
+   :END:
 
 -  this is a list item indented with tabs
 
@@ -238,6 +289,9 @@ Same thing but with paragraphs:
    -  this is an example list item indented with spaces
 
 ** Fancy list markers
+   :PROPERTIES:
+   :id: fancy-list-markers
+   :END:
 
 2) begins with 2
 3) and now 3
@@ -276,6 +330,9 @@ B. Williams
 --------------
 
 * Definition Lists
+  :PROPERTIES:
+  :id: definition-lists
+  :END:
 
 Tight using spaces:
 
@@ -342,6 +399,9 @@ Blank line after term, indented marker, alternate markers:
    2. sublist
 
 * HTML Blocks
+  :PROPERTIES:
+  :id: html-blocks
+  :END:
 
 Simple block on one line:
 
@@ -569,6 +629,9 @@ Hr's:
 --------------
 
 * Inline Markup
+  :PROPERTIES:
+  :id: inline-markup
+  :END:
 
 This is /emphasized/, and so /is this/.
 
@@ -598,6 +661,9 @@ spaces: a\^b c\^d, a~b c~d.
 --------------
 
 * Smart quotes, ellipses, dashes
+  :PROPERTIES:
+  :id: smart-quotes-ellipses-dashes
+  :END:
 
 "Hello," said the spider. "'Shelob' is my name."
 
@@ -619,6 +685,9 @@ Ellipses...and...and....
 --------------
 
 * LaTeX
+  :PROPERTIES:
+  :id: latex
+  :END:
 
 -  \cite[22-23]{smith.1899}
 -  $2+2=4$
@@ -649,6 +718,9 @@ Cat    & 1      \\ \hline
 --------------
 
 * Special Characters
+  :PROPERTIES:
+  :id: special-characters
+  :END:
 
 Here is some unicode:
 
@@ -703,8 +775,14 @@ Minus: -
 --------------
 
 * Links
+  :PROPERTIES:
+  :id: links
+  :END:
 
 ** Explicit
+   :PROPERTIES:
+   :id: explicit
+   :END:
 
 Just a [[/url/][URL]].
 
@@ -725,6 +803,9 @@ Just a [[/url/][URL]].
 [[][Empty]].
 
 ** Reference
+   :PROPERTIES:
+   :id: reference
+   :END:
 
 Foo [[/url/][bar]].
 
@@ -753,6 +834,9 @@ Foo [[/url/][bar]].
 Foo [[/url/][biz]].
 
 ** With ampersands
+   :PROPERTIES:
+   :id: with-ampersands
+   :END:
 
 Here's a [[http://example.com/?foo=1&bar=2][link with an ampersand in the
 URL]].
@@ -764,6 +848,9 @@ Here's an [[/script?foo=1&bar=2][inline link]].
 Here's an [[/script?foo=1&bar=2][inline link in pointy braces]].
 
 ** Autolinks
+   :PROPERTIES:
+   :id: autolinks
+   :END:
 
 With an ampersand: [[http://example.com/?foo=1&bar=2]]
 
@@ -786,6 +873,9 @@ Auto-links should not occur here: =<http://example.com/>=
 --------------
 
 * Images
+  :PROPERTIES:
+  :id: images
+  :END:
 
 From "Voyage dans la Lune" by Georges Melies (1902):
 
@@ -797,6 +887,9 @@ Here is a movie [[movie.jpg]] icon.
 --------------
 
 * Footnotes
+  :PROPERTIES:
+  :id: footnotes
+  :END:
 
 Here is a footnote reference, [1] and another. [2] This should /not/ be a
 footnote reference, because it contains a space.[\^my note] Here is an inline


### PR DESCRIPTION
Add support for `:PROPERTIES:` drawers to both Org reader and writer.