### PR TITLE
FB2 Writer: format LineBlock as poem

### DIFF
--- a/src/Text/Pandoc/Writers/FB2.hs
+++ b/src/Text/Pandoc/Writers/FB2.hs
@@ -56,7 +56,7 @@ import qualified Text.Pandoc.Class as P
 import Text.Pandoc.Definition
 import Text.Pandoc.Logging
 import Text.Pandoc.Options (HTMLMathMethod (..), WriterOptions (..), def)
-import Text.Pandoc.Shared (capitalize, isHeaderBlock, isURI, linesToPara,
+import Text.Pandoc.Shared (capitalize, isHeaderBlock, isURI,
                            orderedListMarkers)
 
 -- | Data to be written at the end of the document:
@@ -331,7 +331,11 @@ blockToXml b@(RawBlock _ _) = do
   return []
 blockToXml (Div _ bs) = cMapM blockToXml bs
 blockToXml (BlockQuote bs) = (list . el "cite") <$> cMapM blockToXml bs
-blockToXml (LineBlock lns) = blockToXml $ linesToPara lns
+blockToXml (LineBlock lns) =
+  (list . el "poem") <$> mapM stanza (split null lns)
+  where
+    v xs = el "v" <$> cMapM toXml xs
+    stanza xs = el "stanza" <$> mapM v xs
 blockToXml (OrderedList a bss) = do
     state <- get
     let pmrk = parentListMarker state


### PR DESCRIPTION
Previously writer produced one paragraph with `<empty-line/>` elements,
which are not allowed inside `<p>` according to FB2 schema.

[reStructuredText Markup Specification](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#line-blocks) suggests using line blocks for verse and Muse reader parses <verse> as LineBlocks, so it makes sense to convert LineBlocks to `<poem>` in FB2 writer.

Also Linux FBReader has problems parsing current output and stops parsing `<p>` after first `<empty-line/>`. It was "fixed" in mobile FBReader at my [request](https://github.com/geometer/FBReaderJ/issues/465), but now that I look at XML schema it looks like it is a bug in pandoc. And with new output we get actual line breaks instead of empty lines (two line breaks) on display.