### PR TITLE
TikiWiki reader: improve list parsing

### DIFF
--- a/src/Text/Pandoc/Readers/TikiWiki.hs
+++ b/src/Text/Pandoc/Readers/TikiWiki.hs
@@ -22,6 +22,7 @@ import Prelude
 import Control.Monad
 import Control.Monad.Except (throwError)
 import qualified Data.Foldable as F
+import Data.List (dropWhileEnd)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -319,7 +320,7 @@ listItem = choice [
 bulletItem :: PandocMonad m => TikiWikiParser m (ListNesting, B.Blocks)
 bulletItem = try $ do
   prefix <- many1 $ char '*'
-  many1 $ char ' '
+  many $ char ' '
   content <- listItemLine (length prefix)
   return (LN Bullet (length prefix), B.plain content)
 
@@ -331,7 +332,7 @@ bulletItem = try $ do
 numberedItem :: PandocMonad m => TikiWikiParser m (ListNesting, B.Blocks)
 numberedItem = try $ do
   prefix <- many1 $ char '#'
-  many1 $ char ' '
+  many $ char ' '
   content <- listItemLine (length prefix)
   return (LN Numbered (length prefix), B.plain content)
 
@@ -346,7 +347,7 @@ listItemLine nest = lineContent >>= parseContent
     listContinuation = string (replicate nest '+') >> lineContent
     parseContent x = do
       parsed <- parseFromString (many1 inline) x
-      return $ mconcat parsed
+      return $ mconcat $ dropWhileEnd (== B.space) parsed
 
 -- Turn the CODE macro attributes into Pandoc code block attributes.
 mungeAttrs :: [(String, String)] -> (String, [String], [(String, String)])

--- a/test/command/4722.md
+++ b/test/command/4722.md
@@ -1,0 +1,34 @@
+```
+% pandoc -f tikiwiki -t native
+*Level 1
+*Level 1
+**Level 2
+***Level 3
+*Level 1
+^D
+[BulletList
+ [[Plain [Str "Level",Space,Str "1"]]
+ ,[Plain [Str "Level",Space,Str "1"]
+  ,BulletList
+   [[Plain [Str "Level",Space,Str "2"]
+    ,BulletList
+     [[Plain [Str "Level",Space,Str "3"]]]]]]
+ ,[Plain [Str "Level",Space,Str "1"]]]]
+```
+```
+% pandoc -f tikiwiki -t native
+#Level 1
+#Level 1
+##Level 2
+###Level 3
+#Level 1
+^D
+[OrderedList (1,DefaultStyle,DefaultDelim)
+ [[Plain [Str "Level",Space,Str "1"]]
+ ,[Plain [Str "Level",Space,Str "1"]
+  ,OrderedList (1,DefaultStyle,DefaultDelim)
+   [[Plain [Str "Level",Space,Str "2"]
+    ,OrderedList (1,DefaultStyle,DefaultDelim)
+     [[Plain [Str "Level",Space,Str "3"]]]]]]
+ ,[Plain [Str "Level",Space,Str "1"]]]]
+```

--- a/test/tikiwiki-reader.native
+++ b/test/tikiwiki-reader.native
@@ -43,52 +43,52 @@ Pandoc (Meta {unMeta = fromList []})
 ,Para [Str "info@example.org"]
 ,Header 1 ("lists",[],[]) [Str "lists"]
 ,BulletList
- [[Plain [Str "Start",Space,Str "each",Space,Str "line",Space]]
- ,[Plain [Str "with",Space,Str "an",Space,Str "asterisk",Space,Str "(*).",Space]
+ [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]
+ ,[Plain [Str "with",Space,Str "an",Space,Str "asterisk",Space,Str "(*)."]
   ,BulletList
-   [[Plain [Str "More",Space,Str "asterisks",Space,Str "gives",Space,Str "deeper",Space]
+   [[Plain [Str "More",Space,Str "asterisks",Space,Str "gives",Space,Str "deeper"]
     ,BulletList
-     [[Plain [Str "and",Space,Str "deeper",Space,Str "levels.",Space]]]]]]
- ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels.",Space]]
- ,[Plain [Str "Continuations",Space,Str "are",Space,Str "also",Space,Str "possible",Space]
+     [[Plain [Str "and",Space,Str "deeper",Space,Str "levels."]]]]]]
+ ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels."]]
+ ,[Plain [Str "Continuations",Space,Str "are",Space,Str "also",Space,Str "possible"]
   ,BulletList
-   [[Plain [Str "and",Space,Str "do",Space,Str "not",Space,Str "break",Space,Str "the",Space,Str "list",Space,Str "flow",Space]]]]
- ,[Plain [Str "Level",Space,Str "one",Space]]]
+   [[Plain [Str "and",Space,Str "do",Space,Str "not",Space,Str "break",Space,Str "the",Space,Str "list",Space,Str "flow"]]]]
+ ,[Plain [Str "Level",Space,Str "one"]]]
 ,Para [Str "Any",Space,Str "other",Space,Str "start",Space,Str "ends",Space,Str "the",Space,Str "list."]
 ,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Start",Space,Str "each",Space,Str "line",Space]]
