### PR TITLE
ConTeXt writer: xtables: correct wrong usage of caption

### DIFF
--- a/src/Text/Pandoc/Writers/ConTeXt.hs
+++ b/src/Text/Pandoc/Writers/ConTeXt.hs
@@ -267,7 +267,7 @@ blockToConTeXt (Table caption aligns widths heads rows) = do
     return $ "\\startplacetable" <> brackets (
       if null caption
         then "location=none"
-        else "caption=" <> braces captionText
+        else "title=" <> braces captionText
       ) $$ body $$ "\\stopplacetable" <> blankline
 
 tableToConTeXt :: PandocMonad m => Tabl -> Doc -> [Doc] -> WM m Doc

--- a/test/Tests/Writers/ConTeXt.hs
+++ b/test/Tests/Writers/ConTeXt.hs
@@ -92,7 +92,7 @@ tests = [ testGroup "inline code"
                            plain $ text "3.3",
                            plain $ text "3.4"]]
               in table caption aligns headers rows
-              =?> unlines [ "\\startplacetable[caption={Table 1}]"
+              =?> unlines [ "\\startplacetable[title={Table 1}]"
                           , "\\startTABLE"
                           , "\\startTABLEhead"
                           , "\\NC[align=left] Right"

--- a/test/tables.context
+++ b/test/tables.context
@@ -1,6 +1,6 @@
 Simple table with caption:
 
-\startplacetable[caption={Demonstration of simple table syntax.}]
+\startplacetable[title={Demonstration of simple table syntax.}]
 \startxtable
 \startxtablehead[head]
 \startxrow
@@ -74,7 +74,7 @@ Simple table without caption:
 
 Simple table indented two spaces:
 
-\startplacetable[caption={Demonstration of simple table syntax.}]
+\startplacetable[title={Demonstration of simple table syntax.}]
 \startxtable
 \startxtablehead[head]
 \startxrow
@@ -111,7 +111,7 @@ Simple table indented two spaces:
 
 Multiline table with caption:
 
-\startplacetable[caption={Here's the caption. It may span multiple lines.}]
+\startplacetable[title={Here's the caption. It may span multiple lines.}]
 \startxtable
 \startxtablehead[head]
 \startxrow


### PR DESCRIPTION
Fixes #4289