### PR TITLE
emphasize Ext_east_asian_line_breaks will not take effect when called as libraries

### DIFF
--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -101,7 +101,10 @@ data Extension =
                                     --   and disallow laziness
     | Ext_definition_lists    -- ^ Definition lists as in pandoc, mmd, php
     | Ext_east_asian_line_breaks  -- ^ Newlines in paragraphs are ignored between
-                                  --   East Asian wide characters
+                                  --   East Asian wide characters(If readers/writers
+                                  --   are called as libraries, this extension will not
+                                  --   take effect. Please use eastAsianLineBreakFilter
+                                  --   instead)
     | Ext_emoji               -- ^ Support emoji like :smile:
     | Ext_empty_paragraphs -- ^ Allow empty paragraphs
     | Ext_epub_html_exts      -- ^ Recognise the EPUB extended version of HTML

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -101,10 +101,10 @@ data Extension =
                                     --   and disallow laziness
     | Ext_definition_lists    -- ^ Definition lists as in pandoc, mmd, php
     | Ext_east_asian_line_breaks  -- ^ Newlines in paragraphs are ignored between
-                                  --   East Asian wide characters(If readers/writers
-                                  --   are called as libraries, this extension will not
-                                  --   take effect. Please use eastAsianLineBreakFilter
-                                  --   instead)
+                                  --   East Asian wide characters. Note: this extension
+                                  --   does not affect readers/writers directly; it causes
+                                  --   the eastAsianLineBreakFilter to be applied after
+                                  --   parsing, in Text.Pandoc.App.convertWithOpts.
     | Ext_emoji               -- ^ Support emoji like :smile:
     | Ext_empty_paragraphs -- ^ Allow empty paragraphs
     | Ext_epub_html_exts      -- ^ Recognise the EPUB extended version of HTML


### PR DESCRIPTION
According to https://github.com/jgm/pandoc/issues/3703, `Ext_east_asian_line_breaks` will not take effect when readers/writers are called as libraries. And I think this is a nice solution for universal conversion with `Ext_east_asian_line_breaks`. However, I have spent hours to find out why my reader options don't take effect, until discover your discussion in https://github.com/jgm/pandoc/issues/3703. So I think it would be great if we add some description about the limitation.