### PR TITLE
Support "toc-title" in the beamer template.

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1352,7 +1352,7 @@ depending on the output format, but include the following:
 
 `toc-title`
 :   title of table of contents (works only with EPUB,
-    opendocument, odt, docx, pptx)
+    opendocument, odt, docx, pptx, beamer)
 
 `include-before`
 :   contents specified by `-B/--include-before-body` (may have

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -361,6 +361,9 @@ $endfor$
 $if(toc)$
 $if(beamer)$
 \begin{frame}
+$if(toc-title)$
+\frametitle{$toc-title$}
+$endif$
 \tableofcontents[hideallsubsections]
 \end{frame}
 $else$


### PR DESCRIPTION
It is a bit awkward to have a title for every frame, but not for the one
that holds the table of contents. Allow users to specify a title if they
wish.