### PR TITLE
LaTeX: Do not set [htbp] figure placement options.

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -421,7 +421,7 @@ blockToLaTeX (Para [Image attr@(ident, _, _) txt (src,'f':'i':'g':':':tit)]) = d
   lab <- labelFor ident
   let caption = "\\caption" <> captForLof <> braces capt <> lab
   figure <- hypertarget ident (cr <>
-            "\\begin{figure}[htbp]" $$ "\\centering" $$ img $$
+            "\\begin{figure}" $$ "\\centering" $$ img $$
             caption $$ "\\end{figure}" <> cr)
   return $ if inNote
               -- can't have figures in notes

--- a/tests/writer.latex
+++ b/tests/writer.latex
@@ -917,7 +917,7 @@ or here: <http://example.com/>
 
 From ``Voyage dans la Lune'' by Georges Melies (1902):
 
-\begin{figure}[htbp]
+\begin{figure}
 \centering
 \includegraphics{lalune.jpg}
 \caption{lalune}


### PR DESCRIPTION
Do not set `[htbp]` placement options on each figure to allow overriding them by them using `\fps@figure` redefintion either in header or in template. See also #3103.