### PR TITLE
Destructuring lua filter functions

### DIFF
--- a/data/pandoc.lua
+++ b/data/pandoc.lua
@@ -173,18 +173,23 @@ end
 --- Meta blocks
 -- @function MetaBlocks
 -- @tparam {Block,...} blocks blocks
+
 --- Meta inlines
 -- @function MetaInlines
 -- @tparam {Inline,...} inlines inlines
+
 --- Meta list
 -- @function MetaList
 -- @tparam {MetaValue,...} meta_values list of meta values
+
 --- Meta boolean
 -- @function MetaBool
 -- @tparam boolean bool boolean value
+
 --- Meta map
 -- @function MetaMap
 -- @tparam table a string-index map of meta values
+
 --- Meta string
 -- @function MetaString
 -- @tparam string str string value
@@ -205,16 +210,165 @@ for i = 1, #M.meta_value_types do
   )
 end
 
---- Inline element class
--- @type Inline
-M.Inline = Element:make_subtype{}
-M.Inline.__call = function (t, ...)
+------------------------------------------------------------------------
+-- Block
+-- @section Block
+
+M.Block = Element:make_subtype{}
+M.Block.__call = function (t, ...)
   return t:new(...)
 end
+
+--- Creates a block quote element
+-- @function BlockQuote
+-- @tparam      {Block,...} content     block content
+-- @treturn     Block                   block quote element
+M.BlockQuote = M.Block:create_constructor(
+  "BlockQuote",
+  function(content) return {c = content} end
+)
+
+--- Creates a bullet (i.e. unordered) list.
+-- @function BulletList
+-- @tparam      {{Block,...},...} content     list of items
+-- @treturn     Block block quote element
+M.BulletList = M.Block:create_constructor(
+  "BulletList",
+  function(content) return {c = content} end
+)
+
+--- Creates a code block element
+-- @function CodeBlock
+-- @tparam      string      code        code string
+-- @tparam[opt] Attributes  attributes  element attributes
+-- @treturn     Block                   code block element
+M.CodeBlock = M.Block:create_constructor(
+  "CodeBlock",
+  function(code, attributes) return {c = {attributes, code}} end
+)
+
+--- Creates a definition list, containing terms and their explanation.
+-- @function DefinitionList
+-- @tparam      {{{Inline,...},{Block,...}},...} content     list of items
+-- @treturn     Block block quote element
+M.DefinitionList = M.Block:create_constructor(
+  "DefinitionList",
+  function(content) return {c = content} end
+)
+
+--- Creates a div element
+-- @function Div
+-- @tparam      {Block,...} content     block content
+-- @tparam[opt] Attributes  attributes  element attributes
+-- @treturn     Block                   code block element
+M.Div = M.Block:create_constructor(
+  "Div",
+  function(content, attributes) return {c = {attributes, content}} end
+)
+
+--- Creates a block quote element.
+-- @function Header
+-- @tparam      int          level       header level
+-- @tparam      Attributes   attributes  element attributes
+-- @tparam      {Inline,...} content     inline content
+-- @treturn     Block                    header element
+M.Header = M.Block:create_constructor(
+  "Header",
+  function(level, attributes, content)
+    return {c = {level, attributes, content}}
+  end
+)
+
+--- Creates a horizontal rule.
+-- @function HorizontalRule
+-- @treturn     Block                   horizontal rule
+M.HorizontalRule = M.Block:create_constructor(
+  "HorizontalRule",
+  function() return {} end
+)
+
+--- Creates a line block element.
+-- @function LineBlock
+-- @tparam      {{Inline,...},...} content    inline content
+-- @treturn     Block                   block quote element
+M.LineBlock = M.Block:create_constructor(
+  "LineBlock",
+  function(content) return {c = content} end
+)
+
+--- Creates a null element.
+-- @function Null
+-- @treturn     Block                   null element
+M.Null = M.Block:create_constructor(
+  "Null",
+  function() return {} end
+)
+
+--- Creates an ordered list.
+-- @function OrderedList
+-- @tparam      {{Block,...},...} items list items
+-- @param[opt]  listAttributes list parameters
+-- @treturn     Block
+M.OrderedList = M.Block:create_constructor(
+  "OrderedList",
+  function(items, listAttributes)
+    return {c = {listAttributes,items}}
+  end
+)
+
+--- Creates a para element.
+-- @function Para
+-- @tparam      {Inline,...} content    inline content
+-- @treturn     Block                   block quote element
+M.Para = M.Block:create_constructor(
+  "Para",
+  function(content) return {c = content} end
+)
+
+--- Creates a plain element.
+-- @function Plain
+-- @tparam      {Inline,...} content    inline content
+-- @treturn     Block                   block quote element
+M.Plain = M.Block:create_constructor(
+  "Plain",
+  function(content) return {c = content} end
+)
+
+--- Creates a raw content block of the specified format.
+-- @function RawBlock
+-- @tparam      string      format      format of content
+-- @tparam      string      content     string content
+-- @treturn     Block                   block quote element
+M.RawBlock = M.Block:create_constructor(
+  "RawBlock",
+  function(format, content) return {c = {format, content}} end
+)
+
+--- Creates a table element.
+-- @function Table
+-- @tparam      {Inline,...} caption    table caption
+-- @tparam      {AlignDefault|AlignLeft|AlignRight|AlignCenter,...} aligns alignments
+-- @tparam      {int,...}    widths     column widths
+-- @tparam      {Block,...}  headers    header row
+-- @tparam      {{Block,...}} rows      table rows
+-- @treturn     Block                   block quote element
+M.Table = M.Block:create_constructor(
+  "Table",
+  function(caption, aligns, widths, headers, rows)
+    return {c = {caption, aligns, widths, headers, rows}}
+  end
+)
+
 
 ------------------------------------------------------------------------
 -- Inline
 -- @section Inline
