### PR TITLE
Vimwiki reader: minor updates

### DIFF
--- a/src/Text/Pandoc/Readers/Vimwiki.hs
+++ b/src/Text/Pandoc/Readers/Vimwiki.hs
@@ -28,20 +28,20 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 Conversion of vimwiki text to 'Pandoc' document.
 -}
 {--
- progress:
+[X]: implemented
+[O]: not implemented
 * block parsers:
     * [X] header
     * [X] hrule
     * [X] comment
     * [X] blockquote
-    * [X] preformatted
+    * [X] preformatted -- using codeblock
     * [X] displaymath
     * [X] bulletlist / orderedlist
-        * [X] orderedlist with 1., i., a) etc identification.
-        * [X] todo lists -- not list builder with attributes? using span.
+        * [X] todo lists -- using span.
     * [X] table
         * [X] centered table -- using div
-        * [O] colspan and rowspan -- pandoc limitation, see issue #1024
+        * [O] colspan and rowspan -- see issue #1024
     * [X] paragraph
     * [X] definition list
 * inline parsers:
@@ -58,8 +58,7 @@ Conversion of vimwiki text to 'Pandoc' document.
 * misc:
     * [X] `TODO:` mark
     * [X] metadata placeholders: %title and %date
-    * [O] control placeholders: %template and %nohtml -- %template added to
-          meta, %nohtml ignored
+    * [O] control placeholders: %template and %nohtml -- ignored
 --}
 
 module Text.Pandoc.Readers.Vimwiki ( readVimwiki

--- a/trypandoc/index.html
+++ b/trypandoc/index.html
@@ -94,6 +94,7 @@ $(document).ready(function() {
         <option value="rst">reStructuredText</option>
         <option value="textile">Textile</option>
         <option value="t2t">Txt2Tags</option>
+        <option value="vimwiki">Vimwiki</option>
       </select>
       <br/>
       <textarea id="text" maxlength="3000" rows="15"></textarea>


### PR DESCRIPTION
- updated comments in Vimwiki.hs to reflect current status of
implementation
- added vimwiki to trypandoc

I haven't found a way to test `trypandoc/index.html`. When I open this webpage locally and write something in say markdown and click "convert" nothing happens. Anyway I've added vimwiki to the "from" list.