### PR TITLE
Make HTML5 header easier to style precisely in default template

### DIFF
--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -46,7 +46,7 @@ $for(include-before)$
 $include-before$
 $endfor$
 $if(title)$
-<header id="document-summary-header">
+<header id="title-block-header">
 <h1 class="title">$title$</h1>
 $if(subtitle)$
 <p class="subtitle">$subtitle$</p>

--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -46,7 +46,7 @@ $for(include-before)$
 $include-before$
 $endfor$
 $if(title)$
-<header>
+<header id="document-summary-header">
 <h1 class="title">$title$</h1>
 $if(subtitle)$
 <p class="subtitle">$subtitle$</p>

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -19,7 +19,7 @@
   <![endif]-->
 </head>
 <body>
-<header>
+<header id="document-summary-header">
 <h1 class="title">Pandoc Test Suite</h1>
 <p class="author">John MacFarlane</p>
 <p class="author">Anonymous</p>

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -19,7 +19,7 @@
   <![endif]-->
 </head>
 <body>
-<header id="document-summary-header">
+<header id="title-block-header">
 <h1 class="title">Pandoc Test Suite</h1>
 <p class="author">John MacFarlane</p>
 <p class="author">Anonymous</p>


### PR DESCRIPTION
I've added an ID to the `header` element of the HTML5 template in order to style the element with a more-precise CSS rule. This should enable more flexibility without damaging any existing style rules out there which styled the `header` tag without reference to the ID I've added.

Composing an article in Typora triggered this change. Pandoc's HTML5 template generates a `header` with document information that I didn't want to display, which led me to style it as `header { display: none; }`. Typora, unfortunately, uses the `header` tag to implement its editor sidebar, including useful things like a file tree and a document outline. By styling the document with `header { display: none; }`, I was turning that useful feature off. I wanted it back on.

Yes, I could use just a local template override, but it seems to me that this change can only benefit users and not hurt them. Anyone who needs to style `header` will not be affected by the change and anyone who would be annoyed by styling `header` instead of more specific subset of HTML nodes is pleasantly surprised by the helpful ID to select for their style rule. By the look of it, everyone wins.

This would introduce a slightly different incompatibility between the HTML4 template (`<div id="{header-prefix}header">`) and the HTML5 template (`<header id="document-summary-header">`), but a similar incompatibility was already there, so this change doesn't make that any worse. We could argue for a better ID for this element, and I really don't mind what it's called.