### PR TITLE
[odt] Infer tables' header props from rows

### DIFF
--- a/src/Text/Pandoc/Readers/Odt/ContentReader.hs
+++ b/src/Text/Pandoc/Readers/Odt/ContentReader.hs
@@ -695,7 +695,7 @@ read_citation     = matchingElement NsText "bibliography-mark"
                         ( findAttrWithDefault NsText "identifier" ""     )
                         ( readAttrWithDefault NsText "number" 0          )
                       )
-                      ( matchChildContent [] read_plain_text                 )
+                      ( matchChildContent [] read_plain_text             )
   where
    makeCitation :: String -> Int -> [Citation]
    makeCitation citeId num = [Citation citeId [] [] NormalCitation num 0]
@@ -708,9 +708,16 @@ read_citation     = matchingElement NsText "bibliography-mark"
 --
 read_table        :: BlockMatcher
 read_table         = matchingElement NsTable "table"
-                     $ liftA (simpleTable [])
+                     $ liftA simpleTable'
                      $ matchChildContent'  [ read_table_row
                                            ]
+
+-- | A simple table without a caption or headers
+-- | Infers the number of headers from rows
+simpleTable' :: [[Blocks]] -> Blocks
+simpleTable' []         = simpleTable [] []
+simpleTable' (x : rest) = simpleTable (fmap (const defaults) x) (x : rest)
+  where defaults = fromList []
 
 --
 read_table_row    :: ElementMatcher [[Blocks]]

--- a/tests/odt/native/simpleTable.native
+++ b/tests/odt/native/simpleTable.native
@@ -1,1 +1,1 @@
-[Table [] [] [] [] [[[Plain [Str "Content"]],[Plain [Str "More",Space,Str "content"]]]],Para []]
+[Table [] [AlignDefault,AlignDefault] [0.0,0.0] [[],[]] [[[Plain [Str "Content"]],[Plain [Str "More",Space,Str "content"]]]],Para []]


### PR DESCRIPTION
ODT reader simply provided an empty header list
which meant that the contents of the whole table,
even if not empty, was simply ignored.
While we still do not infer headers we at least have
to provide default properties of columns.