### PR TITLE
HTML and DocBook writers: fix internal links with writerIdentifierPrefix opt

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -733,10 +733,10 @@ Options affecting specific writers
 
 `--id-prefix=`*STRING*
 
-:   Specify a prefix to be added to all automatically generated identifiers
-    in HTML and DocBook output, and to footnote numbers in Markdown output.
-    This is useful for preventing duplicate identifiers when generating
-    fragments to be included in other pages.
+:   Specify a prefix to be added to all identifiers and internal links
+    in HTML and DocBook output, and to footnote numbers in Markdown
+    and Haddock output. This is useful for preventing duplicate
+    identifiers when generating fragments to be included in other pages.
 
 `-T` *STRING*, `--title-prefix=`*STRING*
 

--- a/src/Text/Pandoc/Writers/Docbook.hs
+++ b/src/Text/Pandoc/Writers/Docbook.hs
@@ -405,7 +405,7 @@ inlineToDocbook opts (Link attr txt (src, _))
   | otherwise = do
       version <- ask
       (if isPrefixOf "#" src
-            then inTags False "link" $ ("linkend", drop 1 src) : idAndRole attr
+            then inTags False "link" $ ("linkend", writerIdentifierPrefix opts ++ drop 1 src) : idAndRole attr
             else if version == DocBook5
                     then inTags False "link" $ ("xlink:href", src) : idAndRole attr
                     else inTags False "ulink" $ ("url", src) : idAndRole attr )

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -933,9 +933,11 @@ inlineToHtml opts inline = do
                         linkText <- inlineListToHtml opts txt
                         slideVariant <- gets stSlideVariant
                         let s' = case s of
-                                      '#':xs | slideVariant == RevealJsSlides
-                                        -> '#':'/':xs
-                                      _ -> s
+                                   '#':xs -> let prefix = if slideVariant == RevealJsSlides
+                                                             then "/"
+                                                             else writerIdentifierPrefix opts
+                                             in  '#' : prefix ++ xs
+                                   _ -> s
                         let link = H.a ! A.href (toValue s') $ linkText
                         let link' = if txt == [Str (unEscapeString s)]
                                        then link ! A.class_ "uri"


### PR DESCRIPTION
fixes #3397

btw, the Haddock writer also uses `writerIdentifierPrefix` for its fake notes, which is not documented in the README... not sure whether to change the writer or the README...