### PR TITLE
Support R filters #3940

### DIFF
--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -570,6 +570,7 @@ externalFilter ropts f args' d = liftIO $ do
                                   ".rb"  -> ("ruby", f:args')
                                   ".php" -> ("php", f:args')
                                   ".js"  -> ("node", f:args')
+                                  ".r"   -> ("Rscript", f:args')
                                   _      -> (f, args')
                         else (f, args')
   unless (exists && isExecutable) $ do


### PR DESCRIPTION
This triggers `Rscript` when encountering a filter ending in `*.R` or `*.r`.

#3940