### PR TITLE
make normalizeDate more forgiving

### DIFF
--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -291,7 +291,7 @@ normalizeDate s = fmap (formatTime defaultTimeLocale "%F")
              parseTime defaultTimeLocale
 #endif
         formats = ["%x","%m/%d/%Y", "%D","%F", "%d %b %Y",
-                    "%d %B %Y", "%b. %d, %Y", "%B %d, %Y",
+                    "%e %B %Y", "%b. %e, %Y", "%B %e, %Y",
                     "%Y%m%d", "%Y%m", "%Y"]
 
 --


### PR DESCRIPTION
also parse two-digit days, e.g. "April 20, 2017"

replace some `%d` with `%e`, from [docs](https://www.stackage.org/haddock/lts-8.21/time-1.6.0.1/Data-Time-Format.html#v:formatTime):

> `%d`: day of month, 1-padded to two chars, 01 - 31
> `%e`: day of month, space-padded to two chars, 2 - 31

this was brought up in #4086