### PR TITLE
Default Theme Boilerplate

### DIFF
--- a/data/default.theme
+++ b/data/default.theme
@@ -1,177 +1,231 @@
 {
     "metadata" : {
         "revision" : 1,
-        "name" : "Default",
-        "author" : "Kate Authors",
-        "license" : "MIT",
-        "read-only" : true
+        "name" : "theme boilerplate",
+        "author" : "your name",
+        "license" : "public domain"
     },
     "text-styles": {
         "Normal" : {
-            "text-color" : "#1f1c1b",
-            "selected-text-color" : "#ffffff",
-            "bold" : false,
-            "italic" : false,
-            "underline" : false,
-            "strike-through" : false
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Keyword" : {
-            "text-color" : "#1f1c1b",
-            "selected-text-color" : "#ffffff",
-            "bold" : true
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Function" : {
-            "text-color" : "#644a9b",
-            "selected-text-color" : "#452886"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Variable" : {
-            "text-color" : "#0057ae",
-            "selected-text-color" : "#00316e"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "ControlFlow" : {
-            "text-color" : "#1f1c1b",
-            "selected-text-color" : "#ffffff",
-            "bold" : true
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Operator" : {
-            "text-color" : "#1f1c1b",
-            "selected-text-color" : "#ffffff"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "BuiltIn" : {
-            "text-color" : "#644a9b",
-            "selected-text-color" : "#452886",
-            "bold" : true
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Extension" : {
-            "text-color" : "#0095ff",
-            "selected-text-color" : "#ffffff",
-            "bold" : true
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Preprocessor" : {
-            "text-color" : "#006e28",
-            "selected-text-color" : "#006e28"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Attribute" : {
-            "text-color" : "#0057ae",
-            "selected-text-color" : "#00316e"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Char" : {
-            "text-color" : "#924c9d",
-            "selected-text-color" : "#6c2477"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "SpecialChar" : {
-            "text-color" : "#3daee9",
-            "selected-text-color" : "#fcfcfc"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "String" : {
-            "text-color" : "#bf0303",
-            "selected-text-color" : "#9c0e0e"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "VerbatimString" : {
-            "text-color" : "#bf0303",
-            "selected-text-color" : "#9c0e0e"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "SpecialString" : {
-            "text-color" : "#ff5500",
-            "selected-text-color" : "#ff5500"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Import" : {
-            "text-color" : "#ff5500",
-            "selected-text-color" : "#ff5500"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "DataType" : {
-            "text-color" : "#0057ae",
-            "selected-text-color" : "#00316e"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "DecVal" : {
-            "text-color" : "#b08000",
-            "selected-text-color" : "#805c00"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "BaseN" : {
-            "text-color" : "#b08000",
-            "selected-text-color" : "#805c00"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Float" : {
-            "text-color" : "#b08000",
-            "selected-text-color" : "#805c00"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Constant" : {
-            "text-color" : "#aa5500",
-            "selected-text-color" : "#5e2f00"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Comment" : {
-            "text-color" : "#898887",
-            "selected-text-color" : "#5e5d5d"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Documentation" : {
-            "text-color" : "#607880",
-            "selected-text-color" : "#46585e"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Annotation" : {
-            "text-color" : "#ca60ca",
-            "selected-text-color" : "#a44ea4"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "CommentVar" : {
-            "text-color" : "#0095ff",
-            "selected-text-color" : "#ffffff"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "RegionMarker" : {
-            "text-color" : "#0057ae",
-            "selected-text-color" : "#00316e",
-            "background-color" : "#e0e9f8"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Information" : {
-            "text-color" : "#b08000",
-            "selected-text-color" : "#805c00"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Warning" : {
-            "text-color" : "#bf0303",
-            "selected-text-color" : "#9c0e0e"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Alert" : {
-            "text-color" : "#bf0303",
-            "selected-text-color" : "#9c0e0e",
-            "background-color" : "#f7e6e6",
-            "bold" : true
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         },
         "Error" : {
-            "text-color" : "#bf0303",
-            "selected-text-color" : "#9c0e0e",
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
             "underline" : true
         },
         "Others" : {
-            "text-color" : "#006e28",
-            "selected-text-color" : "#006e28"
+            "text-color" : "#ffffff",
+            "background-color" : "#333333",
+            "bold" : true,
+            "italic" : true,
+            "underline" : true
         }
    },
     "editor-colors": {
-        "background-color" : "#ffffff",
-        "code-folding" : "#94caef",
-        "bracket-matching" : "#ffff00",
-        "current-line" : "#f8f7f6",
-        "icon-border" : "#f0f0f0",
-        "indentation-line" : "#d2d2d2",
-        "line-numbers" : "#a0a0a0",
-        "current-line-number" : "#1e1e1e",
-        "mark-bookmark" : "#0000ff",
-        "mark-breakpoint-active" : "#ff0000",
-        "mark-breakpoint-reached" : "#ffff00",
-        "mark-breakpoint-disabled" : "#ff00ff",
-        "mark-execution" : "#a0a0a4",
-        "mark-warning" : "#00ff00",
-        "mark-error" : "#ff0000",
-        "modified-lines" : "#fdbc4b",
-        "replace-highlight" : "#00ff00",
-        "saved-lines" : "#2ecc71",
-        "search-highlight" : "#ffff00",
-        "selection" : "#94caef",
-        "separator" : "#898887",
-        "spell-checking" : "#bf0303",
-        "tab-marker" : "#d2d2d2",
-        "template-background" : "#d6d2d0",
-        "template-placeholder" : "#baf8ce",
-        "template-focused-placeholder" : "#76da98",
-        "template-read-only-placeholder" : "#f6e6e6",
-        "word-wrap-marker" : "#ededed"
+        "background-color" : "#000000",
+        "line-numbers" : "#dddddd"
     }
 }


### PR DESCRIPTION
Cut down contents of `default.theme` to entries which are actually used by pandoc.

This commit turns `default.theme` into a boilerplate for creating custom themes, which is what most users probably expect from the `pandoc --print-default-data-file default.theme` command.

(See Issue #4096)