### PR TITLE
Name change OSX -> macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@
         copy /y "%TEMP%\pandoc\pandoc-citeproc.exe" C:\Utils\Console\
         rmdir /s /q "%TEMP%\pandoc\"
 
-## MacOS
+## macOS
 
   - There is a package installer at pandoc's [download page].
     If you later want to uninstall the package, you can do so
@@ -27,12 +27,12 @@
     and running it with `perl uninstall-pandoc.pl`.
 
   - It is possible to extract the pandoc and pandoc-citeproc
-    executables from the MacOS pkg file, if you'd rather not run
+    executables from the macOS pkg file, if you'd rather not run
     the installer.  To do this (for the version 1.19.1 package):
 
         mkdir pandoc-extract
         cd pandoc-extract
-        xar -x ../pandoc-1.19.1-osx.pkg
+        xar -x ../pandoc-2.0-macOS.pkg
         cat pandoc.pkg/Payload | gunzip -dc | cpio -i
         # executables are now in ./usr/bin/, man pages in ./usr/share/man
 
@@ -180,7 +180,7 @@ The easiest way to build pandoc from source is to use [stack]:
 
     Note that this requires the `text-icu` library, which in turn
     depends on the C library `icu4c`.  Installation directions
-    vary by platform.  Here is how it might work on MacOS with homebrew:
+    vary by platform.  Here is how it might work on macOS with homebrew:
 
         brew install icu4c
         cabal install --extra-lib-dirs=/usr/local/Cellar/icu4c/51.1/lib \

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -336,7 +336,7 @@ General options
 
 :   Specify the user data directory to search for pandoc data files.
     If this option is not specified, the default user data directory
-    will be used.  This is, in Unix:
+    will be used.  This is, in UNIX:
 
         $HOME/.pandoc
 
@@ -608,7 +608,7 @@ General writer options
 `--eol=crlf`|`lf`|`native`
 
 :   Manually specify line endings: `crlf` (Windows), `lf`
