### PR TITLE
Latex reader: Skip spaces in image options

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -758,8 +758,10 @@ keyval = try $ do
   Tok _ Word key <- satisfyTok isWordTok
   let isSpecSym (Tok _ Symbol t) = t `elem` [".",":","-","|","\\"]
       isSpecSym _ = False
+  optional sp
   val <- option [] $ do
            symbol '='
+           optional sp
            braced <|> (many1 (satisfyTok isWordTok <|> satisfyTok isSpecSym
                                <|> anyControlSeq))
   optional sp

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -108,6 +108,30 @@ tests = [ testGroup "basic"
           , biblatexCitations
           ]
 
+        , testGroup "images"
+          [ "Basic image" =:
+            "\\includegraphics{foo.png}" =?>
+            para (image "foo.png" "" (text "image"))
+          , "Basic image with blank options" =:
+            "\\includegraphics[]{foo.png}" =?>
+            para (image "foo.png" "" (text "image"))
+          , "Image with both width and height" =:
+            "\\includegraphics[width=17cm,height=5cm]{foo.png}" =?>
+            para (imageWith ("", [], [("width", "17cm"), ("height", "5cm")]) "foo.png" "" "image")
+          , "Image with width and height and a bunch of other options" =:
+            "\\includegraphics[width=17cm,height=5cm,clip,keepaspectratio]{foo.png}" =?>
+            para (imageWith ("", [], [("width", "17cm"), ("height", "5cm")]) "foo.png" "" "image")
+          , "Image with just width" =:
+            "\\includegraphics[width=17cm]{foo.png}" =?>
+            para (imageWith ("", [], [("width", "17cm")]) "foo.png" "" "image")
+          , "Image with just height" =:
+            "\\includegraphics[height=17cm]{foo.png}" =?>
+            para (imageWith ("", [], [("height", "17cm")]) "foo.png" "" "image")
+          , "Image width relative to textsize" =:
+            "\\includegraphics[width=0.6\\textwidth]{foo.png}" =?>
+            para (imageWith ("", [], [("width", "60%")]) "foo.png" "" "image")
+          ]
+
         , let hex = ['0'..'9']++['a'..'f'] in
           testGroup "Character Escapes"
           [ "Two-character escapes" =:

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -130,6 +130,9 @@ tests = [ testGroup "basic"
           , "Image width relative to textsize" =:
             "\\includegraphics[width=0.6\\textwidth]{foo.png}" =?>
             para (imageWith ("", [], [("width", "60%")]) "foo.png" "" "image")
+          , "Image with options with spaces" =:
+            "\\includegraphics[width=12cm, height = 5cm]{foo.png}" =?>
+            para (imageWith ("", [], [("width", "12cm"), ("height", "5cm")]) "foo.png" "" "image")
           ]
 
         , let hex = ['0'..'9']++['a'..'f'] in


### PR DESCRIPTION
Fixes things like this:

```
\includegraphics[width=12cm, height = 5cm]{foo.png}
```