### PR TITLE
add documentation of limitations of grid tables

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2518,6 +2518,15 @@ For headerless tables, the colons go on the top line instead:
     | Right         | Left          | Centered           |
     +---------------+---------------+--------------------+
 
+##### Grid Table Limitations #####
+
+Pandoc does not support grid tables with row spans (variable number
+of columns in a given row). All grid tables must have the same
+number of columns in each row.  For example, the Docutils
+[sample grid tables] will not render as expected with Pandoc.
+
+[sample grid tables]: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables
+
 
 #### Extension: `pipe_tables` ####
 
@@ -3251,7 +3260,7 @@ If you just want a regular inline image, just make sure it is not
 the only thing in the paragraph. One way to do this is to insert a
 nonbreaking space after the image:
 
-    ![This image won't be a figure](/url/of/image.png)\ 
+    ![This image won't be a figure](/url/of/image.png)\
 
 Note that in reveal.js slide shows, an image in a paragraph
 by itself that has the `stretch` class will fill the screen,

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3260,7 +3260,7 @@ If you just want a regular inline image, just make sure it is not
 the only thing in the paragraph. One way to do this is to insert a
 nonbreaking space after the image:
 
-    ![This image won't be a figure](/url/of/image.png)\
+    ![This image won't be a figure](/url/of/image.png)\ 
 
 Note that in reveal.js slide shows, an image in a paragraph
 by itself that has the `stretch` class will fill the screen,

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2520,10 +2520,13 @@ For headerless tables, the colons go on the top line instead:
 
 ##### Grid Table Limitations #####
 
-Pandoc does not support grid tables with row spans (variable number
-of columns in a given row). All grid tables must have the same
-number of columns in each row.  For example, the Docutils
-[sample grid tables] will not render as expected with Pandoc.
+Pandoc does not support grid tables with row spans or column spans.
+This means that neither variable numbers of columns across rows nor
+variable numbers of rows across columns are supported by Pandoc.
+All grid tables must have the same number of columns in each row,
+and the same number of rows in each column.  For example, the
+Docutils [sample grid tables] will not render as expected with
+Pandoc.
 
 [sample grid tables]: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables
 


### PR DESCRIPTION
- grid tables with row spans (variable number of
  columns per row) are not supported
- see discussion: https://groups.google.com/forum/#!topic/pandoc-discuss/r9fAeeV3dSw

I think the formatting makes sense (h5 section, link to example grid tables that would not work), but am happy to change things upon request.

As a side note, I couldn't actually figure out how to build the full website and make sure the real formatting worked as expected.  I just used

```console
$ pandoc -i MANUAL.txt -t html -o test.html
```

Sorry for my ignorance, how does the full website get built?