### PR TITLE
Small caps in Bracketed Spans

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2719,6 +2719,10 @@ To write small caps, you can use an HTML span tag:
 (The semicolon is optional and there may be space after the
 colon.) This will work in all output formats that support small caps.
 
+Alternatively, you can also use the new `bracketed_spans` syntax:
+
+    [Small caps]{style="font-variant:small-caps;"}
+
 Math
 ----
 

--- a/man/pandoc.1
+++ b/man/pandoc.1
@@ -3388,6 +3388,14 @@ To write small caps, you can use an HTML span tag:
 .PP
 (The semicolon is optional and there may be space after the colon.) This
 will work in all output formats that support small caps.
+.PP
+Alternatively, you can also use the new \f[C]bracketed_spans\f[] syntax:
+.IP
+.nf
+\f[C]
+[Small\ caps]{style="font\-variant:small\-caps;"}
+\f[]
+.fi
 .SS Math
 .SS Extension: \f[C]tex_math_dollars\f[]
 .PP

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1758,7 +1758,13 @@ bracketedSpan = try $ do
   guardEnabled Ext_bracketed_spans
   (lab,_) <- reference
   attr <- attributes
-  return $ B.spanWith attr <$> lab
+  let (_,_,keyvals) = attr
+  case lookup "style" keyvals of
+       Just s | 
+            map toLower (filter (`notElem` " \t;") s) ==
+                 "font-variant:small-caps"
+         -> return $ B.smallcaps <$> lab
+       _ -> return $ B.spanWith attr <$> lab
 
 regLink :: (Attr -> String -> String -> Inlines -> Inlines)
         -> F Inlines -> MarkdownParser (F Inlines)

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1758,9 +1758,9 @@ bracketedSpan = try $ do
   guardEnabled Ext_bracketed_spans
   (lab,_) <- reference
   attr <- attributes
-  let (_,_,keyvals) = attr
+  let (ident,classes,keyvals) = attr
   case lookup "style" keyvals of
-       Just s | 
+       Just s | null ident && null classes &&
             map toLower (filter (`notElem` " \t;") s) ==
                  "font-variant:small-caps"
          -> return $ B.smallcaps <$> lab


### PR DESCRIPTION
I adapted the relevant code from `spanHtml` into `bracketedSpan` to check if small caps style is used in bracketed spans.

I then update the `MANUAL.txt` accordingly to reflect this use.

I tested and it compile successfully. The code I used to test if the small caps with bracketed span works is:

``` markdown
1. HTML:
    - <span style="font-variant:small-caps;">Small caps</span>
    - <span style="font-variant:small-caps">Small caps</span>
    - <span style="font-variant: small-caps">Small caps</span>
2. markdown:
    - [Small caps]{style="font-variant:small-caps;"}
    - [Small caps]{style="font-variant:small-caps"}
    - [Small caps]{style="font-variant: small-caps"}
```

I don't know anything about the tests yet so I didn't modify any of the test to test this.

Edit: this should partially resolves issue #2761 
