### PR TITLE
Org reader: support archived trees, headline levels export setting

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -399,6 +399,7 @@ Library
                    Text.Pandoc.Readers.Odt.Arrows.Utils,
                    Text.Pandoc.Readers.Org.BlockStarts,
                    Text.Pandoc.Readers.Org.Blocks,
+                   Text.Pandoc.Readers.Org.ExportSettings,
                    Text.Pandoc.Readers.Org.Inlines,
                    Text.Pandoc.Readers.Org.ParserState,
                    Text.Pandoc.Readers.Org.Parsing,

--- a/src/Text/Pandoc/Readers/Org.hs
+++ b/src/Text/Pandoc/Readers/Org.hs
@@ -52,41 +52,4 @@ parseOrg :: OrgParser Pandoc
 parseOrg = do
   blocks' <- blockList
   meta'   <- meta
-  return . Pandoc meta' $ removeUnwantedBlocks blocks'
- where
-   removeUnwantedBlocks :: [Block] -> [Block]
-   removeUnwantedBlocks = dropCommentTrees . filter (/= Null)
-
--- | Drop COMMENT headers and the document tree below those headers.
-dropCommentTrees :: [Block] -> [Block]
-dropCommentTrees [] = []
-dropCommentTrees (b:bs) =
-  maybe (b:dropCommentTrees bs)
-        (dropCommentTrees . flip dropUntilHeaderAboveLevel bs)
-        (commentHeaderLevel b)
-
--- | Return the level of a header starting a comment or :noexport: tree and
---  Nothing otherwise.
-commentHeaderLevel :: Block -> Maybe Int
-commentHeaderLevel blk =
-   case blk of
-     (Header level _ ((Str "COMMENT"):_))          -> Just level
-     (Header level _ title) | hasNoExportTag title -> Just level
-     _                                             -> Nothing
- where
-   hasNoExportTag :: [Inline] -> Bool
-   hasNoExportTag = any isNoExportTag
-
-   isNoExportTag :: Inline -> Bool
-   isNoExportTag (Span ("", ["tag"], [("data-tag-name", "noexport")]) []) = True
-   isNoExportTag _ = False
-
--- | Drop blocks until a header on or above the given level is seen
-dropUntilHeaderAboveLevel :: Int -> [Block] -> [Block]
-dropUntilHeaderAboveLevel n = dropWhile (not . isHeaderLevelLowerEq n)
-
-isHeaderLevelLowerEq :: Int -> Block -> Bool
-isHeaderLevelLowerEq n blk =
-  case blk of
-    (Header level _ _) -> n >= level
-    _                  -> False
+  return $ Pandoc meta' blocks'

