### PR TITLE
Add publishers option to latex template

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -328,6 +328,9 @@ $if(institute)$
 \institute{$for(institute)$$institute$$sep$ \and $endfor$}
 $endif$
 \date{$date$}
+$if(publishers)$
+\publishers{$publishers$}
+$endif$
 $if(beamer)$
 $if(titlegraphic)$
 \titlegraphic{\includegraphics{$titlegraphic$}}


### PR DESCRIPTION
Add the publishers command as option to the latex template.
These are included on the title page in KOMA document classes.