### PR TITLE
Adding background-image variable to reveal.js template

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -197,6 +197,11 @@ $endif$
 $if(parallaxBackgroundImage)$
         // Parallax background image
         parallaxBackgroundImage: '$parallaxBackgroundImage$', // e.g. "'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg'"
+$else$
+$if(background-image)$
+       // Parallax background image
+       parallaxBackgroundImage: '$background-image$', // e.g. "'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg'"
+$endif$
 $endif$
 $if(parallaxBackgroundSize)$
         // Parallax background size


### PR DESCRIPTION
Provide alternate variable that may be used with other presentation formats.