### PR TITLE
Fix keyval funtion: pandoc did not parse options in braces correctly.…

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1095,7 +1095,7 @@ parseListingsOptions options =
 keyval :: PandocMonad m => LP m (String, String)
 keyval = try $ do
   key <- many1 alphaNum
-  val <- option "" $ char '=' >> (braced) <|> (many1 (alphaNum <|> char '.' <|> char ':' <|> char '-' <|> char '\\'))
+  val <- option "" $ char '=' >> (braced) <|> (many1 (alphaNum <|> char '.' <|> char ':' <|> char '-' <|> char '|' <|> char '\\'))
   skipMany spaceChar
   optional (char ',')
   skipMany spaceChar

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1095,7 +1095,7 @@ parseListingsOptions options =
 keyval :: PandocMonad m => LP m (String, String)
 keyval = try $ do
   key <- many1 alphaNum
-  val <- option "" $ char '=' >> many1 (alphaNum <|> char '.' <|> char '\\')
+  val <- option "" $ char '=' >> (braced) <|> (many1 (alphaNum <|> char '.' <|> char ':' <|> char '-' <|> char '\\'))
   skipMany spaceChar
   optional (char ',')
   skipMany spaceChar

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1095,7 +1095,7 @@ parseListingsOptions options =
 keyval :: PandocMonad m => LP m (String, String)
 keyval = try $ do
   key <- many1 alphaNum
-  val <- option "" $ char '=' >> (braced) <|> (many1 (alphaNum <|> char '.' <|> char ':' <|> char '-' <|> char '|' <|> char '\\'))
+  val <- option "" $ char '=' >> braced <|> (many1 (alphaNum <|> oneOf ".:-|\\"))
   skipMany spaceChar
   optional (char ',')
   skipMany spaceChar

--- a/test/command/lstlisting.md
+++ b/test/command/lstlisting.md
@@ -11,4 +11,15 @@ public class World {
 [CodeBlock ("lst:Hello-World",["java"],[("language","Java"),("caption","Java Example"),("label","lst:Hello-World")]) "public class World {\n    public static void main(String[] args) {\n        System.out.println(\"Hello World\");\n    }\n}"]
 ```
 
-
+```
+% pandoc -f latex -t native
+\begin{lstlisting}[language=Java, escapechar=|, caption={Java Example}, label=lst:Hello-World]
+public class World {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}
+\end{lstlisting}
+^D
+[CodeBlock ("lst:Hello-World",["java"],[("language","Java"),("escapechar","|"),("caption","Java Example"),("label","lst:Hello-World")]) "public class World {\n    public static void main(String[] args) {\n        System.out.println(\"Hello World\");\n    }\n}"]
+```

--- a/test/command/lstlisting.md
+++ b/test/command/lstlisting.md
@@ -1,0 +1,14 @@
+```
+% pandoc -f latex -t native
+\begin{lstlisting}[language=Java, caption={Java Example}, label=lst:Hello-World]
+public class World {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}
+\end{lstlisting}
+^D
+[CodeBlock ("lst:Hello-World",["java"],[("language","Java"),("caption","Java Example"),("label","lst:Hello-World")]) "public class World {\n    public static void main(String[] args) {\n        System.out.println(\"Hello World\");\n    }\n}"]
+```
+
+


### PR DESCRIPTION
… Additionally, dot, dash, and colon were no valid characters. Therefore, options, for example, of the `lstlsiting` won't be parsed correctly. See following LaTeX code

```latex
\begin{lstlisting}[language=Java, caption={Java Example}, label=lst:Hello-World]
public class World {
    public static void main(String[] args) {
        System.out.println("Hello World");
    }
}
\end{lstlisting}
```

The resulting `CodeBlock` did not contain `label` and `caption` as attributes. 

This PR fixes this issue. 