### PR TITLE
Shared.hierarchicalize: fix the "header-in-div" bug (#997)

### DIFF
--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -575,6 +575,9 @@ rebuildTree _ _ = undefined -- These cases should not happen.
 -- The div will be a child of the previous header/section and the header
 -- inside the div will become a child of the previous section, regardless its
 -- depth. The two other functions correct this.
+-- If a header is placed in a div without an identifier, it will keep its own
+-- identifier. If it is placed in a div with an identifier, the header takes
+-- the identifier of the div.
 hierarchicalize :: [Block] -> [Element]
 hierarchicalize blocks = rebuildTree [] $ flatten $ S.evalState (hierarchicalizeWithIds blocks) []
 
@@ -596,6 +599,10 @@ hierarchicalizeWithIds ((Header level attr@(_,classes,_) title'):xs) = do
 hierarchicalizeWithIds ((Div ("",["references"],[])
                          (Header level (ident,classes,kvs) title' : xs)):ys) =
   hierarchicalizeWithIds ((Header level (ident,("references":classes),kvs)
+                           title') : (xs ++ ys))
+hierarchicalizeWithIds ((Div ("",_,[])
+                         (Header level (ident,classes,kvs) title' : xs)):ys) =
+  hierarchicalizeWithIds ((Header level (ident,classes,kvs)
                            title') : (xs ++ ys))
 hierarchicalizeWithIds ((Div (ident,_,[])
                          (Header level (_,classes,kvs) title' : xs)):ys) =

--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -103,7 +103,7 @@ import qualified Text.Pandoc.Builder as B
 import qualified Text.Pandoc.UTF8 as UTF8
 import Data.Char ( toLower, isLower, isUpper, isAlpha,
                    isLetter, isDigit, isSpace )
-import Data.List ( find, stripPrefix, intercalate )
+import Data.List ( find, stripPrefix, intercalate, partition )
 import Data.Maybe (mapMaybe)
 import Data.Version ( showVersion )
 import qualified Data.Map as M
@@ -491,9 +491,92 @@ inlineListToIdentifier =
  where nbspToSp '\160'     =  ' '
        nbspToSp x          =  x
 
--- | Convert list of Pandoc blocks into (hierarchical) list of Elements
+
+-- | Convert a hierarchical list of Elements into a list of sections. All
+-- blocks remain with their parent sections. If the list starts with blocks,
+-- they will be kept at the start.
+flatten :: [Element] -> [Element]
+flatten [] = []
+flatten (b@(Blk _) : es) = b : flatten es
+flatten (Sec d ident attr cont children : es) =
+  Sec d ident attr cont blkChildren : flatten secChildren ++ flatten es
+  where
+  (blkChildren,secChildren) = partition isBlk children
+
+  isBlk :: Element -> Bool
+  isBlk (Blk _) = True
+  isBlk _ = False
+
+-- | Stack of lists of Elements. Each item on the stack is a list of
+-- semi-processed sections.
+type Stack = [[Element]]
+
+-- | Unwind the stack once, then continue to process the remaining sections.
+-- This function is used when we found a Sec at a higher level (e.g. depth=2) than
+-- the current top of stack item has (e.g. depth=4). This function is
+-- concerned with stopping criteria only.
+unwind :: Stack -> [Element] -> [Element]
+unwind [] [] = []
+unwind [tos] [] = reverse tos
+unwind stack [] = unwind (unwind1 stack) []
+unwind stack es = rebuildTree (unwind1 stack) es
+
+-- | Unwind the stack once by appending all siblings of the top of stack as
+-- children to the second item on the stack. As the list are reversed on the
+-- stack, they have to be reversed before adding them as children. The
+-- function is only called if the first list element (last section seen) has a
+-- higher depth than the first item of the second item on the stack. This
+-- function handles an orthogonal set of stopping criteria to reduce the
+-- number of clauses of unwind.
+unwind1 :: Stack -> Stack
+unwind1 [tos , Sec d ident attr cont blkChildren : brothers] =
+  [ Sec d ident attr cont (blkChildren ++ reverse tos) : brothers]
+unwind1 (tos:(Sec d ident attr cont blkChildren : brothers):bos) =
+  (Sec d ident attr cont (blkChildren ++ reverse tos) : brothers) : bos
+unwind1 _ = undefined -- This case should not happen, but makes the compiler happy.
+
+-- | Rebuild the tree from the flattened list of sections. It processes each
+-- entry in the list of elements once. Depending on the depth of the current
+-- element compared to the depth of the top of stack (ToS), we have to handle three
+-- cases:
+-- * The current element has a higher depth than the ToS, it is a child of the
+--   ToS and will be put on the stack.
+-- * The current element has the same depth as the ToS, thus it is a sibling
+--   and can be prepended to the ToS list. The other siblings can't receive
+--   anymore children because all higher-depth sections are children of the
+--   current element.
+-- * The current element has smaller depth than the ToS. In that case, we can
+--   complete all open sections. We therefore unwind once. If that is not
+--   enough, this check will be match again and we unwind one level etc.
+-- We do have to process Blks here, because there could be some before the
+-- first section.
+-- We also have to handle the case that a lower-depth header follows a
+-- higher-depth header at top-level of the file. In that case, unwind will
+-- reduce the stack to one entry. We detect this, push out the contents of the
+-- stack in reverse order and start a new stack.
+rebuildTree :: Stack -> [Element] -> [Element]
+rebuildTree stack [] = unwind stack []
+rebuildTree stack (b@(Blk _):es) = b : rebuildTree stack es
+rebuildTree [] (sec@Sec{} : es) = rebuildTree [[sec]] es
+
+rebuildTree stack@[tpb@(tos@(Sec pd _ _ _ _):brothers)] (sec@(Sec d _ _ _ _) : es)
+  | d > pd = rebuildTree ([sec]:stack) es
+  | d == pd = rebuildTree [(sec:tos:brothers)] es
+  | otherwise = reverse tpb ++ rebuildTree [[sec]] es
+rebuildTree stack@((tos@(Sec pd _ _ _ _):brothers):bos) (sec@(Sec d _ _ _ _) : es)
+  | d > pd = rebuildTree ([sec]:stack) es
+  | d == pd = rebuildTree ((sec:tos:brothers):bos) es
+  | otherwise = unwind stack (sec:es)
+
+rebuildTree _ _ = undefined -- These cases should not happen.
+
+-- | Convert list of Pandoc blocks into (hierarchical) list of Elements. The
+-- worker function hierarchicalizeWithIds has problems with headers in divs.
+-- The div will be a child of the previous header/section and the header
+-- inside the div will become a child of the previous section, regardless its
+-- depth. The two other functions correct this.
 hierarchicalize :: [Block] -> [Element]
-hierarchicalize blocks = S.evalState (hierarchicalizeWithIds blocks) []
+hierarchicalize blocks = rebuildTree [] $ flatten $ S.evalState (hierarchicalizeWithIds blocks) []
 
 hierarchicalizeWithIds :: [Block] -> S.State [Int] [Element]
 hierarchicalizeWithIds [] = return []
@@ -513,6 +596,10 @@ hierarchicalizeWithIds ((Header level attr@(_,classes,_) title'):xs) = do
 hierarchicalizeWithIds ((Div ("",["references"],[])
                          (Header level (ident,classes,kvs) title' : xs)):ys) =
   hierarchicalizeWithIds ((Header level (ident,("references":classes),kvs)
+                           title') : (xs ++ ys))
+hierarchicalizeWithIds ((Div (ident,_,[])
+                         (Header level (_,classes,kvs) title' : xs)):ys) =
+  hierarchicalizeWithIds ((Header level (ident,classes,kvs)
                            title') : (xs ++ ys))
 hierarchicalizeWithIds (x:rest) = do
   rest' <- hierarchicalizeWithIds rest

--- a/test/Tests/Shared.hs
+++ b/test/Tests/Shared.hs
@@ -15,6 +15,7 @@ tests = [ testGroup "compactifyDL"
                in  compactifyDL x == x)
           ]
         , testGroup "collapseFilePath" testCollapse
+        , testGroup "hierarchicalize" testHierarchicalize
         ]
 
 testCollapse :: [TestTree]
@@ -37,3 +38,53 @@ testCollapse = map (testCase "collapse")
  ,  (collapseFilePath (joinPath [ "parent","foo",".."]) @?= (joinPath [ "parent"]))
  ,  (collapseFilePath (joinPath [ "","parent","foo","..","..","bar"]) @?= (joinPath [ "","bar"]))
  ,  (collapseFilePath (joinPath [ "",".","parent","foo"]) @?= (joinPath [ "","parent","foo"]))]
+
+
+blocks1 :: [Block]
+blocks1 =
+  [ Header 1 ("header-one",[],[]) [Str "Header",Space,Str "One"]
+  , Header 2 ("header-two",[],[]) [Str "Header",Space,Str "Two"]
+  , Div ("div1",[],[])
+    [ Header 1 ("header-three",[],[]) [Str "Header",Space,Str "Three"]
+    ]
+  , Div ("div2",[],[])
+    [ Header 2 ("header-five",[],[]) [Str "Header",Space,Str "Five"]
+    ]
+  ]
+
+elems1 :: [Element]
+elems1 =
+  [ Sec 1 [1] ("header-one",[],[]) [Str "Header",Space,Str "One"]
+      [ Sec 2 [1,1] ("header-two",[],[]) [Str "Header",Space,Str "Two"] []
+      ]
+  , Sec 1 [2] ("div1",[],[]) [Str "Header",Space,Str "Three"]
+      [ Sec 2 [2,1] ("div2",[],[]) [Str "Header",Space,Str "Five"] []
+      ]
+  ]
+
+blocks2 :: [Block]
+blocks2 =
+  [ Header 3 ("header-one",[],[]) [Str "Header",Space,Str "One"]
+  , Header 1 ("header-two",[],[]) [Str "Header",Space,Str "Two"]
+  , Div ("div1",[],[])
+    [ Header 2 ("header-three",[],[]) [Str "Header",Space,Str "Three"]
+    ]
+  , Div ("div2",[],[])
+    [ Header 2 ("header-five",[],[]) [Str "Header",Space,Str "Five"]
+    ]
+  ]
+
+elems2 :: [Element]
+elems2 =
+  [ Sec 3 [0,0,1] ("header-one",[],[]) [Str "Header",Space,Str "One"] []
+  , Sec 1 [1] ("header-two",[],[]) [Str "Header",Space,Str "Two"]
+    [ Sec 2 [1,1] ("div1",[],[]) [Str "Header",Space,Str "Three"] []
+    , Sec 2 [1,2] ("div2",[],[]) [Str "Header",Space,Str "Five"] []
+    ]
+  ]
+
+testHierarchicalize :: [TestTree]
+testHierarchicalize = map (testCase "hierarchicalize")
+  [ hierarchicalize blocks1 @?= elems1
+  , hierarchicalize blocks2 @?= elems2
+  ]


### PR DESCRIPTION
I think I found a heuristic that works for divs with and without ids. Since we can't preserve the div at all (that would require a rewrite of either hierarchicalize or the HTML writer, I guess), I reasoned that a div with an id is something special and we should preserve its id at least.