### PR TITLE
Markdown writer: Selectively disable shortcut links.

### DIFF
--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -821,7 +821,8 @@ inlineListToMarkdown opts lst = do
   where go [] = return empty
         go (i:is) = case i of
             (Link _ _ _) -> case is of
-                -- If a link is followed by another link or '[' we don't shortcut
+                -- If a link is followed by another link, or '[', '(' or ':'
+                -- then we don't shortcut
                 (Link _ _ _):_                    -> unshortcutable
                 Space:(Link _ _ _):_              -> unshortcutable
                 Space:(Str('[':_)):_              -> unshortcutable
@@ -831,9 +832,17 @@ inlineListToMarkdown opts lst = do
                 SoftBreak:(Str('[':_)):_          -> unshortcutable
                 SoftBreak:(RawInline _ ('[':_)):_ -> unshortcutable
                 SoftBreak:(Cite _ _):_            -> unshortcutable
+                LineBreak:(Link _ _ _):_          -> unshortcutable
+                LineBreak:(Str('[':_)):_          -> unshortcutable
+                LineBreak:(RawInline _ ('[':_)):_ -> unshortcutable
+                LineBreak:(Cite _ _):_            -> unshortcutable
                 (Cite _ _):_                      -> unshortcutable
                 Str ('[':_):_                     -> unshortcutable
+                Str ('(':_):_                     -> unshortcutable
+                Str (':':_):_                     -> unshortcutable
                 (RawInline _ ('[':_)):_           -> unshortcutable
+                (RawInline _ ('(':_)):_           -> unshortcutable
+                (RawInline _ (':':_)):_           -> unshortcutable
                 (RawInline _ (' ':'[':_)):_       -> unshortcutable
                 _                                 -> shortcutable
             _ -> shortcutable

--- a/test/command/3619.md
+++ b/test/command/3619.md
@@ -1,0 +1,28 @@
+```
+% pandoc -f html -t markdown --reference-links
+<a href="foo">bar</a>: baz
+^D
+[bar][]: baz
+
+  [bar]: foo
+```
+
+```
+% pandoc -f html -t markdown --reference-links
+<a href="foo">bar</a>(baz)
+^D
+[bar][](baz)
+
+  [bar]: foo
+```
+
+```
+% pandoc -f html -t markdown_strict --reference-links
+<a href="a">foo</a><br/><a href="b">bar</a>
+^D
+[foo][]  
+[bar]
+
+  [foo]: a
+  [bar]: b
+```


### PR DESCRIPTION
Add rules for ':' and '(', as well as '[' following a LineBreak.

Closes #3619.

Not sure this is the cleanest way to fix it, but it seemed like the simplest.