### PR TITLE
LaTeX reader: parse sloppypar environment

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -2111,6 +2111,7 @@ environments :: PandocMonad m => M.Map Text (LP m Blocks)
 environments = M.fromList
    [ ("document", env "document" blocks)
    , ("abstract", mempty <$ (env "abstract" blocks >>= addMeta "abstract"))
+   , ("sloppypar", env "sloppypar" $ blocks)
    , ("letter", env "letter" letterContents)
    , ("minipage", env "minipage" $
           skipopts *> spaces *> optional braced *> spaces *> blocks)

--- a/test/command/sloppypar.md
+++ b/test/command/sloppypar.md
@@ -1,0 +1,23 @@
+```
+% pandoc -f latex+raw_tex -t native
+\begin{sloppypar}
+Sequi id qui facere et incidunt ut. Et fuga ut voluptate enim qui. Odit unde magni ipsam dicta modi. Modi soluta velit est aut aut possimus.
+
+Qui et temporibus explicabo. Esse ab ut quidem. Vel qui perspiciatis quae odio consectetur alias non sed. Quo consectetur libero omnis quos eius ad vel.
+\end{sloppypar}
+^D
+[Para [Str "Sequi",Space,Str "id",Space,Str "qui",Space,Str "facere",Space,Str "et",Space,Str "incidunt",Space,Str "ut.",Space,Str "Et",Space,Str "fuga",Space,Str "ut",Space,Str "voluptate",Space,Str "enim",Space,Str "qui.",Space,Str "Odit",Space,Str "unde",Space,Str "magni",Space,Str "ipsam",Space,Str "dicta",Space,Str "modi.",Space,Str "Modi",Space,Str "soluta",Space,Str "velit",Space,Str "est",Space,Str "aut",Space,Str "aut",Space,Str "possimus."]
+,Para [Str "Qui",Space,Str "et",Space,Str "temporibus",Space,Str "explicabo.",Space,Str "Esse",Space,Str "ab",Space,Str "ut",Space,Str "quidem.",Space,Str "Vel",Space,Str "qui",Space,Str "perspiciatis",Space,Str "quae",Space,Str "odio",Space,Str "consectetur",Space,Str "alias",Space,Str "non",Space,Str "sed.",Space,Str "Quo",Space,Str "consectetur",Space,Str "libero",Space,Str "omnis",Space,Str "quos",Space,Str "eius",Space,Str "ad",Space,Str "vel."]]
+```
+
+```
+% pandoc -f latex -t native
+\begin{sloppypar}
+Sequi id qui facere et incidunt ut. Et fuga ut voluptate enim qui. Odit unde magni ipsam dicta modi. Modi soluta velit est aut aut possimus.
+
+Qui et temporibus explicabo. Esse ab ut quidem. Vel qui perspiciatis quae odio consectetur alias non sed. Quo consectetur libero omnis quos eius ad vel.
+\end{sloppypar}
+^D
+[Para [Str "Sequi",Space,Str "id",Space,Str "qui",Space,Str "facere",Space,Str "et",Space,Str "incidunt",Space,Str "ut.",Space,Str "Et",Space,Str "fuga",Space,Str "ut",Space,Str "voluptate",Space,Str "enim",Space,Str "qui.",Space,Str "Odit",Space,Str "unde",Space,Str "magni",Space,Str "ipsam",Space,Str "dicta",Space,Str "modi.",Space,Str "Modi",Space,Str "soluta",Space,Str "velit",Space,Str "est",Space,Str "aut",Space,Str "aut",Space,Str "possimus."]
+,Para [Str "Qui",Space,Str "et",Space,Str "temporibus",Space,Str "explicabo.",Space,Str "Esse",Space,Str "ab",Space,Str "ut",Space,Str "quidem.",Space,Str "Vel",Space,Str "qui",Space,Str "perspiciatis",Space,Str "quae",Space,Str "odio",Space,Str "consectetur",Space,Str "alias",Space,Str "non",Space,Str "sed.",Space,Str "Quo",Space,Str "consectetur",Space,Str "libero",Space,Str "omnis",Space,Str "quos",Space,Str "eius",Space,Str "ad",Space,Str "vel."]]
+```


### PR DESCRIPTION
The `sloppypar` environment is used to tell LaTeX to adjust word spacing less strictly. While parsing with the extension `+raw_tex` `sloppypar` is parsed as `RawBlock`. However, pandoc should threat `sloppypar` not as `RawBlock` because it has no effect on writers. 