### PR TITLE
Add basic support for hyphenat package

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -671,10 +671,10 @@ inlineCommands = M.fromList $
   -- siuntix
   , ("SI", dosiunitx)
   -- hyphenat
-  , ("bshyp", lit "\\")
-  , ("fshyp", lit "/")
-  , ("dothyp", lit ".")
-  , ("colonhyp", lit ":")
+  , ("bshyp", lit "\\\173")
+  , ("fshyp", lit "/\173")
+  , ("dothyp", lit ".\173")
+  , ("colonhyp", lit ":\173")
   , ("hyp", lit "-")
   ] ++ map ignoreInlines
   -- these commands will be ignored unless --parse-raw is specified,

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -670,6 +670,12 @@ inlineCommands = M.fromList $
   , ("hypertarget", braced >> tok)
   -- siuntix
   , ("SI", dosiunitx)
+  -- hyphenat
+  , ("bshyp", lit "\\")
+  , ("fshyp", lit "/")
+  , ("dothyp", lit ".")
+  , ("colonhyp", lit ":")
+  , ("hyp", lit "-")
   ] ++ map ignoreInlines
   -- these commands will be ignored unless --parse-raw is specified,
   -- in which case they will appear as raw latex blocks:

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -518,7 +518,7 @@ inlineCommands = M.fromList $
   , ("textmd", extractSpaces (spanWith ("",["medium"],[])) <$> tok)
   , ("textrm", extractSpaces (spanWith ("",["roman"],[])) <$> tok)
   , ("textup", extractSpaces (spanWith ("",["upright"],[])) <$> tok)
-  , ("texttt", (code . stringify . toList) <$> tok)
+  , ("texttt", ttfamily)
   , ("sout", extractSpaces strikeout <$> tok)
   , ("textsuperscript", extractSpaces superscript <$> tok)
   , ("textsubscript", extractSpaces subscript <$> tok)
@@ -676,6 +676,9 @@ inlineCommands = M.fromList $
   , ("dothyp", lit ".\173")
   , ("colonhyp", lit ":\173")
   , ("hyp", lit "-")
+  , ("nohyphens", tok)
+  , ("textnhtt", ttfamily)
+  , ("nhttfamily", ttfamily)
   ] ++ map ignoreInlines
   -- these commands will be ignored unless --parse-raw is specified,
   -- in which case they will appear as raw latex blocks:
@@ -686,6 +689,9 @@ inlineCommands = M.fromList $
   , "clearpage"
   , "pagebreak"
   ]
+
+ttfamily :: PandocMonad m => LP m Inlines
+ttfamily = (code . stringify . toList) <$> tok
 
 mkImage :: PandocMonad m => [(String, String)] -> String -> LP m Inlines
 mkImage options src = do

--- a/test/command/hyphenat.md
+++ b/test/command/hyphenat.md
@@ -9,19 +9,19 @@ electromagnetic\hyp{}endioscopy
 % pandoc -f latex -t native
 C\colonhyp\bshyp{}Windows\bshyp
 ^D
-[Para [Str "C:\\Windows\\"]]
+[Para [Str "C:\173\\\173Windows\\\173"]]
 ```
 
 ```
 % pandoc -f latex -t native
 \fshyp{}usr\fshyp{}share\fshyp
 ^D
-[Para [Str "/usr/share/"]]
+[Para [Str "/\173usr/\173share/\173"]]
 ```
 
 ```
 % pandoc -f latex -t native
 \fshyp{}home\fshyp{}schrieveslaach\fshyp\dothyp{}m2
 ^D
-[Para [Str "/home/schrieveslaach/.m2"]]
+[Para [Str "/\173home/\173schrieveslaach/\173.\173m2"]]
 ```

--- a/test/command/hyphenat.md
+++ b/test/command/hyphenat.md
@@ -1,0 +1,27 @@
+```
+% pandoc -f latex -t native
+electromagnetic\hyp{}endioscopy
+^D
+[Para [Str "electromagnetic-endioscopy"]]
+```
+
+```
+% pandoc -f latex -t native
+C\colonhyp\bshyp{}Windows\bshyp
+^D
+[Para [Str "C:\\Windows\\"]]
+```
+
+```
+% pandoc -f latex -t native
+\fshyp{}usr\fshyp{}share\fshyp
+^D
+[Para [Str "/usr/share/"]]
+```
+
+```
+% pandoc -f latex -t native
+\fshyp{}home\fshyp{}schrieveslaach\fshyp\dothyp{}m2
+^D
+[Para [Str "/home/schrieveslaach/.m2"]]
+```

--- a/test/command/hyphenat.md
+++ b/test/command/hyphenat.md
@@ -25,3 +25,25 @@ C\colonhyp\bshyp{}Windows\bshyp
 ^D
 [Para [Str "/\173home/\173schrieveslaach/\173.\173m2"]]
 ```
+
+```
+% pandoc -f latex -t native
+\nohyphens{Pneumonoultramicroscopicsilicovolcanoconiosis}
+^D
+[Para [Str "Pneumonoultramicroscopicsilicovolcanoconiosis"]]
+```
+
+```
+% pandoc -f latex -t native
+\textnhtt{Pneumonoultramicroscopicsilicovolcanoconiosis}
+^D
+[Para [Code ("",[],[]) "Pneumonoultramicroscopicsilicovolcanoconiosis"]]
+```
+
+```
+% pandoc -f latex -t native
+\nhttfamily{Pneumonoultramicroscopicsilicovolcanoconiosis}
+^D
+[Para [Code ("",[],[]) "Pneumonoultramicroscopicsilicovolcanoconiosis"]]
+```
+


### PR DESCRIPTION
Many LaTeX documents use the [hyphenat](ftp://ftp.tu-chemnitz.de/pub/tex/macros/latex/contrib/hyphenat/hyphenat.pdf) package. This PR adds support of `\hyp{}`, `\bshyp{}`, `\fshyp{}`, `\dothyp{}`, and `\colonhyp{}` commands.