### PR TITLE
Fix build with cabal 2.x

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -251,16 +251,20 @@ Flag old-locale
   Description:   Use old-locale and time < 1.5
   Default:       False
 
+custom-setup
+  setup-depends: base,
+                 Cabal < 2
+
 Library
   Build-Depends: base >= 4.7 && <5,
-                 syb >= 0.1 && < 0.7,
+                 syb >= 0.1 && < 0.8,
                  containers >= 0.1 && < 0.6,
                  unordered-containers >= 0.2 && < 0.3,
                  array >= 0.3 && < 0.6,
                  parsec >= 3.1 && < 3.2,
                  mtl >= 2.2 && < 2.3,
                  filepath >= 1.1 && < 1.5,
-                 process >= 1 && < 1.5,
+                 process >= 1 && < 1.7,
                  directory >= 1 && < 1.4,
                  bytestring >= 0.9 && < 0.11,
                  text >= 0.11 && < 1.3,
@@ -298,7 +302,7 @@ Library
      Build-Depends: old-locale >= 1 && < 1.1,
                     time >= 1.2 && < 1.5
   else
-     Build-Depends: time >= 1.5 && < 1.7
+     Build-Depends: time >= 1.5 && < 1.9
   if flag(network-uri)
      Build-Depends: network-uri >= 2.6 && < 2.7, network >= 2.6
   else
@@ -498,14 +502,14 @@ Test-Suite test-pandoc
      Hs-Source-Dirs: prelude
      Other-Modules:  Prelude
   Build-Depends:  base >= 4.2 && < 5,
-                  syb >= 0.1 && < 0.7,
+                  syb >= 0.1 && < 0.8,
                   pandoc,
                   pandoc-types >= 1.17 && < 1.18,
                   bytestring >= 0.9 && < 0.11,
                   text >= 0.11 && < 1.3,
                   directory >= 1 && < 1.4,
                   filepath >= 1.1 && < 1.5,
-                  process >= 1 && < 1.5,
+                  process >= 1 && < 1.7,
                   skylighting >= 0.1.1.3 && < 0.2,
                   Diff >= 0.2 && < 0.4,
                   test-framework >= 0.3 && < 0.9,
@@ -515,7 +519,7 @@ Test-Suite test-pandoc
                   HUnit >= 1.2 && < 1.6,
                   containers >= 0.1 && < 0.6,
                   ansi-terminal >= 0.5 && < 0.7,
-                  executable-path >= 0.0 && < 0.1,
+                  executable-path >= 0.0 && < 0.4,
                   zip-archive >= 0.2.3.4 && < 0.4
   Other-Modules:  Tests.Old
                   Tests.Helpers
@@ -553,7 +557,7 @@ benchmark benchmark-pandoc
      Other-Modules:  Prelude
   Build-Depends:   pandoc,
                    base >= 4.2 && < 5,
-                   syb >= 0.1 && < 0.7,
+                   syb >= 0.1 && < 0.8,
                    criterion >= 1.0 && < 1.2
   Ghc-Options:   -rtsopts -Wall -fno-warn-unused-do-bind
   Default-Language: Haskell98


### PR DESCRIPTION
- Setup.hs does not compile with Cabal 2.x, so we require an earlier version
  via setup-depends.

- The following packages need newer versions with GHC 8.2.1 and had their
  constraints relaxed accordingly: executable-path, process, syb, and time.

Resolves https://github.com/jgm/pandoc/issues/3876.