### PR TITLE
Correct the macOS homebrew note

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,9 +29,9 @@
 
   - Alternatively, you can install pandoc using
     [homebrew](http://brew.sh): `brew install pandoc`.
-    Note: This method installs pandoc from source, so it
-    will take a long time and a lot of disk space for the
-    ghc compiler and dependent Haskell libraries.
+    Note: If you are using macOS < 10.10, this method installs 
+    pandoc from source, so it will take a long time and a lot of 
+    disk space for the ghc compiler and dependent Haskell libraries.
 
   - For PDF output, you'll also need LaTeX.  Because a full [MacTeX]
     installation takes more than a gigabyte of disk space, we recommend


### PR DESCRIPTION
By default for all versions of macOS > 10.10 (released in 2015), homebrew does install binary packages, it does not use source to build. So update note to mention a source build is only an issue for old versions of the OS.