### PR TITLE
forward $lang$ and $subtitle$ attributes

### DIFF
--- a/data/templates/default.docbook5
+++ b/data/templates/default.docbook5
@@ -11,7 +11,9 @@ $if(lang)$
 $endif$ >
   <info>
     <title>$title$</title>
+$if(subtitle)$
     <subtitle>$subtitle$</subtitle>
+$endif$
 $if(author)$
     <authorgroup>
 $for(author)$

--- a/data/templates/default.docbook5
+++ b/data/templates/default.docbook5
@@ -6,8 +6,12 @@ $if(mathml)$
   xmlns:mml="http://www.w3.org/1998/Math/MathML"
 $endif$
   xmlns:xlink="http://www.w3.org/1999/xlink" >
+$if(lang)$ 
+      xml:lang="$lang$"
+$endif$ >
   <info>
     <title>$title$</title>
+    <subtitle>$subtitle$</subtitle>
 $if(author)$
     <authorgroup>
 $for(author)$

--- a/data/templates/default.docbook5
+++ b/data/templates/default.docbook5
@@ -5,7 +5,7 @@
 $if(mathml)$
   xmlns:mml="http://www.w3.org/1998/Math/MathML"
 $endif$
-  xmlns:xlink="http://www.w3.org/1999/xlink" >
+  xmlns:xlink="http://www.w3.org/1999/xlink"
 $if(lang)$ 
       xml:lang="$lang$"
 $endif$ >

--- a/data/templates/default.docbook5
+++ b/data/templates/default.docbook5
@@ -7,7 +7,7 @@ $if(mathml)$
 $endif$
   xmlns:xlink="http://www.w3.org/1999/xlink"
 $if(lang)$ 
-      xml:lang="$lang$"
+  xml:lang="$lang$"
 $endif$ >
   <info>
     <title>$title$</title>

--- a/test/writer.docbook5
+++ b/test/writer.docbook5
@@ -2,7 +2,8 @@
 <!DOCTYPE article>
 <article
   xmlns="http://docbook.org/ns/docbook" version="5.0"
-  xmlns:xlink="http://www.w3.org/1999/xlink" >
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+ >
   <info>
     <title>Pandoc Test Suite</title>
     <authorgroup>


### PR DESCRIPTION
$lang$ is needed for non-English documents.
Many articles and books have a $subtitle$.