### PR TITLE
Update default.nix to current nixpkgs-unstable for hslua-0.9.5

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,16 +9,11 @@
 { pkgs ?
     import ((import <nixpkgs> {}).pkgs.fetchFromGitHub {
       owner = "NixOS"; repo = "nixpkgs";
-      rev = "1354099daf98b7a1f79e6c41ce6bfda5c40177ae";
-      sha256 = "1dwnmxirzjrshlaan7cpag77y7nd09chrbakfx3c3f1lzsldbi97";
+      rev = "42b9b8f7c8687cb26e69c3559e0e1346fb0e680f";
+      sha256 = "01zcd0dh9x3qf5yflclbrcvff9yh8k9pmccc7vjlq3phc440qsyb";
     }) {} }:
 let haskellPackages = pkgs.haskellPackages;
-    overrides = self: super: {
-      hslua-module-text = pkgs.haskell.lib.dontCheck
-            super.hslua-module-text;
-      skylighting = super.skylighting_0_5;
-      hslua = super.hslua_0_9_3;
-    };
+    overrides = self: super: { };
     source-overrides = {
       doctemplates = "0.2.1";
       texmath = "0.10";


### PR DESCRIPTION
A month ago bdb911550c2894925be6893a5d93fca484448dd4 bumped `hslua` to version 0.9.5, but the change was not incorporated into `default.nix`. Consequently, `nix-build` fails while complaining about conflicting versions. Updating to a more recent nixpkgs channel resolves this, and the previously specified overrides are no longer necessary.

The revision was taken from [nixos.org/channels/nixpkgs-unstable/git-revision](nixos.org/channels/nixpkgs-unstable/git-revision) and the sha256 hash can be double-checked by running `nix-prefetch-git https://github.com/nixos/nixpkgs.git --rev 42b9b8f7c8687cb26e69c3559e0e1346fb0e680f` and inspecting the output.