### PR TITLE
clarify default html output for --section-divs

### DIFF
--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -80,79 +80,79 @@ disableExtension x (Extensions exts) = Extensions (clearBit exts (fromEnum x))
 
 -- | Individually selectable syntax extensions.
 data Extension =
-      Ext_footnotes           -- ^ Pandoc/PHP/MMD style footnotes
-    | Ext_inline_notes        -- ^ Pandoc-style inline notes
-    | Ext_pandoc_title_block  -- ^ Pandoc title block
-    | Ext_yaml_metadata_block -- ^ YAML metadata block
-    | Ext_mmd_title_block     -- ^ Multimarkdown metadata block
-    | Ext_table_captions      -- ^ Pandoc-style table captions
-    | Ext_implicit_figures    -- ^ A paragraph with just an image is a figure
-    | Ext_simple_tables       -- ^ Pandoc-style simple tables
-    | Ext_multiline_tables    -- ^ Pandoc-style multiline tables
-    | Ext_grid_tables         -- ^ Grid tables (pandoc, reST)
-    | Ext_pipe_tables         -- ^ Pipe tables (as in PHP markdown extra)
-    | Ext_citations           -- ^ Pandoc/citeproc citations
-    | Ext_raw_tex             -- ^ Allow raw TeX (other than math)
-    | Ext_raw_html            -- ^ Allow raw HTML
-    | Ext_tex_math_dollars    -- ^ TeX math between $..$ or $$..$$
-    | Ext_tex_math_single_backslash  -- ^ TeX math btw \(..\) \[..\]
-    | Ext_tex_math_double_backslash  -- ^ TeX math btw \\(..\\) \\[..\\]
-    | Ext_latex_macros        -- ^ Parse LaTeX macro definitions (for math only)
-    | Ext_fenced_code_blocks  -- ^ Parse fenced code blocks
-    | Ext_fenced_code_attributes  -- ^ Allow attributes on fenced code blocks
-    | Ext_backtick_code_blocks    -- ^ GitHub style ``` code blocks
-    | Ext_inline_code_attributes  -- ^ Allow attributes on inline code
-    | Ext_raw_attribute           -- ^ Allow explicit raw blocks/inlines
-    | Ext_markdown_in_html_blocks -- ^ Interpret as markdown inside HTML blocks
-    | Ext_native_divs             -- ^ Use Div blocks for contents of <div> tags
-    | Ext_fenced_divs             -- ^ Allow fenced div syntax :::
-    | Ext_native_spans            -- ^ Use Span inlines for contents of <span>
-    | Ext_bracketed_spans         -- ^ Bracketed spans with attributes
-    | Ext_markdown_attribute      -- ^ Interpret text inside HTML as markdown
-                                  --   iff container has attribute 'markdown'
-    | Ext_escaped_line_breaks     -- ^ Treat a backslash at EOL as linebreak
-    | Ext_link_attributes         -- ^ link and image attributes
-    | Ext_mmd_link_attributes     -- ^ MMD style reference link attributes
-    | Ext_autolink_bare_uris  -- ^ Make all absolute URIs into links
-    | Ext_fancy_lists         -- ^ Enable fancy list numbers and delimiters
-    | Ext_lists_without_preceding_blankline -- ^ Allow lists without preceding blank
-    | Ext_four_space_rule     -- ^ Require 4-space indent for list contents
-    | Ext_startnum            -- ^ Make start number of ordered list significant
-    | Ext_definition_lists    -- ^ Definition lists as in pandoc, mmd, php
-    | Ext_compact_definition_lists  -- ^ Definition lists without
-                               -- space between items, and disallow laziness
-    | Ext_example_lists       -- ^ Markdown-style numbered examples
+      Ext_abbreviations       -- ^ PHP markdown extra abbreviation definitions
     | Ext_all_symbols_escapable  -- ^ Make all non-alphanumerics escapable
+    | Ext_amuse -- ^ Enable Text::Amuse extensions to Emacs Muse markup
     | Ext_angle_brackets_escapable  -- ^ Make < and > escapable
-    | Ext_intraword_underscores  -- ^ Treat underscore inside word as literal
+    | Ext_ascii_identifiers   -- ^ ascii-only identifiers for headers
+    | Ext_auto_identifiers    -- ^ Automatic identifiers for headers
+    | Ext_autolink_bare_uris  -- ^ Make all absolute URIs into links
+    | Ext_backtick_code_blocks    -- ^ GitHub style ``` code blocks
     | Ext_blank_before_blockquote -- ^ Require blank line before a blockquote
     | Ext_blank_before_header     -- ^ Require blank line before a header
