### PR TITLE
Fixed linker error on macOS/OS X 10.9+

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -443,6 +443,8 @@ Executable pandoc
      Build-Depends: network >= 2 && < 2.6
   Ghc-Options:   -rtsopts -with-rtsopts=-K16m -Wall -fno-warn-unused-do-bind
   Ghc-Prof-Options: -fprof-auto-exported -rtsopts -with-rtsopts=-K16m
+  if os(darwin)
+    cpp-options:      -stdlib=libstdc++
   if os(windows)
     Cpp-options:      -D_WINDOWS
   else


### PR DESCRIPTION
I ran into a problem trying to build the project with stack build or
stack install on macOS/OS X version >= 10.9. It spits out this linker
error:
```
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see
invocation)
`gcc' failed in phase `Linker'. (Exit code: 1)
```

I've added `-stdlib=libstdc++` cpp flag to link against libstdc++
instead of libc++ which is default from OS X version 10.9 up.

Fixes #3291