### PR TITLE
Load Google Font using HTTPS by default

### DIFF
--- a/data/templates/default.dzslides
+++ b/data/templates/default.dzslides
@@ -30,7 +30,7 @@ $for(css)$
   <link rel="stylesheet" href="$css$">
 $endfor$
 $else$
-<link href='http://fonts.googleapis.com/css?family=Oswald' rel='stylesheet'>
+<link href='https://fonts.googleapis.com/css?family=Oswald' rel='stylesheet'>
 
 <style>
   html, .view body { background-color: black; counter-reset: slideidx; }


### PR DESCRIPTION
Otherwise they won't show up in current version of firefox/chromium.

https://greut.github.io/slides-devweb/00-presentation.html