--- a/src/Text/Pandoc/Readers/Org/ExportSettings.hs
+++ b/src/Text/Pandoc/Readers/Org/ExportSettings.hs
@@ -1,0 +1,159 @@
+{-
+Copyright (C) 2014-2016 Albert Krewinkel <tarleb+pandoc@moltkeplatz.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+-}
+
+{- |
+   Module      : Text.Pandoc.Readers.Org.Options
+   Copyright   : Copyright (C) 2016 Albert Krewinkel
+   License     : GNU GPL, version 2 or above
+
+   Maintainer  : Albert Krewinkel <tarleb+pandoc@moltkeplatz.de>
+
+Parsers for Org-mode export options.
+-}
+module Text.Pandoc.Readers.Org.ExportSettings
+  ( exportSettings
+  ) where
+
+import           Text.Pandoc.Readers.Org.ParserState
+import           Text.Pandoc.Readers.Org.Parsing
+
+import           Control.Monad ( void )
+import           Data.Char ( toLower )
+
+-- | Read and handle space separated org-mode export settings.
+exportSettings :: OrgParser ()
+exportSettings = void $ sepBy spaces exportSetting
+
+-- | Setter function for export settings.
+type ExportSettingSetter a = a -> ExportSettings -> ExportSettings
+
+-- | Read and process a single org-mode export option.
+exportSetting :: OrgParser ()
+exportSetting = choice
+  [ booleanSetting "^" (\val es -> es { exportSubSuperscripts = val })
+  , booleanSetting "'" (\val es -> es { exportSmartQuotes = val })
+  , booleanSetting "*" (\val es -> es { exportEmphasizedText = val })
+  , booleanSetting "-" (\val es -> es { exportSpecialStrings = val })
+  , ignoredSetting ":"
+  , ignoredSetting "<"
+  , ignoredSetting "\\n"
+  , archivedTreeSetting "arch" (\val es -> es { exportArchivedTrees = val })
+  , ignoredSetting "author"
+  , ignoredSetting "c"
+  , ignoredSetting "creator"
+  , complementableListSetting "d" (\val es -> es { exportDrawers = val })
+  , ignoredSetting "date"
+  , ignoredSetting "e"
+  , ignoredSetting "email"
+  , ignoredSetting "f"
+  , ignoredSetting "H"
+  , ignoredSetting "inline"
+  , ignoredSetting "num"
+  , ignoredSetting "p"
+  , ignoredSetting "pri"
+  , ignoredSetting "prop"
+  , ignoredSetting "stat"
+  , ignoredSetting "tags"
+  , ignoredSetting "tasks"
+  , ignoredSetting "tex"
+  , ignoredSetting "timestamp"
+  , ignoredSetting "title"
+  , ignoredSetting "toc"
+  , ignoredSetting "todo"
+  , ignoredSetting "|"
+  ] <?> "export setting"
+
+genericExportSetting :: OrgParser a
+                     -> String
+                     -> ExportSettingSetter a
+                     -> OrgParser ()
+genericExportSetting optionParser settingIdentifier setter = try $ do
+  _     <- string settingIdentifier *> char ':'
+  value <- optionParser
+  updateState $ modifyExportSettings value
+ where
+   modifyExportSettings val st =
+     st { orgStateExportSettings = setter val . orgStateExportSettings $ st }
+
+-- | A boolean option, either nil (False) or non-nil (True).
+booleanSetting :: String ->  ExportSettingSetter Bool -> OrgParser ()
+booleanSetting = genericExportSetting elispBoolean
+
+-- | Either the string "headline" or an elisp boolean and treated as an
+-- @ArchivedTreesOption@.
+archivedTreeSetting :: String
+                    -> ExportSettingSetter ArchivedTreesOption
+                    -> OrgParser ()
+archivedTreeSetting =
+  genericExportSetting $ archivedTreesHeadlineSetting <|> archivedTreesBoolean
+ where
+   archivedTreesHeadlineSetting = try $ do
+     _ <- string "headline"
+     lookAhead (newline <|> spaceChar)
+     return ArchivedTreesHeadlineOnly
+
+   archivedTreesBoolean = try $ do
+     exportBool <- elispBoolean
+     return $
+       if exportBool
+       then ArchivedTreesExport
+       else ArchivedTreesNoExport
+
+-- | A list or a complement list (i.e. a list starting with `not`).
+complementableListSetting :: String
+                          -> ExportSettingSetter (Either [String] [String])
+                          -> OrgParser ()
+complementableListSetting = genericExportSetting $ choice
+  [ Left  <$> complementStringList
+  , Right <$> stringList
+  , (\b -> if b then Left [] else Right []) <$> elispBoolean
+  ]
+ where
+   -- Read a plain list of strings.
+   stringList :: OrgParser [String]
+   stringList = try $
+     char '('
+       *> sepBy elispString spaces
+       <* char ')'
+
+   -- Read an emacs lisp list specifying a complement set.
+   complementStringList :: OrgParser [String]
+   complementStringList = try $
+     string "(not "
+       *> sepBy elispString spaces
+       <* char ')'
+
+   elispString :: OrgParser String
+   elispString = try $
+     char '"'
+       *> manyTill alphaNum (char '"')
+
+-- | Read but ignore the export setting.
+ignoredSetting :: String -> OrgParser ()
+ignoredSetting s = try (() <$ string s <* char ':' <* many1 nonspaceChar)
+
+-- | Read an elisp boolean.  Only NIL is treated as false, non-NIL values are
+-- interpreted as true.
+elispBoolean :: OrgParser Bool
+elispBoolean = try $ do
+  value <- many1 nonspaceChar
+  return $ case map toLower value of
+             "nil" -> False
+             "{}"  -> False
+             "()"  -> False
+             _     -> True

