### PR TITLE
Replace Google Chart API by CodeCogs

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2715,7 +2715,7 @@ Docx
 
 FictionBook2
   ~ If the `--webtex` option is used, formulas are rendered as images
-    using CodeCogss or other compatible web service, downloaded
+    using CodeCogs or other compatible web service, downloaded
     and embedded in the e-book. Otherwise, they will appear verbatim.
 
 HTML, Slidy, DZSlides, S5, EPUB

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -962,7 +962,7 @@ Math rendering in HTML
 
 :   Render TeX formulas using an external script that converts TeX
     formulas to images. The formula will be concatenated with the URL
-    provided. If *URL* is not specified, the Google Chart API will be used.
+    provided. If *URL* is not specified, the CodeCogs will be used.
     Note:  the `--webtex` option will affect Markdown output
     as well as HTML.
 
@@ -2715,7 +2715,7 @@ Docx
 
 FictionBook2
   ~ If the `--webtex` option is used, formulas are rendered as images
-    using Google Charts or other compatible web service, downloaded
+    using CodeCogss or other compatible web service, downloaded
     and embedded in the e-book. Otherwise, they will appear verbatim.
 
 HTML, Slidy, DZSlides, S5, EPUB
@@ -2758,8 +2758,8 @@ HTML, Slidy, DZSlides, S5, EPUB
     6.  If the `--webtex` option is used, TeX formulas will be converted
         to `<img>` tags that link to an external script that converts
         formulas to images. The formula will be URL-encoded and concatenated
-        with the URL provided. If no URL is specified, the Google Chart
-        API will be used (`http://chart.apis.google.com/chart?cht=tx&chl=`).
+        with the URL provided. If no URL is specified, the CodeCogs
+        will be used (`https://latex.codecogs.com/png.latex?`).
 
     7.  If the `--mathjax` option is used, TeX math will be displayed
         between `\(...\)` (for inline math) or `\[...\]` (for display

--- a/man/pandoc.1
+++ b/man/pandoc.1
@@ -1092,7 +1092,7 @@ If \f[I]URL\f[] is not specified, it is assumed that the script is at
 Render TeX formulas using an external script that converts TeX formulas
 to images.
 The formula will be concatenated with the URL provided.
-If \f[I]URL\f[] is not specified, the Google Chart API will be used.
+If \f[I]URL\f[] is not specified, the CodeCogs will be used.
 Note: the \f[C]\-\-webtex\f[] option will affect Markdown output as well
 as HTML.
 .RS
@@ -3376,7 +3376,7 @@ It will be rendered using OMML math markup.
 .TP
 .B FictionBook2
 If the \f[C]\-\-webtex\f[] option is used, formulas are rendered as
-images using Google Charts or other compatible web service, downloaded
+images using CodeCogs or other compatible web service, downloaded
 and embedded in the e\-book.
 Otherwise, they will appear verbatim.
 .RS
@@ -3433,8 +3433,8 @@ If the \f[C]\-\-webtex\f[] option is used, TeX formulas will be
 converted to \f[C]<img>\f[] tags that link to an external script that
 converts formulas to images.
 The formula will be URL\-encoded and concatenated with the URL provided.
-If no URL is specified, the Google Chart API will be used
-(\f[C]http://chart.apis.google.com/chart?cht=tx&chl=\f[]).
+If no URL is specified, the CodeCogs will be used
+(\f[C]https://latex.codecogs.com/png.latex?\f[]).
 .IP "7." 3
 If the \f[C]\-\-mathjax\f[] option is used, TeX math will be displayed
 between \f[C]\\(...\\)\f[] (for inline math) or \f[C]\\[...\\]\f[] (for

--- a/pandoc.hs
+++ b/pandoc.hs
@@ -823,7 +823,7 @@ options =
     , Option "" ["webtex"]
                  (OptArg
                   (\arg opt -> do
-                      let url' = fromMaybe "http://chart.apis.google.com/chart?cht=tx&chl=" arg
+                      let url' = fromMaybe "https://latex.codecogs.com/png.latex?" arg
                       return opt { optHTMLMathMethod = WebTeX url' })
                   "URL")
                  "" -- "Use web service for HTML math"


### PR DESCRIPTION
I can't reopen #3142. So I open a new one here.

Google Chart API has already been deprecated on April 20, 2015. It is now a "zombie" service:

>While the dynamic and interactive Google Charts are actively maintained, we officially deprecated the static Google Image Charts way back in 2012. This gives us the right to turn it off without notice, although we have no plans to do so.
> from [Image Charts  |  Google Developers](https://developers.google.com/chart/image/)

Info on CodeCogs:

1. [Usage Policy | CodeCogs Equation Editor](http://www.codecogs.com/latex/usage.php): **up to 3,000 equations a day for testing and non-commercial use**
2. [Implement an API call to display LaTeX as inline image - Meta Stack Exchange](http://meta.stackexchange.com/questions/53436/implement-an-api-call-to-display-latex-as-inline-image): from here we see CodeCogs renders better than Google Chart API. (not the reason of the pull request here but a nice bonus.
3. adam-p/markdown-here#144: markdown-here developers has some insightful discussions about replacing Google Chart API by CodeCogs there

I also found a post on usage limit on Google Chart API: [Lifting the limit on calls to the Google Chart API - The official Google Code blog](http://googlecode.blogspot.fr/2008/03/lifting-limit-on-calls-to-google-chart.html), which was 50,000 queries per user per day but lifted practically to 250,000 queries per day.