### PR TITLE
Speed up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ install:
     cabal)
       cabal --version
       travis_retry cabal update
-      cabal install --only-dependencies -ffast --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS
+      cabal install -j --only-dependencies -ffast --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS
       ;;
   esac
 
@@ -117,12 +117,12 @@ script:
       ;;
     cabal)
       cabal configure --enable-tests --enable-benchmarks -v2 -ffast --ghc-options="-O0 -Wall -fno-warn-unused-do-bind -Werror"
-      cabal build
+      cabal build -j
       cabal check
-      cabal test
+      cabal test -j
       cabal copy
       cabal sdist
       SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz && \
-        (cd dist && cabal install --enable-tests --force-reinstalls "$SRC_TGZ")
+        (cd dist && cabal install -j --enable-tests --force-reinstalls "$SRC_TGZ")
       ;;
   esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ cache:
 # If you need to have different apt packages for each combination in the
 # matrix, you can use a line such as:
 #     addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+#
+# fast_finish: build successful when every builds not in allow_failure are finished
+# i.e. not waiting any of the allow_failure to finish
 matrix:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
@@ -67,6 +70,8 @@ matrix:
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head
   - env: BUILD=stack ARGS="--resolver nightly"
+
+  fast_finish: true
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ matrix:
     compiler: ": #stack 8.0.1 osx"
     os: osx
 
-  - env: BUILD=stack ARGS="--resolver nightly"
-    compiler: ": #stack nightly osx"
-    os: osx
+  # - env: BUILD=stack ARGS="--resolver nightly"
+  #   compiler: ": #stack nightly osx"
+  #   os: osx
 
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head


### PR DESCRIPTION
- travis use `fast_finish`
- cabal uses `-j`

I added the comments on fast_finish into the file directly for future reference. This will gives the most "speed up" since it will returns the "green light" when the 2 `allow_failure` builds aren't finished (useful for pull request when waiting for the green light).

The cabal `-j` means it will set parallel jobs according to the number of CPUs. It only speed ups when there're multiple dependencies that can be installed at the same time. I noticed that gitit's travis build uses `-j2` while it isn't used in pandoc. So may be there's a reason behind that?