### PR TITLE
Delete googlecode-upload.sh

### DIFF
--- a/googlecode-upload.sh
+++ b/googlecode-upload.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-VERSION=$1
-googlecode_upload.py -s "Source tarball" -p pandoc -u fiddlosopher --labels=Featured,Type-Source,OpSys-All  dist/pandoc-$VERSION.tar.gz
-googlecode_upload.py -s "Windows installer" -p pandoc -u fiddlosopher --labels=Featured,Type-Installer,OpSys-Windows  pandoc-$VERSION.msi
-googlecode_upload.py -s "Mac OS X installer" -p pandoc -u fiddlosopher --labels=Featured,Type-Installer,OpSys-OSX  pandoc-$VERSION.pkg.zip


### PR DESCRIPTION
Since Google Code was shut down already, it seems that we don't need this script anymore?