### PR TITLE
LaTeX: Add support for tabularx environment

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1156,6 +1156,7 @@ environments = M.fromList
   , ("table",  env "table" $
          resetCaption *> skipopts *> blocks >>= addTableCaption)
   , ("tabular*", env "tabular" $ simpTable True)
+  , ("tabularx", env "tabularx" $ simpTable True)
   , ("tabular", env "tabular"  $ simpTable False)
   , ("quote", blockQuote <$> env "quote" blocks)
   , ("quotation", blockQuote <$> env "quotation" blocks)
@@ -1414,7 +1415,11 @@ parseAligns = try $ do
   let lAlign = AlignLeft <$ char 'l'
   let rAlign = AlignRight <$ char 'r'
   let parAlign = AlignLeft <$ (char 'p' >> braced)
-  let alignChar = cAlign <|> lAlign <|> rAlign <|> parAlign
+  -- algins from tabularx
+  let xAlign = AlignLeft <$ char 'X'
+  let mAlign = AlignLeft <$ (char 'm' >> braced)
+  let bAlign = AlignLeft <$ (char 'b' >> braced)
+  let alignChar = cAlign <|> lAlign <|> rAlign <|> parAlign <|> xAlign <|> mAlign <|> bAlign
   let alignPrefix = char '>' >> braced
   let alignSuffix = char '<' >> braced
   let alignSpec = do

--- a/test/command/tabularx.md
+++ b/test/command/tabularx.md
@@ -1,0 +1,110 @@
+```
+% pandoc -f latex -t native
+\begin{tabularx}{\linewidth}{|c|c|c|}
+\hline
+  Column Heading 1
+  & Column Heading 2
+  & Column Heading 3 \\
+\hline
+  Cell 1.1 
+  & Cell 1.2
+  & Cell 1.3 \\
+\hline
+  Cell 2.1 
+  & Cell 2.2
+  & Cell 2.3 \\
+\hline
+  Cell 3.1 
+  & Cell 3.2
+  & Cell 3.3 \\
+\hline
+\end{tabularx}
+^D
+[Table [] [AlignCenter,AlignCenter,AlignCenter] [0.0,0.0,0.0]
+ [[Plain [Str "Column",Space,Str "Heading",Space,Str "1"]]
+ ,[Plain [Str "Column",Space,Str "Heading",Space,Str "2"]]
+ ,[Plain [Str "Column",Space,Str "Heading",Space,Str "3"]]]
+ [[[Plain [Str "Cell",Space,Str "1.1"]]
+  ,[Plain [Str "Cell",Space,Str "1.2"]]
+  ,[Plain [Str "Cell",Space,Str "1.3"]]]
+ ,[[Plain [Str "Cell",Space,Str "2.1"]]
+  ,[Plain [Str "Cell",Space,Str "2.2"]]
+  ,[Plain [Str "Cell",Space,Str "2.3"]]]
+ ,[[Plain [Str "Cell",Space,Str "3.1"]]
+  ,[Plain [Str "Cell",Space,Str "3.2"]]
+  ,[Plain [Str "Cell",Space,Str "3.3"]]]]]
+```
+
+```
+% pandoc -f latex -t native
+\begin{tabularx}{\linewidth}{|X|c|p{0.25\linewidth}|}
+\hline
+  Column Heading 1
+  & Column Heading 2
+  & Column Heading 3 \\
+\hline
+  Cell 1.1 
+  & Cell 1.2
+  & Cell 1.3 \\
+\hline
+  Cell 2.1 
+  & Cell 2.2
+  & Cell 2.3 \\
+\hline
+  Cell 3.1 
+  & Cell 3.2
+  & Cell 3.3 \\
+\hline
+\end{tabularx}
+^D
+[Table [] [AlignLeft,AlignCenter,AlignLeft] [0.0,0.0,0.0]
+ [[Plain [Str "Column",Space,Str "Heading",Space,Str "1"]]
+ ,[Plain [Str "Column",Space,Str "Heading",Space,Str "2"]]
+ ,[Plain [Str "Column",Space,Str "Heading",Space,Str "3"]]]
+ [[[Plain [Str "Cell",Space,Str "1.1"]]
+  ,[Plain [Str "Cell",Space,Str "1.2"]]
+  ,[Plain [Str "Cell",Space,Str "1.3"]]]
+ ,[[Plain [Str "Cell",Space,Str "2.1"]]
+  ,[Plain [Str "Cell",Space,Str "2.2"]]
+  ,[Plain [Str "Cell",Space,Str "2.3"]]]
+ ,[[Plain [Str "Cell",Space,Str "3.1"]]
+  ,[Plain [Str "Cell",Space,Str "3.2"]]
+  ,[Plain [Str "Cell",Space,Str "3.3"]]]]]
+```
+
+```
+% pandoc -f latex -t native
+\begin{tabularx}{\linewidth}{|b{0.25\linewidth}|c|m{0.25\linewidth}|}
+\hline
+  Column Heading 1
+  & Column Heading 2
+  & Column Heading 3 \\
+\hline
+  Cell 1.1 
+  & Cell 1.2
+  & Cell 1.3 \\
+\hline
+  Cell 2.1 
+  & Cell 2.2
+  & Cell 2.3 \\
+\hline
+  Cell 3.1 
+  & Cell 3.2
+  & Cell 3.3 \\
+\hline
+\end{tabularx}
+^D
+[Table [] [AlignLeft,AlignCenter,AlignLeft] [0.0,0.0,0.0]
+ [[Plain [Str "Column",Space,Str "Heading",Space,Str "1"]]
+ ,[Plain [Str "Column",Space,Str "Heading",Space,Str "2"]]
+ ,[Plain [Str "Column",Space,Str "Heading",Space,Str "3"]]]
+ [[[Plain [Str "Cell",Space,Str "1.1"]]
+  ,[Plain [Str "Cell",Space,Str "1.2"]]
+  ,[Plain [Str "Cell",Space,Str "1.3"]]]
+ ,[[Plain [Str "Cell",Space,Str "2.1"]]
+  ,[Plain [Str "Cell",Space,Str "2.2"]]
+  ,[Plain [Str "Cell",Space,Str "2.3"]]]
+ ,[[Plain [Str "Cell",Space,Str "3.1"]]
+  ,[Plain [Str "Cell",Space,Str "3.2"]]
+  ,[Plain [Str "Cell",Space,Str "3.3"]]]]]
+```


### PR DESCRIPTION
In LaTeX you can use the `tabularx` environment as an alternative to `tabular` environment. For example:

```latex
\begin{tabularx}{\linewidth}{|b{0.25\linewidth}|c|m{0.25\linewidth}|}
\hline
  Column Heading 1
  & Column Heading 2
  & Column Heading 3 \\
\hline
  Cell 1.1 
  & Cell 1.2
  & Cell 1.3 \\
\hline
  Cell 2.1 
  & Cell 2.2
  & Cell 2.3 \\
\hline
  Cell 3.1 
  & Cell 3.2
  & Cell 3.3 \\
\hline
\end{tabularx}
```

This PR adds support for this environment. 