### PR TITLE
Creole Reader: fix lists with triling white space

### DIFF
--- a/src/Text/Pandoc/Readers/Creole.hs
+++ b/src/Text/Pandoc/Readers/Creole.hs
@@ -27,7 +27,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
    License     : GNU GPL, version 2 or above
 
    Maintainer  : Sascha Wilde <wilde@sha-bang.de>
-   Stability   : WIP
+   Stability   : alpha
    Portability : portable
 
 Conversion of creole text to 'Pandoc' document.
@@ -64,7 +64,7 @@ readCreole opts s = do
 type CRLParser = ParserT [Char] ParserState
 
 --
--- Utility funcitons
+-- Utility functions
 --
 
 (<+>) :: (Monad m, Monoid a) => m a -> m a -> m a
@@ -111,7 +111,8 @@ block = do
   return res
 
 nowiki :: PandocMonad m => CRLParser m B.Blocks
-nowiki = try $ fmap (B.codeBlock . mconcat) (nowikiStart >> manyTill content nowikiEnd)
+nowiki = try $ fmap (B.codeBlock . mconcat) (nowikiStart
+                                             >> manyTill content nowikiEnd)
   where
     content = brackets <|> line
     brackets = try $ option "" ((:[]) <$> newline)
@@ -194,7 +195,7 @@ endOfParaElement = lookAhead $ endOfInput <|> endOfPara
    startOf      :: PandocMonad m => CRLParser m a -> CRLParser m ()
    startOf p     = try $ blankline >> p >> return mempty
    startOfList   = startOf $ anyList 1
-   startOfTable  =startOf table
+   startOfTable  = startOf table
    startOfHeader = startOf header
    startOfNowiki = startOf nowiki
    hr            = startOf horizontalRule

--- a/src/Text/Pandoc/Readers/Creole.hs
+++ b/src/Text/Pandoc/Readers/Creole.hs
@@ -154,7 +154,8 @@ listItem :: PandocMonad m => Char -> Int -> CRLParser m B.Blocks
 listItem c n =
   fmap (B.plain . B.trimInlines .mconcat) (listStart >> many1Till inline itemEnd)
   where
-    listStart = try $ optional newline >> skipSpaces >> count n (char c)
+    listStart = try $ skipSpaces >> optional newline >> skipSpaces
+                >> count n (char c)
                 >> lookAhead (noneOf [c]) >> skipSpaces
     itemEnd = endOfParaElement <|> nextItem n
               <|> if n < 3 then nextItem (n+1)

--- a/test/Tests/Readers/Creole.hs
+++ b/test/Tests/Readers/Creole.hs
@@ -203,7 +203,10 @@ tests = [
         , "forced line breaks" =:
           "{{{no break!\\\\here}}} but a break\\\\here!"
           =?> para (code "no break!\\\\here" <> " but a break"
-                    <> linebreak <> "here!")
+                    <> linebreak <> "here!"),
+          "quoted block, after trailing white space" =:
+          "this is a paragraph  \n{{{\nfoo bar\n  //baz//\n}}}"
+          =?> para "this is a paragraph" <> codeBlock "foo bar\n  //baz//"
         ]
   , testGroup "Images and Links" [
           "image simple" =:

--- a/test/Tests/Readers/Creole.hs
+++ b/test/Tests/Readers/Creole.hs
@@ -127,6 +127,11 @@ tests = [
           =?> bulletList [ plain "foo"
                          <> bulletList [ plain "bar", plain "baz" ]
                          , plain "blubb" ]
+        , "nested unordered list, one separating space, trailing space" =:
+          "* foo \n** bar  \n** baz \n* blubb  "
+          =?> bulletList [ plain "foo"
+                         <> bulletList [ plain "bar", plain "baz" ]
+                         , plain "blubb" ]
         , "ordered list, two entries, one separating space" =:
           "# foo\n# bar"
           =?> orderedList [ plain "foo", plain "bar" ]
@@ -138,6 +143,11 @@ tests = [
           =?> para "blubber" <> orderedList [ plain "foo", plain "bar" ]
         , "nested ordered list, one separating space" =:
           "# foo\n## bar\n## baz\n# blubb"
+          =?> orderedList [ plain "foo"
+                         <> orderedList [ plain "bar", plain "baz" ]
+                         , plain "blubb" ]
+        , "nested ordered list, one separating space, trailing space" =:
+          "# foo \n## bar  \n## baz \n# blubb  "
           =?> orderedList [ plain "foo"
                          <> orderedList [ plain "bar", plain "baz" ]
                          , plain "blubb" ]


### PR DESCRIPTION
I found and fixed a problem with my creole parser: when there was trailing white space in list items, the next item was not correctly detected.

In addition I added another test for no-wiki (verbatim code) blocks, to ensure they are not affected by an similar problem (they are not).  And made some minor corrections of typos and code formatting...