### PR TITLE
LaTeX writer: Update \lstinline delimiters.

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -1012,7 +1012,7 @@ inlineToLaTeX (Code (_,classes,_) str) = do
                                Nothing -> ""
         inNote <- gets stInNote
         when inNote $ modify $ \s -> s{ stVerbInNote = True }
-        let chr = case "!\"&'()*,-./:;?@_" \\ str of
+        let chr = case "!\"'()*,-./:;?@" \\ str of
                        (c:_) -> c
                        []    -> '!'
         let str' = escapeStringUsing (backslashEscapes "\\{}%~_&") str


### PR DESCRIPTION
Don't delimit `\lstinline` with characters that are normally escaped in LaTeX, specifically those which Pandoc already needs to escape, like `&` and `_`:

https://github.com/jgm/pandoc/blob/6dcb9744237be713f4ef94017a6b68fc0cfddb73/src/Text/Pandoc/Writers/LaTeX.hs#L1018

This avoids "undefined control sequence" issues with the `\passthrough` command encountered in https://github.com/laboon/ebook/issues/139, and follows up on #4111 and #4271.