### PR TITLE
FB2 writer: make bullet lists consistent with ordered lists

### DIFF
--- a/test/writer.fb2
+++ b/test/writer.fb2
@@ -261,23 +261,23 @@
 <p>Nested</p>
 </title>
 <p>• Tab</p>
-<p>◦ Tab</p>
-<p>* Tab</p>
+<p>• • Tab</p>
+<p>• • • Tab</p>
 <p>Here’s another:</p>
 <p>1. First</p>
 <p>2. Second:</p>
-<p>   • Fee</p>
-<p>   • Fie</p>
-<p>   • Foe</p>
+<p>2. • Fee</p>
+<p>2. • Fie</p>
+<p>2. • Foe</p>
 <p>3. Third</p>
 <p>Same thing but with paragraphs:</p>
 <p>1. First</p>
 <empty-line />
 <p>2. Second:</p>
 <empty-line />
-<p>   • Fee</p>
-<p>   • Fie</p>
-<p>   • Foe</p>
+<p>2. • Fee</p>
+<p>2. • Fie</p>
+<p>2. • Foe</p>
 <p>3. Third</p>
 <empty-line />
 </section>
@@ -289,9 +289,9 @@
 <empty-line />
 <p>• this is a list item indented with spaces</p>
 <empty-line />
-<p>◦ this is an example list item indented with tabs</p>
+<p>• • this is an example list item indented with tabs</p>
 <empty-line />
-<p>◦ this is an example list item indented with spaces</p>
+<p>• • this is an example list item indented with spaces</p>
 <empty-line />
 </section>
 <section>


### PR DESCRIPTION
Previously bullet lists interacted in odd way with ordered lists.
For example, bullet lists nested in ordered list had incorrect
indentation. Besides that, indentation with spaces is not rendered
by FBReader and fbless. To avoid this problem, bullet lists are
indented by appending bullets to marker just the same way it is
done for ordered lists.