### PR TITLE
Don't equate "Latin letters" with ASCII letters

### DIFF
--- a/README
+++ b/README
@@ -3343,8 +3343,8 @@ pointy braces `<...>`.
 #### Extension: `ascii_identifiers` ####
 
 Causes the identifiers produced by `auto_identifiers` to be pure ASCII.
-Accents are stripped off of accented latin letters, and non-latin
-letters are omitted.
+Accents are stripped off of accented Latin letters corresponding to 
+ASCII letters, and non-ASCII letters and digits are omitted.
 
 #### Extension: `mmd_link_attributes` ####
 


### PR DESCRIPTION
Hitherto the documentation for the `ascii_identifiers` extension
has referred to ASCII letters as "latin letters". While this is
correct in a restricted historical sense it is not correct in
Unicode terms. For The Unicode Standard version 8.0.0
[NamesList.txt][] contains 1473 lines which match the (perl)
regular expression `\bLATIN\b.*\bLETTER\b`, which number thus at
least roughly corresponds to the number of characters which count
as Latin letters in Unicode terms. Consequently the term "latin
letters" should be replaced with "ASCII letters". For clarity it
should also be mentioned that non-ASCII digits are stripped.

[NamesList.txt]: ftp://ftp.unicode.org/Public/UNIDATA/UnicodeData.txt