### PR TITLE
Add support for \vdots

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -528,6 +528,7 @@ inlineCommands = M.fromList $
   , ("textbf", extractSpaces strong <$> tok)
   , ("textnormal", extractSpaces (spanWith ("",["nodecor"],[])) <$> tok)
   , ("ldots", lit "…")
+  , ("vdots", lit "\8942")
   , ("dots", lit "…")
   , ("mdots", lit "…")
   , ("sim", lit "~")

--- a/test/command/dots.md
+++ b/test/command/dots.md
@@ -1,0 +1,12 @@
+```
+% pandoc -f latex -t native
+\dots
+
+\ldots
+
+\vdots
+^D
+[Para [Str "\8230"]
+,Para [Str "\8230"]
+,Para [Str "\8942"]]
+```


### PR DESCRIPTION
In LaTeX you can use the `\vdots` command outside of the math environment to show vertical dots. This feature is very helpful to show a sequence in a `tabular` environment. 

```latex
\begin{tabular}{|c|}
    \hline
    start \\
    \hline
    \vdots \\
    \hline
    end \\
    \hline
\end{tabular}
```

This PR enables that pandoc produces following HTML code:

```html
<table>
<thead>
<tr class="header">
<th style="text-align: center;">start</th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td style="text-align: center;">⋮</td>
</tr>
<tr class="even">
<td style="text-align: center;">end</td>
</tr>
</tbody>
</table>
```