### PR TITLE
RFC: Verbose docx

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1974,6 +1974,16 @@ input formats
 output formats
 :  `markdown`, `docx`, `odt`, `opendocument`, `html`
 
+#### Extension: `styles` #### {#ext-styles}
+
+Read all docx styles as divs (for paragraph styles) and spans (for
+character styles) regardless of whether pandoc understands the meaning
+of these styles. This can be used with [docx custom
+styles](#custom-styles-in-docx). Disabled by default.
+
+input formats
+:  `docx`
+
 #### Extension: `amuse` ####
 
 In the `muse` input format, this enables Text::Amuse
@@ -4490,8 +4500,60 @@ To disable highlighting, use the `--no-highlight` option.
 
 [skylighting]: https://github.com/jgm/skylighting
 
-Custom Styles in Docx Output
-============================
+Custom Styles in Docx
+=====================
+
+Input
+-----
+
+The docx reader, by default, only reads those styles that it can
+convert into pandoc elements, either by direct conversion or
+interpreting the derivation of the input document's styles.
+
+By enabling the [`styles` extension](#ext-styles) in the docx reader
+(`-f docx+styles`), you can produce output that maintains the styles
+of the input document, using the `custom-style` class. Paragraph
+styles are interpreted as divs, while character styles are interpreted
+as spans.
+
+For example, using the `custom-style-reference.docx` file in the test
+directory, we have the following different outputs:
+
+Without the `+styles` extension:
+
+    $ pandoc test/docx/custom-style-reference.docx -f docx -t markdown
+    This is some text.
+
+    This is text with an *emphasized* text style. And this is text with a
+    **strengthened** text style.
+
+    > Here is a styled paragraph that inherits from Block Text.
+
+And with the extension:
+
+    $ pandoc test/docx/custom-style-reference.docx -f docx+styles -t markdown
+    ::: {custom-style="FirstParagraph"}
+    This is some text.
+    :::
+
+    ::: {custom-style="BodyText"}
+    This is text with an
+    *[[emphasized]{custom-style="Emphatic"}]{custom-style="Emphatic"}* text
+    style. And this is text with a
+    **[[strengthened]{custom-style="Strengthened"}]{custom-style="Strengthened"}**
+    text style.
+    :::
+
+    ::: {custom-style="MyBlockStyle"}
+    > Here is a styled paragraph that inherits from Block Text.
+    :::
+
+With these custom styles, you can use your input document as a
+reference-doc while creating docx output (see below), and maintain the
+same styles in your input and output files.
+
+Output
+------
 
 By default, pandoc's docx output applies a predefined set of styles for
 blocks such as paragraphs and block quotes, and uses largely default

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -149,6 +149,7 @@ data Extension =
     | Ext_strikeout           -- ^ Strikeout using ~~this~~ syntax
     | Ext_subscript           -- ^ Subscript using ~this~ syntax
     | Ext_superscript         -- ^ Superscript using ^this^ syntax
+    | Ext_styles              -- ^ Read styles that pandoc doesn't know
     | Ext_table_captions      -- ^ Pandoc-style table captions
     | Ext_tex_math_dollars    -- ^ TeX math between $..$ or $$..$$
     | Ext_tex_math_double_backslash  -- ^ TeX math btw \\(..\\) \\[..\\]

--- a/test/Tests/Readers/Docx.hs
+++ b/test/Tests/Readers/Docx.hs
@@ -372,6 +372,17 @@ tests = [ testGroup "inlines"
             "image extraction"
             "docx/image.docx"
           ]
+        , testGroup "custom styles"
+          [ testCompare
+            "custom styles (`+styles`) not enabled (default)"
+            "docx/custom-style-reference.docx"
+            "docx/custom-style-no-styles.native"
+          , testCompareWithOpts
+            def{readerExtensions=extensionsFromList [Ext_styles]}
+            "custom styles (`+styles`) enabled"
+            "docx/custom-style-reference.docx"
+            "docx/custom-style-with-styles.native"
+          ]
         , testGroup "metadata"
           [ testCompareWithOpts def{readerStandalone=True}
             "metadata fields"

--- a/test/docx/custom-style-no-styles.native
+++ b/test/docx/custom-style-no-styles.native
@@ -1,0 +1,4 @@
+[Para [Str "This",Space,Str "is",Space,Str "some",Space,Str "text."]
+,Para [Str "This",Space,Str "is",Space,Str "text",Space,Str "with",Space,Str "an",Space,Emph [Str "emphasized"],Space,Str "text",Space,Str "style.",Space,Str "And",Space,Str "this",Space,Str "is",Space,Str "text",Space,Str "with",Space,Str "a",Space,Strong [Str "strengthened"],Space,Str "text",Space,Str "style."]
+,BlockQuote
+ [Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "styled",Space,Str "paragraph",Space,Str "that",Space,Str "inherits",Space,Str "from",Space,Str "Block",Space,Str "Text."]]]

--- a/test/docx/custom-style-with-styles.native
+++ b/test/docx/custom-style-with-styles.native
@@ -1,0 +1,7 @@
+[Div ("",[],[("custom-style","FirstParagraph")])
+ [Para [Str "This",Space,Str "is",Space,Str "some",Space,Str "text."]]
+,Div ("",[],[("custom-style","BodyText")])
+ [Para [Str "This",Space,Str "is",Space,Str "text",Space,Str "with",Space,Str "an",Space,Emph [Span ("",[],[("custom-style","Emphatic")]) [Span ("",[],[("custom-style","Emphatic")]) [Str "emphasized"]]],Space,Str "text",Space,Str "style.",Space,Str "And",Space,Str "this",Space,Str "is",Space,Str "text",Space,Str "with",Space,Str "a",Space,Strong [Span ("",[],[("custom-style","Strengthened")]) [Span ("",[],[("custom-style","Strengthened")]) [Str "strengthened"]]],Space,Str "text",Space,Str "style."]]
+,Div ("",[],[("custom-style","MyBlockStyle")])
+ [BlockQuote
+  [Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "styled",Space,Str "paragraph",Space,Str "that",Space,Str "inherits",Space,Str "from",Space,Str "Block",Space,Str "Text."]]]]


### PR DESCRIPTION
As discussed on #1843:

We still resolve dependent styles, but we optionally wrap elements in div/span tags derived from paragraph/character style names. This is controlled by `--verbose-docx` which defaults to off.

~~~
$ pandoc test/docx/german_styled_lists.docx -t markdown
-   One level of the list.

-   Second level of the list.

    -   Next level of the list

-   Back to the top level.
~~~

~~~
$ pandoc --verbose-docx test/docx/german_styled_lists.docx -t markdown
-   ::: {.AufzhlungStrich}
    One level of the list.
    :::

-   ::: {.AufzhlungStrich}
    Second level of the list.
    :::

    -   ::: {.AufzhlungStrich}
        Next level of the list
        :::

-   ::: {.AufzhlungStrich}
    Back to the top level.
    :::
~~~