### PR TITLE
Issue237 html5 polyglot: Make default.html5 polyglot markup conformant.

### DIFF
--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
 <head>
-  <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
 $for(author-meta)$
-  <meta name="author" content="$author-meta$">
+  <meta name="author" content="$author-meta$" />
 $endfor$
 $if(date-meta)$
-  <meta name="dcterms.date" content="$date-meta$">
+  <meta name="dcterms.date" content="$date-meta$" />
 $endif$
 $if(keywords)$
-  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$">
+  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
 $endif$
   <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
   <style type="text/css">code{white-space: pre;}</style>

--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
+<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
 <head>
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">

--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang$" xml:lang="$lang$"$if(dir)$ dir="$dir$"$endif$>
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />

--- a/test/lhs-test.html
+++ b/test/lhs-test.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title></title>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">

--- a/test/lhs-test.html
+++ b/test/lhs-test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">

--- a/test/lhs-test.html
+++ b/test/lhs-test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />

--- a/test/lhs-test.html+lhs
+++ b/test/lhs-test.html+lhs
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title></title>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">

--- a/test/lhs-test.html+lhs
+++ b/test/lhs-test.html+lhs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">

--- a/test/lhs-test.html+lhs
+++ b/test/lhs-test.html+lhs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-  <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-  <meta name="author" content="John MacFarlane">
-  <meta name="author" content="Anonymous">
-  <meta name="dcterms.date" content="2006-07-17">
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <meta name="author" content="John MacFarlane" />
+  <meta name="author" content="Anonymous" />
+  <meta name="dcterms.date" content="2006-07-17" />
   <title>Pandoc Test Suite</title>
   <style type="text/css">code{white-space: pre;}</style>
   <!--[if lt IE 9]>

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />


### PR DESCRIPTION
This is a pull request (pr) to make default.html5 polyglot markup conformant. default.html4 is left alone. 

Issue jgm/pandoc-templates#237, "default.html5. Polyglot Markup", ~~(the first two commit messages wrongly reference #237 in jgm/pandoc)~~ contains a prior discussion although the resulting conclusions are expressed here, in the pr comments and commit messages. The following commits are intended to be pushed to this PR. Those ticked have been pushed to this PR:

* [x] html5. Polyglot. html element. Add xml namespace.
* [x] html5. Polyglot. Explicitly close meta tags.
* [x] html5. Polyglot. html element. Add xml:lang. lang values default to blank.    
* ~~html5. Polyglot. Add default title value: "My Title".~~
* [ ]  html5. Polyglot. Add default title value: "Untitled".

In-principle consensus has been reached in issue jgm/pandoc-templates#237 on the changes contained in the first two commits. Consensus has not yet been achieved on the changes contained in the last two commit (yet to be pushed).

Polyglot Markup is a W3C standard: https://www.w3.org/TR/html-polyglot/. Polyglot Markup essentially specifies a syntax that facilitates switching between serving a web document either as HTML or as XHTML, the later requiring a document to be "well-formed" in XML terms. Without these changes default.html5 currently results in a web file that can't be served as XHTML.

Although Polyglot Markup results in a XHTML syntax the specification is not "Use XHTML syntax over HTML syntax", rather it is (using my own words):

> Use markup, and other constraints, common to both XHTML syntax and HTML syntax such that you can serve the same document with either a XHTML mime type or a HTML mime type.

(In practice the mime type is generally set by changing the file extension of your (x)html file: your web server generally looks at the file extension and sends the corresponding mime type in the response header).

These commits either include changes that:
* Are explicitly required by the Polyglot Markup spec to make the output from default.html5 polyglot markup conformant; or
* Where the Polyglot Markup spec is silent, ambiguous, or wrong: make the output from default.html5 polyglot markup conformant if the spec was corrected.

This is my first in-production git and github pull request.

References:
* Issue jgm/pandoc-templates#237, "default.html5. Polyglot Markup"
* The Polyglot Markup spec: https://www.w3.org/TR/html-polyglot/
* The HTML5 spec (using the "latest version of html" link): https://www.w3.org/TR/html/

Edit 01: Struck out "the first two commit messages wrongly reference #237 in jgm/pandoc" due to rebase. 

Edit02: Changed last commit message first line to "html5. Polyglot. Add default title value: "Untitled"."