### PR TITLE
Support for `weasyprint` and `prince`

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -186,12 +186,12 @@ Creating a PDF
 --------------
 
 To produce a PDF, specify an output file with a `.pdf` extension.
-By default, pandoc will use LaTeX to convert it to PDF:
+By default, pandoc will use LaTeX to create the PDF:
 
     pandoc test.txt -o test.pdf
 
 Production of a PDF requires that a LaTeX engine be installed (see
-`--latex-engine`, below), and assumes that the following LaTeX packages
+`--pdf-engine`, below), and assumes that the following LaTeX packages
 are available: [`amsfonts`], [`amsmath`], [`lm`], [`unicode-math`],
 [`ifxetex`], [`ifluatex`], [`listings`] (if the
 `--listings` option is used), [`fancyvrb`], [`longtable`],
@@ -210,16 +210,19 @@ if added to the template or included in any header file. The
 optionally be used for [citation rendering]. These are included
 with all recent versions of [TeX Live].
 
-Alternatively, pandoc can use ConTeXt, `wkhtmltopdf`, or
-`pdfroff` to create a PDF.  To do this, specify an output file
-with a `.pdf` extension, as before, but add `-t context`, `-t
-html5`, or `-t ms` to the command line.
+Alternatively, pandoc can use [ConTeXt], `pdfroff`, or any of the
+following HTML/CSS-to-PDF-engines, to create a PDF: [`wkhtmltopdf`],
+[`weasyprint`] or `prince`.
+To do this, specify an output file with a `.pdf` extension, as before,
+but add the `--pdf-engine` option or `-t context`, `-t html`, or `-t ms`
+to the command line (`-t html` defaults to `--pdf-engine=wkhtmltopdf`).
 
 PDF output can be controlled using [variables for LaTeX] (if
 LaTeX is used) and [variables for ConTeXt] (if ConTeXt is used).
+When using an HTML/CSS-to-PDF-engine, `--css` affects the output.
 If `wkhtmltopdf` is used, then the variables `margin-left`,
 `margin-right`, `margin-top`, `margin-bottom`, and `papersize`
-will affect the output, as will `--css`.
+will affect the output.
 
 [`amsfonts`]: https://ctan.org/pkg/amsfonts
 [`amsmath`]: https://ctan.org/pkg/amsmath
@@ -251,6 +254,8 @@ will affect the output, as will `--css`.
 [`bibtex`]: https://ctan.org/pkg/bibtex
 [`biber`]: https://ctan.org/pkg/biber
 [TeX Live]: http://www.tug.org/texlive/
+[`wkhtmltopdf`]: https://wkhtmltopdf.org
+[`weasyprint`]: http://weasyprint.org
 
 Options
 =======
@@ -990,15 +995,15 @@ Options affecting specific writers
     the EPUB-specific contents.  The default is `EPUB`.  To put
     the EPUB contents in the top level, use an empty string.
 
-`--latex-engine=pdflatex`|`lualatex`|`xelatex`
+`--pdf-engine=pdflatex`|`lualatex`|`xelatex`|`wkhtmltopdf`|`weasyprint`|`prince`|`context`|`pdfroff`
 
-:   Use the specified LaTeX engine when producing PDF output.
+:   Use the specified engine when producing PDF output.
     The default is `pdflatex`.  If the engine is not in your PATH,
     the full path of the engine may be specified here.
 
-`--latex-engine-opt=`*STRING*
+`--pdf-engine-opt=`*STRING*
 
-:   Use the given string as a command-line argument to the `latex-engine`.
+:   Use the given string as a command-line argument to the `pdf-engine`.
     If used multiple times, the arguments are provided with spaces between
     them. Note that no check for duplicate options is done.
 
@@ -1300,7 +1305,7 @@ Language variables
     [Unicode Bidirectional Algorithm].
 
     When using LaTeX for bidirectional documents, only the `xelatex` engine
-    is fully supported (use `--latex-engine=xelatex`).
+    is fully supported (use `--pdf-engine=xelatex`).
 
 [BCP 47]: https://tools.ietf.org/html/bcp47
 [Unicode Bidirectional Algorithm]: http://www.w3.org/International/articles/inline-bidi-markup/uba-basics

--- a/data/bash_completion.tpl
+++ b/data/bash_completion.tpl
@@ -29,8 +29,8 @@ _pandoc()
              COMPREPLY=( $(compgen -W "references javascript none" -- ${cur}) )
              return 0
              ;;
