### PR TITLE
Make pandoc compile on FreeBSD with stack

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -11,4 +11,5 @@ extra-deps:
 - hslua-0.5.0
 - hslua-aeson-0.1.0.3
 - skylighting-0.3.2
+- foundation-0.0.6
 resolver: lts-8.8


### PR DESCRIPTION
Change 1778f232921cd7ef0cf34e8d87562a83262ae367 was not enough, as foundation-0.0.4 from lts-8.8 does not build on FreeBSD.