### PR TITLE
Add siunitx Support

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -728,16 +728,19 @@ dolstinline = do
 doLHSverb :: PandocMonad m => LP m Inlines
 doLHSverb = codeWith ("",["haskell"],[]) <$> manyTill (satisfy (/='\n')) (char '|')
 
+-- converts e.g. \SI{1}[\$]{} to "$ 1" or \SI{1}{\euro} to "1 €"
 dosiunitx :: PandocMonad m => LP m Inlines
 dosiunitx = do
   skipopts
   value <- char '{' >> (mconcat <$> manyTill inline (char '}'))
-  preunit <- option "" $ char '[' >> (mconcat <$> manyTill inline (char ']'))
+  valueprefix <- option "" $ char '[' >> (mconcat <$> manyTill inline (char ']'))
   unit <- char '{' >> (mconcat <$> manyTill inline (char '}'))
-  return . mconcat $ [preunit, 
-                      (if length preunit == 0 then "" else "\160"),
+  let emptyOr160 "" = ""
+      emptyOr160 _  = "\160"
+  return . mconcat $ [valueprefix, 
+                      emptyOr160 valueprefix,
                       value, 
-                      (if length unit == 0 then "" else "\160"),
+                      emptyOr160 unit,
                       unit]
 
 lit :: String -> LP m Inlines

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -734,7 +734,7 @@ dosiunitx = do
   value <- char '{' >> manyTill anyChar (char '}')
   preunit <- (char '[' >> manyTill anyChar (char ']')) <|> (return "")
   unit <- char '{' >> manyTill anyChar (char '}')
-  pure <$> str $ preunit ++ value ++ unit
+  pure <$> str $ preunit ++ (if length preunit == 0 then "" else "\160") ++ value ++ (if length unit == 0 then "" else "\160") ++ unit
 
 lit :: String -> LP m Inlines
 lit = pure . str

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -732,9 +732,9 @@ doLHSverb = codeWith ("",["haskell"],[]) <$> manyTill (satisfy (/='\n')) (char '
 dosiunitx :: PandocMonad m => LP m Inlines
 dosiunitx = do
   skipopts
-  value <- char '{' >> (mconcat <$> manyTill inline (char '}'))
-  valueprefix <- option "" $ char '[' >> (mconcat <$> manyTill inline (char ']'))
-  unit <- char '{' >> (mconcat <$> manyTill inline (char '}'))
+  value <- char '{' >> (mconcat <$> manyTill tok (char '}'))
+  valueprefix <- option "" $ char '[' >> (mconcat <$> manyTill tok (char ']'))
+  unit <- char '{' >> (mconcat <$> manyTill tok (char '}'))
   let emptyOr160 "" = ""
       emptyOr160 _  = "\160"
   return . mconcat $ [valueprefix, 

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -731,10 +731,14 @@ doLHSverb = codeWith ("",["haskell"],[]) <$> manyTill (satisfy (/='\n')) (char '
 dosiunitx :: PandocMonad m => LP m Inlines
 dosiunitx = do
   skipopts
-  value <- char '{' >> manyTill anyChar (char '}')
-  preunit <- (char '[' >> manyTill anyChar (char ']')) <|> (return "")
-  unit <- char '{' >> manyTill anyChar (char '}')
-  pure <$> str $ preunit ++ (if length preunit == 0 then "" else "\160") ++ value ++ (if length unit == 0 then "" else "\160") ++ unit
+  value <- char '{' >> (mconcat <$> manyTill inline (char '}'))
+  preunit <- option "" $ char '[' >> (mconcat <$> manyTill inline (char ']'))
+  unit <- char '{' >> (mconcat <$> manyTill inline (char '}'))
+  return . mconcat $ [preunit, 
+                      (if length preunit == 0 then "" else "\160"),
+                      value, 
+                      (if length unit == 0 then "" else "\160"),
+                      unit]
 
 lit :: String -> LP m Inlines
 lit = pure . str

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -668,6 +668,8 @@ inlineCommands = M.fromList $
   , ("nocite", mempty <$ (citation "nocite" NormalCitation False >>=
                           addMeta "nocite"))
   , ("hypertarget", braced >> tok)
+  -- siuntix
+  , ("SI", dosiunitx)
   ] ++ map ignoreInlines
   -- these commands will be ignored unless --parse-raw is specified,
   -- in which case they will appear as raw latex blocks:
@@ -725,6 +727,14 @@ dolstinline = do
 
 doLHSverb :: PandocMonad m => LP m Inlines
 doLHSverb = codeWith ("",["haskell"],[]) <$> manyTill (satisfy (/='\n')) (char '|')
+
+dosiunitx :: PandocMonad m => LP m Inlines
+dosiunitx = do
+  skipopts
+  value <- char '{' >> manyTill anyChar (char '}')
+  preunit <- (char '[' >> manyTill anyChar (char ']')) <|> (return "")
+  unit <- char '{' >> manyTill anyChar (char '}')
+  pure <$> str $ preunit ++ value ++ unit
 
 lit :: String -> LP m Inlines
 lit = pure . str

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -732,9 +732,9 @@ doLHSverb = codeWith ("",["haskell"],[]) <$> manyTill (satisfy (/='\n')) (char '
 dosiunitx :: PandocMonad m => LP m Inlines
 dosiunitx = do
   skipopts
-  value <- char '{' >> (mconcat <$> manyTill tok (char '}'))
+  value <- tok
   valueprefix <- option "" $ char '[' >> (mconcat <$> manyTill tok (char ']'))
-  unit <- char '{' >> (mconcat <$> manyTill tok (char '}'))
+  unit <- tok
   let emptyOr160 "" = ""
       emptyOr160 _  = "\160"
   return . mconcat $ [valueprefix, 

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -2,13 +2,13 @@
 % pandoc -f latex -t native
 \SI[round-precision=2]{1}{m} is equal to \SI{1000}{mm}
 ^D
-[Para [Str "1m",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "1000mm"]]
+[Para [Str "1\160m",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "1000\160mm"]]
 ```
 
 ```
 % pandoc -f latex -t native
 \SI[round-precision=2]{1}[\$]{} is equal to \SI{0.938094}{\euro}
 ^D
-[Para [Str "$1",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "0.938094\8364"]]
+[Para [Str "$\160\&1",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "0.938094\160\8364"]]
 ```
 

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -1,0 +1,14 @@
+```
+% pandoc -f latex -t native
+\SI[round-precision=2]{1}{m} is equal to \SI{1000}{mm}
+^D
+[Para [Str "1m",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "1000mm"]]
+```
+
+```
+% pandoc -f latex -t native
+\SI[round-precision=2]{1}[\$]{} is equal to \SI{0.938094}{\euro}
+^D
+[Para [Str "$1",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "0.938094\8364"]]
+```
+

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -12,3 +12,10 @@
 [Para [Str "$\160\&1",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "0.938094\160\8364"]]
 ```
 
+
+```
+% pandoc -f latex -t native
+\SI[round-precision=2]{\{\}}[\{\}]{\{\}}
+^D
+[Para [Str "{}\160{}\160{}"]]
+```


### PR DESCRIPTION
I want to resolve #3587.

Basic command parsing works, but preunit, value, and unit do not get parsed further (e.g. `\euro` is not translated into `€`). I assume I have to use the function `tok`.  @jgm, can you help me to use it correctly? 