### PR TITLE
Add beamer option to show notes on second screen

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1,6 +1,6 @@
 % Pandoc User's Guide
 % John MacFarlane
-% January 7, 2018
+% January 10, 2018
 
 Synopsis
 ========
@@ -1541,6 +1541,10 @@ LaTeX variables are used when [creating a PDF].
 
 `natbiboptions`
 :   list of options for natbib.
+
+`notes2screen`
+:   In beamer, show notes on second screen. Value can be 'top', 'left', 'right' or
+    'bottom'.
 
 `pagestyle`
 :   An option for LaTeX's `\pagestyle{}`. The default article class

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1,6 +1,6 @@
 % Pandoc User's Guide
 % John MacFarlane
-% January 10, 2018
+% January 7, 2018
 
 Synopsis
 ========

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -10,6 +10,10 @@ $if(beamer)$
 \setbeamertemplate{caption label separator}{: }
 \setbeamercolor{caption name}{fg=normal text.fg}
 \beamertemplatenavigationsymbols$if(navigation)$$navigation$$else$empty$endif$
+$if(notes2screen)$
+\usepackage{pgfpages}
+\setbeameroption{show notes on second screen=$notes2screen$}
+$endif$
 $endif$
 $if(beamerarticle)$
 \usepackage{beamerarticle} % needs to be loaded first


### PR DESCRIPTION
Hi,

To use speaker mode in pdfpc or pympress, i need pandoc to render notes on *second screen*. I suggest to add a beamer specific option for this, since this behaviour is completely specific to beamer.

What do you think of this ?

Thanks for pandoc !

Regards,