### PR TITLE
GitHub Markdown: Don't use dots in header identifiers

### DIFF
--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -129,6 +129,7 @@ data Extension =
     | Ext_emoji               -- ^ Support emoji like :smile:
     | Ext_auto_identifiers    -- ^ Automatic identifiers for headers
     | Ext_ascii_identifiers   -- ^ ascii-only identifiers for headers
+    | Ext_no_dots_in_identifiers -- ^ Don't use dots in header identifiers
     | Ext_header_attributes   -- ^ Explicit header attributes {#id .class k=v}
     | Ext_mmd_header_identifiers -- ^ Multimarkdown style header identifiers [myid]
     | Ext_implicit_header_references -- ^ Implicit reference links for headers
@@ -231,6 +232,7 @@ githubMarkdownExtensions = extensionsFromList
   , Ext_fenced_code_blocks
   , Ext_auto_identifiers
   , Ext_ascii_identifiers
+  , Ext_no_dots_in_identifiers
   , Ext_backtick_code_blocks
   , Ext_autolink_bare_uris
   , Ext_space_in_atx_header

--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -1146,10 +1146,14 @@ registerHeader (ident,classes,kvs) header' = do
        let id'' = if Ext_ascii_identifiers `extensionEnabled` exts
                      then catMaybes $ map toAsciiChar id'
                      else id'
+       let id''' = if Ext_no_dots_in_identifiers `extensionEnabled` exts
+                     then filter (/= '.') id''
+                     else id''
        updateState $ updateIdentifierList $ Set.insert id'
        updateState $ updateIdentifierList $ Set.insert id''
+       updateState $ updateIdentifierList $ Set.insert id'''
        updateState $ updateHeaderMap $ insert' header' id'
-       return (id'',classes,kvs)
+       return (id''',classes,kvs)
      else do
         unless (null ident) $ do
           when (ident `Set.member` ids) $ do

--- a/test/command/github-identifiers.md
+++ b/test/command/github-identifiers.md
@@ -1,0 +1,6 @@
+```
+% pandoc -f markdown_github -t html
+# GitHub doesn't keep dots in header identifiers. And so does Pandoc!
+^D
+<h1 id="github-doesnt-keep-dots-in-header-identifiers-and-so-does-pandoc">GitHub doesn't keep dots in header identifiers. And so does Pandoc!</h1>
+```


### PR DESCRIPTION
GitHub doesn't use dots in header identifiers, but Pandoc does.
So when a header contains dots, links to the header that work on GitHub won't work in a HTML page built using Pandoc.

Here is an example of such Markdown document: https://github.com/asmgf/github-markdown-identifiers/blob/master/README.md