### PR TITLE
catch IO errors when writing media files, closes #4559

### DIFF
--- a/src/Text/Pandoc/Logging.hs
+++ b/src/Text/Pandoc/Logging.hs
@@ -85,6 +85,7 @@ data LogMessage =
   | InlineNotRendered Inline
   | BlockNotRendered Block
   | DocxParserWarning String
+  | IgnoredIOError String
   | CouldNotFetchResource String String
   | CouldNotDetermineImageSize String String
   | CouldNotConvertImage String String
@@ -174,6 +175,8 @@ instance ToJSON LogMessage where
       BlockNotRendered bl ->
            ["contents" .= toJSON bl]
       DocxParserWarning s ->
+           ["contents" .= Text.pack s]
+      IgnoredIOError s ->
            ["contents" .= Text.pack s]
       CouldNotFetchResource fp s ->
            ["path" .= Text.pack fp,
@@ -265,6 +268,8 @@ showLogMessage msg =
          "Not rendering " ++ show bl
        DocxParserWarning s ->
          "Docx parser warning: " ++ s
+       IgnoredIOError s ->
+         "IO Error (ignored): " ++ s
        CouldNotFetchResource fp s ->
          "Could not fetch resource '" ++ fp ++ "'" ++
            if null s then "" else ": " ++ s
@@ -332,6 +337,7 @@ messageVerbosity msg =
        InlineNotRendered{}          -> INFO
        BlockNotRendered{}           -> INFO
        DocxParserWarning{}          -> INFO
+       IgnoredIOError{}             -> WARNING
        CouldNotFetchResource{}      -> WARNING
        CouldNotDetermineImageSize{} -> WARNING
        CouldNotConvertImage{}       -> WARNING


### PR DESCRIPTION
if we do not catch these errors, any malformed entry in a media bag
could cause the loss of a whole document output. an example of
malformed entry is an entry with an empty file path.

for the error logging i looked for a way to preserve information from the IO error. An IO error like `media/.: openBinaryFile: inappropriate type (Is a directory)` can give helpful troubleshooting information to the users in case of errors in a path or problems with permission
