### PR TITLE
travis: use language generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@
 # Use new container infrastructure to enable caching
 sudo: false
 
-# Choose a lightweight base image; we provide our own build tools.
-language: c
+# Do not choose a language; we provide our own build tools.
+language: generic
 
 # Caching so the next build will be fast too.
 cache:


### PR DESCRIPTION
See commercialhaskell/stack#2784:

>Although `language: generic` is undocumented, it is widely used...

It doesn’t give any visible speed boost, if any, probably only shave dozens seconds in boot up time. But since commercialhaskell/stack accepted this pull request, I figure it at least does no harm to make into pandoc.