### PR TITLE
Relax `http-types` dependency.

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -338,7 +338,7 @@ library
                  doctemplates >= 0.2.1 && < 0.3,
                  http-client >= 0.4.30 && < 0.6,
                  http-client-tls >= 0.2.4 && < 0.4,
-                 http-types >= 0.8 && < 0.10,
+                 http-types >= 0.8 && < 0.11,
                  case-insensitive >= 1.2 && < 1.3
   if os(windows)
     cpp-options:      -D_WINDOWS


### PR DESCRIPTION
Tested on GHC-8.2 with [`http-types-10.0`](http://hackage.haskell.org/package/http-types-0.10).