### PR TITLE
[doc] FIX #4871 : Encoding issue with `--listings`

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -904,7 +904,7 @@ Options affecting specific writers
 :   Use the [`listings`] package for LaTeX code blocks. The package
     does not support multi-byte encoding for source code. To handle UTF-8
     you would need to use a custom template. This issue is fully 
-    documented here : [Encoding issue with the listings package].
+    documented here: [Encoding issue with the listings package].
 
 `-i`, `--incremental`
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1132,7 +1132,8 @@ Options affecting specific writers
 
 [Dublin Core elements]: http://dublincore.org/documents/dces/
 [ISO 8601 format]: http://www.w3.org/TR/NOTE-datetime
-[Encoding issue with the listings package]: https://en.wikibooks.org/wiki/LaTeX/Source_Code_Listings#Encoding_issue
+[Encoding issue with the listings package]:
+  https://en.wikibooks.org/wiki/LaTeX/Source_Code_Listings#Encoding_issue
 
 Citation rendering
 ------------------

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -901,7 +901,10 @@ Options affecting specific writers
 
 `--listings`
 
-:   Use the [`listings`] package for LaTeX code blocks
+:   Use the [`listings`] package for LaTeX code blocks. The package
+    does not support multi-byte encoding for source code. To handle UTF-8
+    you would need to use a custom template. This issue is fully 
+    documented here : [Encoding issue with the listings package].
 
 `-i`, `--incremental`
 
@@ -1129,6 +1132,7 @@ Options affecting specific writers
 
 [Dublin Core elements]: http://dublincore.org/documents/dces/
 [ISO 8601 format]: http://www.w3.org/TR/NOTE-datetime
+[Encoding issue with the listings package]: https://en.wikibooks.org/wiki/LaTeX/Source_Code_Listings#Encoding_issue
 
 Citation rendering
 ------------------


### PR DESCRIPTION
Small patch to provide more details about potential UTF8 enconding problems with `listings` and a link to possible workarounds.

Closes #4871 