### PR TITLE
INSTALL.md: mentioning Stack version.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,7 +120,7 @@ the last released version.
 
 The easiest way to build pandoc from source is to use [stack]:
 
-1.  Install [stack].
+1.  Install [stack]. Note that Pandoc requires stack >= 1.6.0.
 
 2.  Change to the pandoc source directory and issue the following commands:
 


### PR DESCRIPTION
Since I was using Stack from Ubuntu repositories, [I've lost some time](https://stackoverflow.com/questions/48595711/error-building-pandoc-error-in-ghc-options-failed-to-parse-field-ghc-opt/48595712#48595712) trying to figure out why pandoc was not building. I believe mentioning the version can be useful to other developers. (Now, if you don't think this is a relevant question, that's ok as well, I just thought I needed to suggest the change.)