### PR TITLE
Fix stale references to `tests` directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ or, if you're using [stack],
     stack setup
     stack test
 
-The test program is `tests/test-pandoc.hs`.
+The test program is `test/test-pandoc.hs`.
 
 Benchmarks
 ----------
@@ -242,7 +242,7 @@ github: <http://github.com/jgm/pandoc>.  To get a local copy of the source:
 
 The source for the main pandoc program is `pandoc.hs`.  The source for
 the pandoc library is in `src/`, the source for the tests is in
-`tests/`, and the source for the benchmarks is in `benchmark/`.
+`test/`, and the source for the benchmarks is in `benchmark/`.
 
 The modules `Text.Pandoc.Definition`, `Text.Pandoc.Builder`, and
 `Text.Pandoc.Generic` are in a separate library `pandoc-types`.  The code can

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -57,7 +57,7 @@ Released under the GNU General Public License version 2 or later.
 
 ----------------------------------------------------------------------
 src/Text/Pandoc/Readers/Org.hs
-tests/Tests/Readers/Org.hs
+test/Tests/Readers/Org.hs
 Copyright (C) 2014-2015 Albert Krewinkel
 
 Released under the GNU General Public License version 2 or later.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -281,10 +281,10 @@ the `-t` option:
 
 If you add a new feature to pandoc, please add tests as well, following
 the pattern of the existing tests. The test suite code is in
-`tests/test-pandoc.hs`. If you are adding a new reader or writer, it is
-probably easiest to add some data files to the `tests` directory, and
-modify `tests/Tests/Old.hs`. Otherwise, it is better to modify the module
-under the `tests/Tests` hierarchy corresponding to the pandoc module you
+`test/test-pandoc.hs`. If you are adding a new reader or writer, it is
+probably easiest to add some data files to the `test` directory, and
+modify `test/Tests/Old.hs`. Otherwise, it is better to modify the module
+under the `test/Tests` hierarchy corresponding to the pandoc module you
 are changing.
 
 ### Running benchmarks

--- a/benchmark/benchmark-pandoc.hs
+++ b/benchmark/benchmark-pandoc.hs
@@ -61,9 +61,9 @@ main = do
       matchWriter (_, _) = False
   let matchedReaders = filter matchReader readers
   let matchedWriters = filter matchWriter writers
-  inp <- readFile "tests/testsuite.txt"
-  lalune <- B.readFile "tests/lalune.jpg"
-  movie <- B.readFile "tests/movie.jpg"
+  inp <- readFile "test/testsuite.txt"
+  lalune <- B.readFile "test/lalune.jpg"
+  movie <- B.readFile "test/movie.jpg"
   time <- getCurrentTime
   let setupFakeFiles = modifyPureState $ \st -> st{ stFiles =
                         FileTree $ Map.fromList [

--- a/benchmark/weigh-pandoc.hs
+++ b/benchmark/weigh-pandoc.hs
@@ -3,7 +3,7 @@ import Text.Pandoc
 
 main :: IO ()
 main = do
-  doc <- read <$> readFile "tests/testsuite.native"
+  doc <- read <$> readFile "test/testsuite.native"
   mainWith $ do
     func "Pandoc document" id doc
     mapM_


### PR DESCRIPTION
I noticed failures running the benchmarks:

```
pandoc-2.0: benchmarks
Running 1 benchmarks...
Benchmark benchmark-pandoc: RUNNING...
benchmark-pandoc: tests/testsuite.txt: openFile: does not exist (No such file or directory)
Benchmark benchmark-pandoc: ERROR
Completed 2 action(s).

--  While building package pandoc-2.0 using:
      /home/or/programming/haskell/pandoc/.stack-work/dist/x86_64-linux/Cabal-1.24.2.0/setup/setup --builddir=.stack-work/dist/x86_64-linux/Cabal-1.24.2.0 bench benchmark-pandoc
    Process exited with code: ExitFailure 1
```

So I looked and saw stale references to a directory `tests` which should instead be `test`.  Updating the references fixed the benchmark failures.  I then searched through the project to see if there were other references to it, and found and updated a few.

Anyway, this is my first PR to pandoc, so if I'm running foul of any guidelines (e.g. if I should have first created an issue about the benchmark failure and then referenced it in the PR, or whatever) please let me know.

Cheers!