### PR TITLE
EMF Image size support

### DIFF
--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -1339,6 +1339,7 @@ inlineToOpenXML' opts (Image attr alt (src, title)) = do
                                               Just Pdf  -> ".pdf"
                                               Just Eps  -> ".eps"
                                               Just Svg  -> ".svg"
+                                              Just Emf  -> ".emf"
                                               Nothing   -> ""
           if null imgext
              then -- without an extension there is no rule for content type

--- a/src/Text/Pandoc/Writers/Powerpoint/Output.hs
+++ b/src/Text/Pandoc/Writers/Powerpoint/Output.hs
@@ -475,6 +475,7 @@ registerMedia fp caption = do
                  Just Pdf  -> Just ".pdf"
                  Just Eps  -> Just ".eps"
                  Just Svg  -> Just ".svg"
+                 Just Emf  -> Just ".emf"
                  Nothing   -> Nothing
 
   let newGlobalId = case M.lookup fp globalIds of


### PR DESCRIPTION
ref #3798

Correct aspect ratio for *.emf files when exporting to docx. There are two issues however unrelated to this PR:

1. If using multiple of the same image in a docx, the docx will resize every image (not just .emf) to the size of the first image. The size descriptions of the other copies are ignored. (#3930)
2. .emf files exported by Inkscape are non-compliant to the specification of emf, so don't use these images for testing. 

The only emf files I could find that weren't generated by Inkscape were included by default on windows.