### PR TITLE
use the `-threaded` GHC flag when building benchmarks, related to #4130

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -599,7 +599,7 @@ benchmark weigh-pandoc
      hs-source-dirs: prelude
      other-modules:  Prelude
      build-depends:  base-compat >= 0.9
-  ghc-options:   -rtsopts -Wall -fno-warn-unused-do-bind
+  ghc-options:   -rtsopts -Wall -fno-warn-unused-do-bind -threaded
   default-language: Haskell2010
   other-extensions: NoImplicitPrelude
 
@@ -702,6 +702,6 @@ benchmark benchmark-pandoc
      hs-source-dirs: prelude
      other-modules:  Prelude
      build-depends:  base-compat >= 0.9
-  ghc-options:   -rtsopts -Wall -fno-warn-unused-do-bind
+  ghc-options:   -rtsopts -Wall -fno-warn-unused-do-bind -threaded
   default-language: Haskell2010
   other-extensions: NoImplicitPrelude


### PR DESCRIPTION
without these flags i get errors similar to those described in #4130 when trying to run the benchmarks (ubuntu 16.04 LTS)

```
 pandoc (4581)*$ stack bench
pandoc-2.1.4: unregistering (local file changes: pandoc.cabal)
pandoc-2.1.4: configure (lib + exe + bench)
Configuring pandoc-2.1.4...
pandoc-2.1.4: build (lib + exe + bench)
Preprocessing library for pandoc-2.1.4..
Building library for pandoc-2.1.4..
Preprocessing benchmark 'benchmark-pandoc' for pandoc-2.1.4..
Building benchmark 'benchmark-pandoc' for pandoc-2.1.4..
Linking .stack-work/dist/x86_64-linux/Cabal-2.0.1.0/build/benchmark-pandoc/benchmark-pandoc ...
             
/home/francesco/pandoc/rts/posix/OSThreads.c:137:0: error:
     error: undefined reference to 'pthread_create'
             
/home/francesco/pandoc/rts/posix/OSThreads.c:139:0: error:
     error: undefined reference to 'pthread_detach'
             
/home/francesco/pandoc/rts/posix/OSThreads.c:141:0: error:
     error: undefined reference to 'pthread_setname_np'
             
/home/francesco/pandoc/rts/posix/OSThreads.c:184:0: error:
     error: undefined reference to 'pthread_key_create'
             
/home/francesco/pandoc/rts/posix/OSThreads.c:192:0: error:
     error: undefined reference to 'pthread_getspecific'
             
/home/francesco/pandoc/rts/posix/OSThreads.c:203:0: error:
     error: undefined reference to 'pthread_setspecific'
             
/home/francesco/pandoc/rts/posix/OSThreads.c:212:0: error:
     error: undefined reference to 'pthread_key_delete'
             
/home/francesco/pandoc/rts/posix/OSThreads.c:371:0: error:
     error: undefined reference to 'pthread_kill'
             
/home/francesco/pandoc/includes/rts/OSThreads.h:59:0: error:
     error: undefined reference to 'pthread_mutex_trylock'
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
Progress: 1/2
--  While building custom Setup.hs for package pandoc-2.1.4 using:
      /home/francesco/pandoc/.stack-work/dist/x86_64-linux/Cabal-2.0.1.0/setup/setup --builddir=.stack-work/dist/x86_64-linux/Cabal-2.0.1.0 build lib:pandoc exe:pandoc bench:benchmark-pandoc bench:weigh-pandoc --ghc-options " -ddump-hi -ddump-to-file -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
```