--- a/src/Text/Pandoc/Readers/Org/ExportSettings.hs
+++ b/src/Text/Pandoc/Readers/Org/ExportSettings.hs
@@ -32,8 +32,9 @@ module Text.Pandoc.Readers.Org.ExportSettings
 import           Text.Pandoc.Readers.Org.ParserState
 import           Text.Pandoc.Readers.Org.Parsing
 
-import           Control.Monad ( void )
+import           Control.Monad ( mzero, void )
 import           Data.Char ( toLower )
+import           Data.Maybe ( listToMaybe )
 
 -- | Read and handle space separated org-mode export settings.
 exportSettings :: OrgParser ()
@@ -61,7 +62,7 @@ exportSetting = choice
   , ignoredSetting "e"
   , ignoredSetting "email"
   , ignoredSetting "f"
-  , ignoredSetting "H"
+  , integerSetting "H" (\val es -> es { exportHeadlineLevels = val })
   , ignoredSetting "inline"
   , ignoredSetting "num"
   , ignoredSetting "p"
@@ -93,6 +94,13 @@ genericExportSetting optionParser settingIdentifier setter = try $ do
 -- | A boolean option, either nil (False) or non-nil (True).
 booleanSetting :: String ->  ExportSettingSetter Bool -> OrgParser ()
 booleanSetting = genericExportSetting elispBoolean
+
+-- | An integer-valued option.
+integerSetting :: String -> ExportSettingSetter Int -> OrgParser ()
+integerSetting = genericExportSetting parseInt
+ where
+   parseInt = try $
+     many1 digit >>= maybe mzero (return . fst) . listToMaybe . reads
 
 -- | Either the string "headline" or an elisp boolean and treated as an
 -- @ArchivedTreesOption@.

--- a/src/Text/Pandoc/Readers/Org/ParserState.hs
+++ b/src/Text/Pandoc/Readers/Org/ParserState.hs
@@ -158,6 +158,8 @@ data ExportSettings = ExportSettings
   -- explicitly excluded from the resulting output while @Right@ means that
   -- only the listed drawer names should be included.
   , exportEmphasizedText  :: Bool -- ^ Parse emphasized text
+  , exportHeadlineLevels  :: Int
+  -- ^ Maximum depth of headlines, deeper headlines are convert to list
   , exportSmartQuotes     :: Bool -- ^ Parse quotes smartly
   , exportSpecialStrings  :: Bool -- ^ Parse ellipses and dashes smartly
   , exportSubSuperscripts :: Bool -- ^ TeX-like syntax for sub- and superscripts
@@ -171,6 +173,7 @@ defaultExportSettings = ExportSettings
   { exportArchivedTrees = ArchivedTreesHeadlineOnly
   , exportDrawers = Left ["LOGBOOK"]
   , exportEmphasizedText = True
+  , exportHeadlineLevels = 3
   , exportSmartQuotes = True
   , exportSpecialStrings = True
   , exportSubSuperscripts = True

--- a/src/Text/Pandoc/Readers/Org/ParserState.hs
+++ b/src/Text/Pandoc/Readers/Org/ParserState.hs
@@ -40,16 +40,8 @@ module Text.Pandoc.Readers.Org.ParserState
   , trimInlinesF
   , runF
   , returnF
-  , ExportSettingSetter
   , ExportSettings (..)
   , ArchivedTreesOption (..)
-  , setExportArchivedTrees
-  , setExportDrawers
-  , setExportEmphasizedText
-  , setExportSmartQuotes
-  , setExportSpecialStrings
-  , setExportSubSuperscripts
-  , modifyExportSettings
   , optionsToParserState
   ) where
 