+
+--- Inline element class
+M.Inline = Element:make_subtype{}
+M.Inline.__call = function (t, ...)
+  return t:new(...)
+end
 
 --- Creates a Cite inline element
 -- @function Cite
@@ -406,42 +560,6 @@ M.Superscript = M.Inline:create_constructor(
 
 
 ------------------------------------------------------------------------
--- Block elements
--- @type Block
-M.Block = Element:make_subtype{}
-
---- Block constructors
-M.Block.constructors = {
-  BlockQuote = true,
-  BulletList = true,
-  CodeBlock = true,
-  DefinitionList = true,
-  Div = true,
-  Header = true,
-  HorizontalRule = true,
-  HorizontalRule = true,
-  LineBlock = true,
-  Null = true,
-  OrderedList = true,
-  Para = true,
-  Plain = true,
-  RawBlock = true,
-  Table = true,
-}
-
-local set_of_inline_types = {}
-for k, _ in pairs(M.Inline.constructor) do
-  set_of_inline_types[k] = true
-end
-
-for block_type, _ in pairs(M.Block.constructors) do
-  M[block_type] = function(...)
-    return M.Block:new(block_type, ...)
-  end
-end
-
-
-------------------------------------------------------------------------
 -- Constants
 -- @section constants
 
@@ -482,6 +600,81 @@ M.SuppressAuthor.t = "SuppressAuthor"
 M.NormalCitation = {}
 M.NormalCitation.t = "NormalCitation"
 
+--- Table cells aligned left.
+-- @see Table
+M.AlignLeft = {}
+M.AlignLeft.t = "AlignLeft"
+
+--- Table cells right-aligned.
+-- @see Table
+M.AlignRight = {}
+M.AlignRight.t = "AlignRight"
+
+--- Table cell content is centered.
+-- @see Table
+M.AlignCenter = {}
+M.AlignCenter.t = "AlignCenter"
+
+--- Table cells are alignment is unaltered.
+-- @see Table
+M.AlignDefault = {}
+M.AlignDefault.t = "AlignDefault"
+
+--- Default list number delimiters are used.
+-- @see OrderedList
+M.DefaultDelim = {}
+M.DefaultDelim.t = "DefaultDelim"
+
+--- List numbers are delimited by a period.
+-- @see OrderedList
+M.Period = {}
+M.Period.t = "Period"
+
+--- List numbers are delimited by a single parenthesis.
+-- @see OrderedList
+M.OneParen = {}
+M.OneParen.t = "OneParen"
+
+--- List numbers are delimited by a double parentheses.
+-- @see OrderedList
+M.TwoParens = {}
+M.TwoParens.t = "TwoParens"
+
+--- List are numbered in the default style
+-- @see OrderedList
+M.DefaultStyle = {}
+M.DefaultStyle.t = "DefaultStyle"
+
+--- List items are numbered as examples.
+-- @see OrderedList
+M.Example = {}
+M.Example.t = "Example"
+
+--- List are numbered using decimal integers.
+-- @see OrderedList
+M.Decimal = {}
+M.Decimal.t = "Decimal"
+
+--- List are numbered using lower-case roman numerals.
+-- @see OrderedList
+M.LowerRoman = {}
+M.LowerRoman.t = "LowerRoman"
+
+--- List are numbered using upper-case roman numerals
+-- @see OrderedList
+M.UpperRoman = {}
+M.UpperRoman.t = "UpperRoman"
+
+--- List are numbered using lower-case alphabetic characters.
+-- @see OrderedList
+M.LowerAlpha = {}
+M.LowerAlpha.t = "LowerAlpha"
+
+--- List are numbered using upper-case alphabetic characters.
+-- @see OrderedList
+M.UpperAlpha = {}
+M.UpperAlpha.t = "UpperAlpha"
+
 
 ------------------------------------------------------------------------
 -- Helper Functions
@@ -503,7 +696,7 @@ M.NormalCitation.t = "NormalCitation"
 function M.global_filter()
   local res = {}
   for k, v in pairs(_G) do
-    if M.Inline.constructor[k] or M.Block.constructors[k] or k == "Doc" then
+    if M.Inline.constructor[k] or M.Block.constructor[k] or M.Block.constructors[k] or k == "Doc" then
       res[k] = v
     end
   end

--- a/data/pandoc.lua
+++ b/data/pandoc.lua
@@ -26,7 +26,10 @@ function M.Attributes(id, classes, key_values)
   return {id, classes, key_values}
 end
 
+------------------------------------------------------------------------
+--- Document AST elements
 local Element = {}
+
 --- Create a new element subtype
 function Element:make_subtype(o)
   o = o or {}
@@ -34,6 +37,7 @@ function Element:make_subtype(o)
   self.__index = self
   return o
 end
+
 --- Create a new element given its tag and arguments
 function Element:new(tag, ...)
   local element = { t = tag }
@@ -51,6 +55,35 @@ function Element:new(tag, ...)
   return element
 end
 
+--- Create a new constructor
+-- @param tag Tag used to identify the constructor
+-- @param fn Function to be called when constructing a new element
+-- @return function that constructs a new element
+function Element:create_constructor(tag, fn)
+  local constr = self:make_subtype({tag = tag})
+  function constr:new(...)
+    local obj = fn(...)
+    setmetatable(obj, self)
+    self.__index = function(t, k)
+      if k == "c" then
+        return t["content"]
+      elseif k == "t" then
+        return getmetatable(t)["tag"]
+      else
+        return getmetatable(t)[k]
+      end
+    end
+    return obj
+  end
+  return constr
+end
+
+function Element.__call(t, ...)
+  return t:new(...)
+end
+
+------------------------------------------------------------------------
+-- Document
 local function Doc(blocks, meta)
   return {
     ["blocks"] = blocks,
@@ -58,9 +91,131 @@ local function Doc(blocks, meta)
     ["pandoc-api-version"] = {1,17,0,5},
   }
 end
-
 local Inline = Element:make_subtype{}
+function Inline.__call(t, ...)
+  return t:new(...)
+end
+
 local Block = Element:make_subtype{}
+
+------------------------------------------------------------------------
+-- Inline element constructors
+-- @section
+
+--- Create a Cite inline element
+-- @function Inline.Cite
+Inline.Cite = Inline:create_constructor(
+  "Cite",
+  function(lst, cs) return {c = {cs, lst}} end
+)
+--- Create a Code inline element
+-- @function Inline.Code
+Inline.Code = Inline:create_constructor(
+  "Code",
+  function(code, attr) return {c = {attr, code}} end
+)
+--- Create a Emph inline element
+-- @function Inline.Emph
+Inline.Emph = Inline:create_constructor(
+  "Emph",
+  function(xs) return {c = xs} end
+)
+--- Create a Image inline element
+-- @function Inline.Image
+Inline.Image = Inline:create_constructor(
+  "Image",
+  function(capt, src, tit, attr) return {c = {attr, capt, {src, tit}}} end
+)
+--- Create a LineBreak inline element
+-- @function Inline.LineBreak
+Inline.LineBreak = Inline:create_constructor(
+  "LineBreak",
+  function() return {} end
+)
+--- Create a Link inline element
+-- @function Inline.Link
+Inline.Link = Inline:create_constructor(
+  "Link",
+  function(txt, src, tit, attr) return {c = {attr, txt, {src, tit}}} end
+)
+--- Create a Math inline element
+-- @function Inline.Math
+Inline.Math = Inline:create_constructor(
+  "Math",
+  function(m, str) return {c = {m, str}} end
+)
+--- Create a Note inline element
+-- @function Inline.Note
+Inline.Note = Inline:create_constructor(
+  "Note",
+  function(contents) return {c = contents} end
+)
+--- Create a Quoted inline element
+-- @function Inline.Quoted
+Inline.Quoted = Inline:create_constructor(
+  "Quoted",
+  function(qt, lst) return {c = {qt, lst}} end
+)
+--- Create a RawInline inline element
+-- @function Inline.RawInline
+Inline.RawInline = Inline:create_constructor(
+  "RawInline",
+  function(f, xs) return {c = {f, xs}} end
+)
+--- Create a SmallCaps inline element
+-- @function Inline.SmallCaps
+Inline.SmallCaps = Inline:create_constructor(
+  "SmallCaps",
+  function(xs) return {c = xs} end
+)
+--- Create a SoftBreak inline element
+-- @function Inline.SoftBreak
+Inline.SoftBreak = Inline:create_constructor(
+  "SoftBreak",
+  function() return {} end
+)
+--- Create a Space inline element
+-- @function Inline.Space
+Inline.Space = Inline:create_constructor(
+  "Space",
+  function() return {} end
+)
+--- Create a Span inline element
+-- @function Inline.Span
+Inline.Span = Inline:create_constructor(
+  "Span",
+  function(ls, attr) return {c = {attr, xs}} end
+)
+--- Create a Str inline element
+-- @function Inline.Str
+Inline.Str = Inline:create_constructor(
+  "Str",
+  function(str) return {c = str} end
+)
+--- Create a Strikeout inline element
+-- @function Inline.Strikeout
+Inline.Strikeout = Inline:create_constructor(
+  "Strikeout",
+  function(xs) return {c = xs} end
+)
+--- Create a Strong inline element
+-- @function Inline.Strong
+Inline.Strong = Inline:create_constructor(
+  "Strong",
+  function(xs) return {c = xs} end
+)
+--- Create a Subscript inline element
+-- @function Inline.Subscript
+Inline.Subscript = Inline:create_constructor(
+  "Subscript",
+  function(xs) return {c = xs} end
+)
+--- Create a Superscript inline element
+-- @function Inline.Superscript
+Inline.Superscript = Inline:create_constructor(
+  "Superscript",
+  function(xs) return {c = xs} end
+)
 
 M.block_types = {
   "BlockQuote",
@@ -102,6 +257,7 @@ M.inline_types = {
   "Superscript"
 }
 
+
 for _, block_type in pairs(M.block_types) do
   M[block_type] = function(...)
     return Block:new(block_type, ...)
@@ -109,9 +265,7 @@ for _, block_type in pairs(M.block_types) do
 end
 
 for _, inline_type in pairs(M.inline_types) do
-  M[inline_type] = function(...)
-    return Inline:new(inline_type, ...)
-  end
+  M[inline_type] = Inline[inline_type]
 end
 
 --- Arrays to provide fast lookup of element types
@@ -136,5 +290,7 @@ function M.global_filter()
 end
 
 M["Doc"] = Doc
+M["Inline"] = Inline
+M["Block"] = Block
 
 return M

--- a/data/pandoc.lua
+++ b/data/pandoc.lua
@@ -163,6 +163,48 @@ function M.Doc(blocks, meta)
 end
 
 
+------------------------------------------------------------------------
+-- MetaValue
+-- @section MetaValue
+M.MetaValue = Element:make_subtype{}
+M.MetaValue.__call = function(t, ...)
+  return t:new(...)
+end
+--- Meta blocks
+-- @function MetaBlocks
+-- @tparam {Block,...} blocks blocks
+--- Meta inlines
+-- @function MetaInlines
+-- @tparam {Inline,...} inlines inlines
+--- Meta list
+-- @function MetaList
+-- @tparam {MetaValue,...} meta_values list of meta values
+--- Meta boolean
+-- @function MetaBool
+-- @tparam boolean bool boolean value
+--- Meta map
+-- @function MetaMap
+-- @tparam table a string-index map of meta values
+--- Meta string
+-- @function MetaString
+-- @tparam string str string value
+M.meta_value_types = {
+  "MetaBlocks",
+  "MetaBool",
+  "MetaInlines",
+  "MetaList",
+  "MetaMap",
+  "MetaString"
+}
+for i = 1, #M.meta_value_types do
+  M[M.meta_value_types[i]] = M.MetaValue:create_constructor(
+    M.meta_value_types[i],
+    function(content)
+      return {c = content}
+    end
+  )
+end
+
 --- Inline element class
 -- @type Inline
 M.Inline = Element:make_subtype{}

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -300,7 +300,6 @@ Library
                  pandoc-types >= 1.17 && < 1.18,
                  aeson >= 0.7 && < 1.2,
                  aeson-pretty >= 0.8 && < 0.9,
-                 hslua-aeson >= 0.1.0.2 && < 1,
                  tagsoup >= 0.13.7 && < 0.15,
                  base64-bytestring >= 0.1 && < 1.1,
                  zlib >= 0.5 && < 0.7,

--- a/src/Text/Pandoc/Lua.hs
+++ b/src/Text/Pandoc/Lua.hs
@@ -29,7 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 Pandoc lua utils.
 -}
-module Text.Pandoc.Lua ( runLuaFilter ) where
+module Text.Pandoc.Lua ( runLuaFilter, pushPandocModule ) where
 
 import Control.Monad ( (>=>), when )
 import Control.Monad.Trans ( MonadIO(..) )
@@ -39,7 +39,7 @@ import Data.Text.Encoding ( decodeUtf8 )
 import Scripting.Lua ( LuaState, StackValue(..) )
 import Scripting.Lua.Aeson ( newstate )
 import Text.Pandoc.Definition ( Block(..), Inline(..), Pandoc(..) )
-import Text.Pandoc.Lua.PandocModule
+import Text.Pandoc.Lua.PandocModule ( pushPandocModule )
 import Text.Pandoc.Lua.StackInstances ()
 import Text.Pandoc.Walk
 

--- a/src/Text/Pandoc/Lua/StackInstances.hs
+++ b/src/Text/Pandoc/Lua/StackInstances.hs
@@ -41,7 +41,6 @@ import Scripting.Lua
   , call, getglobal2, gettable, ltype, newtable, next, objlen
   , pop, pushnil, rawgeti, rawseti, settable
   )
