### PR TITLE
Fix hyperref options clash

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -1,3 +1,9 @@
+\PassOptionsToPackage{unicode=true}{hyperref} % options for packages loaded elsewhere
+\PassOptionsToPackage{hyphens}{url}
+$if(colorlinks)$
+\PassOptionsToPackage{usenames,dvipsnames}{color}
+$endif$
+%
 \documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
 $if(beamerarticle)$
 \usepackage{beamerarticle} % needs to be loaded first
@@ -78,14 +84,10 @@ $else$
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
 }
 $endif$
-\PassOptionsToPackage{hyphens}{url} % url is loaded by hyperref
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 $endif$
-\usepackage[unicode=true]{hyperref}
-$if(colorlinks)$
-\PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
-$endif$
+\usepackage{hyperref}
 \hypersetup{
 $if(title-meta)$
             pdftitle={$title-meta$},


### PR DESCRIPTION
Avoids an options clash when loading a package (e.g. `tufte-latex`) that uses `hyperref` settings different from those in the template (introduced in <https://github.com/jgm/pandoc-templates/commit/feffd7c64abab863abd3f6458d1c445d6bfe7fc4>).

This replaces <https://github.com/jgm/pandoc-templates/pull/230>.