-    | Ext_space_in_atx_header -- ^ Require space between # and header text
-    | Ext_strikeout           -- ^ Strikeout using ~~this~~ syntax
-    | Ext_superscript         -- ^ Superscript using ^this^ syntax
-    | Ext_subscript           -- ^ Subscript using ~this~ syntax
-    | Ext_hard_line_breaks    -- ^ All newlines become hard line breaks
-    | Ext_ignore_line_breaks  -- ^ Newlines in paragraphs are ignored
+    | Ext_bracketed_spans         -- ^ Bracketed spans with attributes
+    | Ext_citations           -- ^ Pandoc/citeproc citations
+    | Ext_compact_definition_lists  -- ^ Definition lists without space between items,
+                                    --   and disallow laziness
+    | Ext_definition_lists    -- ^ Definition lists as in pandoc, mmd, php
     | Ext_east_asian_line_breaks  -- ^ Newlines in paragraphs are ignored between
-                              -- East Asian wide characters
-    | Ext_literate_haskell    -- ^ Enable literate Haskell conventions
-    | Ext_abbreviations       -- ^ PHP markdown extra abbreviation definitions
+                                  --   East Asian wide characters
     | Ext_emoji               -- ^ Support emoji like :smile:
-    | Ext_auto_identifiers    -- ^ Automatic identifiers for headers
-    | Ext_gfm_auto_identifiers  -- ^ Automatic identifiers for headers,
-                                -- using GitHub's method for generating identifiers
-    | Ext_ascii_identifiers   -- ^ ascii-only identifiers for headers
-    | Ext_header_attributes   -- ^ Explicit header attributes {#id .class k=v}
-    | Ext_mmd_header_identifiers -- ^ Multimarkdown style header identifiers [myid]
-    | Ext_implicit_header_references -- ^ Implicit reference links for headers
-    | Ext_line_blocks         -- ^ RST style line blocks
-    | Ext_epub_html_exts      -- ^ Recognise the EPUB extended version of HTML
-    | Ext_shortcut_reference_links -- ^ Shortcut reference links
-    | Ext_smart               -- ^ "Smart" quotes, apostrophes, ellipses, dashes
-    | Ext_old_dashes          -- ^ -- = em, - before number = en
-    | Ext_spaced_reference_links -- ^ Allow space between two parts of ref link
-    | Ext_amuse -- ^ Enable Text::Amuse extensions to Emacs Muse markup
     | Ext_empty_paragraphs -- ^ Allow empty paragraphs
+    | Ext_epub_html_exts      -- ^ Recognise the EPUB extended version of HTML
+    | Ext_escaped_line_breaks     -- ^ Treat a backslash at EOL as linebreak
+    | Ext_example_lists       -- ^ Markdown-style numbered examples
+    | Ext_fancy_lists         -- ^ Enable fancy list numbers and delimiters
+    | Ext_fenced_code_attributes  -- ^ Allow attributes on fenced code blocks
+    | Ext_fenced_code_blocks  -- ^ Parse fenced code blocks
+    | Ext_fenced_divs             -- ^ Allow fenced div syntax :::
+    | Ext_footnotes           -- ^ Pandoc/PHP/MMD style footnotes
+    | Ext_four_space_rule     -- ^ Require 4-space indent for list contents
+    | Ext_gfm_auto_identifiers  -- ^ Automatic identifiers for headers, using
+                                --  GitHub's method for generating identifiers
+    | Ext_grid_tables         -- ^ Grid tables (pandoc, reST)
+    | Ext_hard_line_breaks    -- ^ All newlines become hard line breaks
+    | Ext_header_attributes   -- ^ Explicit header attributes {#id .class k=v}
+    | Ext_ignore_line_breaks  -- ^ Newlines in paragraphs are ignored
+    | Ext_implicit_figures    -- ^ A paragraph with just an image is a figure
+    | Ext_implicit_header_references -- ^ Implicit reference links for headers
+    | Ext_inline_code_attributes  -- ^ Allow attributes on inline code
+    | Ext_inline_notes        -- ^ Pandoc-style inline notes
+    | Ext_intraword_underscores  -- ^ Treat underscore inside word as literal
+    | Ext_latex_macros        -- ^ Parse LaTeX macro definitions (for math only)
+    | Ext_line_blocks         -- ^ RST style line blocks
+    | Ext_link_attributes         -- ^ link and image attributes
+    | Ext_lists_without_preceding_blankline -- ^ Allow lists without preceding blank
+    | Ext_literate_haskell    -- ^ Enable literate Haskell conventions
+    | Ext_markdown_attribute      -- ^ Interpret text inside HTML as markdown iff
+                                  --   container has attribute 'markdown'
+    | Ext_markdown_in_html_blocks -- ^ Interpret as markdown inside HTML blocks
+    | Ext_mmd_header_identifiers -- ^ Multimarkdown style header identifiers [myid]
+    | Ext_mmd_link_attributes     -- ^ MMD style reference link attributes
+    | Ext_mmd_title_block     -- ^ Multimarkdown metadata block
+    | Ext_multiline_tables    -- ^ Pandoc-style multiline tables
+    | Ext_native_divs             -- ^ Use Div blocks for contents of <div> tags
+    | Ext_native_spans            -- ^ Use Span inlines for contents of <span>
+    | Ext_old_dashes          -- ^ -- = em, - before number = en
+    | Ext_pandoc_title_block  -- ^ Pandoc title block
+    | Ext_pipe_tables         -- ^ Pipe tables (as in PHP markdown extra)
+    | Ext_raw_attribute           -- ^ Allow explicit raw blocks/inlines
+    | Ext_raw_html            -- ^ Allow raw HTML
+    | Ext_raw_tex             -- ^ Allow raw TeX (other than math)
+    | Ext_shortcut_reference_links -- ^ Shortcut reference links
+    | Ext_simple_tables       -- ^ Pandoc-style simple tables
+    | Ext_smart               -- ^ "Smart" quotes, apostrophes, ellipses, dashes
+    | Ext_space_in_atx_header -- ^ Require space between # and header text
+    | Ext_spaced_reference_links -- ^ Allow space between two parts of ref link
+    | Ext_startnum            -- ^ Make start number of ordered list significant
+    | Ext_strikeout           -- ^ Strikeout using ~~this~~ syntax
+    | Ext_subscript           -- ^ Subscript using ~this~ syntax
+    | Ext_superscript         -- ^ Superscript using ^this^ syntax
+    | Ext_table_captions      -- ^ Pandoc-style table captions
+    | Ext_tex_math_dollars    -- ^ TeX math between $..$ or $$..$$
+    | Ext_tex_math_double_backslash  -- ^ TeX math btw \\(..\\) \\[..\\]
+    | Ext_tex_math_single_backslash  -- ^ TeX math btw \(..\) \[..\]
+    | Ext_yaml_metadata_block -- ^ YAML metadata block
     deriving (Show, Read, Enum, Eq, Ord, Bounded, Data, Typeable, Generic)
 
 -- | Extensions to be used with pandoc-flavored markdown.


### PR DESCRIPTION
In Pandoc v2 using --section-divs and -t html results in <section>s, not <div>s, by default, as was the case for v1.9.
This change to the Manual emphasizes that you must use -t html4 if you want divs, otherwise you get sections.