### PR TITLE
Muse reader: fix list item continuation parsing

### DIFF
--- a/src/Text/Pandoc/Readers/Muse.hs
+++ b/src/Text/Pandoc/Readers/Muse.hs
@@ -295,9 +295,9 @@ withListContext p = do
 
 listContinuation :: PandocMonad m => Int -> MuseParser m String
 listContinuation markerLength = try $ do
-  result <- many1 $ listLine markerLength
   blanks <- many1 blankline
-  return $ concat result ++ blanks
+  result <- many1 $ listLine markerLength
+  return $ blanks ++ concat result
 
 listStart :: PandocMonad m => MuseParser m Int -> MuseParser m Int
 listStart marker = try $ do

--- a/test/Tests/Readers/Muse.hs
+++ b/test/Tests/Readers/Muse.hs
@@ -260,5 +260,18 @@ tests =
                                                                      ]
                               ]
                     ]
+      , "List continuation" =:
+         T.unlines
+           [ " - a"
+           , ""
+           , "   b"
+           , ""
+           , "   c"
+           ] =?>
+         bulletList [ mconcat [ para "a"
+                              , para "b"
+                              , para "c"
+                              ]
+                    ]
       ]
   ]


### PR DESCRIPTION
Found a bug by testing on Text::Amuse `lists.muse` testcase, now `pandoc -f muse -t muse` successfully passes it.