### PR TITLE
Use SVG instead of PNG when using webtex.

### DIFF
--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -1221,7 +1221,7 @@ options =
     , Option "" ["webtex"]
                  (OptArg
                   (\arg opt -> do
-                      let url' = fromMaybe "https://latex.codecogs.com/png.latex?" arg
+                      let url' = fromMaybe "https://latex.codecogs.com/svg.latex?" arg
                       return opt { optHTMLMathMethod = WebTeX url' })
                   "URL")
                  "" -- "Use web service for HTML math"


### PR DESCRIPTION
Codecogs supports svg and not only png. In my opinion it's a much better choice and I think `pandoc` should use it as default.