### PR TITLE
Support `yaml_metadata_block` extension in more formats

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -830,8 +830,9 @@ Options affecting specific writers
 
 :   Use the specified image as the EPUB cover.  It is recommended
     that the image be less than 1000px in width and height. Note that
-    in a Markdown source document you can also specify `cover-image`
-    in a YAML metadata block (see [EPUB Metadata], below).
+    in a Markdown, RST, Org-mode, or LaTeX source document you can also
+    specify `cover-image` in a YAML metadata block (see [EPUB Metadata],
+    below).
 
 `--epub-metadata=`*FILE*
 
@@ -850,9 +851,10 @@ Options affecting specific writers
     id="BookId">` (a randomly generated UUID). Any of these may be
     overridden by elements in the metadata file.
 
-    Note: if the source document is Markdown, a YAML metadata block
-    in the document can be used instead.  See below under
-    [EPUB Metadata].
+    Note: if the source document supports the `yaml_metadata_block`
+    syntax extension (currently Markdown, RST, Org-mode, and LaTeX), a
+    YAML metadata block in the document can be used instead.  See below
+    under [EPUB Metadata].
 
 `--epub-embed-font=`*FILE*
 
@@ -1081,7 +1083,7 @@ directory (see `--data-dir`, above). *Exceptions:*
   `--reference-docx` to customize the output).
 
 Templates contain *variables*, which allow for the inclusion of
-arbitrary information at any point in the file. Variables may be set
+arbitrary information at any point in the file.  Variables may be set
 within the document using [YAML metadata blocks][Extension:
 `yaml_metadata_block`].  They may also be set at the
 command line using the `-V/--variable` option: variables set in this
@@ -2493,7 +2495,9 @@ will also have "Version 4.0" in the header.
 
 A YAML metadata block is a valid YAML object, delimited by a line of three
 hyphens (`---`) at the top and a line of three hyphens (`---`) or three dots
-(`...`) at the bottom.  A YAML metadata block may occur anywhere in the
+(`...`) at the bottom.  When used as a syntax extension to LaTeX, Org-mode, or
+RST, the YAML block must be at the very beginning of the document.  In
+Markdown formatted text a YAML metadata block may occur anywhere in the
 document, but if it is not at the beginning, it must be preceded by a blank
 line.  (Note that, because of the way pandoc concatenates input files when
 several are provided, you may also keep the metadata in a separate YAML file
@@ -3213,7 +3217,8 @@ Note that `pandoc-citeproc --bib2json` and `pandoc-citeproc --bib2yaml`
 can produce `.json` and `.yaml` files from any of the supported formats.
 
 In-field markup: In BibTeX and BibLaTeX databases, pandoc-citeproc parses
-a subset of LaTeX markup; in CSL YAML databases, pandoc Markdown; and in CSL JSON databases, an [HTML-like markup][CSL markup specs]:
+a subset of LaTeX markup; in CSL YAML databases, pandoc Markdown; and in
+CSL JSON databases, an [HTML-like markup][CSL markup specs]:
 
 `<i>...</i>`
 :   italics

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -412,6 +412,7 @@ Library
                    Text.Pandoc.Emoji,
                    Text.Pandoc.Parsing,
                    Text.Pandoc.UUID,
+                   Text.Pandoc.YAML,
                    Text.Pandoc.ImageSize,
                    Text.Pandoc.Slides,
                    Text.Pandoc.Highlighting,

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -41,6 +41,7 @@ import Text.Pandoc.Shared
 import Text.Pandoc.Options
 import Text.Pandoc.Parsing hiding ((<|>), many, optional, space,
                                    mathDisplay, mathInline)
+import Text.Pandoc.YAML (yamlMetaBlock)
 import qualified Text.Pandoc.UTF8 as UTF8
 import Data.Char ( chr, ord, isLetter, isAlphaNum )
 import Control.Monad.Trans (lift)
@@ -65,6 +66,7 @@ readLaTeX opts = readWith parseLaTeX def{ stateOptions = opts }
 
 parseLaTeX :: LP Pandoc
 parseLaTeX = do
+  optional latexYamlMetaBlock
   bs <- blocks
   eof
   st <- getState
@@ -73,6 +75,11 @@ parseLaTeX = do
   return $ Pandoc meta bs'
 
 type LP = Parser String ParserState
+
+latexYamlMetaBlock :: LP ()
+latexYamlMetaBlock = try $ do
+  meta' <- yamlMetaBlock readLaTeX
+  updateState $ \st -> st{ stateMeta = stateMeta st <> meta' }
 
 anyControlSeq :: LP String
 anyControlSeq = do

--- a/src/Text/Pandoc/Readers/Org/ParserState.hs
+++ b/src/Text/Pandoc/Readers/Org/ParserState.hs
@@ -34,6 +34,7 @@ module Text.Pandoc.Readers.Org.ParserState
   , OrgNoteRecord
   , HasReaderOptions (..)
   , HasQuoteContext (..)
+  , HasWarnings (..)
   , F(..)
   , askF
   , asksF
@@ -60,6 +61,7 @@ import           Text.Pandoc.Parsing ( HasHeaderMap(..)
                                      , HasLastStrPosition(..)
                                      , HasQuoteContext(..)
                                      , HasReaderOptions(..)
+                                     , HasWarnings(..)
                                      , ParserContext(..)
                                      , QuoteContext(..)
                                      , SourcePos )
@@ -88,6 +90,7 @@ data OrgParserState = OrgParserState
   , orgStateNotes'               :: OrgNoteTable
   , orgStateOptions              :: ReaderOptions
   , orgStateParserContext        :: ParserContext
+  , orgStateWarnings             :: [String]
   }
 
 data OrgParserLocal = OrgParserLocal { orgLocalQuoteContext :: QuoteContext }
@@ -114,6 +117,10 @@ instance HasHeaderMap OrgParserState where
   extractHeaderMap = orgStateHeaderMap
   updateHeaderMap  f s = s{ orgStateHeaderMap = f (orgStateHeaderMap s) }
 
+instance HasWarnings OrgParserState where
+  getWarnings = orgStateWarnings
+  setWarnings ws st = st { orgStateWarnings = ws }
+
 instance Default OrgParserState where
   def = defaultOrgParserState
 
@@ -133,6 +140,7 @@ defaultOrgParserState = OrgParserState
   , orgStateNotes' = []
   , orgStateOptions = def
   , orgStateParserContext = NullState
+  , orgStateWarnings = []
   }
 
 optionsToParserState :: ReaderOptions -> OrgParserState

--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -38,6 +38,7 @@ import Text.Pandoc.Builder (setMeta, fromList)
 import Text.Pandoc.Shared
 import Text.Pandoc.Parsing
 import Text.Pandoc.Options
+import Text.Pandoc.YAML (yamlMetaBlock)
 import Control.Monad ( when, liftM, guard, mzero )
 import Data.List ( findIndex, intercalate,
                    transpose, sort, deleteFirstsBy, isSuffixOf , nub, union)
@@ -141,8 +142,14 @@ metaFromDefList ds meta = adjustAuthors $ foldr f meta ds
                                                 factorSemi (Str ys)
        factorSemi x                   = [x]
 
+rstYamlMetaBlock :: RSTParser ()
+rstYamlMetaBlock = try $ do
+  meta' <- yamlMetaBlock readRST
+  updateState $ \st -> st{ stateMeta = stateMeta st <> meta' }
+
 parseRST :: RSTParser Pandoc
 parseRST = do
+  optional rstYamlMetaBlock
   optional blanklines -- skip blank lines at beginning of file
   startPos <- getPosition
   -- go through once just to get list of reference keys and notes

--- a/src/Text/Pandoc/YAML.hs
+++ b/src/Text/Pandoc/YAML.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-
+Copyright (C) 2013-2016 John MacFarlane <jgm@berkeley.edu>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+-}
+
+{- |
+   Module      : Text.Pandoc.MIME
+   Copyright   : Copyright (C) 2013-2016 John MacFarlane
+   License     : GNU GPL, version 2 or later
+
+   Maintainer  : John MacFarlane <jgm@berkeley.edu>
+   Portability : portable
+
+YAML block parser utils.
+-}
+module Text.Pandoc.YAML ( yamlMetaBlock ) where
+
+import qualified Text.Pandoc.Builder as B
+import           Text.Pandoc.Definition
+import           Text.Pandoc.Error
+import           Text.Pandoc.Options
+import           Text.Pandoc.Parsing
+import qualified Text.Pandoc.UTF8 as UTF8
+import qualified Data.HashMap.Strict as H
+import qualified Data.Map as M
+import           Data.Scientific (coefficient, base10Exponent)
+import qualified Data.Set as Set
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+import qualified Data.Yaml as Yaml
+import           Data.Yaml (ParseException(..), YamlException(..), YamlMark(..))
+
+
+yamlMetaBlock :: ( Stream [Char] m Char, HasReaderOptions st, HasWarnings st )
+              => (ReaderOptions -> String -> Either PandocError Pandoc)
+              -> ParserT [Char] st m Meta
+yamlMetaBlock formatReader = try $ do
+  guardEnabled Ext_yaml_metadata_block
+  pos <- getPosition
+  string "---"
+  blankline
+  notFollowedBy blankline  -- if --- is followed by a blank it's an HRULE
+  rawYamlLines <- manyTill anyLine stopLine
+  -- by including --- and ..., we allow yaml blocks with just comments:
+  let rawYaml = unlines ("---" : (rawYamlLines ++ ["..."]))
+  optional blanklines
+  opts <- extractReaderOptions <$> getState
+  let formatTextReader = formatReader (noHeaderBlockExtensions opts) . T.unpack
+  case Yaml.decodeEither' $ UTF8.fromString rawYaml of
+    Right (Yaml.Object hashmap) -> return $
+      H.foldrWithKey (\k v m ->
+           if ignorable k
+              then m
+              else case yamlToMeta formatTextReader v of
+                     Left _  -> m
+                     Right v' -> B.setMeta (T.unpack k) v' m)
+        nullMeta hashmap
+    Right Yaml.Null -> return nullMeta
+    Right _ -> do
+      addWarning (Just pos) "YAML header is not an object"
+      return nullMeta
+    Left err' -> do
+      case err' of
+         InvalidYaml (Just YamlParseException{
+                     yamlProblem = problem
+                   , yamlContext = _ctxt
+                   , yamlProblemMark = Yaml.YamlMark {
+                         yamlLine = yline
+                       , yamlColumn = ycol
+                   }}) ->
+              addWarning (Just $ setSourceLine
+                 (setSourceColumn pos
+                    (sourceColumn pos + ycol))
+                 (sourceLine pos + 1 + yline))
+                 $ "Could not parse YAML header: " ++ problem
+         _ -> addWarning (Just pos)
+                 $ "Could not parse YAML header: " ++ show err'
+      return nullMeta
+ where
+    noHeaderBlockExtensions o =
+      o { readerExtensions = readerExtensions o `Set.difference` meta_exts }
+    meta_exts = Set.fromList
+      [ Ext_pandoc_title_block
+      , Ext_mmd_title_block
+      , Ext_yaml_metadata_block
+      ]
+
+-- ignore fields ending with _
+ignorable :: Text -> Bool
+ignorable t = (T.pack "_") `T.isSuffixOf` t
+
+toMetaValue :: (Text -> Either PandocError Pandoc)
+            -> Text
+            -> Either PandocError MetaValue
+toMetaValue formatReader x = toMeta <$> formatReader x
+  where
+    toMeta p =
+      case p of
+        Pandoc _ [Plain xs]  -> MetaInlines xs
+        Pandoc _ [Para xs]
+         | endsWithNewline x -> MetaBlocks [Para xs]
+         | otherwise         -> MetaInlines xs
+        Pandoc _ bs          -> MetaBlocks bs
+    endsWithNewline t = T.pack "\n" `T.isSuffixOf` t
+
+yamlToMeta :: (Text -> Either PandocError Pandoc)
+           -> Yaml.Value -> Either PandocError MetaValue
+yamlToMeta fp (Yaml.String t) = toMetaValue fp t
+yamlToMeta _  (Yaml.Number n)
+  -- avoid decimal points for numbers that don't need them:
+  | base10Exponent n >= 0     = return $ MetaString $ show
+                                $ coefficient n * (10 ^ base10Exponent n)
+  | otherwise                 = return $ MetaString $ show n
+yamlToMeta _  (Yaml.Bool b)   = return $ MetaBool b
+yamlToMeta fp (Yaml.Array xs) = B.toMetaValue <$> mapM (yamlToMeta fp)
+                                                  (V.toList xs)
+yamlToMeta fp (Yaml.Object o) = MetaMap <$> H.foldrWithKey (\k v m ->
+                                if ignorable k
+                                   then m
+                                   else (do
+                                    v' <- yamlToMeta fp v
+                                    m' <- m
+                                    return (M.insert (T.unpack k) v' m')))
+                                (return M.empty) o
+yamlToMeta _ _ = return $ MetaString ""
+
+stopLine :: Stream s m Char => ParserT s st m ()
+stopLine = try $ (string "---" <|> string "...") >> blankline >> return ()


### PR DESCRIPTION
This allows to specify metadata using yaml blocks with input formats RST, Org-mode, and LaTeX when the `yaml_metadata_block` extension is specified.  Other than with Markdown, YAML blocks are not fully integrated into the language parser and may only appear at the top of a document.  This should add enough flexibility to pass metadata in the form of a YAML block, yet limits the extend this feature has on language parsing.

This closes #1960.
