### PR TITLE
HTML reader: parse <main> like <div role=main>.

### DIFF
--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -922,7 +922,7 @@ blockHtmlTags = Set.fromList
     "dir", "div", "dl", "dt", "fieldset", "figcaption", "figure",
     "footer", "form", "h1", "h2", "h3", "h4",
     "h5", "h6", "head", "header", "hgroup", "hr", "html",
-    "isindex", "menu", "noframes", "ol", "output", "p", "pre",
+    "isindex", "main", "menu", "noframes", "ol", "output", "p", "pre",
     "section", "table", "tbody", "textarea",
     "thead", "tfoot", "ul", "dd",
     "dt", "frameset", "li", "tbody", "td", "tfoot",
@@ -1004,10 +1004,10 @@ _ `closes` "html" = False
 "optgroup" `closes` "optgroup" = True
 "optgroup" `closes` "option" = True
 "option" `closes` "option" = True
--- http://www.w3.org/TR/html-markup/p.html
+-- https://html.spec.whatwg.org/multipage/syntax.html#optional-tags
 x `closes` "p" | x `elem` ["address", "article", "aside", "blockquote",
    "dir", "div", "dl", "fieldset", "footer", "form", "h1", "h2", "h3", "h4",
-   "h5", "h6", "header", "hr", "menu", "nav", "ol", "p", "pre", "section",
+   "h5", "h6", "header", "hr", "main", "menu", "nav", "ol", "p", "pre", "section",
    "table", "ul"] = True
 "meta" `closes` "meta" = True
 "form" `closes` "form" = True
@@ -1020,8 +1020,8 @@ t `closes` "select" | t /= "option" = True
 "tfoot" `closes` t | t `elem` ["thead","colgroup"] = True
 "tbody" `closes` t | t `elem` ["tbody","tfoot","thead","colgroup"] = True
 t `closes` t2 |
-   t `elem` ["h1","h2","h3","h4","h5","h6","dl","ol","ul","table","div","p"] &&
-   t2 `elem` ["h1","h2","h3","h4","h5","h6","p" ] = True -- not "div"
+   t `elem` ["h1","h2","h3","h4","h5","h6","dl","ol","ul","table","div","main","p"] &&
+   t2 `elem` ["h1","h2","h3","h4","h5","h6","p" ] = True -- not "div" or "main"
 t1 `closes` t2 |
    t1 `Set.member` blockTags &&
    t2 `Set.notMember` blockTags &&

--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -54,7 +54,7 @@ import Text.Pandoc.Parsing hiding ((<|>))
 import Text.Pandoc.Walk
 import qualified Data.Map as M
 import Data.Foldable ( for_ )
-import Data.Maybe ( fromMaybe, isJust)
+import Data.Maybe ( fromMaybe, isJust, isNothing )
 import Data.List ( intercalate, isPrefixOf )
 import Data.Char ( isDigit, isLetter, isAlphaNum )
 import Control.Monad ( guard, mzero, void, unless )
@@ -376,6 +376,7 @@ pDiv = try $ do
   guardEnabled Ext_native_divs
   let isDivLike "div" = True
       isDivLike "section" = True
+      isDivLike "main" = True
       isDivLike _ = False
   TagOpen tag attr' <- lookAhead $ pSatisfy $ tagOpen isDivLike (const True)
   let attr = toStringAttr attr'
@@ -384,7 +385,10 @@ pDiv = try $ do
   let classes' = if tag == "section"
                     then "section":classes
                     else classes
-  return $ B.divWith (ident, classes', kvs) contents
+      kvs' = if tag == "main" && isNothing (lookup "role" kvs)
+               then ("role", "main"):kvs
+               else kvs
+  return $ B.divWith (ident, classes', kvs') contents
 
 pRawHtmlBlock :: PandocMonad m => TagParser m Blocks
 pRawHtmlBlock = do

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -11,6 +11,9 @@ import Data.Text (Text)
 html :: Text -> Pandoc
 html = purely $ readHtml def
 
+htmlNativeDivs :: Text -> Pandoc
+htmlNativeDivs = purely $ readHtml def { readerExtensions = enableExtension Ext_native_divs $ readerExtensions def }
+
 tests :: [TestTree]
 tests = [ testGroup "base tag"
           [ test html "simple" $
@@ -35,5 +38,13 @@ tests = [ testGroup "base tag"
             setMeta "lang" (text "es") (doc (plain (text "hola")))
           , test html "xml:lang on <html>" $ "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"es\"><head></head><body>hola</body></html>" =?>
             setMeta "lang" (text "es") (doc (plain (text "hola")))
+          ]
+        , testGroup "main"
+          [ test htmlNativeDivs "<main> becomes <div role=main>" $ "<main>hello</main>" =?>
+            doc (divWith ("", [], [("role", "main")]) (plain (text "hello")))
+          , test htmlNativeDivs "<main role=X> becomes <div role=X>" $ "<main role=foobar>hello</main>" =?>
+            doc (divWith ("", [], [("role", "foobar")]) (plain (text "hello")))
+          , test htmlNativeDivs "<main> has attributes preserved" $ "<main id=foo class=bar data-baz=qux>hello</main>" =?>
+            doc (divWith ("foo", ["bar"], [("role", "main"), ("data-baz", "qux")]) (plain (text "hello")))
           ]
         ]

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -46,5 +46,9 @@ tests = [ testGroup "base tag"
             doc (divWith ("", [], [("role", "foobar")]) (plain (text "hello")))
           , test htmlNativeDivs "<main> has attributes preserved" $ "<main id=foo class=bar data-baz=qux>hello</main>" =?>
             doc (divWith ("foo", ["bar"], [("role", "main"), ("data-baz", "qux")]) (plain (text "hello")))
+          , test htmlNativeDivs "<main> closes <p>" $ "<p>hello<main>main content</main>" =?>
+            doc (para (text "hello") <> divWith ("", [], [("role", "main")]) (plain (text "main content")))
+          , test htmlNativeDivs "<main> followed by text" $ "<main>main content</main>non-main content" =?>
+            doc (divWith ("", [], [("role", "main")]) (plain (text "main content")) <> plain (text "non-main content"))
           ]
         ]


### PR DESCRIPTION
Doing the reverse transformation in the HTML writer, and probably other writers too, might make sense, but this is a very good semantic match as it is.