### PR TITLE
implemented #3663

### DIFF
--- a/src/Text/Pandoc/Class.hs
+++ b/src/Text/Pandoc/Class.hs
@@ -111,7 +111,7 @@ import Control.Monad.RWS (RWST)
 import Data.Word (Word8)
 import Data.Default
 import System.IO.Error
-import System.IO (stderr)
+import System.IO (stderr, nativeNewline)
 import qualified Data.Map as M
 import Text.Pandoc.Error
 
@@ -261,17 +261,17 @@ instance PandocMonad PandocIO where
   getCommonState = PandocIO $ lift get
   putCommonState x = PandocIO $ lift $ put x
   logOutput msg = liftIO $ do
-    UTF8.hPutStr stderr $ "[" ++
+    UTF8.hPutStr stderr nativeNewline $ "[" ++
        (map toLower $ show (messageVerbosity msg)) ++ "] "
     alertIndent $ lines $ showLogMessage msg
 
 alertIndent :: [String] -> IO ()
 alertIndent [] = return ()
 alertIndent (l:ls) = do
-  UTF8.hPutStrLn stderr l
+  UTF8.hPutStrLn stderr nativeNewline l
   mapM_ go ls
-  where go l' = do UTF8.hPutStr stderr "! "
-                   UTF8.hPutStrLn stderr l'
+  where go l' = do UTF8.hPutStr stderr nativeNewline "! "
+                   UTF8.hPutStrLn stderr nativeNewline l'
 
 -- | Specialized version of parseURIReference that disallows
 -- single-letter schemes.  Reason:  these are usually windows absolute

--- a/src/Text/Pandoc/Error.hs
+++ b/src/Text/Pandoc/Error.hs
@@ -41,7 +41,7 @@ import Text.Parsec.Error
 import Text.Parsec.Pos hiding (Line)
 import qualified Text.Pandoc.UTF8 as UTF8
 import System.Exit (exitWith, ExitCode(..))
-import System.IO (stderr)
+import System.IO (stderr, nativeNewline)
 import Network.HTTP.Client (HttpException)
 
 type Input = String
@@ -105,6 +105,6 @@ handleError (Left e) =
 
 err :: Int -> String -> IO a
 err exitCode msg = do
-  UTF8.hPutStrLn stderr msg
+  UTF8.hPutStrLn stderr nativeNewline msg
   exitWith $ ExitFailure exitCode
   return undefined

--- a/src/Text/Pandoc/MediaBag.hs
+++ b/src/Text/Pandoc/MediaBag.hs
@@ -47,7 +47,7 @@ import Data.Typeable (Typeable)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath
 import qualified System.FilePath.Posix as Posix
-import System.IO (stderr)
+import System.IO (stderr, nativeNewline)
 import Text.Pandoc.MIME (MimeType, getMimeTypeDef)
 import qualified Text.Pandoc.UTF8 as UTF8
 
@@ -108,7 +108,7 @@ writeMedia verbose dir (subpath, bs) = do
   -- in zip containers all paths use /
   let fullpath = dir </> normalise subpath
   createDirectoryIfMissing True $ takeDirectory fullpath
-  when verbose $ UTF8.hPutStrLn stderr $ "pandoc: extracting " ++ fullpath
+  when verbose $ UTF8.hPutStrLn stderr nativeNewline $ "pandoc: extracting " ++ fullpath
   BL.writeFile fullpath bs
 
 

--- a/src/Text/Pandoc/PDF.hs
+++ b/src/Text/Pandoc/PDF.hs
@@ -48,7 +48,7 @@ import System.Directory
 import System.Environment
 import System.Exit (ExitCode (..))
 import System.FilePath
-import System.IO (stdout)
+import System.IO (stdout, nativeNewline)
 import System.IO.Temp (withTempDirectory, withTempFile)
 import Text.Pandoc.Definition
 import Text.Pandoc.MediaBag
@@ -228,7 +228,7 @@ runTeXProgram :: Verbosity -> String -> [String] -> Int -> Int -> FilePath
 runTeXProgram verbosity program args runNumber numRuns tmpDir source = do
     let file = tmpDir </> "input.tex"
     exists <- doesFileExist file
-    unless exists $ UTF8.writeFile file source
+    unless exists $ UTF8.writeFile nativeNewline file source
 #ifdef _WINDOWS
     -- note:  we want / even on Windows, for TexLive
     let tmpDir' = changePathSeparators tmpDir
@@ -307,7 +307,7 @@ html2pdf  :: Verbosity    -- ^ Verbosity level
 html2pdf verbosity args source = do
   file <- withTempFile "." "html2pdf.html" $ \fp _ -> return fp
   pdfFile <- withTempFile "." "html2pdf.pdf" $ \fp _ -> return fp
