### PR TITLE
Markdown writer: Case-insensitive reference links.

### DIFF
--- a/test/command/3615.md
+++ b/test/command/3615.md
@@ -1,0 +1,18 @@
+```
+% pandoc -f html -t markdown --reference-links
+<a href="a">foo</a> <a href="b">Foo</a>
+^D
+[foo][] [Foo][1]
+
+  [foo]: a
+  [1]: b
+```
+
+```
+% pandoc -f html -t markdown --reference-links
+<a href="a">foo</a> <a href="a">Foo</a>
+^D
+[foo][] [Foo]
+
+  [foo]: a
+```


### PR DESCRIPTION
Ensure that we do not generate reference links
whose labels differ only by case.

Also allow implicit reference links when the link
text and label are identical up to case.

Closes #3615.