### PR TITLE
ImageSize: add derived Eq instance to Dimension

### DIFF
--- a/src/Text/Pandoc/ImageSize.hs
+++ b/src/Text/Pandoc/ImageSize.hs
@@ -83,6 +83,7 @@ data Dimension = Pixel Integer
                | Inch Double
                | Percent Double
                | Em Double
+               deriving Eq
 
 instance Show Dimension where
   show (Pixel a)      = show   a ++ "px"


### PR DESCRIPTION
@jgm: Any objections? It will allow me to derive Eq on some picture props in the Powerpoint writer. (With given caveat that pixel equality depends on dpi).