### PR TITLE
Several fixes for EPUB footnotes

### DIFF
--- a/test/command/4235.md
+++ b/test/command/4235.md
@@ -5,8 +5,6 @@ This.^[Has a footnote.]
 <p>This.<a href="#foofn1" class="footnote-ref" id="foofnref1"><sup>1</sup></a></p>
 <section class="footnotes">
 <hr />
-<ol>
-<li id="foofn1"><p>Has a footnote.<a href="#foofnref1" class="footnote-back">↩</a></p></li>
-</ol>
+<aside id="foofn1"><p><a href="#foofnref1" class="footnote-back">1.</a> Has a footnote.</p></aside>
 </section>
 ```

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -534,16 +534,14 @@ Blah
 <p>This paragraph should not be part of the note, as it is not indented.</p>
 <div class="footnotes">
 <hr />
-<ol>
-<li id="fn1"><p>Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.<a href="#fnref1" class="footnote-back">↩</a></p></li>
-<li id="fn2"><p>Here’s the long note. This one contains multiple blocks.</p>
+<div id="fn1"><p><a href="#fnref1" class="footnote-back">1.</a> Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.</p></div>
+<div id="fn2"><p><a href="#fnref2" class="footnote-back">2.</a> Here’s the long note. This one contains multiple blocks.</p>
 <p>Subsequent blocks are indented to show that they belong to the footnote (as with list items).</p>
 <pre><code>  { &lt;code&gt; }</code></pre>
-<p>If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.<a href="#fnref2" class="footnote-back">↩</a></p></li>
-<li id="fn3"><p>This is <em>easier</em> to type. Inline notes may contain <a href="http://google.com">links</a> and <code>]</code> verbatim characters, as well as [bracketed text].<a href="#fnref3" class="footnote-back">↩</a></p></li>
-<li id="fn4"><p>In quote.<a href="#fnref4" class="footnote-back">↩</a></p></li>
-<li id="fn5"><p>In list.<a href="#fnref5" class="footnote-back">↩</a></p></li>
-</ol>
+<p>If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.</p></div>
+<div id="fn3"><p><a href="#fnref3" class="footnote-back">3.</a> This is <em>easier</em> to type. Inline notes may contain <a href="http://google.com">links</a> and <code>]</code> verbatim characters, as well as [bracketed text].</p></div>
+<div id="fn4"><p><a href="#fnref4" class="footnote-back">4.</a> In quote.</p></div>
+<div id="fn5"><p><a href="#fnref5" class="footnote-back">5.</a> In list.</p></div>
 </div>
 </body>
 </html>

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -536,16 +536,14 @@ Blah
 <p>This paragraph should not be part of the note, as it is not indented.</p>
 <section class="footnotes">
 <hr />
-<ol>
-<li id="fn1"><p>Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.<a href="#fnref1" class="footnote-back">↩</a></p></li>
-<li id="fn2"><p>Here’s the long note. This one contains multiple blocks.</p>
+<aside id="fn1"><p><a href="#fnref1" class="footnote-back">1.</a> Here is the footnote. It can go anywhere after the footnote reference. It need not be placed at the end of the document.</p></aside>
+<aside id="fn2"><p><a href="#fnref2" class="footnote-back">2.</a> Here’s the long note. This one contains multiple blocks.</p>
 <p>Subsequent blocks are indented to show that they belong to the footnote (as with list items).</p>
 <pre><code>  { &lt;code&gt; }</code></pre>
-<p>If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.<a href="#fnref2" class="footnote-back">↩</a></p></li>
-<li id="fn3"><p>This is <em>easier</em> to type. Inline notes may contain <a href="http://google.com">links</a> and <code>]</code> verbatim characters, as well as [bracketed text].<a href="#fnref3" class="footnote-back">↩</a></p></li>
-<li id="fn4"><p>In quote.<a href="#fnref4" class="footnote-back">↩</a></p></li>
-<li id="fn5"><p>In list.<a href="#fnref5" class="footnote-back">↩</a></p></li>
-</ol>
+<p>If you want, you can indent every line, but you can also be lazy and just indent the first line of each block.</p></aside>
+<aside id="fn3"><p><a href="#fnref3" class="footnote-back">3.</a> This is <em>easier</em> to type. Inline notes may contain <a href="http://google.com">links</a> and <code>]</code> verbatim characters, as well as [bracketed text].</p></aside>
+<aside id="fn4"><p><a href="#fnref4" class="footnote-back">4.</a> In quote.</p></aside>
+<aside id="fn5"><p><a href="#fnref5" class="footnote-back">5.</a> In list.</p></aside>
 </section>
 </body>
 </html>


### PR DESCRIPTION
With the current EPUB output (after converting with Kindle previewer and copying to Kindle...), the pop-over footnotes will often have problems:

1. Several footnotes run together and appear as one when clicking on a footnote.
2. Some footnotes do not work at all with pop-over and the link will jump you directly to the footnote section.

Here's an example showing the footnotes running together:
![Multiple footnotes run together](https://user-images.githubusercontent.com/12575/37863166-db0fda6e-2fad-11e8-9c2e-a06e161a0a44.jpg)

I believe that both of these problems are caused by having the footnote back-link at the end of the footnote. Changing the link to be at the start of the footnote fixes this. (I don't know why this causes problems with the Kindle software.)

Here's the same footnote after making this change:
 ![Single footnote at a time](https://user-images.githubusercontent.com/12575/37863167-e17e3a58-2fad-11e8-9b12-4a40bc5fd6c1.jpg)

Putting the '↩' back-link at the start of the footnote doesn't make much sense, so I changed it to a numeric back-link instead. This was based on the examples given in both the [Amazon Kindle Publishing Guidelines](https://kindlegen.s3.amazonaws.com/AmazonKindlePublishingGuidelines.pdf) and the [EPUB3 Accessibility Guidelines](https://idpf.github.io/a11y-guidelines/content/xhtml/notes.html#xhtm080-ex04).

However, making the back-link numeric meant that the ordered list that Pandoc outputs for footnotes would duplicate the numbering provided in the back-link. To avoid this (and implement something suggested on #1995), I've also changed the footnote output to use `<aside>` (on HTML5/EPUB3) or fall back to `<div>` (on HTML4/EPUB2). Using asides is something that is "strongly recommended" by Amazon's guidelines, and is what Apple recommends in the [iBooks Asset Guide](https://help.apple.com/itc/booksassetguide/en.lproj/static.html#itccf8ecf5c8). (There is an additional feature provided by iBooks which is that the asides are hidden from the main flow of the text.) So we seem to be able to solve two issues at once 🙂

I've also checked the new output in Calibre, Edge, Kindle Previewer, and iBooks to confirm that it works as expected. 


