### PR TITLE
Markdown Writer: put space before refLinks, fixes #3630

### DIFF
--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -241,7 +241,7 @@ keyToMarkdown opts (label', (src, tit), attr) = do
                 else space <> "\"" <> text tit <> "\""
   return $ nest 2 $ hang 2
             ("[" <> label' <> "]:" <> space) (text src <> tit')
-            <> linkAttributes opts attr
+            <+> linkAttributes opts attr
 
 -- | Return markdown representation of notes.
 notesToMarkdown :: PandocMonad m => WriterOptions -> [[Block]] -> MD m Doc

--- a/test/command/3630.md
+++ b/test/command/3630.md
@@ -1,0 +1,8 @@
+```
+% pandoc -f markdown -t markdown --reference-links
+![foo](bar.png){#myId}
+^D
+![foo]
+
+  [foo]: bar.png {#myId}
+```


### PR DESCRIPTION
fixes https://github.com/jgm/pandoc/issues/3630