### PR TITLE
Muse reader: fix horizontal rule parsing

### DIFF
--- a/src/Text/Pandoc/Readers/Muse.hs
+++ b/src/Text/Pandoc/Readers/Muse.hs
@@ -200,8 +200,10 @@ comment = try $ do
 
 separator :: PandocMonad m => MuseParser m (F Blocks)
 separator = try $ do
-  string "---"
-  newline
+  string "----"
+  many $ char '-'
+  many spaceChar
+  void newline <|> eof
   return $ return B.horizontalRule
 
 header :: PandocMonad m => MuseParser m (F Blocks)

--- a/test/Tests/Readers/Muse.hs
+++ b/test/Tests/Readers/Muse.hs
@@ -91,7 +91,18 @@ tests =
       ]
 
   , testGroup "Blocks"
-      [ "Quote" =: "<quote>Hello, world</quote>" =?> blockQuote (para $ text "Hello, world")
+      [ "Block elements end paragraphs" =:
+        T.unlines [ "First paragraph"
+                  , "----"
+                  , "Second paragraph"
+                  ] =?> para (text "First paragraph") <> horizontalRule <> para (text "Second paragraph")
+      , testGroup "Horizontal rule"
+        [ "Less than 4 dashes is not a horizontal rule" =: "---" =?> para (text "---")
+        , "4 dashes is a horizontal rule" =: "----" =?> horizontalRule
+        , "5 dashes is a horizontal rule" =: "-----" =?> horizontalRule
+        , "4 dashes with spaces is a horizontal rule" =: "----  " =?> horizontalRule
+        ]
+      , "Quote" =: "<quote>Hello, world</quote>" =?> blockQuote (para $ text "Hello, world")
       , "Center" =: "<center>Hello, world</center>" =?> para (text "Hello, world")
       , "Right" =: "<right>Hello, world</right>" =?> para (text "Hello, world")
       , testGroup "Comments"


### PR DESCRIPTION
Do not parse 3 dashes as horizontal rule and allow whitespace after rule