### PR TITLE
MANUAL/README: Fixed broken links

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -67,7 +67,7 @@ Markdown can be expected to be lossy.
 [LaTeX]: http://latex-project.org
 [`beamer`]: https://ctan.org/pkg/beamer
 [Beamer User's Guide]: http://ctan.math.utah.edu/ctan/tex-archive/macros/latex/contrib/beamer/doc/beameruserguide.pdf
-[ConTeXt]: http://contextgarden.net/
+[ConTeXt]: http://www.contextgarden.net/
 [RTF]: http://en.wikipedia.org/wiki/Rich_Text_Format
 [DocBook]: http://docbook.org
 [txt2tags]: http://txt2tags.org
@@ -81,13 +81,13 @@ Markdown can be expected to be lossy.
 [ZimWiki markup]: http://zim-wiki.org/manual/Help/Wiki_Syntax.html
 [TWiki markup]: http://twiki.org/cgi-bin/view/TWiki/TextFormattingRules
 [Haddock markup]: https://www.haskell.org/haddock/doc/html/ch03s08.html
-[groff man]: http://developer.apple.com/DOCUMENTATION/Darwin/Reference/ManPages/man7/groff_man.7.html
+[groff man]: http://man7.org/linux/man-pages/man7/groff_man.7.html
 [Haskell]: https://www.haskell.org
 [GNU Texinfo]: http://www.gnu.org/software/texinfo/
 [Emacs Org mode]: http://orgmode.org
 [AsciiDoc]: http://www.methods.co.nz/asciidoc/
 [DZSlides]: http://paulrouget.com/dzslides/
-[Word docx]: http://www.microsoft.com/interop/openup/openxml/default.aspx
+[Word docx]: https://en.wikipedia.org/wiki/Office_Open_XML
 [PDF]: https://www.adobe.com/pdf/
 [reveal.js]: http://lab.hakim.se/reveal-js/
 [FictionBook2]: http://www.fictionbook.org/index.php/Eng:XML_Schema_Fictionbook_2.1

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Markdown can be expected to be lossy.
 [LaTeX]: http://latex-project.org
 [`beamer`]: https://ctan.org/pkg/beamer
 [Beamer User's Guide]: http://ctan.math.utah.edu/ctan/tex-archive/macros/latex/contrib/beamer/doc/beameruserguide.pdf
-[ConTeXt]: http://contextgarden.net/
+[ConTeXt]: http://www.contextgarden.net/
 [RTF]: http://en.wikipedia.org/wiki/Rich_Text_Format
 [DocBook]: http://docbook.org
 [txt2tags]: http://txt2tags.org
@@ -83,13 +83,13 @@ Markdown can be expected to be lossy.
 [ZimWiki markup]: http://zim-wiki.org/manual/Help/Wiki_Syntax.html
 [TWiki markup]: http://twiki.org/cgi-bin/view/TWiki/TextFormattingRules
 [Haddock markup]: https://www.haskell.org/haddock/doc/html/ch03s08.html
-[groff man]: http://developer.apple.com/DOCUMENTATION/Darwin/Reference/ManPages/man7/groff_man.7.html
+[groff man]: http://man7.org/linux/man-pages/man7/groff_man.7.html
 [Haskell]: https://www.haskell.org
 [GNU Texinfo]: http://www.gnu.org/software/texinfo/
 [Emacs Org mode]: http://orgmode.org
 [AsciiDoc]: http://www.methods.co.nz/asciidoc/
 [DZSlides]: http://paulrouget.com/dzslides/
-[Word docx]: http://www.microsoft.com/interop/openup/openxml/default.aspx
+[Word docx]: https://en.wikipedia.org/wiki/Office_Open_XML
 [PDF]: https://www.adobe.com/pdf/
 [reveal.js]: http://lab.hakim.se/reveal-js/
 [FictionBook2]: http://www.fictionbook.org/index.php/Eng:XML_Schema_Fictionbook_2.1


### PR DESCRIPTION
- ConTeXt garden: trivial editing
- groff man: Apple's link returned 401. But if clicked through, it actually works. Nonetheless, I replace the link to GNU's version since it is the source.
- docx openxml: the link is broken. I replaced it with the best I can find. Please double check it is ok.


By the way, when building the `man`, it got errors. It doesn't affect this commit because the `man` doesn't have those links. The error is:

```bash
$ make man/pandoc.1
pandoc MANUAL.txt -t man -s --template man/pandoc.1.template \
	--filter man/capitalizeHeaders.hs \
	--filter man/removeNotes.hs \
	--filter man/removeLinks.hs \
	--variable version="pandoc 1.19.1" \
	-o man/pandoc.1
pandoc: Error running filter man/capitalizeHeaders.hs
fd:4: hPutBuf: resource vanished (Broken pipe)
make: *** [Makefile:41: man/pandoc.1] Error 83
```