### PR TITLE
Dynamic classes for docx output

### DIFF
--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -732,6 +732,12 @@ getUniqueId :: MonadIO m => m String
 -- already in word/document.xml.rel
 getUniqueId = liftIO $ (show . (+ 20) . hashUnique) `fmap` newUnique
 
+
+-- | This will be the "namespace" (along with a colon) for dynamic
+-- classes that will be passed along to paragraphs.
+dynamicClassNS :: String
+dynamicClassNS = "pandoc"
+
 -- | Convert a Pandoc block element to OpenXML.
 blockToOpenXML :: WriterOptions -> Block -> WS [Element]
 blockToOpenXML _ Null = return []

--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -793,10 +793,12 @@ blockToOpenXML opts (Para lst) = do
                                [Math DisplayMath _] -> True
                                _                    -> False
   bodyTextStyle <- pStyleM "Body Text"
+  mDynClass <- asks envDynamicClass
   let paraProps' = case paraProps of
-        [] | isFirstPara -> [mknode "w:pPr" [] [pCustomStyle "FirstParagraph"]]
-        []               -> [mknode "w:pPr" [] [bodyTextStyle]]
-        ps               -> ps
+        [] | Just cls <- mDynClass -> [mknode "w:pPr" [] [pCustomStyle cls]]
+           | isFirstPara           -> [mknode "w:pPr" [] [pCustomStyle "FirstParagraph"]]
+           | otherwise             -> [mknode "w:pPr" [] [bodyTextStyle]]
+        ps                         -> ps
   modify $ \s -> s { stFirstPara = False }
   contents <- inlinesToOpenXML opts lst
   return [mknode "w:p" [] (paraProps' ++ contents)]


### PR DESCRIPTION
SUPERSEDED BY #3070

This is an RFC PR (I'll be writing to the mailing list) and shouldn't be considered final.

This would allow us to dynamically control the styles on docx output. People could either write divs by hand or -- more what I had in mind -- script to control indentation or whatever.

A few notes:

1. This requires divs, since we can't add attributes to arbitrary blocks. However, it will only affect the `Para` blocks within the div. The reason is that nearly everything in docx is a paragraph, with the style being the main difference. So if you change the style on, say, a block quote or a list item, it will change the block. So, only paragraphs will be affected.

2. We don't want all classes to be passed through to the writer, so we need some sort of convention. In this implementation, I've used a namespace-like prefix (`<div class="pandoc:FizzPop">...</div>`). Another more elegant, if much less explicit, option would be to use uppercase. Docx paragraph styles are in uppercase, while most standard div names are in lowercase. So we could decide by convention that uppercase class names would be passed through. (I probably prefer the less elegant and more foolproof option, myself.)

3. The styles won't do anything if they're not already in your `reference.docx`. In fact, they'll just show up as "Normal Text", and convert to that upon saving. So this is only useful if you have a reference.docx already.