### PR TITLE
Add command line option allowing to set type of top-level divisions

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -661,16 +661,19 @@ Options affecting specific writers
 
 `--chapters`
 
-:   Treat top-level headers as chapters in LaTeX, ConTeXt, and DocBook
-    output.  When the LaTeX document class is set to `report`, `book`,
-    or `memoir` (unless the `article` option is specified), this
-    option is implied.  If `beamer` is the output format, top-level
-    headers will become `\part{..}`.
+:   Deprecated synonym for `--top-level-division=chapter`.
 
-`--parts`
-:   Treat top-level headers as parts in LaTeX output.  The second level
-    headers will be chapters, i.e. `--chapters` is implied.  This does not
-    effect the `beamer` output format.
+`--top-level-division=[section|chapter|part]`
+
+:   Treat top-level headers as the given division type in LaTeX, ConTeXt,
+    DocBook, and  TEI output. The hierarchy order is part, chapter, then section;
+    all headers are shifted such that the top-level header becomes the specified
+    type.  The default is `section`. When the LaTeX document class is set to
+    `report`, `book`, or `memoir` (unless the `article` option is specified),
+    `chapter` is implied as the setting for this option.  If `beamer` is the
+    output format, specifying either `chapter` or `part` will cause top-level
+    headers to become `\part{..}`, while second-level headers remain as their
+    default type.
 
 `-N`, `--number-sections`
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -667,6 +667,11 @@ Options affecting specific writers
     option is implied.  If `beamer` is the output format, top-level
     headers will become `\part{..}`.
 
+`--parts`
+:   Treat top-level headers as parts in LaTeX output.  The second level
+    headers will be chapters, i.e. `--chapters` is implied.  This does not
+    effect the `beamer` output format.
+
 `-N`, `--number-sections`
 
 :   Number section headings in LaTeX, ConTeXt, HTML, or EPUB output.

--- a/pandoc.hs
+++ b/pandoc.hs
@@ -184,6 +184,7 @@ data Opt = Opt
     , optHighlight         :: Bool    -- ^ Highlight source code
     , optHighlightStyle    :: Style   -- ^ Style to use for highlighted code
     , optChapters          :: Bool    -- ^ Use chapter for top-level sects
+    , optParts             :: Bool    -- ^ Use parts for top-level sects in latex
     , optHTMLMathMethod    :: HTMLMathMethod -- ^ Method to print HTML math
     , optReferenceODT      :: Maybe FilePath -- ^ Path of reference.odt
     , optReferenceDocx     :: Maybe FilePath -- ^ Path of reference.docx
@@ -249,6 +250,7 @@ defaultOpts = Opt
     , optHighlight             = True
     , optHighlightStyle        = pygments
     , optChapters              = False
+    , optParts                 = False
     , optHTMLMathMethod        = PlainMath
     , optReferenceODT          = Nothing
     , optReferenceDocx         = Nothing
@@ -608,6 +610,11 @@ options =
                  (NoArg
                   (\opt -> return opt { optChapters = True }))
                  "" -- "Use chapter for top-level sections in LaTeX, DocBook"
