### PR TITLE
[WIP] Parse siunitx num command

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -600,6 +600,11 @@ dosiunitx = do
                       emptyOr160 unit,
                       unit]
 
+dosinum :: PandocMonad m => LP m Inlines
+dosinum = do
+  skipopts
+  tok
+
 lit :: String -> LP m Inlines
 lit = pure . str
 
@@ -1302,6 +1307,7 @@ inlineCommands = M.fromList $
   , ("hypertarget", braced >> tok)
   -- siuntix
   , ("SI", dosiunitx)
+  , ("num", dosinum)
   -- hyphenat
   , ("bshyp", lit "\\\173")
   , ("fshyp", lit "/\173")

--- a/test/command/siunitx.md
+++ b/test/command/siunitx.md
@@ -19,3 +19,17 @@
 ^D
 [Para [Str "{}\160{}\160{}"]]
 ```
+
+```
+% pandoc -f latex -t native
+\num{123}     \\
+\num{1234}    \\
+\num{12345}   \\
+\num{0.123}   \\
+\num{0,1234}  \\
+\num{.12345}  \\
+\num{3.45d-4} \\
+\num{-e10}
+^D
+[Para [Str "123",LineBreak,Str "1234",LineBreak,Str "12345",LineBreak,Str "0.123",LineBreak,Str "0.1234",LineBreak,Str "0.12345",LineBreak,Str "3.45 × 10⁻⁴",LineBreak,Str "−10¹⁰"]]
+```


### PR DESCRIPTION
I want to add support for the `\num[〈options〉]{〈number〉}` command of the [siunitx](http://ftp.dante.de/tex-archive/macros/latex2e/exptl/siunitx/siunitx.pdf) package.

```latex
\num{123}     \\
\num{1234}    \\
\num{12345}   \\
\num{0.123}   \\
\num{0,1234}  \\
\num{.12345}  \\
\num{3.45d-4} \\
\num{-e10}
```

Current code does not work yet. I need some help in order to parse the numbers correctly. 