### PR TITLE
Implemented #168

### DIFF
--- a/test/command/168.md
+++ b/test/command/168.md
@@ -1,0 +1,87 @@
+
+```
+% pandoc -f markdown -t html
+:::{.class}
+foo
+:::
+^D
+<div class="class">
+foo
+</div>
+```
+
+```
+% pandoc -f markdown -t html
+:::::: info ::
+foo
+:::
+^D
+<div class="info">
+foo
+</div>
+```
+
+```
+% pandoc -f markdown -t html
+:::::: info :: {.combine}
+foo
+:::
+^D
+<div class="info combine">
+foo
+</div>
+```
+
+```
+% pandoc -f markdown -t html
+:::::: {#id .class}
+foo
+:::
+^D
+<div id="id" class="class">
+foo
+</div>
+```
+
+```
+% pandoc -f markdown -t html
+{#id .class}
+! foo
+^D
+<div id="id" class="class">
+foo
+</div>
+```
+
+```
+% pandoc -f markdown -t html
+! foo
+! 
+! {.attr}
+! ! nested
+^D
+<div>
+<p>foo</p>
+<div class="attr">
+nested
+</div>
+</div>
+```
+
+```
+% pandoc -f markdown -t html
+!noimage
+^D
+<div>
+noimage
+</div>
+```
+
+```
+% pandoc -f markdown -t html
+![](foo)
+^D
+<figure>
+<img src="foo" />
+</figure>
+```

--- a/test/command/168.md
+++ b/test/command/168.md
@@ -76,12 +76,3 @@ nested
 noimage
 </div>
 ```
-
-```
-% pandoc -f markdown -t html
-![](foo)
-^D
-<figure>
-<img src="foo" />
-</figure>
-```


### PR DESCRIPTION
This PR implements #168 as described in https://github.com/jgm/pandoc/issues/168#issuecomment-270833294

It should work for normal and nested blocks with both syntaxes described.

There are no tests yet, as i don't know how you want them implemented properly.

A `stack test` shows that it should not break other things:

`All 968 tests passed (81.94s)`