### PR TITLE
Muse reader: do not allow closing tags with EOF

### DIFF
--- a/src/Text/Pandoc/Readers/Muse.hs
+++ b/src/Text/Pandoc/Readers/Muse.hs
@@ -114,11 +114,10 @@ nested p = do
 htmlElement :: PandocMonad m => String -> MuseParser m (Attr, String)
 htmlElement tag = try $ do
   (TagOpen _ attr, _) <- htmlTag (~== TagOpen tag [])
-  content <- manyTill anyChar (endtag <|> endofinput)
+  content <- manyTill anyChar endtag
   return (htmlAttrToPandoc attr, content)
   where
-    endtag     = void $ htmlTag (~== TagClose tag)
-    endofinput = lookAhead $ try $ skipMany blankline >> skipSpaces >> eof
+    endtag = void $ htmlTag (~== TagClose tag)
 
 htmlAttrToPandoc :: [Attribute String] -> Attr
 htmlAttrToPandoc attrs = (ident, classes, keyvals)

--- a/test/Tests/Readers/Muse.hs
+++ b/test/Tests/Readers/Muse.hs
@@ -54,6 +54,12 @@ tests =
 
       , "Strikeout tag" =: "<del>Strikeout</del>" =?> para (strikeout "Strikeout")
 
+      , "Opening inline tags" =: "foo <em> bar <strong>baz" =?> para "foo <em> bar <strong>baz"
+
+      , "Closing inline tags" =: "foo </em> bar </strong>baz" =?> para "foo </em> bar </strong>baz"
+
+      , "Tag soup" =: "foo <em> bar </strong>baz" =?> para "foo <em> bar </strong>baz"
+
       , "Linebreak" =: "Line <br>  break" =?> para ("Line" <> linebreak <> "break")
 
       , "Code" =: "=foo(bar)=" =?> para (code "foo(bar)")


### PR DESCRIPTION
This behavior is compatible to Amusewiki