### PR TITLE
Get ready for `Semigroup` as `Monoid` superclass.

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -296,6 +296,7 @@ custom-setup
 library
   build-depends: base >= 4.7 && < 5,
                  syb >= 0.1 && < 0.8,
+                 semigroups,
                  containers >= 0.4.2.1 && < 0.6,
                  unordered-containers >= 0.2 && < 0.3,
                  parsec >= 3.1 && < 3.2,

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -51,6 +51,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..), defaultOptions)
 import Data.Aeson.TH (deriveJSON)
 import Data.Bits (clearBit, setBit, testBit, (.|.))
 import Data.Data (Data)
+import Data.Semigroup (Semigroup ((<>)))
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Text.Pandoc.Shared (safeRead)
@@ -59,6 +60,7 @@ import Text.Parsec
 newtype Extensions = Extensions Integer
   deriving (Show, Read, Eq, Ord, Data, Typeable, Generic, ToJSON, FromJSON)
 
+instance Semigroup Extensions where (<>) = mappend
 instance Monoid Extensions where
   mempty = Extensions 0
   mappend (Extensions a) (Extensions b) = Extensions (a .|. b)

--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -188,13 +188,14 @@ where
 
 import Control.Monad.Identity
 import Control.Monad.Reader
+import Control.Applicative (liftA2)
 import Data.Char (chr, isAlphaNum, isAscii, isAsciiUpper, isHexDigit, isPunctuation, isSpace,
                   ord, toLower, toUpper)
 import Data.Default
 import Data.List (intercalate, isSuffixOf, transpose)
 import qualified Data.Map as M
 import Data.Maybe (mapMaybe)
-import Data.Monoid ((<>))
+import Data.Semigroup (Semigroup ((<>)))
 import qualified Data.Set as Set
 import Data.Text (Text)
 import Text.HTML.TagSoup.Entity (lookupEntity)
@@ -242,9 +243,11 @@ returnF = return . return
 trimInlinesF :: Future s Inlines -> Future s Inlines
 trimInlinesF = liftM trimInlines
 
-instance Monoid a => Monoid (Future s a) where
+instance Semigroup a => Semigroup (Future s a) where
+  (<>) = liftA2 (<>)
+instance (Monoid a, Semigroup a) => Monoid (Future s a) where
   mempty = return mempty
-  mappend = liftM2 mappend
+  mappend = (<>)
   mconcat = liftM mconcat . sequence
 
 -- | Parse characters while a predicate is true.
@@ -1411,7 +1414,8 @@ token :: (Stream s m t)
 token pp pos match = tokenPrim pp (\_ t _ -> pos t) match
 
 infixr 5 <+?>
-(<+?>) :: (Monoid a) => ParserT s st m a -> ParserT s st m a -> ParserT s st m a
+(<+?>) :: (Semigroup a, Monoid a)
+              => ParserT s st m a -> ParserT s st m a -> ParserT s st m a
 a <+?> b = a >>= flip fmap (try b <|> return mempty) . (<>)
 
 extractIdClass :: Attr -> Attr

--- a/src/Text/Pandoc/Readers/Odt/ContentReader.hs
+++ b/src/Text/Pandoc/Readers/Odt/ContentReader.hs
@@ -46,10 +46,11 @@ import qualified Data.ByteString.Lazy as B
 import Data.List (find, intercalate)
 import qualified Data.Map as M
 import Data.Maybe
+import Data.Semigroup (Semigroup ((<>)))
 
 import qualified Text.XML.Light as XML
 
-import Text.Pandoc.Builder
+import Text.Pandoc.Builder hiding ((<>))
 import Text.Pandoc.MediaBag (MediaBag, insertMedia)
 import Text.Pandoc.Shared
 
@@ -513,13 +514,13 @@ type BlockMatcher  = ElementMatcher Blocks
 
 
 --
-matchingElement :: (Monoid e)
+matchingElement :: (Semigroup e)
                 => Namespace -> ElementName
                 -> OdtReaderSafe  e e
                 -> ElementMatcher e
 matchingElement ns name reader = (ns, name, asResultAccumulator reader)
   where
-   asResultAccumulator :: (ArrowChoice a, Monoid m) => a m m -> a m (Fallible m)
+   asResultAccumulator :: (ArrowChoice a, Semigroup m) => a m m -> a m (Fallible m)
    asResultAccumulator a = liftAsSuccess $ keepingTheValue a >>% (<>)
 
 --

--- a/src/Text/Pandoc/Readers/Odt/StyleReader.hs
+++ b/src/Text/Pandoc/Readers/Odt/StyleReader.hs
@@ -67,6 +67,7 @@ import Data.List (unfoldr)
 import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Set as S
+import Data.Semigroup (Semigroup ((<>)))
 
 import qualified Text.XML.Light as XML
 
@@ -183,7 +184,8 @@ data Styles           = Styles
                           }
   deriving ( Show )
 
--- Styles from a monoid under union
+-- | Styles from a semigroup under union
+instance Semigroup Styles where (<>) = mappend
 instance Monoid Styles where
   mempty  = Styles M.empty M.empty M.empty
   mappend  (Styles sBn1 dSm1 lsBn1)


### PR DESCRIPTION
This will happen with [GHC#14191](https://ghc.haskell.org/trac/ghc/ticket/14191) (scheduled for GHC-8.4).