-         --latex-engine)
-             COMPREPLY=( $(compgen -W "pdflatex lualatex xelatex" -- ${cur}) )
+         --pdf-engine)
+             COMPREPLY=( $(compgen -W "pdflatex lualatex xelatex wkhtmltopdf weasyprint prince context pdfroff" -- ${cur}) )
              return 0
              ;;
          --print-default-data-file)

--- a/src/Text/Pandoc/Error.hs
+++ b/src/Text/Pandoc/Error.hs
@@ -96,7 +96,7 @@ handleError (Left e) =
     PandocSyntaxMapError s -> err 67 s
     PandocFailOnWarningError -> err 3 "Failing because there were warnings."
     PandocPDFProgramNotFoundError pdfprog -> err 47 $
-        pdfprog ++ " not found. " ++ pdfprog ++ " is needed for pdf output."
+        pdfprog ++ " not found. Please select a different --pdf-engine or install " ++ pdfprog
     PandocPDFError logmsg -> err 43 $ "Error producing PDF.\n" ++ logmsg
     PandocFilterError filtername msg -> err 83 $ "Error running filter " ++
         filtername ++ ":\n" ++ msg

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -216,7 +216,7 @@ data WriterOptions = WriterOptions
   , writerEpubChapterLevel  :: Int            -- ^ Header level for chapters (separate files)
   , writerTOCDepth          :: Int            -- ^ Number of levels to include in TOC
   , writerReferenceDoc      :: Maybe FilePath -- ^ Path to reference document if specified
-  , writerLaTeXArgs         :: [String]       -- ^ Flags to pass to latex-engine
+  , writerPdfArgs           :: [String]       -- ^ Flags to pass to pdf-engine
   , writerReferenceLocation :: ReferenceLocation    -- ^ Location of footnotes and references for writing markdown
   , writerSyntaxMap         :: SyntaxMap
   } deriving (Show, Data, Typeable, Generic)
@@ -252,7 +252,7 @@ instance Default WriterOptions where
                       , writerEpubChapterLevel = 1
                       , writerTOCDepth         = 3
                       , writerReferenceDoc     = Nothing
-                      , writerLaTeXArgs        = []
+                      , writerPdfArgs          = []
                       , writerReferenceLocation = EndOfDocument
                       , writerSyntaxMap        = defaultSyntaxMap
                       }

--- a/src/Text/Pandoc/PDF.hs
+++ b/src/Text/Pandoc/PDF.hs
@@ -78,8 +78,8 @@ changePathSeparators :: FilePath -> FilePath
 changePathSeparators = intercalate "/" . splitDirectories
 #endif
 
-makePDF :: String              -- ^ pdf creator (pdflatex, lualatex,
-                               -- xelatex, context, wkhtmltopdf, pdfroff)
+makePDF :: String              -- ^ pdf creator (pdflatex, lualatex, xelatex,
+                               -- wkhtmltopdf, weasyprint, prince, context, pdfroff)
         -> (WriterOptions -> Pandoc -> PandocIO Text)  -- ^ writer
         -> WriterOptions       -- ^ options
         -> Verbosity           -- ^ verbosity level
@@ -94,7 +94,7 @@ makePDF "wkhtmltopdf" writer opts verbosity _ doc@(Pandoc meta _) = do
                       _ -> []
   meta' <- metaToJSON opts (return . stringify) (return . stringify) meta
   let toArgs (f, mbd) = maybe [] (\d -> ['-':'-':f, d]) mbd