-import Scripting.Lua.Aeson ()
 import Text.Pandoc.Definition
 
 import qualified Data.Map as M

--- a/stack.full.yaml
+++ b/stack.full.yaml
@@ -24,5 +24,4 @@ extra-deps:
 - doctemplates-0.1.0.2
 - skylighting-0.3.1
 - hslua-0.5.0
-- hslua-aeson-0.1.0.3
 resolver: lts-8.4

--- a/stack.pkg.yaml
+++ b/stack.pkg.yaml
@@ -19,6 +19,5 @@ packages:
   extra-dep: false
 extra-deps:
 - hslua-0.5.0
-- hslua-aeson-0.1.0.3
 - skylighting-0.3.2
 resolver: lts-8.8

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,6 @@ packages:
 - '.'
 extra-deps:
 - hslua-0.5.0
-- hslua-aeson-0.1.0.3
 - skylighting-0.3.2
 - foundation-0.0.6
 resolver: lts-8.8

--- a/test/Tests/Lua.hs
+++ b/test/Tests/Lua.hs
@@ -64,10 +64,14 @@ roundtripEqual x = (x ==) <$> roundtripped
   roundtripped :: (Lua.StackValue a) => IO a
   roundtripped = do
     lua <- Lua.newstate
+    Lua.openlibs lua
+    pushPandocModule lua
+    Lua.setglobal lua "pandoc"
+    oldSize <- Lua.gettop lua
     Lua.push lua x
     size <- Lua.gettop lua
