### PR TITLE
Org writer: improve Div handling

### DIFF
--- a/tests/writer.org
+++ b/tests/writer.org
@@ -405,53 +405,13 @@ Blank line after term, indented marker, alternate markers:
 
 Simple block on one line:
 
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
 foo
-
-#+BEGIN_HTML
-  </div>
-#+END_HTML
 
 And nested without indentation:
 
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
 foo
 
-#+BEGIN_HTML
-  </div>
-#+END_HTML
-
-#+BEGIN_HTML
-  </div>
-#+END_HTML
-
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
 bar
-
-#+BEGIN_HTML
-  </div>
-#+END_HTML
-
-#+BEGIN_HTML
-  </div>
-#+END_HTML
 
 Interpreted markdown in a table:
 
@@ -497,15 +457,7 @@ And this is *strong*
 
 Here's a simple block:
 
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
 foo
-
-#+BEGIN_HTML
-  </div>
-#+END_HTML
 
 This should be a code block, though:
 
@@ -523,31 +475,7 @@ As should this:
 
 Now, nested:
 
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
-#+BEGIN_HTML
-  <div>
-#+END_HTML
-
 foo
-
-#+BEGIN_HTML
-  </div>
-#+END_HTML
-
-#+BEGIN_HTML
-  </div>
-#+END_HTML
-
-#+BEGIN_HTML
-  </div>
-#+END_HTML
 
 This should just be an HTML comment:
 


### PR DESCRIPTION
Div blocks handling is changed to make the output look more like
idiomatic org mode:

  - Div-wrapped content is output as-is if the div's attribute is the
    null attribute.
  - Div containers with an id but neither classes nor key-value pairs
    are unwrapped and the id is added as an anchor.
  - Divs with classes associated with greater block elements are
    wrapped in a `#+BEGIN`...`#+END` block.
  - The old behavior for Divs with more complex attributes is kept.