-  let args   = mathArgs ++
+  let args   = writerPdfArgs opts ++ mathArgs ++
                concatMap toArgs
                  [("page-size", getField "papersize" meta')
                  ,("title", getField "title" meta')
@@ -108,11 +108,19 @@ makePDF "wkhtmltopdf" writer opts verbosity _ doc@(Pandoc meta _) = do
                             (getField "margin-left" meta'))
                  ]
   source <- writer opts doc
-  liftIO $ html2pdf verbosity args source
+  liftIO $ html2pdf verbosity "wkhtmltopdf" args source
+makePDF "weasyprint" writer opts verbosity _ doc = do
+  let args = writerPdfArgs opts
+  source <- writer opts doc
+  liftIO $ html2pdf verbosity "weasyprint" args source
+makePDF "prince" writer opts verbosity _ doc = do
+  let args = writerPdfArgs opts
+  source <- writer opts doc
+  liftIO $ html2pdf verbosity "prince" args source
 makePDF "pdfroff" writer opts verbosity _mediabag doc = do
   source <- writer opts doc
   let args   = ["-ms", "-mpdfmark", "-e", "-t", "-k", "-KUTF-8", "-i",
-                "--no-toc-relocation"]
+                "--no-toc-relocation"] ++ writerPdfArgs opts
   liftIO $ ms2pdf verbosity args source
 makePDF program writer opts verbosity mediabag doc = do
   let withTemp = if takeBaseName program == "context"
@@ -124,7 +132,7 @@ makePDF program writer opts verbosity mediabag doc = do
     source <- runIOorExplode $ do
                 setVerbosity verbosity
                 writer opts doc'
-    let args   = writerLaTeXArgs opts
+    let args = writerPdfArgs opts
     case takeBaseName program of
        "context" -> context2pdf verbosity tmpdir source
        prog | prog `elem` ["pdflatex", "lualatex", "xelatex"]
@@ -212,7 +220,7 @@ tex2pdf' verbosity args tmpDir program source = do
                 case logmsg of
                      x | "! Package inputenc Error" `BC.isPrefixOf` x
                            && program /= "xelatex"
-                       -> "\nTry running pandoc with --latex-engine=xelatex."
+                       -> "\nTry running pandoc with --pdf-engine=xelatex."
                      _ -> ""
           return $ Left $ logmsg <> extramsg
        (ExitSuccess, Nothing)  -> return $ Left ""
@@ -347,18 +355,22 @@ ms2pdf verbosity args source = do
              ExitSuccess   -> Right out
 
 html2pdf  :: Verbosity    -- ^ Verbosity level
-          -> [String]     -- ^ Args to wkhtmltopdf
+          -> String       -- ^ Program (wkhtmltopdf, weasyprint or prince)
+          -> [String]     -- ^ Args to program
           -> Text         -- ^ HTML5 source
           -> IO (Either ByteString ByteString)
-html2pdf verbosity args source = do
+html2pdf verbosity program args source = do
   file <- withTempFile "." "html2pdf.html" $ \fp _ -> return fp
   pdfFile <- withTempFile "." "html2pdf.pdf" $ \fp _ -> return fp
+  let pdfFileArgName = if program == "prince"
+                       then ["-o"]
+                       else []
   BS.writeFile file $ UTF8.fromText source
-  let programArgs = args ++ [file, pdfFile]
+  let programArgs = args ++ [file] ++ pdfFileArgName ++ [pdfFile]
   env' <- getEnvironment
   when (verbosity >= INFO) $ do
     putStrLn "[makePDF] Command line:"
-    putStrLn $ "wkhtmltopdf" ++ " " ++ unwords (map show programArgs)
+    putStrLn $ program ++ " " ++ unwords (map show programArgs)
     putStr "\n"
     putStrLn "[makePDF] Environment:"
     mapM_ print env'
@@ -367,10 +379,10 @@ html2pdf verbosity args source = do
     BL.readFile file >>= BL.putStr
     putStr "\n"
   (exit, out) <- E.catch
-    (pipeProcess (Just env') "wkhtmltopdf" programArgs BL.empty)
+    (pipeProcess (Just env') program programArgs BL.empty)
     (\(e :: IOError) -> if isDoesNotExistError e
                            then E.throwIO $
-                                  PandocPDFProgramNotFoundError "wkhtml2pdf"
+                                  PandocPDFProgramNotFoundError program
                            else E.throwIO e)
   removeFile file
   when (verbosity >= INFO) $ do


### PR DESCRIPTION
Rename `--latex-engine` to `--pdf-engine` and add support for `weasyprint` and `prince`, in addition to `wkhtmltopdf`

closes #3906 

Three remarks/TODOs.

1. In `PDF.hs#html2pdf`: could we use "program - html2pdf.pdf" to read from stdin instead of using a tempFile? All three HTML-to-PDF-engines support it.

2. It's still a bit counter-intuitive that you have to specify a writer when not using LaTeX, e.g. see:

        $ pandoc -o output.pdf --pdf-engine=weasyprint
        pdf-engine weasyprint is not compatible with format latex, please use `-t html`

    I guess we could change the `App.hs#defaultWriterName` function to depend on the pdf-engine. Then the only question is: why can't I also use `context` and `pdfroff` with `--pdf-engine`?

3. TODO: research and implement best approach to [math-handling for `weasyprint`](https://github.com/Kozea/WeasyPrint/issues/59) and `prince`
