### PR TITLE
Support for \faCheck and \faClose

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -681,6 +681,9 @@ inlineCommands = M.fromList $
   , ("nohyphens", tok)
   , ("textnhtt", ttfamily)
   , ("nhttfamily", ttfamily)
+  -- fontawesome
+  , ("faCheck", lit "\10003")
+  , ("faClose", lit "\10007")
   ] ++ map ignoreInlines
   -- these commands will be ignored unless --parse-raw is specified,
   -- in which case they will appear as raw latex blocks:

--- a/test/command/latex-fontawesome.md
+++ b/test/command/latex-fontawesome.md
@@ -1,0 +1,13 @@
+```
+% pandoc -f latex -t native
+Check: \faCheck
+^D
+[Para [Str "Check:",Space,Str "\10003"]]
+```
+
+```
+% pandoc -f latex -t native
+Close: \faClose
+^D
+[Para [Str "Close:",Space,Str "\10007"]]
+```


### PR DESCRIPTION
This PR adds support for some fontawesome commands. 

Check: ✓ 
Close: ✗