### PR TITLE
Txt2Tags parser: newline is not indentation

### DIFF
--- a/src/Text/Pandoc/Readers/Txt2Tags.hs
+++ b/src/Text/Pandoc/Readers/Txt2Tags.hs
@@ -281,7 +281,7 @@ anyLineNewline :: T2T String
 anyLineNewline = (++ "\n") <$> anyLine
 
 indentWith :: Int -> T2T String
-indentWith n = count n space
+indentWith n = count n spaceChar
 
 -- Table
 


### PR DESCRIPTION
space parses '\n', while spaceChar parses only ' ' and '\t'