### PR TITLE
Add -V beameroption variable

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1443,6 +1443,9 @@ LaTeX variables are used when [creating a PDF].
 :   option for document class, e.g. `oneside`; may be repeated
     for multiple options
 
+`beameroption`
+:   In beamer, add extra beamer option with `\setbeameroption{}`
+
 `geometry`
 :   option for [`geometry`] package, e.g. `margin=1in`;
     may be repeated for multiple options

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -6,6 +6,7 @@ $endif$
 %
 \documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$endif$$if(beamer)$ignorenonframetext,$if(handout)$handout,$endif$$if(aspectratio)$aspectratio=$aspectratio$,$endif$$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
 $if(beamer)$
+\usepackage{pgfpages}
 \setbeamertemplate{caption}[numbered]
 \setbeamertemplate{caption label separator}{: }
 \setbeamercolor{caption name}{fg=normal text.fg}

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -11,6 +11,9 @@ $if(beamer)$
 \setbeamertemplate{caption label separator}{: }
 \setbeamercolor{caption name}{fg=normal text.fg}
 \beamertemplatenavigationsymbols$if(navigation)$$navigation$$else$empty$endif$
+$for(beameroption)$
+\setbeameroption{$beameroption$}
+$endfor$
 $endif$
 $if(beamerarticle)$
 \usepackage{beamerarticle} % needs to be loaded first


### PR DESCRIPTION
Hi,

This PR implements https://github.com/jgm/pandoc/pull/4242#discussion_r163044697 and supersedes #4242 .

I also add `pgfpages` package which is very common when using beamer, and required for using `show notes on second screen`, the target case of `beameroption`.

I'm closing #4242 as soon as this PR is opened.