### PR TITLE
4581

### DIFF
--- a/test/Tests/Readers/RST.hs
+++ b/test/Tests/Readers/RST.hs
@@ -188,4 +188,12 @@ tests = [ "line block with blank line" =:
             ] =?>
               para ("foo" <> note (para "bar"))
           ]
+        , testGroup "inlines"
+          [ "links can contain an URI without being parsed twice" =:
+            "`http://loc <http://loc>`__" =?>
+            para (link "http://loc" "" "http://loc")
+          , "inline markup cannot be nested" =:
+            "**a*b*c**" =?>
+            para (strong "a*b*c")
+          ]
         ]


### PR DESCRIPTION
This fixes the problem with double parsing of some links. Since i introduced `inlineContent` in order to fix the error, it made sense to also fix the parsing of `strong` and `emph` at least