### PR TITLE
fixes for docx writer

### DIFF
--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -981,7 +981,7 @@ blockToOpenXML' opts (Table caption aligns widths headers rows) = do
       ( mknode "w:tblPr" []
         (   mknode "w:tblStyle" [("w:val","Table")] () :
             mknode "w:tblW" [("w:type", "pct"), ("w:w", show rowwidth)] () :
-            mknode "w:tblLook" [("w:firstRow","1") | hasHeader ] () :
+            mknode "w:tblLook" [("w:firstRow",if hasHeader then "1" else "0") ] () :
           [ mknode "w:tblCaption" [("w:val", captionStr)] ()
           | not (null caption) ] )
       : mknode "w:tblGrid" []

--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -763,9 +763,7 @@ makeTOC _ = return []
 -- OpenXML elements (the main document and footnotes).
 writeOpenXML :: (PandocMonad m) => WriterOptions -> Pandoc -> WS m ([Element], [Element],[Element])
 writeOpenXML opts (Pandoc meta blocks) = do
-  let tit = docTitle meta ++ case lookupMeta "subtitle" meta of
-                                  Just (MetaBlocks [Plain xs]) -> LineBreak : xs
-                                  _ -> []
+  let tit = docTitle meta
   let auths = docAuthors meta
   let dat = docDate meta
   let abstract' = case lookupMeta "abstract" meta of


### PR DESCRIPTION
docx output has two bugs:

- if a subtitle is defined, the subtitle was appended to the title string (output as pStyleM "Title" paragraph), and in addition to that written as new paragraph (pStyleM "Subtitle") after the title. This leads to double subtitle. As the subtitle is added as a separate paragraph, there is no need to append it to the title

- Word 2016 seems to default to a header format in tables, if there is no "firstRow" definition. setting it explicitly to "0" is compatible with Word 2013 and fixes it for Word 2016