### PR TITLE
Org reader: raw inlines in arbitrary formats

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -118,6 +118,7 @@ inline =
          , subscript
          , superscript
          , inlineLaTeX
+         , exportSnippet
          , smart
          , symbol
          ] <* (guard =<< newlinesCountWithinLimits)
@@ -129,7 +130,7 @@ inlines = trimInlinesF . mconcat <$> many1 inline
 
 -- treat these as potentially non-text when parsing inline:
 specialChars :: [Char]
-specialChars = "\"$'()*+-,./:;<=>[\\]^_{|}~"
+specialChars = "\"$'()*+-,./:;<=>@[\\]^_{|}~"
 
 
 whitespace :: OrgParser (F Inlines)
@@ -840,6 +841,13 @@ inlineLaTeXCommand = try $ do
 -- Taken from Data.OldList.
 dropWhileEnd :: (a -> Bool) -> [a] -> [a]
 dropWhileEnd p = foldr (\x xs -> if p x && null xs then [] else x : xs) []
+
+exportSnippet :: OrgParser (F Inlines)
+exportSnippet = try $ do
+  string "@@"
+  format <- many1Till (alphaNum <|> char '-') (char ':')
+  snippet <- manyTill anyChar (try $ string "@@")
+  returnF $ B.rawInline format snippet
 
 smart :: OrgParser (F Inlines)
 smart = do

--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -305,9 +305,10 @@ inlineToOrg (Math t str) = do
   return $ if t == InlineMath
               then "$" <> text str <> "$"
               else "$$" <> text str <> "$$"
-inlineToOrg (RawInline f str) | isRawFormat f =
-  return $ text str
-inlineToOrg (RawInline _ _) = return empty
+inlineToOrg (RawInline f@(Format f') str) =
+  return $ if isRawFormat f
+           then text str
+           else "@@" <> text f' <> ":" <> text str <> "@@"
 inlineToOrg (LineBreak) = return (text "\\\\" <> cr)
 inlineToOrg Space = return space
 inlineToOrg SoftBreak = do

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -405,6 +405,10 @@ tests =
           "\\notacommand{foo}" =?>
           para (rawInline "latex" "\\notacommand{foo}")
 
+      , "Export snippet" =:
+          "@@html:<kbd>M-x org-agenda</kbd>@@" =?>
+          para (rawInline "html" "<kbd>M-x org-agenda</kbd>")
+
       , "MathML symbol in LaTeX-style" =:
           "There is a hackerspace in Lübeck, Germany, called nbsp (unicode symbol: '\\nbsp')." =?>
           para ("There is a hackerspace in Lübeck, Germany, called nbsp (unicode symbol: ' ').")


### PR DESCRIPTION
Org mode allows arbitrary raw inlines ("export snippets" in Emacs
parlance) to be included as `@@format:raw foreign format text@@`.

Support for this features is added to the Org reader and writer.