### PR TITLE
Relax time and process in preparation for GHC 8.2

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -287,7 +287,7 @@ Library
                  parsec >= 3.1 && < 3.2,
                  mtl >= 2.2 && < 2.3,
                  filepath >= 1.1 && < 1.5,
-                 process >= 1.2.3 && < 1.5,
+                 process >= 1.2.3 && < 1.7,
                  directory >= 1 && < 1.4,
                  bytestring >= 0.9 && < 0.11,
                  text >= 0.11 && < 1.3,
@@ -331,7 +331,7 @@ Library
      Build-Depends: old-locale >= 1 && < 1.1,
                     time >= 1.2 && < 1.5
   else
-     Build-Depends: time >= 1.5 && < 1.7
+     Build-Depends: time >= 1.5 && < 1.9
   if flag(network-uri)
      Build-Depends: network-uri >= 2.6 && < 2.7, network >= 2.6
   else
@@ -532,7 +532,7 @@ Test-Suite test-pandoc
                   directory >= 1 && < 1.4,
                   filepath >= 1.1 && < 1.5,
                   hslua >= 0.4 && < 0.6,
-                  process >= 1.2.3 && < 1.5,
+                  process >= 1.2.3 && < 1.7,
                   skylighting >= 0.3.3 && < 0.4,
                   temporary >= 1.1 && < 1.3,
                   Diff >= 0.2 && < 0.4,


### PR DESCRIPTION
GHC 8.2 is very likely to ship with process-1.6.0.0
and time-1.8.0.1.

Consult:
https://ghc.haskell.org/trac/ghc/wiki/Commentary/Libraries/VersionHistory