### PR TITLE
slidy uses https instead of http

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1320,7 +1320,7 @@ including all [reveal.js configuration options].
 
 `slidy-url`
 :   base URL for Slidy documents (defaults to
-    `http://www.w3.org/Talks/Tools/Slidy2`)
+    `https://www.w3.org/Talks/Tools/Slidy2`)
 
 `slideous-url`
 :   base URL for Slideous documents (defaults to `slideous`)

--- a/man/pandoc.1
+++ b/man/pandoc.1
@@ -1487,7 +1487,7 @@ logo for Beamer documents
 .TP
 .B \f[C]slidy\-url\f[]
 base URL for Slidy documents (defaults to
-\f[C]http://www.w3.org/Talks/Tools/Slidy2\f[])
+\f[C]https://www.w3.org/Talks/Tools/Slidy2\f[])
 .RS
 .RE
 .TP

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -304,7 +304,7 @@ pandocToHtml opts (Pandoc meta blocks) = do
                   defField "idprefix" (writerIdentifierPrefix opts) $
                   -- these should maybe be set in pandoc.hs
                   defField "slidy-url"
-                    ("http://www.w3.org/Talks/Tools/Slidy2" :: String) $
+                    ("https://www.w3.org/Talks/Tools/Slidy2" :: String) $
                   defField "slideous-url" ("slideous" :: String) $
                   defField "revealjs-url" ("reveal.js" :: String) $
                   defField "s5-url" ("s5/default" :: String) $


### PR DESCRIPTION
The reason behind this pull request is that if I deliver my presentation over https, the browsers (tested on Safari and Chrome) will block the access of non-https files like the http css and js used in slidy.

Edit: although `slidy-url` can be used to change this manually, but I think defaulting to https is good practice enough for a pull request.