### PR TITLE
Allow tagsoup 0.14

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -266,7 +266,7 @@ Library
                  extensible-exceptions >= 0.1 && < 0.2,
                  pandoc-types >= 1.16 && < 1.17,
                  aeson >= 0.7 && < 0.12,
-                 tagsoup >= 0.13.7 && < 0.14,
+                 tagsoup >= 0.13.7 && < 0.15,
                  base64-bytestring >= 0.1 && < 1.1,
                  zlib >= 0.5 && < 0.7,
                  highlighting-kate >= 0.6.2 && < 0.7,


### PR DESCRIPTION
Building with the new release went fine here, and it works correctly.