### PR TITLE
Remove mmd raw tex

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3460,7 +3460,7 @@ variants are supported:
 
 `markdown_mmd` (MultiMarkdown)
 :   `pipe_tables`, `raw_html`, `markdown_attribute`, `mmd_link_attributes`,
-    `raw_tex`, `tex_math_double_backslash`, `intraword_underscores`,
+    `tex_math_double_backslash`, `intraword_underscores`,
     `mmd_title_block`, `footnotes`, `definition_lists`,
     `all_symbols_escapable`, `implicit_header_references`,
     `auto_identifiers`, `mmd_header_identifiers`,

--- a/man/pandoc.1
+++ b/man/pandoc.1
@@ -4303,7 +4303,7 @@ variants are supported:
 .TP
 .B \f[C]markdown_mmd\f[] (MultiMarkdown)
 \f[C]pipe_tables\f[], \f[C]raw_html\f[], \f[C]markdown_attribute\f[],
-\f[C]mmd_link_attributes\f[], \f[C]raw_tex\f[],
+\f[C]mmd_link_attributes\f[],
 \f[C]tex_math_double_backslash\f[], \f[C]intraword_underscores\f[],
 \f[C]mmd_title_block\f[], \f[C]footnotes\f[], \f[C]definition_lists\f[],
 \f[C]all_symbols_escapable\f[], \f[C]implicit_header_references\f[],

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -223,7 +223,9 @@ multimarkdownExtensions = Set.fromList
   , Ext_raw_html
   , Ext_markdown_attribute
   , Ext_mmd_link_attributes
-  , Ext_raw_tex
+  -- , Ext_raw_tex
+  -- Note: MMD's raw TeX syntax requires raw TeX to be
+  -- enclosed in HTML comment
   , Ext_tex_math_double_backslash
   , Ext_intraword_underscores
   , Ext_mmd_title_block

--- a/temp2.txt
+++ b/temp2.txt
@@ -1,0 +1,8 @@
+.//MANUAL.txt
+.//changelog
+.//man/pandoc.1
+.//src/Text/Pandoc.hs
+.//src/Text/Pandoc/Options.hs
+.//src/Text/Pandoc/Templates.hs
+.//trypandoc/index.html
+.//trypandoc/trypandoc.hs

--- a/temp2.txt
+++ b/temp2.txt
@@ -1,8 +1,8 @@
-.//MANUAL.txt
-.//changelog
-.//man/pandoc.1
-.//src/Text/Pandoc.hs
-.//src/Text/Pandoc/Options.hs
-.//src/Text/Pandoc/Templates.hs
-.//trypandoc/index.html
-.//trypandoc/trypandoc.hs
+MANUAL.txt
+changelog
+man/pandoc.1
+# src/Text/Pandoc.hs
+# src/Text/Pandoc/Options.hs
+src/Text/Pandoc/Templates.hs
+trypandoc/index.html
+trypandoc/trypandoc.hs

--- a/temp2.txt
+++ b/temp2.txt
@@ -1,8 +1,9 @@
-MANUAL.txt
-changelog
-man/pandoc.1
+# MANUAL.txt
+# changelog
+# man/pandoc.1
+# README.md
 # src/Text/Pandoc.hs
 # src/Text/Pandoc/Options.hs
-src/Text/Pandoc/Templates.hs
-trypandoc/index.html
-trypandoc/trypandoc.hs
+# src/Text/Pandoc/Templates.hs
+# trypandoc/index.html
+# trypandoc/trypandoc.hs

--- a/temp2.txt
+++ b/temp2.txt
@@ -1,9 +1,0 @@
-# MANUAL.txt
-# changelog
-# man/pandoc.1
-# README.md
-# src/Text/Pandoc.hs
-# src/Text/Pandoc/Options.hs
-# src/Text/Pandoc/Templates.hs
-# trypandoc/index.html
-# trypandoc/trypandoc.hs


### PR DESCRIPTION
According to [MultiMarkdown-5/using_mmd.md](https://github.com/fletcher/MultiMarkdown-5/blob/gh-pages/using_mmd.md#multimarkdown-and-latex), MultiMarkdown expects raw LaTeX to be within HTML comments, *e.g.*,


```html
<!-- \FloatBarrier -->
<!-- \begin{flushright} --><div align="right">
testing flush right.
<!-- \end{flushright} --></div>
```

I tried to compile the above file by `pandoc -f markdown_mmd -o test-pandoc.md test.md` and the HTML comments is not parsed as raw LaTeX.

I don't think pandoc should have a reader for that syntax since by [MultiMarkdown-5/Raw Source](http://fletcher.github.io/MultiMarkdown-5/raw.html), the same syntax could be used for "Raw LaTeX/OpenDocument/etc.".

The pull request is to remove the inclusion of `raw_tex` in `markdown_mmd` variants.

In other words, a raw LaTeX in the pandoc sense would never appears in a valid MultiMarkdown document (for example, if a raw LaTeX in the pandoc sense, say, `\FloatBarrier` is included in a MultiMarkdown document, the TeX output of that would becomes something like `\backslash FloatBarrier`. I tried that in the past.). And it would be better to remove it in the definition of `markdown_mmd` to avoid confusion.

I compiled it and everything looks fine except I also run into issue #3131.