### PR TITLE
Add missing rollingLinks option to revealjs template

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -170,6 +170,10 @@ $if(mouseWheel)$
         // Enable slide navigation via mouse wheel
         mouseWheel: $mouseWheel$,
 $endif$
+$if(rollingLinks)$
+        // Apply a 3D roll to links on hover
+        rollingLinks: $rollingLinks$,
+$endif$
 $if(hideAddressBar)$
         // Hides the address bar on mobile devices
         hideAddressBar: $hideAddressBar$,


### PR DESCRIPTION
Fix (add) the missing option [rollingLinks](https://github.com/hakimel/reveal.js/blob/3.6.0/js/reveal.js#L142) in reveal.js template.

