### PR TITLE
Remove unnecessary indenting of TOC title in ODT template

### DIFF
--- a/data/templates/default.opendocument
+++ b/data/templates/default.opendocument
@@ -26,9 +26,7 @@ $endfor$
 $if(toc)$
 <text:table-of-content>
   <text:table-of-content-source text:outline-level="10">
-    <text:index-title-template text:style-name="Contents_20_Heading">
-        $toc-title$
-    </text:index-title-template>
+    <text:index-title-template text:style-name="Contents_20_Heading">$toc-title$</text:index-title-template>
     <text:table-of-content-entry-template text:outline-level="1"
     text:style-name="Contents_20_1">
       <text:index-entry-link-start text:style-name="Internet_20_link" />


### PR DESCRIPTION
Remove unnecessary indenting of TOC title in ODT template.
Fixes #4798