### PR TITLE
markdown reader: disallow space between inline code and attributes

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1561,8 +1561,8 @@ code = try $ do
                        (char '\n' >> notFollowedBy' blankline >> return " "))
                       (try (skipSpaces >> count (length starts) (char '`') >>
                       notFollowedBy (char '`')))
-  attr <- option ([],[],[]) (try $ guardEnabled Ext_inline_code_attributes >>
-                                   optional whitespace >> attributes)
+  attr <- option ([],[],[]) (try $ guardEnabled Ext_inline_code_attributes
+                                   >> attributes)
   return $ return $ B.codeWith attr $ trim $ concat result
 
 math :: MarkdownParser (F Inlines)

--- a/tests/Tests/Readers/Markdown.hs
+++ b/tests/Tests/Readers/Markdown.hs
@@ -149,7 +149,8 @@ tests = [ testGroup "inline code"
                 (codeWith ("",["javascript"],[]) "document.write(\"Hello\");")
           , "with attribute space" =:
             "`*` {.haskell .special x=\"7\"}"
-            =?> para (codeWith ("",["haskell","special"],[("x","7")]) "*")
+            =?> para (code "*" <> space <> str "{.haskell" <> space <>
+                      str ".special" <> space <> str "x=\"7\"}")
           ]
         , testGroup "emph and strong"
           [ "two strongs in emph" =:


### PR DESCRIPTION
closes #3323

I think the change is worth the risk of possibly breaking a small handful of existing documents... maybe discussion needed?