### PR TITLE
pandoc.cabal: fix lowe yaml bound up to 0.8.11

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -374,7 +374,7 @@ library
                  temporary >= 1.1 && < 1.4,
                  blaze-html >= 0.9 && < 0.10,
                  blaze-markup >= 0.8 && < 0.9,
-                 yaml >= 0.8.10.1 && < 0.9,
+                 yaml >= 0.8.11 && < 0.9,
                  scientific >= 0.2 && < 0.4,
                  vector >= 0.10 && < 0.13,
                  hslua >= 0.9.5 && < 0.9.6,


### PR DESCRIPTION
`prettyPrintParseException` was added to yaml-0.8.11:
https://hackage.haskell.org/package/yaml-0.8.30/docs/src/Data.Yaml.Internal.html#prettyPrintParseException

Noticed by tgbugs in https://github.com/gentoo-haskell/gentoo-haskell/issues/725

Reported-by: tgbugs
Bug: https://github.com/jgm/pandoc/issues/4726
Bug: https://github.com/gentoo-haskell/gentoo-haskell/issues/725
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>