### PR TITLE
Lua filters: preload text module

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -327,6 +327,7 @@ library
                  scientific >= 0.2 && < 0.4,
                  vector >= 0.10 && < 0.13,
                  hslua >= 0.9 && < 0.10,
+                 hslua-module-text >= 0.1.2 && < 0.2,
                  binary >= 0.5 && < 0.9,
                  SHA >= 1.6 && < 1.7,
                  haddock-library >= 1.1 && < 1.5,

--- a/src/Text/Pandoc/Lua.hs
+++ b/src/Text/Pandoc/Lua.hs
@@ -46,6 +46,7 @@ import Text.Pandoc.Lua.PandocModule (pushMediaBagModule, pushPandocModule)
 import Text.Pandoc.Lua.Filter (LuaFilter, walkMWithLuaFilter)
 import Text.Pandoc.MediaBag (MediaBag)
 import qualified Foreign.Lua as Lua
+import qualified Foreign.Lua.Module.Text as Lua
 
 runLuaFilter :: Maybe FilePath -> FilePath -> String
              -> Pandoc -> PandocIO (Either LuaException Pandoc)
@@ -64,6 +65,7 @@ runLuaFilter' :: CommonState
               -> Pandoc -> Lua Pandoc
 runLuaFilter' commonState datadir filterPath format mbRef pd = do
   Lua.openlibs
+  Lua.preloadTextModule "text"
   -- store module in global "pandoc"
   pushPandocModule datadir
   Lua.setglobal "pandoc"

--- a/stack.pkg.yaml
+++ b/stack.pkg.yaml
@@ -15,6 +15,7 @@ packages:
 extra-deps:
 - pandoc-types-1.17.3
 - hslua-0.9.2
+- hslua-module-text-0.1.2
 - skylighting-0.4.3.2
 - texmath-0.10
 - cmark-gfm-0.1.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,7 @@ packages:
 extra-deps:
 - pandoc-types-1.17.3
 - hslua-0.9.2
+- hslua-module-text-0.1.2
 - skylighting-0.4.3.2
 - texmath-0.10
 - cmark-gfm-0.1.1

--- a/test/Tests/Lua.hs
+++ b/test/Tests/Lua.hs
@@ -7,9 +7,9 @@ import Test.Tasty (TestTree, localOption)
 import Test.Tasty.HUnit (Assertion, assertEqual, testCase)
 import Test.Tasty.QuickCheck (QuickCheckTests (..), ioProperty, testProperty)
 import Text.Pandoc.Arbitrary ()
-import Text.Pandoc.Builder (bulletList, doc, doubleQuoted, emph, linebreak,
-                            para, plain, rawBlock, singleQuoted, space, str,
-                            strong, (<>))
+import Text.Pandoc.Builder (bulletList, doc, doubleQuoted, emph, header,
+                            linebreak, para, plain, rawBlock, singleQuoted,
+                            space, str, strong, (<>))
 import Text.Pandoc.Class (runIOorExplode)
 import Text.Pandoc.Definition (Block, Inline, Meta, Pandoc)
 import Text.Pandoc.Lua
@@ -77,6 +77,12 @@ tests = map (localOption (QuickCheckTests 20))
       "block-count.lua"
       (doc $ para "one" <> para "two")
       (doc $ para "2")
+
+  , testCase "Convert header upper case" $
+    assertFilterConversion "converting header to upper case failed"
+      "uppercase-header.lua"
+      (doc $ header 1 "les états-unis" <> para "text")
+      (doc $ header 1 "LES ÉTATS-UNIS" <> para "text")
   ]
 
 assertFilterConversion :: String -> FilePath -> Pandoc -> Pandoc -> Assertion

--- a/test/lua/uppercase-header.lua
+++ b/test/lua/uppercase-header.lua
@@ -1,0 +1,9 @@
+local text = require 'text'
+
+local function str_to_uppercase (s)
+  return pandoc.Str(text.upper(s.text))
+end
+
+function Header (el)
+  return pandoc.walk_block(el, {Str = str_to_uppercase})
+end


### PR DESCRIPTION
The `text` module is preloaded in lua. The module contains some UTF-8
aware string functions, implemented in Haskell.  The module is loaded on
request only, e.g.:

    text = require 'text'
    function Str (s)
      s.text = text.upper(s.text)
      return s
    end