### PR TITLE
LaTeX writer: escape & in lstinline

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -1015,7 +1015,7 @@ inlineToLaTeX (Code (_,classes,_) str) = do
         let chr = case "!\"&'()*,-./:;?@_" \\ str of
                        (c:_) -> c
                        []    -> '!'
-        let str' = escapeStringUsing (backslashEscapes "\\{}%~_") str
+        let str' = escapeStringUsing (backslashEscapes "\\{}%~_&") str
         -- we always put lstinline in a dummy 'passthrough' command
         -- (defined in the default template) so that we don't have
         -- to change the way we escape characters depending on whether


### PR DESCRIPTION
I get an error when I've got a backticked `&` in my document and `--listings` enabled.
```
! Improper alphabetic constant.
<to be read again> 
                   \unskip 
l.69 \passthrough{\lstinline!&!}
```
Strangely, it only seems to happen inside tables like
```
col1 col2
---- ----
`&`  abc
```
Also see #4111.