-    when (size /= 1) $
-      error ("not exactly one element on the stack: " ++ show size)
+    when ((size - oldSize) /= 1) $
+      error ("not exactly one additional element on the stack: " ++ show size)
     res <- Lua.peek lua (-1)
     retval <- case res of
                 Nothing -> error "could not read from stack"

--- a/test/lua/markdown-reader.lua
+++ b/test/lua/markdown-reader.lua
@@ -1,7 +1,6 @@
 return {
   {
-    RawBlock = function (blk)
-      local format, content = unpack(blk.c)
+    RawBlock = function (format, content)
       if format == "markdown" then
         return pandoc.reader.markdown.read_block(content)
       else

--- a/test/lua/plain-to-para.lua
+++ b/test/lua/plain-to-para.lua
@@ -1,6 +1,6 @@
 return {
-  { Plain = function (blk)
-      return pandoc.Para(blk.c)
+  { Plain = function (content)
+      return pandoc.Para(content)
   end,
   }
 }

--- a/test/lua/strmacro.lua
+++ b/test/lua/strmacro.lua
@@ -1,10 +1,11 @@
 return {
-  { Str = function (inline)
-      if inline.c == "{{helloworld}}" then
+  {
+    Str = function (str)
+      if str == "{{helloworld}}" then
         return pandoc.Emph {pandoc.Str "Hello, World"}
       else
-        return inline
+        return pandoc.Str(str)
       end
-  end,
+    end,
   }
 }


### PR DESCRIPTION
Lua filter functions and `Inline` constructors in the `pandoc.lua` module are changed to take the same arguments as those lua functions used for custom writers.  The result is a uniform interface for the lua subsystem.

Example for filtering on `Span`:

``` lua
Span = function(lst, attr)
  return pandoc.Span(lst, attr)
end
```

Performance is improved slightly and lua documentation can be generated via `ldoc`.  The only downside is that `pandoc.lua` becomes larger and less simple.