- ,[Plain [Str "with",Space,Str "a",Space,Str "number",Space,Str "(1.).",Space]
+ [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]
+ ,[Plain [Str "with",Space,Str "a",Space,Str "number",Space,Str "(1.)."]
   ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "More",Space,Str "number",Space,Str "signs",Space,Str "gives",Space,Str "deeper",Space]
+   [[Plain [Str "More",Space,Str "number",Space,Str "signs",Space,Str "gives",Space,Str "deeper"]
     ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "and",Space,Str "deeper",Space]]
-     ,[Plain [Str "levels.",Space]]]]]]
- ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels.",Space]]
- ,[Plain [Str "Blank",Space,Str "lines",Space]]]
+     [[Plain [Str "and",Space,Str "deeper"]]
+     ,[Plain [Str "levels."]]]]]]
+ ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels."]]
+ ,[Plain [Str "Blank",Space,Str "lines"]]]
 ,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "end",Space,Str "the",Space,Str "list",Space,Str "and",Space,Str "start",Space,Str "another.",Space]]]
+ [[Plain [Str "end",Space,Str "the",Space,Str "list",Space,Str "and",Space,Str "start",Space,Str "another."]]]
 ,Para [Str "Any",Space,Str "other",Space,Str "start",Space,Str "also",Space,Str "ends",Space,Str "the",Space,Str "list."]
 ,DefinitionList
  [([Str "item",Space,Str "1"],
-   [[Plain [Str "definition",Space,Str "1",Space]]])
+   [[Plain [Str "definition",Space,Str "1"]]])
  ,([Str "item",Space,Str "2"],
-   [[Plain [Str "definition",Space,Str "2-1",Space,Str "definition",Space,Str "2-2",Space]]])
+   [[Plain [Str "definition",Space,Str "2-1",Space,Str "definition",Space,Str "2-2"]]])
  ,([Str "item",Space,Emph [Str "3"]],
-   [[Plain [Str "definition",Space,Emph [Str "3"],Space]]])]
+   [[Plain [Str "definition",Space,Emph [Str "3"]]]])]
 ,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "one",Space]]
- ,[Plain [Str "two",Space]
+ [[Plain [Str "one"]]
+ ,[Plain [Str "two"]
   ,BulletList
-   [[Plain [Str "two",Space,Str "point",Space,Str "one",Space]]
-   ,[Plain [Str "two",Space,Str "point",Space,Str "two",Space]]]]
- ,[Plain [Str "three",Space]]
- ,[Plain [Str "four",Space]]
- ,[Plain [Str "five",Space]
+   [[Plain [Str "two",Space,Str "point",Space,Str "one"]]
+   ,[Plain [Str "two",Space,Str "point",Space,Str "two"]]]]
+ ,[Plain [Str "three"]]
+ ,[Plain [Str "four"]]
+ ,[Plain [Str "five"]
   ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "five",Space,Str "sub",Space,Str "1",Space]
+   [[Plain [Str "five",Space,Str "sub",Space,Str "1"]
     ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "five",Space,Str "sub",Space,Str "1",Space,Str "sub",Space,Str "1",Space]]]]
-   ,[Plain [Str "five",Space,Str "sub",Space,Str "2",Space]]]]]
+     [[Plain [Str "five",Space,Str "sub",Space,Str "1",Space,Str "sub",Space,Str "1"]]]]
+   ,[Plain [Str "five",Space,Str "sub",Space,Str "2"]]]]]
 ,Header 1 ("tables",[],[]) [Str "tables"]
 ,Table [] [AlignDefault,AlignDefault] [0.0,0.0]
  [[Plain [Str ""]]


### PR DESCRIPTION
- remove trailing Space from list items
- also parse lists that have no space after list marker (fixes #4722)

@rlpowell what do you think?