### PR TITLE
Haddock Writer: Use proper haddock math escapes

### DIFF
--- a/src/Text/Pandoc/Writers/Haddock.hs
+++ b/src/Text/Pandoc/Writers/Haddock.hs
@@ -251,8 +251,8 @@ inlineToHaddock _ (Str str) =
   return $ text $ escapeString str
 inlineToHaddock _ (Math mt str) =
   return $ case mt of
-    DisplayMath -> cr <> "\\\\[" <> text str <> "\\\\]" <> cr
-    InlineMath  -> ("\\(" <> text str <> "\\)")
+    DisplayMath -> cr <> "\\[" <> text str <> "\\]" <> cr
+    InlineMath  -> "\\(" <> text str <> "\\)"
 inlineToHaddock _ il@(RawInline f str)
   | f == "haddock" = return $ text str
   | otherwise = do

--- a/src/Text/Pandoc/Writers/Haddock.hs
+++ b/src/Text/Pandoc/Writers/Haddock.hs
@@ -45,7 +45,6 @@ import Text.Pandoc.Options
 import Text.Pandoc.Pretty
 import Text.Pandoc.Shared
 import Text.Pandoc.Templates (renderTemplate')
-import Text.Pandoc.Writers.Math (texMathToInlines)
 import Text.Pandoc.Writers.Shared
 
 type Notes = [[Block]]
@@ -250,11 +249,10 @@ inlineToHaddock _ (Code _ str) =
   return $ "@" <> text (escapeString str) <> "@"
 inlineToHaddock _ (Str str) =
   return $ text $ escapeString str
-inlineToHaddock opts (Math mt str) = do
-  let adjust x = case mt of
-                      DisplayMath -> cr <> x <> cr
-                      InlineMath  -> x
-  adjust <$> (lift (texMathToInlines mt str) >>= inlineListToHaddock opts)
+inlineToHaddock _ (Math mt str) =
+  return $ case mt of
+    DisplayMath -> cr <> "\\\\[" <> text str <> "\\\\]" <> cr
+    InlineMath  -> ("\\(" <> text str <> "\\)")
 inlineToHaddock _ il@(RawInline f str)
   | f == "haddock" = return $ text str
   | otherwise = do

--- a/test/writer.haddock
+++ b/test/writer.haddock
@@ -454,15 +454,15 @@ ______________________________________________________________________________
 = LaTeX
 #latex#
 
--   
--   2 + 2 = 4
--   /x/ ∈ /y/
--   /α/ ∧ /ω/
--   223
--   /p/-Tree
+-
 -   Here’s some display math:
-    $$\\frac{d}{dx}f(x)=\\lim_{h\\to 0}\\frac{f(x+h)-f(x)}{h}$$
--   Here’s one that has a line break in it: /α/ + /ω/ × /x/2.
+-   \(2+2=4\)
+-   \(x \in y\)
+-   \(\alpha \wedge \omega\)
+-   \(223\)
+-   \(p\)-Tree
+    \[\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}\]
+-   Here’s one that has a line break in it: \(\alpha + \omega \times x^2\).
 
 These shouldn’t be math:
 


### PR DESCRIPTION
As implemented here: https://github.com/haskell/haddock/pull/465/commits/3f50b955324bd4b42f88a421f0203bc46a3ccf64