### PR TITLE
Muse writer: Do not reflow directives

### DIFF
--- a/src/Text/Pandoc/Writers/Muse.hs
+++ b/src/Text/Pandoc/Writers/Muse.hs
@@ -85,8 +85,8 @@ pandocToMuse (Pandoc meta blocks) = do
                     then Just $ writerColumns opts
                     else Nothing
   metadata <- metaToJSON opts
-               (fmap (render colwidth) . blockListToMuse)
-               (fmap (render colwidth) . inlineListToMuse)
+               (fmap (render Nothing) . blockListToMuse)
+               (fmap (render Nothing) . inlineListToMuse)
                meta
   body <- blockListToMuse blocks
   notes <- liftM (reverse . stNotes) get >>= notesToMuse


### PR DESCRIPTION
Directives at the beginning of documents cannot
span multiple lines so they must not be reflown.