@@ -79,26 +71,6 @@ type OrgNoteTable = [OrgNoteRecord]
 -- | Map of functions for link transformations.  The map key is refers to the
 -- link-type, the corresponding function transforms the given link string.
 type OrgLinkFormatters = M.Map String (String -> String)
-
--- | Options for the way archived trees are handled.
-data ArchivedTreesOption =
-    ArchivedTreesExport       -- ^ Export the complete tree
-  | ArchivedTreesNoExport     -- ^ Exclude archived trees from exporting
-  | ArchivedTreesHeadlineOnly -- ^ Export only the headline, discard the contents
-
--- | Export settings <http://orgmode.org/manual/Export-settings.html>
--- These settings can be changed via OPTIONS statements.
-data ExportSettings = ExportSettings
-  { exportArchivedTrees   :: ArchivedTreesOption -- ^ How to treat archived trees
-  , exportDrawers         :: Either [String] [String]
-  -- ^ Specify drawer names which should be exported.  @Left@ names are
-  -- explicitly excluded from the resulting output while @Right@ means that
-  -- only the listed drawer names should be included.
-  , exportEmphasizedText  :: Bool -- ^ Parse emphasized text
-  , exportSmartQuotes     :: Bool -- ^ Parse quotes smartly
-  , exportSpecialStrings  :: Bool -- ^ Parse ellipses and dashes smartly
-  , exportSubSuperscripts :: Bool -- ^ TeX-like syntax for sub- and superscripts
-  }
 
 -- | Org-mode parser state
 data OrgParserState = OrgParserState
@@ -142,9 +114,6 @@ instance HasHeaderMap OrgParserState where
   extractHeaderMap = orgStateHeaderMap
   updateHeaderMap  f s = s{ orgStateHeaderMap = f (orgStateHeaderMap s) }
 
-instance Default ExportSettings where
-  def = defaultExportSettings
-
 instance Default OrgParserState where
   def = defaultOrgParserState
 
@@ -166,6 +135,37 @@ defaultOrgParserState = OrgParserState
   , orgStateParserContext = NullState
   }
 
+optionsToParserState :: ReaderOptions -> OrgParserState
+optionsToParserState opts =
+  def { orgStateOptions = opts }
+
+--
+-- Export Settings
+--
+
+-- | Options for the way archived trees are handled.
+data ArchivedTreesOption =
+    ArchivedTreesExport       -- ^ Export the complete tree
+  | ArchivedTreesNoExport     -- ^ Exclude archived trees from exporting
+  | ArchivedTreesHeadlineOnly -- ^ Export only the headline, discard the contents
+
+-- | Export settings <http://orgmode.org/manual/Export-settings.html>
+-- These settings can be changed via OPTIONS statements.
+data ExportSettings = ExportSettings
+  { exportArchivedTrees   :: ArchivedTreesOption -- ^ How to treat archived trees
+  , exportDrawers         :: Either [String] [String]
+  -- ^ Specify drawer names which should be exported.  @Left@ names are
+  -- explicitly excluded from the resulting output while @Right@ means that
+  -- only the listed drawer names should be included.
+  , exportEmphasizedText  :: Bool -- ^ Parse emphasized text
+  , exportSmartQuotes     :: Bool -- ^ Parse quotes smartly
+  , exportSpecialStrings  :: Bool -- ^ Parse ellipses and dashes smartly
+  , exportSubSuperscripts :: Bool -- ^ TeX-like syntax for sub- and superscripts
+  }
+
+instance Default ExportSettings where
+  def = defaultExportSettings
+
 defaultExportSettings :: ExportSettings
 defaultExportSettings = ExportSettings
   { exportArchivedTrees = ArchivedTreesHeadlineOnly
@@ -175,51 +175,6 @@ defaultExportSettings = ExportSettings
   , exportSpecialStrings = True
   , exportSubSuperscripts = True
   }
