### PR TITLE
Fix sample.lua barfing on Raw data

### DIFF
--- a/data/sample.lua
+++ b/data/sample.lua
@@ -173,8 +173,9 @@ end
 function RawInline(format, str)
   if format == "html" then
     return str
+  else
+    return ''
   end
-  return ''
 end
 
 function Cite(s, cs)
@@ -322,8 +323,9 @@ end
 function RawBlock(format, str)
   if format == "html" then
     return str
+  else
+    return ''
   end
-  return ''
 end
 
 function Div(s, attr)

--- a/data/sample.lua
+++ b/data/sample.lua
@@ -174,6 +174,7 @@ function RawInline(format, str)
   if format == "html" then
     return str
   end
+  return ''
 end
 
 function Cite(s, cs)
@@ -322,6 +323,7 @@ function RawBlock(format, str)
   if format == "html" then
     return str
   end
+  return ''
 end
 
 function Div(s, attr)


### PR DESCRIPTION
Fix for "pandoc: user error (Incorrect result type (string expected, got nil))." when the source format contains Raw data.