### PR TITLE
MANUAL: clarify gfm vs markdown_github

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -225,9 +225,9 @@ General options
     - `epub` ([EPUB])
     - `fb2` ([FictionBook2] e-book)
     - `gfm` ([GitHub-Flavored Markdown]),
-      or `markdown_github`, which provides deprecated and less accurate
-      support for Github-Flavored Markdown; please use `gfm` instead,
-      unless you need to use extensions other than `smart`.
+      or the deprecated and less accurate `markdown_github`;
+      use [`markdown_github`](#markdown-variants) only
+      if you need extensions not supported in [`gfm`](#markdown-variants).
     - `haddock` ([Haddock markup])
     - `html` ([HTML])
     - `jats` ([JATS] XML)
@@ -274,9 +274,9 @@ General options
     - `epub2` (EPUB v2)
     - `fb2` ([FictionBook2] e-book)
     - `gfm` ([GitHub-Flavored Markdown]),
-      or `markdown_github`, which provides deprecated and less accurate
-      support for Github-Flavored Markdown; please use `gfm` instead,
-      unless you use extensions that do not work with `gfm`.
+      or the deprecated and less accurate `markdown_github`;
+      use [`markdown_github`](#markdown-variants) only
+      if you need extensions not supported in [`gfm`](#markdown-variants).
     - `haddock` ([Haddock markup])
     - `html` or `html5` ([HTML], i.e. [HTML5]/XHTML [polyglot markup])
     - `html4` ([XHTML] 1.0 Transitional)
@@ -4186,7 +4186,7 @@ individually disabled.
 Also, `raw_tex` only affects `gfm` output, not input.
 
 `gfm` (GitHub-Flavored Markdown)
-:   `pipe_tables`, `raw_html`, `fenced_code_blocks`, `auto_identifiers`,
+:   `pipe_tables`, `raw_html`, `fenced_code_blocks`, `gfm_auto_identifiers`,
     `ascii_identifiers`, `backtick_code_blocks`, `autolink_bare_uris`,
     `intraword_underscores`, `strikeout`, `hard_line_breaks`, `emoji`,
     `shortcut_reference_links`, `angle_brackets_escapable`.


### PR DESCRIPTION
Hopefully, this wording is clearer? There was at least [someone](https://github.com/jgm/pandoc/issues/4782) thinking `gfm` and `markdown_github` were synonyms. And a few other people asking why `gfm` doesn't support certain extensions.