### PR TITLE
new Greek fallback typeface (would fix #4405)

### DIFF
--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -54,7 +54,7 @@ $endif$
 
 \setupbodyfontenvironment[default][em=italic] % use italic as em, not slanted
 
-\definefallbackfamily[mainface][rm][DejaVu Serif][preset=range:greek, force=yes]
+\definefallbackfamily[mainface][rm][CMU Serif][preset=range:greek, force=yes]
 \definefontfamily[mainface][rm][$if(mainfont)$$mainfont$$else$Latin Modern Roman$endif$]
 \definefontfamily[mainface][mm][$if(mathfont)$$mathfont$$else$Latin Modern Math$endif$]
 \definefontfamily[mainface][ss][$if(sansfont)$$sansfont$$else$Latin Modern Sans$endif$]


### PR DESCRIPTION
CMU Serif would give better typographic results
than the current Greek fallback DejaVu Serif.