### PR TITLE
Add support to parse unit string of \SI command

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -665,7 +665,7 @@ dosiunitx = do
   skipopts
   value <- tok
   valueprefix <- option "" $ bracketed tok
-  unit <- tok
+  unit <- inlineCommand' <|> tok
   let emptyOr160 "" = ""
       emptyOr160 _  = "\160"
   return . mconcat $ [valueprefix,
@@ -673,6 +673,12 @@ dosiunitx = do
                       value,
                       emptyOr160 unit,
                       unit]
+
+-- siunitx's \square command
+dosquare :: PandocMonad m => LP m Inlines
+dosquare = do
+  unit <- inlineCommand' <|> tok
+  return . mconcat $ [unit, "\178"]
 
 lit :: String -> LP m Inlines
 lit = pure . str
@@ -1467,6 +1473,13 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList
   , ("acsp", doAcronymPlural "abbrv")
   -- siuntix
   , ("SI", dosiunitx)
+  -- units of siuntix
+  , ("celsius", lit "°C")
+  , ("degreeCelsius", lit "°C")
+  , ("gram", lit "g")
+  , ("meter", lit "m")
+  , ("milli", lit "m")
+  , ("square", dosquare)
   -- hyphenat
   , ("bshyp", lit "\\\173")
   , ("fshyp", lit "/\173")

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -19,3 +19,39 @@
 ^D
 [Para [Str "{}\160{}\160{}"]]
 ```
+
+```
+% pandoc -f latex -t native
+\SI{30}{\milli\meter}
+^D
+[Para [Str "30\160mm"]]
+```
+
+```
+% pandoc -f latex -t native
+\SI{6}{\gram}
+^D
+[Para [Str "6\160g"]]
+```
+
+```
+% pandoc -f latex -t native
+\SI{25}{\square\meter}
+^D
+[Para [Str "25\160m\178"]]
+```
+
+```
+% pandoc -f latex -t native
+\SI{18.2}{\degreeCelsius}
+^D
+[Para [Str "18.2\160\176C"]]
+```
+
+```
+% pandoc -f latex -t native
+\SI{18.2}{\celsius}
+^D
+[Para [Str "18.2\160\176C"]]
+```
+


### PR DESCRIPTION
I want to resolve #4296