-
-optionsToParserState :: ReaderOptions -> OrgParserState
-optionsToParserState opts =
-  def { orgStateOptions = opts }
-
-
---
--- Setter for exporting options
---
-
--- This whole section could be scraped if we were using lenses.
-
-type ExportSettingSetter a = a -> ExportSettings -> ExportSettings
-
--- | Set export options for archived trees.
-setExportArchivedTrees :: ExportSettingSetter ArchivedTreesOption
-setExportArchivedTrees val es = es { exportArchivedTrees = val }
-
--- | Set export options for drawers.  See the @exportDrawers@ in ADT
--- @ExportSettings@ for details.
-setExportDrawers :: ExportSettingSetter (Either [String] [String])
-setExportDrawers val es = es { exportDrawers = val }
-
--- | Set export options for emphasis parsing.
-setExportEmphasizedText :: ExportSettingSetter Bool
-setExportEmphasizedText val es = es { exportEmphasizedText = val }
-
--- | Set export options for parsing of smart quotes.
-setExportSmartQuotes :: ExportSettingSetter Bool
-setExportSmartQuotes val es = es { exportSmartQuotes = val }
-
--- | Set export options for parsing of special strings (like em/en dashes or
--- ellipses).
-setExportSpecialStrings :: ExportSettingSetter Bool
-setExportSpecialStrings val es = es { exportSpecialStrings = val }
-
--- | Set export options for sub/superscript parsing.  The short syntax will
--- not be parsed if this is set set to @False@.
-setExportSubSuperscripts :: ExportSettingSetter Bool
-setExportSubSuperscripts val es = es { exportSubSuperscripts = val }
-
--- | Modify a parser state
-modifyExportSettings :: ExportSettingSetter a -> a -> OrgParserState -> OrgParserState
-modifyExportSettings setter val state =
-  state { orgStateExportSettings = setter val . orgStateExportSettings $ state }
 
 
 --

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -611,6 +611,18 @@ tests =
                   ] =?>
           let tagSpan t = spanWith ("", ["tag"], [("data-tag-name", t)]) mempty
           in headerWith ("old", [], mempty) 1 ("old" <> tagSpan "ARCHIVE")
+
+      , "Export option: limit headline depth" =:
+          unlines [ "#+OPTIONS: H:2"
+                  , "* section"
+                  , "** subsection"
+                  , "*** list item 1"
+                  , "*** list item 2"
+                  ] =?>
+          mconcat [ headerWith ("section", [], [])    1 "section"
+                  , headerWith ("subsection", [], []) 2 "subsection"
+                  , orderedList [ para "list item 1", para "list item 2" ]
+                  ]
       ]
 
   , testGroup "Basic Blocks" $

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -587,6 +587,30 @@ tests =
                   , ":END:"
                   ] =?>
           divWith (mempty, ["IMPORTANT", "drawer"], mempty) (para "5")
+
+      , "Export option: don't include archive trees" =:
+          unlines [ "#+OPTIONS: arch:nil"
+                  , "* old  :ARCHIVE:"
+                  ] =?>
+          (mempty ::Blocks)
+
+      , "Export option: include complete archive trees" =:
+          unlines [ "#+OPTIONS: arch:t"
+                  , "* old  :ARCHIVE:"
+                  , "  boring"
+                  ] =?>
+          let tagSpan t = spanWith ("", ["tag"], [("data-tag-name", t)]) mempty
+          in mconcat [ headerWith ("old", [], mempty) 1 ("old" <> tagSpan "ARCHIVE")
+                     , para "boring"
+                     ]
+
+      , "Export option: include archive tree header only" =:
+          unlines [ "#+OPTIONS: arch:headline"
+                  , "* old  :ARCHIVE:"
+                  , "  boring"
+                  ] =?>
+          let tagSpan t = spanWith ("", ["tag"], [("data-tag-name", t)]) mempty
+          in headerWith ("old", [], mempty) 1 ("old" <> tagSpan "ARCHIVE")
       ]
 
   , testGroup "Basic Blocks" $


### PR DESCRIPTION
Support for the `H` (maximum level of headlines) and `arch` (treatment of archived trees) settings is added to the reader.

The document is now parsed into a document tree consisting of headlines and their block contents nodes and subsections as subtrees.  This structure resembles that used by the Emacs Org mode parser and simplifies transformations of the document tree. 