### PR TITLE
markdown writer: always write bracketed_spans' attributes

### DIFF
--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -952,8 +952,10 @@ inlineToMarkdown opts (Span attrs ils) = do
                 True -> contents
                 False | attrs == nullAttr -> contents
                       | isEnabled Ext_bracketed_spans opts ->
-                        "[" <> contents <> "]" <>
-                             linkAttributes opts attrs
+                        let attrs' = if attrs /= nullAttr
+                                        then attrsToMarkdown attrs
+                                        else empty
+                        in "[" <> contents <> "]" <> attrs'
                       | isEnabled Ext_raw_html opts ||
                         isEnabled Ext_native_spans opts ->
                         tagWithAttrs "span" attrs <> contents <> text "</span>"


### PR DESCRIPTION
this should fix https://github.com/jgm/pandoc/issues/3790.