### PR TITLE
docx writer - activate evenAndOddHeaders from reference doc

### DIFF
--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -549,6 +549,7 @@ writeDocx opts doc@(Pandoc meta _) = do
                      , "w:consecutiveHyphenLimit"
                      , "w:hyphenationZone"
                      , "w:doNotHyphenateCap"
+                     , "w:evenAndOddHeaders"
                      ]
   settingsEntry <- copyChildren refArchive distArchive settingsPath epochtime settingsList
 


### PR DESCRIPTION
Fixes #3901 by checking for the evenAndOddHeaders mark in the
reference doc, and copying it to the resulting docx if present.