### PR TITLE
Add support for $toc-title$ to LaTeX (and PDF).

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1352,7 +1352,7 @@ depending on the output format, but include the following:
 
 `toc-title`
 :   title of table of contents (works only with EPUB,
-    opendocument, odt, docx, pptx, beamer)
+    opendocument, odt, docx, pptx, beamer, LaTeX)
 
 `include-before`
 :   contents specified by `-B/--include-before-body` (may have

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -360,6 +360,9 @@ $include-before$
 
 $endfor$
 $if(toc)$
+$if(toc-title)$
+\renewcommand*\contentsname{$toc-title$}
+$endif$
 $if(beamer)$
 \begin{frame}
 $if(toc-title)$


### PR DESCRIPTION
This PR adds support for a [custom toc title](https://pandoc.org/MANUAL.html#variables-set-by-pandoc) to the default LaTeX template (and resulting PDFs). It also updates the manual for the option `toc-title`.