### PR TITLE
Org reader: support figure labels

### DIFF
--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -767,37 +767,47 @@ tests =
                   , "#+END_COMMENT"] =?>
           (mempty::Blocks)
 
-      , "Figure" =:
-          unlines [ "#+caption: A very courageous man."
-                  , "#+name: goodguy"
-                  , "[[edward.jpg]]"
-                  ] =?>
-          para (image "edward.jpg" "fig:goodguy" "A very courageous man.")
+      , testGroup "Figures" $
+        [ "Figure" =:
+            unlines [ "#+caption: A very courageous man."
+                    , "#+name: goodguy"
+                    , "[[edward.jpg]]"
+                    ] =?>
+            para (image "edward.jpg" "fig:goodguy" "A very courageous man.")
 
-      , "Figure with no name" =:
-          unlines [ "#+caption: I've been through the desert on this"
-                  , "[[horse.png]]"
-                  ] =?>
-          para (image "horse.png" "fig:" "I've been through the desert on this")
+        , "Figure with no name" =:
+            unlines [ "#+caption: I've been through the desert on this"
+                    , "[[horse.png]]"
+                    ] =?>
+            para (image "horse.png" "fig:" "I've been through the desert on this")
 
-      , "Figure with `fig:` prefix in name" =:
-          unlines [ "#+caption: Used as a metapher in evolutionary biology."
-                  , "#+name: fig:redqueen"
-                  , "[[the-red-queen.jpg]]"
-                  ] =?>
-          para (image "the-red-queen.jpg" "fig:redqueen"
-                      "Used as a metapher in evolutionary biology.")
+        , "Figure with `fig:` prefix in name" =:
+            unlines [ "#+caption: Used as a metapher in evolutionary biology."
+                    , "#+name: fig:redqueen"
+                    , "[[the-red-queen.jpg]]"
+                    ] =?>
+            para (image "the-red-queen.jpg" "fig:redqueen"
+                        "Used as a metapher in evolutionary biology.")
 
-      , "Figure with HTML attributes" =:
-          unlines [ "#+CAPTION: mah brain just explodid"
-                  , "#+NAME: lambdacat"
-                  , "#+ATTR_HTML: :style color: blue :role button"
-                  , "[[lambdacat.jpg]]"
-                  ] =?>
-          let kv = [("style", "color: blue"), ("role", "button")]
-              name = "fig:lambdacat"
-              caption = "mah brain just explodid"
-          in para (imageWith (mempty, mempty, kv) "lambdacat.jpg" name caption)
+        , "Figure with HTML attributes" =:
+            unlines [ "#+CAPTION: mah brain just explodid"
+                    , "#+NAME: lambdacat"
+                    , "#+ATTR_HTML: :style color: blue :role button"
+                    , "[[lambdacat.jpg]]"
+                    ] =?>
+            let kv = [("style", "color: blue"), ("role", "button")]
+                name = "fig:lambdacat"
+                caption = "mah brain just explodid"
+            in para (imageWith (mempty, mempty, kv) "lambdacat.jpg" name caption)
+
+        , "Labelled figure" =:
+            unlines [ "#+CAPTION: My figure"
+                    , "#+LABEL: fig:myfig"
+                    , "[[blub.png]]"
+                    ] =?>
+            let attr = ("fig:myfig", mempty, mempty)
+            in para (imageWith attr "blub.png" "fig:" "My figure")
+        ]
 
       , "Footnote" =:
           unlines [ "A footnote[1]"


### PR DESCRIPTION
Figure labels given as `#+LABEL: thelabel` are used as the ID of the
respective image.  This allows e.g. the LaTeX writer to add proper `\label`
markup.

This fixes half of #2496 and #2999.