### PR TITLE
LaTeX Reader: support \lettrine

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1320,7 +1320,7 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList $
   , ("i", lit "i")
   , ("\\", linebreak <$ (do inTableCell <- sInTableCell <$> getState
                             guard $ not inTableCell
-                            optional (bracketed inline)
+                            optional opt
                             spaces))
   , (",", lit "\8198")
   , ("@", pure mempty)
@@ -1750,7 +1750,7 @@ include = do
   (Tok _ (CtrlSeq name) _) <-
                     controlSeq "include" <|> controlSeq "input" <|>
                     controlSeq "subfile" <|> controlSeq "usepackage"
-  skipMany $ bracketed inline -- skip options
+  skipMany opt
   fs <- (map (T.unpack . removeDoubleQuotes . T.strip) . T.splitOn "," .
          untokenize) <$> braced
   let fs' = if name == "usepackage"
@@ -2355,7 +2355,7 @@ hline = try $ do
     controlSeq "endhead" <|>
     controlSeq "endfirsthead"
   spaces
-  optional $ bracketed inline
+  optional opt
   return ()
 
 lbreak :: PandocMonad m => LP m Tok

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1264,6 +1264,7 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList $
   , ("cref", rawInlineOr "cref" $ doref "ref")       -- from cleveref.sty
   , ("vref", rawInlineOr "vref" $ doref "ref+page")  -- from varioref.sty
   , ("eqref", rawInlineOr "eqref" $ doref "eqref")   -- from amsmath.sty
+  , ("lettrine", optional opt >> extractSpaces (spanWith ("",["lettrine"],[])) <$> tok)
   , ("(", mathInline . toksToString <$> manyTill anyTok (controlSeq ")"))
   , ("[", mathDisplay . toksToString <$> manyTill anyTok (controlSeq "]"))
   , ("ensuremath", mathInline . toksToString <$> braced)

--- a/test/command/lettrine.md
+++ b/test/command/lettrine.md
@@ -1,0 +1,9 @@
+```
+% pandoc -f latex -t native
+\lettrine{A}{category} is
+
+\lettrine[lhang=0.17]{A}{category} is
+^D
+[Para [Span ("",["lettrine"],[]) [Str "A"],Span ("",[],[]) [Str "category"],Space,Str "is"]
+,Para [Span ("",["lettrine"],[]) [Str "A"],Span ("",[],[]) [Str "category"],Space,Str "is"]]
+```


### PR DESCRIPTION
Lettrine, e.g. as in https://tex.stackexchange.com/a/52744/33952

Not sure what's up with all the empty spans (this is something we have in https://github.com/jgm/pandoc/issues/3488 as well).

I was thinking of adding a class to the span, but this can probably be done just as well using CSS pseudo-elements like `p::first-letter`.