### PR TITLE
MediaWiki reader: Fix quotation mark parsing

### DIFF
--- a/src/Text/Pandoc/Readers/MediaWiki.hs
+++ b/src/Text/Pandoc/Readers/MediaWiki.hs
@@ -671,9 +671,6 @@ strong = B.strong <$> nested (inlinesBetween start end)
           end   = try $ sym "'''"
 
 doubleQuotes :: MWParser Inlines
-doubleQuotes = B.doubleQuoted . trimInlines . mconcat <$> try
- ((getState >>= guard . readerSmart . mwOptions) *>
-   openDoubleQuote *> manyTill inline closeDoubleQuote )
-    where openDoubleQuote = char '"' <* lookAhead alphaNum
-          closeDoubleQuote = char '"' <* notFollowedBy alphaNum
-
+doubleQuotes = B.doubleQuoted <$> nested (inlinesBetween openDoubleQuote closeDoubleQuote)
+    where openDoubleQuote = sym "\"" >> lookAhead nonspaceChar
+          closeDoubleQuote = try $ sym "\""


### PR DESCRIPTION
Change MediaWiki reader's behavior when the smart option is parsed to
match other readers' behavior.

Fix #2012.