### PR TITLE
ConTeXt writer: Print also tex and latex raw elements

### DIFF
--- a/src/Text/Pandoc/Writers/ConTeXt.hs
+++ b/src/Text/Pandoc/Writers/ConTeXt.hs
@@ -188,6 +188,8 @@ blockToConTeXt (CodeBlock _ str) =
   return $ flush ("\\starttyping" <> cr <> text str <> cr <> "\\stoptyping") $$ blankline
   -- blankline because \stoptyping can't have anything after it, inc. '}'
 blockToConTeXt (RawBlock "context" str) = return $ text str <> blankline
+blockToConTeXt (RawBlock "latex" str) = return $ text str <> blankline
+blockToConTeXt (RawBlock "tex" str) = return $ text str <> blankline
 blockToConTeXt b@(RawBlock _ _ ) = do
   report $ BlockNotRendered b
   return empty
@@ -399,6 +401,7 @@ inlineToConTeXt (Math InlineMath str) =
 inlineToConTeXt (Math DisplayMath str) =
   return $ text "\\startformula "  <> text str <> text " \\stopformula" <> space
 inlineToConTeXt (RawInline "context" str) = return $ text str
+inlineToConTeXt (RawInline "latex" str) = return $ text str
 inlineToConTeXt (RawInline "tex" str) = return $ text str
 inlineToConTeXt il@(RawInline _ _) = do
   report $ InlineNotRendered il

--- a/test/writer.context
+++ b/test/writer.context
@@ -703,6 +703,12 @@ These shouldn't be math:
 
 Here's a LaTeX table:
 
+\begin{tabular}{|l|l|}\hline
+Animal & Number \\ \hline
+Dog    & 2      \\
+Cat    & 1      \\ \hline
+\end{tabular}
+
 \thinrule
 
 \section[special-characters]{Special Characters}


### PR DESCRIPTION
Fixes #3969 

This blindly prints out any raw blocks which are marked `tex` or `latex` in the ConTeXt writer.  The rationale behind this is that people probably do not write inline markup and then have ConTeXt *and* LaTeX output generated from this.  I think this is a reasonable approach because the conversion of foreign inline markup is highly non-deterministic and as a user I wouldn't want to rely on pandoc reading my mind and doing the right thing.

This is of course open for discussion and I would especially like to hear voices of people who *do* use inline markup and multiple output.
@alnjxn @aksdb @ousia @DaveJarvis @adunning @PeterDavidson