### PR TITLE
Write euro symbol directly in LaTeX

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -193,7 +193,7 @@ By default, pandoc will use LaTeX to convert it to PDF:
 Production of a PDF requires that a LaTeX engine be installed (see
 `--latex-engine`, below), and assumes that the following LaTeX packages
 are available: [`amsfonts`], [`amsmath`], [`lm`], [`unicode-math`],
-[`ifxetex`], [`ifluatex`], [`eurosym`], [`listings`] (if the
+[`ifxetex`], [`ifluatex`], [`listings`] (if the
 `--listings` option is used), [`fancyvrb`], [`longtable`],
 [`booktabs`], [`graphicx`] and [`grffile`] (if the document
 contains images), [`hyperref`], [`xcolor`] (with `colorlinks`), [`ulem`], [`geometry`] (with the
@@ -226,7 +226,6 @@ will affect the output, as will `--css`.
 [`lm`]: https://ctan.org/pkg/lm
 [`ifxetex`]: https://ctan.org/pkg/ifxetex
 [`ifluatex`]: https://ctan.org/pkg/ifluatex
-[`eurosym`]: https://ctan.org/pkg/eurosym
 [`listings`]: https://ctan.org/pkg/listings
 [`fancyvrb`]: https://ctan.org/pkg/fancyvrb
 [`longtable`]: https://ctan.org/pkg/longtable

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -29,9 +29,7 @@ $endif$
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
   \usepackage[utf8]{inputenc}
-$if(euro)$
-  \usepackage{eurosym}
-$endif$
+  \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
 $if(mathspec)$
   \ifxetex
@@ -46,9 +44,6 @@ $endif$
 $for(fontfamilies)$
   \newfontfamily{$fontfamilies.name$}[$fontfamilies.options$]{$fontfamilies.font$}
 $endfor$
-$if(euro)$
-  \newcommand{\euro}{€}
-$endif$
 $if(mainfont)$
     \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -82,7 +82,6 @@ data WriterState =
               , stHighlighting  :: Bool          -- true if document has highlighted code
               , stIncremental   :: Bool          -- true if beamer lists should be displayed bit by bit
               , stInternalLinks :: [String]      -- list of internal link targets
-              , stUsesEuro      :: Bool          -- true if euro symbol used
               , stBeamer        :: Bool          -- produce beamer
               , stEmptyLine     :: Bool          -- true if no content on line
               }
@@ -111,7 +110,6 @@ startingState options = WriterState {
                 , stHighlighting = False
                 , stIncremental = writerIncremental options
                 , stInternalLinks = []
-                , stUsesEuro = False
                 , stBeamer = False
                 , stEmptyLine = True }
 
@@ -233,7 +231,6 @@ pandocToLaTeX options (Pandoc meta blocks) = do
                   defField "lhs" (stLHS st) $
                   defField "graphics" (stGraphics st) $
                   defField "book-class" (stBook st) $
-                  defField "euro" (stUsesEuro st) $
                   defField "listings" (writerListings options || stLHS st) $
                   defField "beamer" beamer $
                   (if stHighlighting st
@@ -320,11 +317,8 @@ stringToLaTeX  ctx (x:xs) = do
   rest <- stringToLaTeX ctx xs
   let ligatures = isEnabled Ext_smart opts && ctx == TextString
   let isUrl = ctx == URLString
-  when (x == '€') $
-     modify $ \st -> st{ stUsesEuro = True }
   return $
     case x of
-       '€' -> "\\euro{}" ++ rest
        '{' -> "\\{" ++ rest
        '}' -> "\\}" ++ rest
        '`' | ctx == CodeString -> "\\textasciigrave{}" ++ rest

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -9,6 +9,7 @@
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -9,6 +9,7 @@
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}


### PR DESCRIPTION
The textcomp package allows pdfLaTeX to parse `€` directly, making the \euro command unneeded. Closes #3801.