### PR TITLE
RST writer: preserve empty inline parents in flatten

### DIFF
--- a/src/Text/Pandoc/Writers/RST.hs
+++ b/src/Text/Pandoc/Writers/RST.hs
@@ -457,8 +457,11 @@ transformInlines =  insertBS .
 -- them either collapsing them in the outer inline container or
 -- pulling them out of it
 flatten :: Inline -> [Inline]
-flatten outer = combineAll $ dropInlineParent outer
-  where combineAll = foldl combine []
+flatten outer
+  | null contents = [outer]
+  | otherwise     = combineAll contents
+  where contents = dropInlineParent outer
+        combineAll = foldl combine []
 
         combine :: [Inline] -> Inline -> [Inline]
         combine f i = 

--- a/test/Tests/Writers/RST.hs
+++ b/test/Tests/Writers/RST.hs
@@ -64,6 +64,9 @@ tests = [ testGroup "rubrics"
             -- the test above is the reason why we call
             -- stripLeadingTrailingSpace through transformNested after
             -- flatten
+          , testCase "preserves empty parents" $
+            flatten (Image ("",[],[]) [] ("loc","title")) @?=
+            [Image ("",[],[]) [] ("loc","title")]
           ]
         , testGroup "inlines"
           [ "are removed when empty" =: -- #4434


### PR DESCRIPTION
this fixes a bad error introduced with #4554 