### PR TITLE
LaTeX reader: RN and Rn, from biblatex

### DIFF
--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -159,6 +159,12 @@ tests = [ testGroup "basic"
           , "zero" =:
             "\\RN{0}" =?>
             para (str "")
+          , "space then unbraced argument" =:
+            "\\RN 7 ok" =?>
+            para (str "VII" <> space <> str "ok")
+          , "space before braced argument" =:
+            "\\Rn {13}ok" =?>
+            para (str "xiiiok")
           ]
         ]
 

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -143,6 +143,23 @@ tests = [ testGroup "basic"
             "hello\\pfbreak*{}goodbye" =?>
             para (str "hello") <> horizontalRule <> para (str "goodbye")
           ]
+        , testGroup "biblatex roman numerals"
+          [ "upper" =:
+            "number \\RN{12}" =?>
+            para (str "number" <> space <> str "XII")
+          , "lower" =:
+            "number \\Rn{29}" =?>
+            para (str "number" <> space <> str "xxix")
+          , "leading zero" =:
+            "\\Rn{014}" =?>
+            para (str "xiv")
+          , "surrounding spaces" =:
+            "number \\Rn{ 41 }" =?>
+            para (str "number" <> space <> str "xli")
+          , "zero" =:
+            "\\RN{0}" =?>
+            para (str "")
+          ]
         ]
 
 baseCitation :: Citation


### PR DESCRIPTION
This is not bug-for-bug compatible: it barfs on weird input, whereas biblatex will accept just about anything that starts with a digit and several things that don't. Is that acceptable?

I had a go at bug-for-bug compatibility, but the implementation was getting a little bit silly. Here are the test cases that I cut out when I gave up:
```
          , "internal spaces" =:
            "\\RN{ 2 3 }" =?>
            para (str "II3")
          , "internal spaces many words" =:
            "\\RN{5 hello there}" =?>
            para (str "V" <> str "HELLO" <> space <> "THERE")
          , "newlines" =:
            "\\RN{\n15\n17\n}" =?>
            para (str "XV17")
          , "number then space then non-number" =:
            "\\Rn{5 HELLO}" =?>
            para (str "vHELLO")
          , "number then non-number, non-number gets upcased by RN" =:
            "\\RN{4hello}" =?>
            para (str "IVHELLO")
          , "internal command" =:
            "\\Rn{4\\textit{8}}" =?>
            para (str "iv" <> emph (str "8"))
          , "dotted" =:
            "\\RN{3.8}" =?>
            para (str "III.8")
          , "negative" =:
            "\\RN{-3}" =?>
            (mempty :: Blocks)
          , "double negative" =:
            "\\RN{--3}" =?>
            para (str "III")
          , "triple negative" =:
            "\\RN{---3 2}" =?>
            para (str "2")
          , "quadruple negative" =:
            "\\RN{----3 2}" =?>
            para (str "III2")
          , "negative zero" =:
            "\\RN{-0}" =?>
            (mempty :: Blocks)
          , "spaced negative" =:
            "\\RN{- 3 5}" =?>
            para (str "5")
          , "spaced double negative" =:
            "\\Rn{- - 3 5}" =?>
            para (str "iii5")
          , "internal hyphen" =:
            "\\RN{3-5}" =?>
            para (str "III-5")
          , "space then unbraced argument" =:
            "\\RN 7 ok" =?>
            para (str "VII" <> space <> str "ok")
          , "space then unbraced argument with trailing nondigits" =:
            "\\RN 7ok" =?>
            para (str "VIIok")
          , "multiple zeroes" =:
            "\\Rn{0 0 3}" =?>
            para (str "0" <> space <> str "3")
          -- The next cases cause errors when processed by LaTeX, but we would rather produce wonky output than fail.
          -- Other things that make biblatex error, and hence which we don't mind if they don't work:
          -- - "\\RN{hello}"
          -- - "\\RN\n\n"
          , "argument in textit" =:
            "\\RN{\\textit{8}}" =?>
            para (emph (str "8"))
          , "leading dot" =:
            "\\Rn{.3}" =?>
            para (str ".3")
          , "empty brace" =:
            "\\RN{}" =?>
            (mempty :: Blocks)
```

More things that don't work:
  * "\\RN{{3}}"
  * "\\Rn \\bgroup 13 \\egroup"