-  UTF8.writeFile file source
+  UTF8.writeFile nativeNewline file source
   let programArgs = args ++ [file, pdfFile]
   env' <- getEnvironment
   when (verbosity >= INFO) $ do
@@ -346,7 +346,7 @@ context2pdf :: Verbosity    -- ^ Verbosity level
             -> IO (Either ByteString ByteString)
 context2pdf verbosity tmpDir source = inDirectory tmpDir $ do
   let file = "input.tex"
-  UTF8.writeFile file source
+  UTF8.writeFile nativeNewline file source
 #ifdef _WINDOWS
   -- note:  we want / even on Windows, for TexLive
   let tmpDir' = changePathSeparators tmpDir

--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -183,6 +183,7 @@ import Text.Pandoc.Builder (Blocks, Inlines, rawBlock, HasMeta(..), trimInlines)
 import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.XML (fromEntities)
 import qualified Text.Pandoc.UTF8 as UTF8 (putStrLn)
+import System.IO (nativeNewline)
 import Text.Parsec hiding (token)
 import Text.Parsec.Pos (newPos)
 import Data.Char ( toLower, toUpper, ord, chr, isAscii, isAlphaNum,
@@ -957,7 +958,7 @@ testStringWith :: (Show a)
                => ParserT [Char] ParserState Identity a
                -> [Char]
                -> IO ()
-testStringWith parser str = UTF8.putStrLn $ show $
+testStringWith parser str = UTF8.putStrLn nativeNewline $ show $
                             readWith parser defaultParserState str
 
 -- | Parsing options.

--- a/src/Text/Pandoc/UTF8.hs
+++ b/src/Text/Pandoc/UTF8.hs
@@ -61,23 +61,23 @@ readFile f = do
   h <- openFile (encodePath f) ReadMode
   hGetContents h
 
-writeFile :: FilePath -> String -> IO ()
-writeFile f s = withFile (encodePath f) WriteMode $ \h -> hPutStr h s
+writeFile :: Newline -> FilePath -> String -> IO ()
+writeFile eol f s = withFile (encodePath f) WriteMode $ \h -> hPutStr h eol s
 
 getContents :: IO String
 getContents = hGetContents stdin
 
-putStr :: String -> IO ()
-putStr s = hPutStr stdout s
+putStr :: Newline -> String -> IO ()
+putStr eol s = hPutStr stdout eol s
 
-putStrLn :: String -> IO ()
-putStrLn s = hPutStrLn stdout s
+putStrLn :: Newline -> String -> IO ()
+putStrLn eol s = hPutStrLn stdout eol s
 
-hPutStr :: Handle -> String -> IO ()
-hPutStr h s = hSetEncoding h utf8 >> IO.hPutStr h s
+hPutStr :: Handle -> Newline -> String -> IO ()
+hPutStr h eol s = hSetNewlineMode h (NewlineMode eol eol) >> hSetEncoding h utf8 >> IO.hPutStr h s
 
-hPutStrLn :: Handle -> String -> IO ()
-hPutStrLn h s = hSetEncoding h utf8 >> IO.hPutStrLn h s
+hPutStrLn :: Handle -> Newline -> String -> IO ()
+hPutStrLn h eol s = hSetNewlineMode h (NewlineMode eol eol) >> hSetEncoding h utf8 >> IO.hPutStrLn h s
 
 hGetContents :: Handle -> IO String
 hGetContents = fmap toString . B.hGetContents

--- a/test/Tests/Old.hs
+++ b/test/Tests/Old.hs
@@ -5,6 +5,7 @@ import Prelude hiding (readFile)
 import System.Exit
 import System.FilePath (joinPath, splitDirectories, (<.>), (</>))
 import System.IO.Temp (withTempFile)
+import System.IO (nativeNewline)
 import System.Process (runProcess, waitForProcess)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden.Advanced (goldenTest)
@@ -245,7 +246,7 @@ testWithNormalize normalizer testname opts inp norm =
                            if null errcontents
                               then ""
                               else '\n':errcontents
-        updateGolden = UTF8.writeFile norm
+        updateGolden = UTF8.writeFile nativeNewline norm
         options = ["--quiet", "--data-dir", ".." </> "data"] ++ [inp] ++ opts
 
 compareValues :: FilePath -> [String] -> String -> String -> IO (Maybe String)


### PR DESCRIPTION
#3663 sounded reasonable for me so i just implemented it because it was mostly search/replace in the UTF8-Module.

Sadly Mac (cr) is not in System.IO in GHC. Otherwise it should be caught in https://github.com/jgm/pandoc/compare/master...Drezil:issue3663?expand=1#diff-5da4b57212f9458ea23f6f27f62bfd87R971

Also: Errors and other things now get rendered with `\r\n` under windows (due to the usage of `nativeNewline` in those calls) and so the console-output should look better there.