### PR TITLE
EPUB Reader: normalise Link id as well

### DIFF
--- a/src/Text/Pandoc/Readers/EPUB.hs
+++ b/src/Text/Pandoc/Readers/EPUB.hs
@@ -194,8 +194,10 @@ fixInlineIRs s (Span as v) =
   Span (fixAttrs s as) v
 fixInlineIRs s (Code as code) =
   Code (fixAttrs s as) code
-fixInlineIRs s (Link attr t ('#':url, tit)) =
-  Link attr t (addHash s url, tit)
+fixInlineIRs s (Link as is ('#':url, tit)) =
+  Link (fixAttrs s as) is (addHash s url, tit)
+fixInlineIRs s (Link as is t) =
+  Link (fixAttrs s as) is t
 fixInlineIRs _ v = v
 
 prependHash :: [String] -> Inline -> Inline


### PR DESCRIPTION
Consider this [example epub](https://www.dropbox.com/s/u11iwp021sqtslb/linktest.epub).

With this pull, at least `pandoc linktest.epub -o out.html` preserves all the links.

However, because the epub reader [prepends each file in the epub simply with a span with the appropriate id](https://github.com/jgm/pandoc/blob/master/src/Text/Pandoc/Readers/EPUB.hs#L75) and that (empty) span is not rendered in the LaTeX writer, the following still has broken links: `pandoc linktest.epub -o out.pdf`