### PR TITLE
RST reader: treat preceding and following blank lines equally in line blocks

### DIFF
--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -838,7 +838,7 @@ blankLineBlockLine = try (char '|' >> blankline)
 lineBlockLines :: Monad m => ParserT [Char] st m [String]
 lineBlockLines = try $ do
   lines' <- many1 (lineBlockLine <|> ((:[]) <$> blankLineBlockLine))
-  skipMany1 $ blankline <|> blankLineBlockLine
+  skipMany $ blankline
   return lines'
 
 -- | Parse a table using 'headerParser', 'rowParser',

--- a/test/Tests/Readers/RST.hs
+++ b/test/Tests/Readers/RST.hs
@@ -136,6 +136,19 @@ tests = [ "line block with blank line" =:
                  para "but must stop here")
           , "line block with 3 lines" =: "| a\n| b\n| c"
             =?> lineBlock ["a", "b", "c"]
+          , "line blocks with blank lines" =: T.unlines
+            [ "|"
+            , ""
+            , "|"
+            , "| a"
+            , "| b"
+            , "|"
+            , ""
+            , "|"
+            ] =?>
+            lineBlock [""] <>
+            lineBlock ["", "a", "b", ""] <>
+            lineBlock [""]
           , "quoted literal block using >" =: "::\n\n> quoted\n> block\n\nOrdinary paragraph"
             =?> codeBlock "> quoted\n> block" <> para "Ordinary paragraph"
           , "quoted literal block using | (not  a line block)" =: "::\n\n| quoted\n| block\n\nOrdinary paragraph"


### PR DESCRIPTION
Test is checked to be consisted with http://rst.ninjs.org/