### PR TITLE
Muse reader: allow inline markup to be followed by punctuation

### DIFF
--- a/src/Text/Pandoc/Readers/Muse.hs
+++ b/src/Text/Pandoc/Readers/Muse.hs
@@ -45,6 +45,7 @@ module Text.Pandoc.Readers.Muse (readMuse) where
 import Control.Monad
 import Control.Monad.Except (throwError)
 import qualified Data.Map as M
+import Data.Char (isLetter)
 import Data.Text (Text, unpack)
 import Data.List (stripPrefix)
 import Data.Maybe (fromMaybe)
@@ -582,7 +583,7 @@ enclosedInlines :: (PandocMonad m, Show a, Show b)
                 -> MuseParser m b
                 -> MuseParser m (F Inlines)
 enclosedInlines start end = try $
-  trimInlinesF . mconcat <$> enclosed start end inline
+  trimInlinesF . mconcat <$> (enclosed start end inline <* notFollowedBy (satisfy isLetter))
 
 inlineTag :: PandocMonad m
           => (Inlines -> Inlines)
@@ -629,7 +630,7 @@ code = try $ do
   guard $ not $ null contents
   guard $ head contents `notElem` " \t\n"
   guard $ last contents `notElem` " \t\n"
-  notFollowedBy nonspaceChar
+  notFollowedBy $ satisfy isLetter
   return $ return (sp B.<> B.code contents)
 
 codeTag :: PandocMonad m => MuseParser m (F Inlines)

--- a/test/Tests/Readers/Muse.hs
+++ b/test/Tests/Readers/Muse.hs
@@ -34,9 +34,21 @@ tests =
           "Hello, World" =?>
           para "Hello, World"
 
-      , "Emphasis" =: "*Foo bar*" =?> para (emph . spcSep $ ["Foo", "bar"])
+      , "Emphasis" =:
+        "*Foo bar*" =?>
+        para (emph . spcSep $ ["Foo", "bar"])
 
-      , "Emphasis tag" =: "<em>Foo bar</em>" =?> para (emph . spcSep $ ["Foo", "bar"])
+      , "Comma after closing *" =:
+        "Foo *bar*, baz" =?>
+        para ("Foo " <> emph "bar" <> ", baz")
+
+      , "Letter after closing *" =:
+        "Foo *bar*x baz" =?>
+        para "Foo *bar*x baz"
+
+      , "Emphasis tag" =:
+        "<em>Foo bar</em>" =?>
+        para (emph . spcSep $ ["Foo", "bar"])
 
       , "Strong" =:
           "**Cider**" =?>
@@ -81,6 +93,10 @@ tests =
         , "Not code if closing = is detached" =: "=this is not a code =" =?> para "=this is not a code ="
 
         , "Not code if opening = is detached" =: "= this is not a code=" =?> para "= this is not a code="
+
+        , "Code if followed by comma" =:
+          "Foo =bar=, baz" =?>
+          para (text "Foo " <> code "bar" <> text ", baz")
 
         , "One character code" =: "=c=" =?> para (code "c")
 


### PR DESCRIPTION
Previously code was not allowed to be followed by comma,
and emphasis was allowed to be followed by letter.