### PR TITLE
Beamer: Allow "noframenumbering" option

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4438,7 +4438,7 @@ introducing the slide:
 All of the other frame attributes described in Section 8.1 of
 the [Beamer User's Guide] may also be used: `allowdisplaybreaks`,
 `allowframebreaks`, `b`, `c`, `t`, `environment`, `label`, `plain`,
-`shrink`.
+`shrink`, `standout`, `noframenumbering`.
 
 Background in reveal.js
 -----------------------

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -402,7 +402,8 @@ elementToBeamer slideLevel  (Sec lvl _num (ident,classes,kvs) tit elts)
                     not (null $ query hasCodeBlock elts ++ query hasCode elts)
       let frameoptions = ["allowdisplaybreaks", "allowframebreaks", "fragile",
                           "b", "c", "t", "environment",
-                          "label", "plain", "shrink", "standout"]
+                          "label", "plain", "shrink", "standout",
+                          "noframenumbering"]
       let optionslist = ["fragile" | fragile && isNothing (lookup "fragile" kvs)] ++
                         [k | k <- classes, k `elem` frameoptions] ++
                         [k ++ "=" ++ v | (k,v) <- kvs, k `elem` frameoptions]


### PR DESCRIPTION
As noted [here](https://tex.stackexchange.com/a/49805) ([beamer commit here](https://github.com/josephwright/beamer/commit/ff70090f36b631667b472cfe675fc3514fe46f7e)), `noframenumbering` is an undocumented, but long existing option to disable frame numbering for a particular slide. This is useful to avoid numbering backup slides (the natural approach of defining an appendix doesn't work due to the issue described [here](https://github.com/jgm/pandoc/issues/4403)). This PR makes the trivial change to support this option by adding it to the available `frameoptions`.

(I also noted the "standout" option in the manual while adding "noframenumbering")

Thanks for developing such an excellent tool!