-    (macOS/linux/unix), or `native` (line endings appropriate
+    (macOS/Linux/UNIX), or `native` (line endings appropriate
     to the OS on which pandoc is being run).  The default is
     `native`.
 
@@ -706,7 +706,7 @@ General writer options
 `--resource-path=`*SEARCHPATH*
 
 :   List of paths to search for images and other resources.
-    The paths should be separated by `:` on linux, unix, and
+    The paths should be separated by `:` on Linux, UNIX, and
     macOS systems, and by `;` on Windows.  If `--resource-path`
     is not specified, the default resource path is the working
     directory. Note that, if `--resource-path` is specified,

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -608,7 +608,7 @@ General writer options
 `--eol=crlf`|`lf`|`native`
 
 :   Manually specify line endings: `crlf` (Windows), `lf`
-    (MacOS/linux/unix), or `native` (line endings appropriate
+    (macOS/linux/unix), or `native` (line endings appropriate
     to the OS on which pandoc is being run).  The default is
     `native`.
 
@@ -707,7 +707,7 @@ General writer options
 
 :   List of paths to search for images and other resources.
     The paths should be separated by `:` on linux, unix, and
-    MacOS systems, and by `;` on Windows.  If `--resource-path`
+    macOS systems, and by `;` on Windows.  If `--resource-path`
     is not specified, the default resource path is the working
     directory. Note that, if `--resource-path` is specified,
     the working directory must be explicitly listed or it

--- a/RELEASE-CHECKLIST
+++ b/RELEASE-CHECKLIST
@@ -12,7 +12,7 @@ _ Push templates:
 
 _ Generate Windows package (make winpkg)
 
-_ Generate MacOS package (make macospkg)
+_ Generate macOS package (make macospkg)
 
 _ Generate Ubuntu/Debian deb package (make debpkg)
 

--- a/RELEASE-CHECKLIST
+++ b/RELEASE-CHECKLIST
@@ -1,4 +1,4 @@
-_ Test, on linux, windows, mac (inc. website demos)
+_ Test, on Linux, Windows, macOS (inc. website demos)
 
 _ Finalize changelog
   git log --pretty='format:%n%n* %s (%an)%n%b%n%h%n' --reverse --name-only 1.17.0.3..HEAD > LOG

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -11,7 +11,7 @@
 
 - [ ] Generate Windows package (`make winpkg`)
 
-- [ ] Generate Mac OSX package (`make osxpkg`)
+- [ ] Generate macOS package (`make macospkg`)
 
 - [ ] Generate Ubuntu/Debian deb package (`make debpkg`)
 

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -1,4 +1,4 @@
-- [ ] Test, on linux, windows, mac (inc. website demos)
+- [ ] Test, on Linux, Windows, macOS (inc. website demos)
 
 - [ ] Finalize changelog:
    `git log --pretty='format:%n%n* %s (%an)%n%b%n%h%n' --reverse --name-only 1.17.0.3..HEAD > LOG`

--- a/macos/make_macos_package.sh
+++ b/macos/make_macos_package.sh
@@ -59,15 +59,15 @@ $PANDOC --data data -t html5 -s COPYING.md -Vpagetitle="License" -o $RESOURCES/l
 # make sure it's valid... returns nonzero exit code if it isn't:
 #spctl --assess --type execute $DEST/bin/pandoc
 
-echo Creating MacOS package...
+echo Creating macOS package...
 
 sed -e "s/PANDOCVERSION/$VERSION/" $MACOS/distribution.xml.in > $MACOS/distribution.xml
 
 pkgbuild --root $ROOT --identifier net.johnmacfarlane.pandoc --version $VERSION --ownership recommended $DIST/pandoc.pkg
-productbuild --distribution $MACOS/distribution.xml --resources $DIST/Resources --package-path $DIST --version $VERSION --sign "${DEVELOPER_ID_INSTALLER}" $BASE-MacOS.pkg
+productbuild --distribution $MACOS/distribution.xml --resources $DIST/Resources --package-path $DIST --version $VERSION --sign "${DEVELOPER_ID_INSTALLER}" $BASE-macOS.pkg
 
 # verify signature
-spctl --assess --type install $BASE-MacOS.pkg
+spctl --assess --type install $BASE-macOS.pkg
 
 # cleanup
 rm -r $DIST

--- a/macos/uninstall-pandoc.pl
+++ b/macos/uninstall-pandoc.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Script to remove all files installed by the OSX pandoc installer
+# Script to remove all files installed by the macOS pandoc installer
 # and unregister the package.  Modified from a script contributed
 # by Daniel T. Staal.
 

--- a/man/pandoc.1
+++ b/man/pandoc.1
@@ -638,7 +638,7 @@ Files in the user data directory are ignored.
 .TP
 .B \f[C]\-\-eol=crlf\f[]|\f[C]lf\f[]|\f[C]native\f[]
 Manually specify line endings: \f[C]crlf\f[] (Windows), \f[C]lf\f[]
-(MacOS/linux/unix), or \f[C]native\f[] (line endings appropriate to the
+(macOS/linux/unix), or \f[C]native\f[] (line endings appropriate to the
 OS on which pandoc is being run).
 The default is \f[C]native\f[].
 .RS
@@ -760,7 +760,7 @@ Implies \f[C]\-\-standalone\f[].
 .TP
 .B \f[C]\-\-resource\-path=\f[]\f[I]SEARCHPATH\f[]
 List of paths to search for images and other resources.
-The paths should be separated by \f[C]:\f[] on linux, unix, and MacOS
+The paths should be separated by \f[C]:\f[] on linux, unix, and macOS
 systems, and by \f[C];\f[] on Windows.
 If \f[C]\-\-resource\-path\f[] is not specified, the default resource
 path is the working directory.

--- a/man/pandoc.1
+++ b/man/pandoc.1
@@ -304,7 +304,7 @@ If \f[I]FILE\f[] is \f[C]\-\f[], output will go to \f[I]stdout\f[].
 Specify the user data directory to search for pandoc data files.
 If this option is not specified, the default user data directory will be
 used.
-This is, in Unix:
+This is, in UNIX:
 .RS
 .IP
 .nf
@@ -638,7 +638,7 @@ Files in the user data directory are ignored.
 .TP
 .B \f[C]\-\-eol=crlf\f[]|\f[C]lf\f[]|\f[C]native\f[]
 Manually specify line endings: \f[C]crlf\f[] (Windows), \f[C]lf\f[]
-(macOS/linux/unix), or \f[C]native\f[] (line endings appropriate to the
+(macOS/Linux/UNIX), or \f[C]native\f[] (line endings appropriate to the
 OS on which pandoc is being run).
 The default is \f[C]native\f[].
 .RS
@@ -760,7 +760,7 @@ Implies \f[C]\-\-standalone\f[].
 .TP
 .B \f[C]\-\-resource\-path=\f[]\f[I]SEARCHPATH\f[]
 List of paths to search for images and other resources.
-The paths should be separated by \f[C]:\f[] on linux, unix, and macOS
+The paths should be separated by \f[C]:\f[] on Linux, UNIX, and macOS
 systems, and by \f[C];\f[] on Windows.
 If \f[C]\-\-resource\-path\f[] is not specified, the default resource
 path is the working directory.

--- a/stack.full.yaml
+++ b/stack.full.yaml
@@ -9,7 +9,7 @@ flags:
   pandoc-citeproc:
     bibutils: true
     embed_data_files: true
-# if you are on OSX, stack install cpphs and
+# if you are on macOS, stack install cpphs and
 # uncomment the following three lines:
 ghc-options:
   pandoc-citeproc:  '-pgmP cpphs -optP--cpp'

--- a/windows/Pandoc-en-us.wxl
+++ b/windows/Pandoc-en-us.wxl
@@ -9,6 +9,6 @@
 
 [APPLICATIONFOLDER]. 
     
-You may need to restart Cmd/Powershell windows before using it.</String>
+You may need to restart Cmd/Powershell Windows before using it.</String>
 
 </WixLocalization>


### PR DESCRIPTION
fix commit c96b64e

This commit finishes remaining osx to macOS change, as well as replacing MacOS with macOS.

The reason for the later one is because the "correct" casing of macOS is like that. Apple styles it to looks like iOS, watchOS, tvOS, etc. And unfortunately they all start with a lowercase letter, making propercasing (or even title-casing) odd.

Edit: I add 1 more commit to fix the casing of Linux, UNIX, and Windows when they are addressed as the name of the OSes. (I noticed them when they are addressed alongside macOS.)