### PR TITLE
[odt] proper formatting of an image with a caption

### DIFF
--- a/src/Text/Pandoc/Readers/Odt/ContentReader.hs
+++ b/src/Text/Pandoc/Readers/Odt/ContentReader.hs
@@ -779,8 +779,12 @@ read_frame_text_box = matchingElement NsDraw "text-box"
                          arr read_img_with_caption                             -< toList paragraphs
 
 read_img_with_caption :: [Block] -> Inlines
-read_img_with_caption ((Para ((Image attr _ target) : txt)) : _) =
-  singleton (Image attr txt target)             -- override caption with the text that follows
+read_img_with_caption ((Para ((Image attr alt (src,title)) : [])) : _) =
+  singleton (Image attr alt (src, 'f':'i':'g':':':title))   -- no text, default caption
+read_img_with_caption ((Para ((Image attr _ (src,title)) : txt)) : _) =
+  singleton (Image attr txt (src, 'f':'i':'g':':':title) )  -- override caption with the text that follows
+read_img_with_caption  ( (Para (_ : xs)) : ys) =
+  read_img_with_caption ((Para xs) : ys)
 read_img_with_caption _ =
   mempty
 

--- a/tests/odt/native/imageIndex.native
+++ b/tests/odt/native/imageIndex.native
@@ -1,1 +1,1 @@
-[Para [Image ("",[],[("width","5.292cm"),("height","5.292cm")]) [Str "Abbildung",Space,Str "1:",Space,Str "Image",Space,Str "caption"] ("Pictures/10000000000000FA000000FAD6A15225.jpg","")]]
+[Para [Image ("",[],[("width","5.292cm"),("height","5.292cm")]) [Str "Abbildung",Space,Str "1:",Space,Str "Image",Space,Str "caption"] ("Pictures/10000000000000FA000000FAD6A15225.jpg","fig:")]]

--- a/tests/odt/native/imageWithCaption.native
+++ b/tests/odt/native/imageWithCaption.native
@@ -1,1 +1,1 @@
-[Para [Image ("",[],[("width","5.292cm"),("height","5.292cm")]) [Str "Abbildung",Space,Str "1:",Space,Str "Image",Space,Str "caption"] ("Pictures/10000000000000FA000000FAD6A15225.jpg","")]]
+[Para [Image ("",[],[("width","5.292cm"),("height","5.292cm")]) [Str "Abbildung",Space,Str "1:",Space,Str "Image",Space,Str "caption"] ("Pictures/10000000000000FA000000FAD6A15225.jpg","fig:")]]


### PR DESCRIPTION
Latex Writer only handles captions if the image's title
is prefixed with 'fig:'.