### PR TITLE
Allow setting Japanese fonts when using LuaLaTeX

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -63,10 +63,21 @@ $else$
   \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
 $endif$
+  \ifxetex
 $if(CJKmainfont)$
     \usepackage{xeCJK}
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
 $endif$
+  \fi
+  \ifluatex
+$if(luatexjapresetoptions)$
+    \usepackage[$for(luatexjapresetoptions)$$luatexjapresetoptions$$sep$,$endfor$]{luatexja-preset}
+$endif$
+$if(CJKmainfont)$
+    \usepackage[$for(luatexjafontspecoptions)$$luatexjafontspecoptions$$sep$,$endfor$]{luatexja-fontspec}
+    \setmainjfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+$endif$
+  \fi
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -63,21 +63,23 @@ $else$
   \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
 $endif$
-  \ifxetex
 $if(CJKmainfont)$
+  \ifxetex
     \usepackage{xeCJK}
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
-$endif$
   \fi
-  \ifluatex
+$endif$
 $if(luatexjapresetoptions)$
+  \ifluatex
     \usepackage[$for(luatexjapresetoptions)$$luatexjapresetoptions$$sep$,$endfor$]{luatexja-preset}
+  \fi
 $endif$
 $if(CJKmainfont)$
+  \ifluatex
     \usepackage[$for(luatexjafontspecoptions)$$luatexjafontspecoptions$$sep$,$endfor$]{luatexja-fontspec}
     \setmainjfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
-$endif$
   \fi
+$endif$
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}


### PR DESCRIPTION
...by using the `luatexja-fontspec` and `luatexja-preset` packages. Use
existing `CJKmainfont` and `CJKoptions` template variables. Add
`luatexjafontspecoptions` for `luatexja-fontspec` and `luatexjapresetoptions`
for `luatexja-preset`.

This resolves jgm/pandoc-templates#227.