### PR TITLE
travis: catch #3372

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ matrix:
     compiler: ": #GHC 8.0.1"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5], sources: [hvr-ghc]}}
 
+  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24
+    compiler: ": #GHC 8.0.2"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5], sources: [hvr-ghc]}}
+
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
   - env: BUILD=cabal GHCVER=head  CABALVER=head
@@ -68,6 +72,7 @@ matrix:
   #   os: osx
 
   allow_failures:
+  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24
   - env: BUILD=cabal GHCVER=head  CABALVER=head
   - env: BUILD=stack ARGS="--resolver nightly"
 


### PR DESCRIPTION
I added GHC 8.0.2 to the Travis build and allow it to fail (since it is not a stable release yet)

I tried to catch the error reported in #3372 but instead [it just passed](https://travis-ci.org/ickc/pandoc/jobs/194631003).