### PR TITLE
Stop using overlapping instances

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -301,6 +301,7 @@ library
                  containers >= 0.4.2.1 && < 0.6,
                  unordered-containers >= 0.2 && < 0.3,
                  parsec >= 3.1 && < 3.2,
+                 transformers >=0.4 && < 0.6,
                  mtl >= 2.2 && < 2.3,
                  filepath >= 1.1 && < 1.5,
                  process >= 1.2.3 && < 1.7,


### PR DESCRIPTION
Use `DefaultInstances` instead, with one instance per transformer.

Fixes #4122