### PR TITLE
HTML Writer: consistently use dashed class-names

### DIFF
--- a/data/epub.css
+++ b/data/epub.css
@@ -12,7 +12,7 @@ h2.author { }
 h3.date { }
 ol.toc { padding: 0; margin-left: 1em; }
 ol.toc li { list-style-type: none; margin: 0; padding: 0; }
-a.footnoteRef { vertical-align: super; }
+a.footnote-ref { vertical-align: super; }
 em, em em em, em em em em em { font-style: italic;}
 em em, em em em em { font-style: normal; }
 

--- a/data/templates/default.s5
+++ b/data/templates/default.s5
@@ -64,7 +64,7 @@ $endfor$
 </div>
 <div class="presentation">
 $if(title)$
-<div class="titleslide slide">
+<div class="title-slide slide">
   <h1 class="title">$title$</h1>
 $if(subtitle)$
   <h2 class="subtitle">$subtitle$</h2>

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -438,7 +438,7 @@ elementToHtml slideLevel opts (Sec level num (id',classes,keyvals) title' elemen
                                   []     -> []
                                   (x:xs) -> x ++ concatMap inDiv xs
   let inNl x = mconcat $ nl opts : intersperse (nl opts) x ++ [nl opts]
-  let classes' = ["titleslide" | titleSlide] ++ ["slide" | slide] ++
+  let classes' = ["title-slide" | titleSlide] ++ ["slide" | slide] ++
                   ["section" | (slide || writerSectionDivs opts) &&
                                not html5 ] ++
                   ["level" ++ show level | slide || writerSectionDivs opts ]
@@ -1100,7 +1100,7 @@ inlineToHtml opts inline = do
                         let link = H.a ! A.href (toValue $ "#" ++
                                          revealSlash ++
                                          writerIdentifierPrefix opts ++ "fn" ++ ref)
-                                       ! A.class_ "footnoteRef"
+                                       ! A.class_ "footnote-ref"
                                        ! prefixedId opts ("fnref" ++ ref)
                                        $ (if isJust epubVersion
                                              then id
@@ -1120,7 +1120,7 @@ blockListToNote :: PandocMonad m => WriterOptions -> String -> [Block] -> StateT
 blockListToNote opts ref blocks =
   -- If last block is Para or Plain, include the backlink at the end of
   -- that block. Otherwise, insert a new Plain block with the backlink.
-  let backlink = [Link ("",["footnoteBack"],[]) [Str "↩"] ("#" ++ writerIdentifierPrefix opts ++ "fnref" ++ ref,[])]
+  let backlink = [Link ("",["footnote-back"],[]) [Str "↩"] ("#" ++ writerIdentifierPrefix opts ++ "fnref" ++ ref,[])]
       blocks'  = if null blocks
                     then []
                     else let lastBlock   = last blocks

--- a/test/s5-basic.html
+++ b/test/s5-basic.html
@@ -38,7 +38,7 @@
 </div>
 </div>
 <div class="presentation">
-<div class="titleslide slide">
+<div class="title-slide slide">
   <h1 class="title">My S5 Document</h1>
   <h3 class="author">Sam Smith<br/>Jen Jones</h3>
   <h4 class="date">July 15, 2006</h4>

--- a/test/s5-fancy.html
+++ b/test/s5-fancy.html
@@ -239,7 +239,7 @@
 </div>
 </div>
 <div class="presentation">
-<div class="titleslide slide">
+<div class="title-slide slide">
   <h1 class="title">My S5 Document</h1>
   <h3 class="author">Sam Smith<br/>Jen Jones</h3>
   <h4 class="date">July 15, 2006</h4>

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -524,25 +524,25 @@ Blah
 <p>Here is a movie <img src="movie.jpg" alt="movie" /> icon.</p>
 <hr />
 <h1 id="footnotes">Footnotes</h1>
-<p>Here is a footnote reference,<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a> and another.<a href="#fn2" class="footnoteRef" id="fnref2"><sup>2</sup></a> This should <em>not</em> be a footnote reference, because it contains a space.[^my note] Here is an inline note.<a href="#fn3" class="footnoteRef" id="fnref3"><sup>3</sup></a></p>
+<p>Here is a footnote reference,<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a> and another.<a href="#fn2" class="footnote-ref" id="fnref2"><sup>2</sup></a> This should <em>not</em> be a footnote reference, because it contains a space.[^my note] Here is an inline note.<a href="#fn3" class="footnote-ref" id="fnref3"><sup>3</sup></a></p>
 <blockquote>
-<p>Notes can go in quotes.<a href="#fn4" class="footnoteRef" id="fnref4"><sup>4</sup></a></p>
+<p>Notes can go in quotes.<a href="#fn4" class="footnote-ref" id="fnref4"><sup>4</sup></a></p>
 </blockquote>
 <ol style="list-style-type: decimal">
-<li>And in list items.<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a></li>
+<li>And in list items.<a href="#fn5" class="footnote-ref" id="fnref5"><sup>5</sup></a></li>
 </ol>
 <p>This paragraph should not be part of the note, as it is not indented.</p>
 <div class="footnotes">
 <hr />
 <ol>
-<li id="fn1"><p>Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.<a href="#fnref1" class="footnoteBack">↩</a></p></li>
+<li id="fn1"><p>Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.<a href="#fnref1" class="footnote-back">↩</a></p></li>
 <li id="fn2"><p>Here’s the long note. This one contains multiple blocks.</p>
 <p>Subsequent blocks are indented to show that they belong to the footnote (as with list items).</p>
 <pre><code>  { &lt;code&gt; }</code></pre>
-<p>If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.<a href="#fnref2" class="footnoteBack">↩</a></p></li>
-<li id="fn3"><p>This is <em>easier</em> to type. Inline notes may contain <a href="http://google.com">links</a> and <code>]</code> verbatim characters, as well as [bracketed text].<a href="#fnref3" class="footnoteBack">↩</a></p></li>
-<li id="fn4"><p>In quote.<a href="#fnref4" class="footnoteBack">↩</a></p></li>
-<li id="fn5"><p>In list.<a href="#fnref5" class="footnoteBack">↩</a></p></li>
+<p>If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.<a href="#fnref2" class="footnote-back">↩</a></p></li>
+<li id="fn3"><p>This is <em>easier</em> to type. Inline notes may contain <a href="http://google.com">links</a> and <code>]</code> verbatim characters, as well as [bracketed text].<a href="#fnref3" class="footnote-back">↩</a></p></li>
+<li id="fn4"><p>In quote.<a href="#fnref4" class="footnote-back">↩</a></p></li>
+<li id="fn5"><p>In list.<a href="#fnref5" class="footnote-back">↩</a></p></li>
 </ol>
 </div>
 </body>

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -526,25 +526,25 @@ Blah
 <p>Here is a movie <img src="movie.jpg" alt="movie" /> icon.</p>
 <hr />
 <h1 id="footnotes">Footnotes</h1>
-<p>Here is a footnote reference,<a href="#fn1" class="footnoteRef" id="fnref1"><sup>1</sup></a> and another.<a href="#fn2" class="footnoteRef" id="fnref2"><sup>2</sup></a> This should <em>not</em> be a footnote reference, because it contains a space.[^my note] Here is an inline note.<a href="#fn3" class="footnoteRef" id="fnref3"><sup>3</sup></a></p>
+<p>Here is a footnote reference,<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a> and another.<a href="#fn2" class="footnote-ref" id="fnref2"><sup>2</sup></a> This should <em>not</em> be a footnote reference, because it contains a space.[^my note] Here is an inline note.<a href="#fn3" class="footnote-ref" id="fnref3"><sup>3</sup></a></p>
 <blockquote>
-<p>Notes can go in quotes.<a href="#fn4" class="footnoteRef" id="fnref4"><sup>4</sup></a></p>
+<p>Notes can go in quotes.<a href="#fn4" class="footnote-ref" id="fnref4"><sup>4</sup></a></p>
 </blockquote>
 <ol type="1">
-<li>And in list items.<a href="#fn5" class="footnoteRef" id="fnref5"><sup>5</sup></a></li>
+<li>And in list items.<a href="#fn5" class="footnote-ref" id="fnref5"><sup>5</sup></a></li>
 </ol>
 <p>This paragraph should not be part of the note, as it is not indented.</p>
 <section class="footnotes">
 <hr />
 <ol>
-<li id="fn1"><p>Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.<a href="#fnref1" class="footnoteBack">↩</a></p></li>
+<li id="fn1"><p>Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.<a href="#fnref1" class="footnote-back">↩</a></p></li>
 <li id="fn2"><p>Here’s the long note. This one contains multiple blocks.</p>
 <p>Subsequent blocks are indented to show that they belong to the footnote (as with list items).</p>
 <pre><code>  { &lt;code&gt; }</code></pre>
-<p>If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.<a href="#fnref2" class="footnoteBack">↩</a></p></li>
-<li id="fn3"><p>This is <em>easier</em> to type. Inline notes may contain <a href="http://google.com">links</a> and <code>]</code> verbatim characters, as well as [bracketed text].<a href="#fnref3" class="footnoteBack">↩</a></p></li>
-<li id="fn4"><p>In quote.<a href="#fnref4" class="footnoteBack">↩</a></p></li>
-<li id="fn5"><p>In list.<a href="#fnref5" class="footnoteBack">↩</a></p></li>
+<p>If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.<a href="#fnref2" class="footnote-back">↩</a></p></li>
+<li id="fn3"><p>This is <em>easier</em> to type. Inline notes may contain <a href="http://google.com">links</a> and <code>]</code> verbatim characters, as well as [bracketed text].<a href="#fnref3" class="footnote-back">↩</a></p></li>
+<li id="fn4"><p>In quote.<a href="#fnref4" class="footnote-back">↩</a></p></li>
+<li id="fn5"><p>In list.<a href="#fnref5" class="footnote-back">↩</a></p></li>
 </ol>
 </section>
 </body>


### PR DESCRIPTION
see #3556

I went through the HTML writer and corrected those I could find. However, I left `smallcaps` and `literatehaskell` as is, since it feels like that could also be one word, or what do you think?