### PR TITLE
Fix #3651.

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -155,7 +155,7 @@ $if(graphics)$
 $endif$
 $if(links-as-notes)$
 % Make links footnotes instead of hotlinks:
-\renewcommand{\href}[2]{#2\footnote{\url{#1}}}
+\DeclareRobustCommand{\href}[2]{#2\footnote{\url{#1}}}
 $endif$
 $if(strikeout)$
 \usepackage[normalem]{ulem}


### PR DESCRIPTION
Declare our redefined `\href` robust.