### PR TITLE
Indent code on the installation page.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,16 +160,16 @@ The easiest way to build pandoc from source is to use [stack]:
     use the locale-sensitive unicode collation algorithm instead,
     specify the `unicode_collation` flag:
 
-       cabal install pandoc-citeproc -funicode_collation
+        cabal install pandoc-citeproc -funicode_collation
 
     Note that this requires the `text-icu` library, which in turn
     depends on the C library `icu4c`.  Installation directions
     vary by platform.  Here is how it might work on OSX with homebrew:
 
-       brew install icu4c
-       cabal install --extra-lib-dirs=/usr/local/Cellar/icu4c/51.1/lib \
-         --extra-include-dirs=/usr/local/Cellar/icu4c/51.1/include \
-         -funicode_collation text-icu pandoc-citeproc
+        brew install icu4c
+        cabal install --extra-lib-dirs=/usr/local/Cellar/icu4c/51.1/lib \
+          --extra-include-dirs=/usr/local/Cellar/icu4c/51.1/include \
+          -funicode_collation text-icu pandoc-citeproc
 
 6.  The `pandoc.1` man page will be installed automatically.  cabal shows
     you where it is installed: you may need to set your `MANPATH`


### PR DESCRIPTION
Previously, not all code on the installation page was highlighted/wrapped in code blocks due to incorrect indentation.

A screenshot of incorrectly generated output is attached.

<img width="870" alt="screen shot 2017-01-01 at 8 23 29 pm" src="https://cloud.githubusercontent.com/assets/171007/21583849/583ebf0e-d060-11e6-821a-c743cd10a222.png">

http://pandoc.org/installing.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgm/pandoc/3335)
<!-- Reviewable:end -->
