### PR TITLE
Org reader: fix parsing of verbatim inlines

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -614,7 +614,7 @@ displayMath = return . B.displayMath <$> choice [ rawMathBetween "\\[" "\\]"
                                                 ]
 
 updatePositions :: Char
-                -> OrgParser (Char)
+                -> OrgParser Char
 updatePositions c = do
   when (c `elem` emphasisPreChars) updateLastPreCharPos
   when (c `elem` emphasisForbiddenBorderChars) updateLastForbiddenCharPos
@@ -637,7 +637,9 @@ verbatimBetween :: Char
                 -> OrgParser String
 verbatimBetween c = try $
   emphasisStart c *>
-  many1TillNOrLessNewlines 1 (noneOf "\n\r") (emphasisEnd c)
+  many1TillNOrLessNewlines 1 verbatimChar (emphasisEnd c)
+ where
+   verbatimChar = noneOf "\n\r" >>= updatePositions
 
 -- | Parses a raw string delimited by @c@ using Org's math rules
 mathStringBetween :: Char

--- a/tests/Tests/Readers/Org.hs
+++ b/tests/Tests/Readers/Org.hs
@@ -185,6 +185,9 @@ tests =
                       , "3" <> subscript "{}"
                       , "4" <> superscript ("(a(" <> strong "b(c" <> ")d))")
                       ])
+      , "Verbatim text can contain equal signes (=)" =:
+          "=is_subst = True=" =?>
+          para (code "is_subst = True")
 
       , "Image" =:
           "[[./sunset.jpg]]" =?>


### PR DESCRIPTION
Org rules for allowed characters before or after markup chars were not
checked for verbatim text.  This resultet in wrong parsing outcomes of
if the verbatim text contained e.g. space enclosed markup characters as
part of the text (`=is_substr = True=`).  Forcing the parser to update
the positions of allowed/forbidden markup border characters fixes this.

This fixes #3016.