### PR TITLE
Fix example in lua-filters docs. Fixes #4459

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -351,7 +351,7 @@ local vars = {}
 function get_vars (meta)
   for k, v in pairs(meta) do
     if v.t == 'MetaInlines' then
-      vars["$" .. k .. "$"] = v
+      vars["$" .. k .. "$"] = {table.unpack(v)}
     end
   end
 end


### PR DESCRIPTION
Fixes Macro Replacement example filter in lua-filters doc. Fixed by copying elements from MetaInline (with table.unpack) instead of storing the MetaInline element directly.