### PR TITLE
Adding a variable romanfont

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -57,6 +57,9 @@ $endfor$
 $if(mainfont)$
     \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$
+$if(romanfont)$
+	\setsansfont[$for(romanfontoptions)$$romanfontoptions$$sep$,$endfor$]{$romanfont$}
+$endif$
 $if(sansfont)$
     \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
 $endif$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -58,7 +58,7 @@ $if(mainfont)$
     \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$
 $if(romanfont)$
-	\setsansfont[$for(romanfontoptions)$$romanfontoptions$$sep$,$endfor$]{$romanfont$}
+	\setromanfont[$for(romanfontoptions)$$romanfontoptions$$sep$,$endfor$]{$romanfont$}
 $endif$
 $if(sansfont)$
     \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}


### PR DESCRIPTION
It would be nice to have a possibility to set the romanfont in xelatex/lualatex over a variable since mainfont actually oversets sansfont in headings