### PR TITLE
Add newlines around inlined display math for mathjax HTML output

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -1042,10 +1042,13 @@ inlineToHtml opts inline = do
                         ppcElement conf (annotateMML r str)
                     Left il  -> (H.span ! A.class_ mathClass) <$>
                                    inlineToHtml opts il
-           MathJax _ -> return $ H.span ! A.class_ mathClass $ toHtml $
-              case t of
-                InlineMath  -> "\\(" ++ str ++ "\\)"
-                DisplayMath -> "\\[" ++ str ++ "\\]"
+           MathJax _ -> do
+              let newLine = strToHtml $ if t == DisplayMath then "\n" else ""
+              let mathExpr = case t of
+                               InlineMath  -> "\\(" ++ str ++ "\\)"
+                               DisplayMath -> "\\[" ++ str ++ "\\]"
+              let m = H.span ! A.class_ mathClass $ toHtml $ mathExpr
+              return $ newLine >> m >> newLine
            KaTeX _ -> return $ H.span ! A.class_ mathClass $ toHtml $
               case t of
                 InlineMath  -> "\\(" ++ str ++ "\\)"


### PR DESCRIPTION
The change is to ease reading when grepping and allowing bookdown to parse inlined display
math properly.