### PR TITLE
Introduce --metadata-file option

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -578,6 +578,16 @@ Reader options
     printed in some output formats) and metadata values will be escaped
     when inserted into the template.
 
+`--metadata-file=`*FILE*
+
+:   Read metadata from the supplied YAML (or JSON) file.
+    This option can be used with every input format, but string
+    scalars in the YAML file will always be parsed as Markdown.
+    Generally, the input will be handled the same as in
+    [YAML metadata blocks][Extension: `yaml_metadata_block`].
+    Metadata values specified inside the document, or by using `-M`,
+    overwrite values specified with this option.
+
 `-p`, `--preserve-tabs`
 
 :   Preserve tabs instead of converting them to spaces (the default).
@@ -3061,7 +3071,9 @@ and pass it to pandoc as an argument, along with your Markdown files:
     pandoc chap1.md chap2.md chap3.md metadata.yaml -s -o book.html
 
 Just be sure that the YAML file begins with `---` and ends with `---` or
-`...`.)
+`...`.) Alternatively, you can use the `--metadata-file` option. Using
+that approach however, you cannot reference content (like footnotes)
+from the main markdown input document.
 
 Metadata will be taken from the fields of the YAML object and added to any
 existing document metadata.  Metadata can contain lists and objects (nested

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -193,6 +193,7 @@ extra-source-files:
                  test/command/sub-file-chapter-1.tex
                  test/command/sub-file-chapter-2.tex
                  test/command/bar.tex
+                 test/command/yaml-metadata.yaml
                  test/command/3510-subdoc.org
                  test/command/3510-export.latex
                  test/command/3510-src.hs

--- a/test/command/yaml-metadata-blocks.md
+++ b/test/command/yaml-metadata-blocks.md
@@ -1,0 +1,48 @@
+```
+% pandoc -s -t native
+---
+foobar_: this should be ignored
+foo:
+  bar_: as should this
+---
+^D
+Pandoc (Meta {unMeta = fromList [("foo",MetaMap (fromList []))]})
+[]
+```
+```
+% pandoc -s -t native
+---
+# For precedence, see multiple-metadata-blocks.md and vars-and-metadata.md
+# For Bools, see also 4819.md
+# For Multiline strings, see yaml-with-chomp.md
+int: 7
+float: 1.5
+scientific: 3.7e-5
+bool: true
+more: False
+nothing: null
+emtpy: []
+nested:
+  int: 8
+  float: 2.5
+  bool: true
+  more: False
+  nothing: null
+  emtpy: []
+  scientific: 3.7e-5
+---
+^D
+Pandoc (Meta {unMeta = fromList [("bool",MetaBool True),("emtpy",MetaList []),("float",MetaInlines [Str "1.5"]),("int",MetaInlines [Str "7"]),("more",MetaBool False),("nested",MetaMap (fromList [("bool",MetaBool True),("emtpy",MetaList []),("float",MetaInlines [Str "2.5"]),("int",MetaInlines [Str "8"]),("more",MetaBool False),("nothing",MetaInlines [Str "null"]),("scientific",MetaInlines [Str "3.7e-5"])])),("nothing",MetaInlines [Str "null"]),("scientific",MetaInlines [Str "3.7e-5"])]})
+[]
+```
+```
+% pandoc -s -t native
+---
+array:
+  - foo: bar
+  - bool: True
+---
+^D
+Pandoc (Meta {unMeta = fromList [("array",MetaList [MetaMap (fromList [("foo",MetaInlines [Str "bar"])]),MetaMap (fromList [("bool",MetaBool True)])])]})
+[]
+```

--- a/test/command/yaml-metadata-blocks.md
+++ b/test/command/yaml-metadata-blocks.md
@@ -46,3 +46,18 @@ array:
 Pandoc (Meta {unMeta = fromList [("array",MetaList [MetaMap (fromList [("foo",MetaInlines [Str "bar"])]),MetaMap (fromList [("bool",MetaBool True)])])]})
 []
 ```
+```
+% pandoc -s -t native --metadata-file command/yaml-metadata.yaml
+---
+title: document
+---
+^D
+Pandoc (Meta {unMeta = fromList [("other",MetaInlines [Emph [Str "markdown"],Space,Str "value"]),("title",MetaInlines [Str "document"])]})
+[]
+```
+```
+% pandoc -s -t native --metadata-file command/yaml-metadata.yaml -M title=cmdline
+^D
+Pandoc (Meta {unMeta = fromList [("other",MetaInlines [Emph [Str "markdown"],Space,Str "value"]),("title",MetaString "cmdline")]})
+[]
+```

--- a/test/command/yaml-metadata.yaml
+++ b/test/command/yaml-metadata.yaml
@@ -1,0 +1,4 @@
+---
+title: file
+other: _markdown_ value
+---


### PR DESCRIPTION
implements #1960 and solves https://github.com/jgm/pandoc/issues/3115

I finally got this compiling... still need to do some testing (especially around whether metadata from different sources has the right precedences) and write docs.

But feel free to play around with it!

Also: since YAML is a superset of JSON, you can actually already use this with `--metadata-file file.json`