### PR TITLE
Ms writer: Added papersize variable

### DIFF
--- a/data/templates/default.ms
+++ b/data/templates/default.ms
@@ -40,6 +40,10 @@ $endif$
 .nr FL \n[LL]
 .\" footnote point size
 .nr FPS (\n[PS] - 2000)
+.\" paper size
+$if(papersize)$
+.ds paper $papersize$
+$endif$
 .\" color used for strikeout
 .defcolor strikecolor rgb 0.7 0.7 0.7
 .\" color for links (rgb)


### PR DESCRIPTION
I believe the title is self-describing. Should I also write some documentation, since this variable, and some others mentioned in the template aren't explicitly found in the manual?