### PR TITLE
Simplify linkText in Text.Pandoc.Readers.TWiki

### DIFF
--- a/src/Text/Pandoc/Readers/TWiki.hs
+++ b/src/Text/Pandoc/Readers/TWiki.hs
@@ -520,9 +520,9 @@ linkText :: PandocMonad m => TWParser m (String, String, B.Inlines)
 linkText = do
   string "[["
   url <- many1Till anyChar (char ']')
-  content <- option [B.str url] linkContent
+  content <- option (B.str url) (mconcat <$> linkContent)
   char ']'
-  return (url, "", mconcat content)
+  return (url, "", content)
   where
     linkContent      = (char '[') >> many1Till anyChar (char ']') >>= parseLinkContent
     parseLinkContent = parseFromString $ many1 inline


### PR DESCRIPTION
Avoid constructing list of one element ([B.str url]) just to flatten it
back with mconcat.