### PR TITLE
Use http to access online documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Markdown can be expected to be lossy.
 Documentation
 -------------
 
-The full documentation can be found [online](https://pandoc.org/MANUAL.html)
+The full documentation can be found [online](http://pandoc.org/MANUAL.html)
 and as pandoc-flavored Markdown in the file `MANUAL.txt`.
 
 


### PR DESCRIPTION
The link to the online manual used the `https` schema, which doesn't work for this resource.  Changed to `http`.