### PR TITLE
Org anchor links

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -530,6 +530,7 @@ Test-Suite test-pandoc
                   Tests.Writers.Docbook
                   Tests.Writers.HTML
                   Tests.Writers.Markdown
+                  Tests.Writers.Org
                   Tests.Writers.Plain
                   Tests.Writers.AsciiDoc
                   Tests.Writers.LaTeX

--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -374,7 +374,7 @@ orgPath :: String -> String
 orgPath src =
   case src of
     []                 -> mempty         -- wiki link
-    ('#':xs)           -> xs             -- internal link
+    ('#':_)            -> src            -- internal link
     _ | isUrl src      -> src
     _ | isFilePath src -> src
     _                  -> "file:" <> src

--- a/test/Tests/Writers/Org.hs
+++ b/test/Tests/Writers/Org.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Tests.Writers.Org (tests) where
+
+import Test.Framework
+import Text.Pandoc.Builder
+import Text.Pandoc
+import Tests.Helpers
+import Text.Pandoc.Arbitrary()
+
+infix 4 =:
+(=:) :: (ToString a, ToPandoc a)
+     => String -> (a, String) -> Test
+(=:) = test (purely (writeOrg def . toPandoc))
+
+tests :: [Test]
+tests = [ testGroup "links"
+          -- See http://orgmode.org/manual/Internal-links.html#Internal-links
+          [ "simple link"
+              =: link "/url" "" "foo"
+              =?> "[[/url][foo]]"
+          , "internal link to anchor"
+              =: link "#my-custom-id" "" "#my-custom-id"
+              =?> "[[#my-custom-id]]"
+          ]
+        ]

--- a/test/test-pandoc.hs
+++ b/test/test-pandoc.hs
@@ -21,6 +21,7 @@ import qualified Tests.Writers.HTML
 import qualified Tests.Writers.Docbook
 import qualified Tests.Writers.Native
 import qualified Tests.Writers.Markdown
+import qualified Tests.Writers.Org
 import qualified Tests.Writers.Plain
 import qualified Tests.Writers.AsciiDoc
 import qualified Tests.Writers.Docx
@@ -41,6 +42,7 @@ tests = [ Tests.Command.tests
           , testGroup "HTML" Tests.Writers.HTML.tests
           , testGroup "Docbook" Tests.Writers.Docbook.tests
           , testGroup "Markdown" Tests.Writers.Markdown.tests
+          , testGroup "Org" Tests.Writers.Org.tests
           , testGroup "Plain" Tests.Writers.Plain.tests
           , testGroup "AsciiDoc" Tests.Writers.AsciiDoc.tests
           , testGroup "Docx" Tests.Writers.Docx.tests


### PR DESCRIPTION
According to [The Org Manual](http://orgmode.org/manual/Internal-links.html#Internal-links), internal links should contain `#`. Links without `#`
> lead to a text search in the current file

Likely stripping `#` was not intended.