+
+    , Option "" ["parts"]
+                 (NoArg
+                  (\opt -> return opt { optParts = True }))
+                 "" -- "Use part for top-level sections in LaTeX"
 
     , Option "N" ["number-sections"]
                  (NoArg
@@ -1124,6 +1131,7 @@ convertWithOpts opts args = do
               , optHighlightStyle        = highlightStyle
               , optChapters              = chapters
               , optHTMLMathMethod        = mathMethod'
+              , optParts                 = parts
               , optReferenceODT          = referenceODT
               , optReferenceDocx         = referenceDocx
               , optEpubStylesheet        = epubStylesheet
@@ -1387,6 +1395,7 @@ convertWithOpts opts args = do
                             writerHtml5            = html5,
                             writerHtmlQTags        = htmlQTags,
                             writerChapters         = chapters,
+                            writerParts            = parts,
                             writerListings         = listings,
                             writerBeamer           = False,
                             writerSlideLevel       = slideLevel,

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -374,6 +374,7 @@ data WriterOptions = WriterOptions
   , writerBeamer           :: Bool       -- ^ Produce beamer LaTeX slide show
   , writerSlideLevel       :: Maybe Int  -- ^ Force header level of slides
   , writerChapters         :: Bool       -- ^ Use "chapter" for top-level sects
+  , writerParts            :: Bool       -- ^ Use "part" for top-level sects in LaTeX
   , writerListings         :: Bool       -- ^ Use listings package for code
   , writerHighlight        :: Bool       -- ^ Highlight source code
   , writerHighlightStyle   :: Style      -- ^ Style to use for highlighting
@@ -422,6 +423,7 @@ instance Default WriterOptions where
                       , writerBeamer           = False
                       , writerSlideLevel       = Nothing
                       , writerChapters         = False
+                      , writerParts            = False
                       , writerListings         = False
                       , writerHighlight        = False
                       , writerHighlightStyle   = pygments

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -43,6 +43,7 @@ module Text.Pandoc.Options ( Extension(..)
                            , HTMLSlideVariant (..)
                            , EPUBVersion (..)
                            , WrapOption (..)
+                           , Division (..)
                            , WriterOptions (..)
                            , TrackChanges (..)
                            , ReferenceLocation (..)
@@ -337,6 +338,12 @@ data WrapOption = WrapAuto        -- ^ Automatically wrap to width
                 | WrapPreserve    -- ^ Preserve wrapping of input source
                 deriving (Show, Read, Eq, Data, Typeable, Generic)
 
+-- | Options defining the type of top-level headers.
+data Division = Part              -- ^ Top-level headers become parts
+              | Chapter           -- ^ Top-level headers become chapters
+              | Section           -- ^ Top-level headers become sections
+              deriving (Show, Read, Eq, Ord, Data, Typeable, Generic)
+
 -- | Locations for footnotes and references in markdown output
 data ReferenceLocation = EndOfBlock    -- ^ End of block
                        | EndOfSection  -- ^ prior to next section header (or end of document)
@@ -373,8 +380,7 @@ data WriterOptions = WriterOptions
   , writerHtmlQTags        :: Bool       -- ^ Use @<q>@ tags for quotes in HTML
   , writerBeamer           :: Bool       -- ^ Produce beamer LaTeX slide show
   , writerSlideLevel       :: Maybe Int  -- ^ Force header level of slides
-  , writerChapters         :: Bool       -- ^ Use "chapter" for top-level sects
-  , writerParts            :: Bool       -- ^ Use "part" for top-level sects in LaTeX
+  , writerTopLevelDivision :: Division   -- ^ Type of top-level divisions
   , writerListings         :: Bool       -- ^ Use listings package for code
   , writerHighlight        :: Bool       -- ^ Highlight source code
   , writerHighlightStyle   :: Style      -- ^ Style to use for highlighting
@@ -422,8 +428,7 @@ instance Default WriterOptions where
                       , writerHtmlQTags        = False
                       , writerBeamer           = False
                       , writerSlideLevel       = Nothing
-                      , writerChapters         = False
-                      , writerParts            = False
+                      , writerTopLevelDivision = Section
                       , writerListings         = False
                       , writerHighlight        = False
                       , writerHighlightStyle   = pygments

--- a/src/Text/Pandoc/Writers/TEI.hs
+++ b/src/Text/Pandoc/Writers/TEI.hs
@@ -60,7 +60,10 @@ writeTEI opts (Pandoc meta blocks) =
                     then Just $ writerColumns opts
                     else Nothing
       render' = render colwidth
-      startLvl = if writerChapters opts then 0 else 1
+      startLvl = case writerTopLevelDivision opts of
+                   Part    -> -1
+                   Chapter -> 0
+                   Section -> 1
       auths'   = map (authorToTEI opts) $ docAuthors meta
       meta'    = B.setMeta "author" auths' meta
       Just metadata = metaToJSON opts
@@ -86,8 +89,10 @@ elementToTEI opts lvl (Sec _ _num (id',_,_) title elements) =
   let elements' = if null elements
                     then [Blk (Para [])]
                     else elements
+      -- level numbering correspond to LaTeX internals
       divType = case lvl of
-                 n | n == 0           -> "chapter"
+                 n | n == -1          -> "part"
+                   | n == 0           -> "chapter"
                    | n >= 1 && n <= 5 -> "level" ++ show n
                    | otherwise        -> "section"
   in inTags True "div" [("type", divType) | not (null id')] $

--- a/src/Text/Pandoc/Writers/TEI.hs
+++ b/src/Text/Pandoc/Writers/TEI.hs
@@ -35,7 +35,7 @@ import Text.Pandoc.Shared
 import Text.Pandoc.Writers.Shared
 import Text.Pandoc.Options
 import Text.Pandoc.Templates (renderTemplate')
-import Data.List ( stripPrefix, isPrefixOf, isSuffixOf )
+import Data.List ( stripPrefix, isPrefixOf )
 import Data.Char ( toLower )
 import Text.Pandoc.Highlighting ( languages, languagesByExtension )
 import Text.Pandoc.Pretty
@@ -60,19 +60,15 @@ writeTEI opts (Pandoc meta blocks) =
                     then Just $ writerColumns opts
                     else Nothing
       render' = render colwidth
-      opts' = if "/book>" `isSuffixOf`
-                      (trimr $ writerTemplate opts)
-                 then opts{ writerChapters = True }
-                 else opts
-      startLvl = if writerChapters opts' then 0 else 1
+      startLvl = if writerChapters opts then 0 else 1
       auths'   = map (authorToTEI opts) $ docAuthors meta
       meta'    = B.setMeta "author" auths' meta
       Just metadata = metaToJSON opts
                  (Just . render colwidth . (vcat .
-                          (map (elementToTEI opts' startLvl)) . hierarchicalize))
-                 (Just . render colwidth . inlinesToTEI opts')
+                          (map (elementToTEI opts startLvl)) . hierarchicalize))
+                 (Just . render colwidth . inlinesToTEI opts)
                  meta'
-      main    = render' $ vcat (map (elementToTEI opts' startLvl) elements)
+      main    = render' $ vcat (map (elementToTEI opts startLvl) elements)
       context = defField "body" main
               $ defField "mathml" (case writerHTMLMathMethod opts of
                                         MathML _ -> True


### PR DESCRIPTION
Add --parts command line argument.
This only effects LaTeX writer, and only for non-beamer output formats.
It changes the output levels so the top level is 'part', the next
'chapter' and then into sections.

This is a rebased and slightly altered version of PR #1554.  @cwoac, I hope you don't mind the changes.