### PR TITLE
Created shared F monad functions

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -50,7 +50,7 @@ import Data.Yaml (ParseException (..), YamlException (..), YamlMark (..))
 import qualified Data.Yaml as Yaml
 import System.FilePath (addExtension, takeExtension)
 import Text.HTML.TagSoup
-import Text.Pandoc.Builder (Blocks, Inlines, trimInlines)
+import Text.Pandoc.Builder (Blocks, Inlines)
 import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Class (PandocMonad, report)
 import Text.Pandoc.Definition
@@ -79,9 +79,6 @@ readMarkdown opts s = do
   case parsed of
     Right result -> return result
     Left e       -> throwError e
-
-trimInlinesF :: F Inlines -> F Inlines
-trimInlinesF = liftM trimInlines
 
 --
 -- Constants and data structure definitions

--- a/src/Text/Pandoc/Readers/Org/Blocks.hs
+++ b/src/Text/Pandoc/Readers/Org/Blocks.hs
@@ -701,7 +701,7 @@ endOfParagraph = try $ skipSpaces *> newline *> endOfBlock
 -- | Example code marked up by a leading colon.
 example :: Monad m => OrgParser m (F Blocks)
 example = try $ do
-  return . return . exampleCode =<< unlines <$> many1 exampleLine
+  returnF . exampleCode =<< unlines <$> many1 exampleLine
  where
    exampleLine :: Monad m => OrgParser m String
    exampleLine = try $ exampleLineStart *> anyLine
@@ -885,7 +885,7 @@ latexFragment :: Monad m => OrgParser m (F Blocks)
 latexFragment = try $ do
   envName <- latexEnvStart
   content <- mconcat <$> manyTill anyLineNewline (latexEnd envName)
-  return . return $ B.rawBlock "latex" (content `inLatexEnv` envName)
+  returnF $ B.rawBlock "latex" (content `inLatexEnv` envName)
  where
    c `inLatexEnv` e = mconcat [ "\\begin{", e, "}\n"
                               , c

--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -157,7 +157,7 @@ endline = try $ do
   decEmphasisNewlinesCount
   guard =<< newlinesCountWithinLimits
   updateLastPreCharPos
-  return . return $ B.softbreak
+  returnF B.softbreak
 
 
 --

--- a/src/Text/Pandoc/Readers/Org/Parsing.hs
+++ b/src/Text/Pandoc/Readers/Org/Parsing.hs
@@ -110,7 +110,7 @@ module Text.Pandoc.Readers.Org.Parsing
 
 import Text.Pandoc.Readers.Org.ParserState
 
-import Text.Pandoc.Parsing hiding (anyLine, blanklines, newline,
+import Text.Pandoc.Parsing hiding (F, anyLine, blanklines, newline,
                             parseFromString)
 import qualified Text.Pandoc.Parsing as P
 


### PR DESCRIPTION
Extended version of #3604, supplemented with an approach to build the different F monads used in the readers from a single data type.  Changes to the Markdown reader are kept to a minimum.