### PR TITLE
[latex] forced linebreaks for fenced code using

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -211,7 +211,7 @@ When using LaTeX, the following packages need to be available
 (they are included with all recent versions of [TeX Live]):
 [`amsfonts`], [`amsmath`], [`lm`], [`unicode-math`],
 [`ifxetex`], [`ifluatex`], [`listings`] (if the
-`--listings` option is used), [`fancyvrb`], [`longtable`],
+`--listings` option is used), [`fancyvrb`], [`fvextra`], [`longtable`],
 [`booktabs`], [`graphicx`] and [`grffile`] (if the document
 contains images), [`hyperref`], [`xcolor`] (with `colorlinks`),
 [`ulem`], [`geometry`] (with the `geometry` variable set),
@@ -234,6 +234,7 @@ optionally be used for [citation rendering].
 [`ifluatex`]: https://ctan.org/pkg/ifluatex
 [`listings`]: https://ctan.org/pkg/listings
 [`fancyvrb`]: https://ctan.org/pkg/fancyvrb
+[`fvextra`]: https://ctan.org/pkg/fvextra
 [`longtable`]: https://ctan.org/pkg/longtable
 [`booktabs`]: https://ctan.org/pkg/booktabs
 [`graphicx`]: https://ctan.org/pkg/graphicx

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -34,9 +34,10 @@
 \urlstyle{same}  % don't use monospace font for urls
 \usepackage{color}
 \usepackage{fancyvrb}
+\usepackage{fvextra}
 \newcommand{\VerbBar}{|}
 \newcommand{\VERB}{\Verb[commandchars=\\\{\}]}
-\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,commandchars=\\\{\}}
 % Add ',fontsize=\small' for more characters per line
 \newenvironment{Shaded}{}{}
 \newcommand{\AlertTok}[1]{\textcolor[rgb]{1.00,0.00,0.00}{\textbf{#1}}}


### PR DESCRIPTION
Per suggestion in #4302. The patch makes sure that long lines of fenced code are broken (LaTeX). The solution requires the additional package [fvextra](https://ctan.org/pkg/fvextra) which nicely collaborates with `fancyvrb`.

@jgm I hope this is the correct place to make these innocent edits. I am not sure if additional commits are needed in the documentation area.