### PR TITLE
Include \VerbatimFootnotes for highlighted code blocks

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -554,8 +554,11 @@ blockToLaTeX (CodeBlock (identifier,classes,keyvalAttr) str) = do
                  unless (null msg) $
                    report $ CouldNotHighlight msg
                  rawCodeBlock
-               Right h -> modify (\st -> st{ stHighlighting = True }) >>
-                          return (flush $ linkAnchor $$ text (T.unpack h))
+               Right h -> do
+                  st <- get
+                  when (stInNote st) $ modify (\s -> s{ stVerbInNote = True })
+                  modify (\s -> s{ stHighlighting = True })
+                  return (flush $ linkAnchor $$ text (T.unpack h))
   case () of
      _ | isEnabled Ext_literate_haskell opts && "haskell" `elem` classes &&
          "literate" `elem` classes           -> lhsCodeBlock


### PR DESCRIPTION
Updated the LaTeX writer to also include \VerbatimFootnotes in the
preamble for highlighted code blocks. Previously this was only done for
raw code blocks.

This is my first attempt in contributing to pandoc, so my apologies for any mistakes I might have made.