### PR TITLE
CommonMark writer: correctly ignore LaTeX raw blocks when not raw_tex

### DIFF
--- a/src/Text/Pandoc/Writers/CommonMark.hs
+++ b/src/Text/Pandoc/Writers/CommonMark.hs
@@ -116,7 +116,7 @@ blockToNodes _ (CodeBlock (_,classes,_) xs) ns = return
 blockToNodes opts (RawBlock fmt xs) ns
   | fmt == Format "html" && isEnabled Ext_raw_html opts
               = return (node (HTML_BLOCK (T.pack xs)) [] : ns)
-  | fmt == Format "latex" || fmt == Format "tex" && isEnabled Ext_raw_tex opts
+  | (fmt == Format "latex" || fmt == Format "tex") && isEnabled Ext_raw_tex opts
               = return (node (CUSTOM_BLOCK (T.pack xs) T.empty) [] : ns)
   | otherwise = return ns
 blockToNodes opts (BlockQuote bs) ns = do

--- a/test/command/4527.md
+++ b/test/command/4527.md
@@ -1,0 +1,21 @@
+# Raw TeX blocks in CommonMark with and without raw_tex
+
+```
+% pandoc -f latex -t commonmark-raw_tex
+\someunknowncommand
+
+Hello.
+^D
+Hello.
+```
+
+```
+% pandoc -f latex -t commonmark+raw_tex
+\someunknowncommand
+
+Hello.
+^D
+\someunknowncommand
+
+Hello.
+```


### PR DESCRIPTION
Issue #4527.