### PR TITLE
Add image class to HTML figure. Closes #3928.

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -634,12 +634,13 @@ figure opts attr@(_,classes,_) txt (s,tit) = do
   capt <- if null txt
              then return mempty
              else tocapt `fmap` inlineListToHtml opts txt
-  let figureClasses = unwords . map (++ "-figure") $ classes
+  let figureClasses = fromString . unwords $
+        [ "figure" | not html5 ] ++ map (++ "-figure") classes
   return $ if html5
-              then H5.figure ! A.class_ (fromString figureClasses) $ mconcat
-                    [nl opts, img, capt, nl opts]
-              else H.div ! A.class_ (fromString $ "figure " ++ figureClasses) $
-                    mconcat [nl opts, img, nl opts, capt, nl opts]
+              then H5.figure !? (not . null $ classes, A.class_ figureClasses) $
+                    mconcat [nl opts, img, capt, nl opts]
+              else H.div ! A.class_ figureClasses $ mconcat
+                    [nl opts, img, nl opts, capt, nl opts]
 
 -- | Convert Pandoc block element to HTML.
 blockToHtml :: PandocMonad m => WriterOptions -> Block -> StateT WriterState m Html

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -625,7 +625,7 @@ treatAsImage fp =
 figure :: PandocMonad m
        => WriterOptions -> Attr -> [Inline] -> (String, String)
        -> StateT WriterState m Html
-figure opts attr txt (s,tit) = do
+figure opts attr@(_,classes,_) txt (s,tit) = do
   img <- inlineToHtml opts (Image attr txt (s,tit))
   html5 <- gets stHtml5
   let tocapt = if html5
@@ -634,11 +634,12 @@ figure opts attr txt (s,tit) = do
   capt <- if null txt
              then return mempty
              else tocapt `fmap` inlineListToHtml opts txt
+  let figureClasses = unwords . map (++ "-figure") $ classes
   return $ if html5
-              then H5.figure $ mconcat
+              then H5.figure ! A.class_ (fromString figureClasses) $ mconcat
                     [nl opts, img, capt, nl opts]
-              else H.div ! A.class_ "figure" $ mconcat
-                    [nl opts, img, nl opts, capt, nl opts]
+              else H.div ! A.class_ (fromString $ "figure " ++ figureClasses) $
+                    mconcat [nl opts, img, nl opts, capt, nl opts]
 
 -- | Convert Pandoc block element to HTML.
 blockToHtml :: PandocMonad m => WriterOptions -> Block -> StateT WriterState m Html

--- a/test/Tests/Writers/HTML.hs
+++ b/test/Tests/Writers/HTML.hs
@@ -28,6 +28,12 @@ infix 4 =:
      => String -> (a, String) -> TestTree
 (=:) = test html
 
+imgHTMLWithClasses :: String
+imgHTMLWithClasses =
+  "<div class=\"figure my-class1-figure my-class2-figure\">" ++
+    "<img src=\"/url\" title=\"title\" class=\"my-class1 my-class2\" />" ++
+  "</div>"
+
 tests :: [TestTree]
 tests = [ testGroup "inline code"
           [ "basic" =: code "@&" =?> "<code>@&amp;</code>"
@@ -40,5 +46,9 @@ tests = [ testGroup "inline code"
           [ "alt with formatting" =:
             image "/url" "title" ("my " <> emph "image")
             =?> "<img src=\"/url\" title=\"title\" alt=\"my image\" />"
+          , "with class attribute" =:
+            para (imageWith
+                   ("",[ "my-class1", "my-class2" ],[])  "/url" "fig:title" "")
+            =?> imgHTMLWithClasses
           ]
         ]


### PR DESCRIPTION
Add the class attribute associated with the image to the enclosing
figure with a `-figure` suffix as suggested by @mb21. Closes #3928.

Example input:
```markdown
![a](b){.myClass1 .myClass2 #id}
```

HTML output without the change:
```html
<figure>
<img src="b" alt="a" id="id" class="myClass1 myClass2" /><figcaption>a</figcaption>
</figure>
```

HTML output with the change:
```html
<figure class="myClass1-figure myClass2-figure">
<img src="b" alt="a" id="id" class="myClass1 myClass2" /><figcaption>a</figcaption>
</figure>
```