### PR TITLE
Markdown writer: missing \n

### DIFF
--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -788,7 +788,7 @@ blockListToMarkdown opts blocks = do
       isListBlock _                  = False
       commentSep                     = if isEnabled Ext_raw_html opts
                                           then RawBlock "html" "<!-- -->\n"
-                                          else RawBlock "markdown" "&nbsp;"
+                                          else RawBlock "markdown" "&nbsp;\n"
   mapM (blockToMarkdown opts) (fixBlocks blocks) >>= return . cat
 
 getKey :: Doc -> Key


### PR DESCRIPTION
This fixes the behaviour of `echo '<ul><li>foo</li></ul><ul><li>bar</li><li>baz</li></ul>' | pandoc -f html -t markdown-raw_html | pandoc`