### PR TITLE
Add \begin{html} environment to LaTeX reader

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1132,6 +1132,7 @@ environments = M.fromList
   , ("align*", mathEnv para (Just "aligned") "align*")
   , ("alignat", mathEnv para (Just "aligned") "alignat")
   , ("alignat*", mathEnv para (Just "aligned") "alignat*")
+  , ("html", (rawBlock "html") <$> verbEnv "html")
   ]
 
 letterContents :: LP Blocks

--- a/tests/Tests/Readers/LaTeX.hs
+++ b/tests/Tests/Readers/LaTeX.hs
@@ -115,6 +115,11 @@ tests = [ testGroup "basic"
             concat ["^^"++[i] | i <- hex] =?>
             para (str $ ['p'..'y']++['!'..'&'])
           ]
+        , testGroup "Raw HTML"
+          [ "Raw HTML environment" =:
+            "\\begin{html}<div class='test'>Hello, world!</div>\\end{html}" =?>
+            rawBlock "html" "<div class='test'>Hello, world!</div>"
+          ]
         ]
 
 baseCitation :: Citation

--- a/tests/latex-reader.latex
+++ b/tests/latex-reader.latex
@@ -845,4 +845,10 @@ indented.
 
 \$ \% \& \# \_ \{ \}
 
+\section{Raw HTML}
+
+\begin{html}
+  <div class="test">Hello, world!</div>
+\end{html}
+
 \end{document}

--- a/tests/latex-reader.native
+++ b/tests/latex-reader.native
@@ -372,4 +372,6 @@ Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Spa
  [[Para [Str "And",Space,Str "in",Space,Str "list",Space,Str "items.",Note [Para [Str "In",Space,Str "list."]]]]]
 ,Para [Str "This",Space,Str "paragraph",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "part",Space,Str "of",Space,Str "the",Space,Str "note,",Space,Str "as",Space,Str "it",Space,Str "is",Space,Str "not",SoftBreak,Str "indented."]
 ,Header 1 ("escaped-characters",[],[]) [Str "Escaped",Space,Str "characters"]
-,Para [Str "$",Space,Str "%",Space,Str "&",Space,Str "#",Space,Str "_",Space,Str "{",Space,Str "}"]]
+,Para [Str "$",Space,Str "%",Space,Str "&",Space,Str "#",Space,Str "_",Space,Str "{",Space,Str "}"]
+,Header 1 ("raw-html",[],[]) [Str "Raw",Space,Str "HTML"]
+,RawBlock (Format "html") "  <div class=\"test\">Hello, world!</div>"]


### PR DESCRIPTION
This allows embedding raw HTML blocks in a LaTeX document for conversion
to HTML, Markdown, or other formats that support HTML.

``` latex
\begin{html}
<h1>Hello, World!</h1>
\end{html}
```

This is very useful to me for a project I am working on where I want to write in LaTeX, but need to produce HTML documents as a final result. There are some things, like YouTube embeds, where sticking some raw HTML in the LaTeX document is the simplest solution. The `\begin{html}` environment does not actually exist in LaTeX, nor do I know of something similar that I could have used instead, so I made up my own environment. I understand if pandoc does not want to extend LaTeX in this manner.

Another possible option would be an environment such as `\begin{raw}[format]`, which would allow embedding fragments of any format in a LaTeX document for similar purposes:

``` latex
\begin{raw}[html]
<h1>Hello, world!</h1>
\end{raw}
\begin{raw}[markdown]
# Hello, world!
\end{raw}
```

And thirdly, another option would be to run pandoc over the contents of the raw blocks, so that:

``` latex
\section{LaTeX heading}
\begin{raw}[html]
<h1>HTML heading</h1>
\end{raw}
```

would have an internal representation something like:

``` haskell
[ Header 1 ("",[],[]) "LaTeX heading"
, Header 2 ("",[],[]) "HTML heading"
]
```

I went with the option that I've submitted because it was quick and dirty, and works for what I need. If this option or one of the other options sound like something that you want in pandoc, I am happy make any changes.
