### PR TITLE
Make template polyglot

### DIFF
--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -29,7 +29,7 @@ $highlighting-css$
   </style>
 $endif$
 $for(css)$
-  <link rel="stylesheet" href="$css$">
+  <link rel="stylesheet" href="$css$" />
 $endfor$
 $if(math)$
   $math$


### PR DESCRIPTION
The HTML produced by this template may not be well-formed in an XML sense due to this line:  \<link rel="stylesheet" href="$css$"\>
So by making the link element self-closing the HTML produced by the template will be polyglot.