### PR TITLE
Add "default" syntax highlighter language

### DIFF
--- a/src/Text/Pandoc/Highlighting.hs
+++ b/src/Text/Pandoc/Highlighting.hs
@@ -149,6 +149,7 @@ langsList =
   ("command.com","command.com"),
   ("comsol","Comsol"),
   ("csh","csh"),
+  ("default","default"),
   ("delphi","Delphi"),
   ("elan","Elan"),
   ("erlang","erlang"),


### PR DESCRIPTION
@jgm Thanks for your amazing work on Pandoc, it's an incredible tool!

This adds [skylighting's `default` syntax description](https://github.com/jgm/skylighting/blob/master/skylighting-core/xml/default.xml) as a syntax highlighter language. 

Currently, code blocks rendered with skylighting and "plain text" code blocks lead to different outputs (background color settings from the highlighting theme are not applied):

<img width="560" alt="screenshot 2018-08-26 14 16 17" src="https://user-images.githubusercontent.com/306708/44633100-05c8a400-a93b-11e8-9df0-96fe2c50b515.png">

This change allows rendering code blocks containing plain text (no syntax highlighting) with the same background and text color settings used by skylighting-styled by setting their language to `default`.

About the `default` language:

> This just highlights everything as Normal Text; use it when you don't want highlighting but you do want the other formatting added by this library to be consistent with that of highlighted code. [Source](https://github.com/jgm/skylighting/commits/master/skylighting-core/xml/default.xml)