### PR TITLE
Writers: Use gets to access MonadState where possible

### DIFF
--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -286,7 +286,7 @@ bulletListItemToAsciiDoc opts blocks = do
                                           return $ d <> cr <> chomp x
       addBlock d b = do x <- blockToAsciiDoc opts b
                         return $ d <> cr <> text "+" <> cr <> chomp x
-  lev <- bulletListLevel `fmap` get
+  lev <- gets bulletListLevel
   modify $ \s -> s{ bulletListLevel = lev + 1 }
   contents <- foldM addBlock empty blocks
   modify $ \s -> s{ bulletListLevel = lev }
@@ -307,7 +307,7 @@ orderedListItemToAsciiDoc opts marker blocks = do
                                           return $ d <> cr <> chomp x
       addBlock d b = do x <- blockToAsciiDoc opts b
                         return $ d <> cr <> text "+" <> cr <> chomp x
-  lev <- orderedListLevel `fmap` get
+  lev <- gets orderedListLevel
   modify $ \s -> s{ orderedListLevel = lev + 1 }
   contents <- foldM addBlock empty blocks
   modify $ \s -> s{ orderedListLevel = lev }
@@ -320,7 +320,7 @@ definitionListItemToAsciiDoc :: PandocMonad m
                              -> ADW m Doc
 definitionListItemToAsciiDoc opts (label, defs) = do
   labelText <- inlineListToAsciiDoc opts label
-  marker <- defListMarker `fmap` get
+  marker <- gets defListMarker
   if marker == "::"
      then modify (\st -> st{ defListMarker = ";;"})
      else modify (\st -> st{ defListMarker = "::"})

--- a/src/Text/Pandoc/Writers/DokuWiki.hs
+++ b/src/Text/Pandoc/Writers/DokuWiki.hs
@@ -53,7 +53,7 @@ import Data.List ( intersect, intercalate, isPrefixOf, transpose )
 import Data.Default (Default(..))
 import Network.URI ( isURI )
 import Control.Monad ( zipWithM )
-import Control.Monad.State ( modify, State, get, evalState )
+import Control.Monad.State ( modify, State, gets, evalState )
 import Control.Monad.Reader ( ReaderT, runReaderT, ask, local )
 import Text.Pandoc.Class (PandocMonad)
 
@@ -93,7 +93,7 @@ pandocToDokuWiki opts (Pandoc meta blocks) = do
               (inlineListToDokuWiki opts)
               meta
   body <- blockListToDokuWiki opts blocks
-  notesExist <- stNotes <$> get
+  notesExist <- gets stNotes
   let notes = if notesExist
                  then "" -- TODO Was "\n<references />" Check whether I can really remove this:
                          -- if it is definitely to do with footnotes, can remove this whole bit

--- a/src/Text/Pandoc/Writers/Man.hs
+++ b/src/Text/Pandoc/Writers/Man.hs
@@ -82,10 +82,10 @@ pandocToMan opts (Pandoc meta blocks) = do
               (fmap (render colwidth) . inlineListToMan opts)
               $ deleteMeta "title" meta
   body <- blockListToMan opts blocks
-  notes <- liftM stNotes get
+  notes <- gets stNotes
   notes' <- notesToMan opts (reverse notes)
   let main = render' $ body $$ notes' $$ text ""
-  hasTables <- liftM stHasTables get
+  hasTables <- gets stHasTables
   let context = defField "body" main
               $ setFieldsFromTitle
               $ defField "has-tables" hasTables
@@ -376,6 +376,6 @@ inlineToMan opts (Image attr alternate (source, tit)) = do
 inlineToMan _ (Note contents) = do
   -- add to notes in state
   modify $ \st -> st{ stNotes = contents : stNotes st }
-  notes <- liftM stNotes get
+  notes <- gets stNotes
   let ref = show $ (length notes)
   return $ char '[' <> text ref <> char ']'


### PR DESCRIPTION
Replaced  `liftM`, `fmap` and recurring `get >>= return` with dedicated `gets`