### PR TITLE
Fix percentage image scaling in ODT

### DIFF
--- a/src/Text/Pandoc/Writers/ODT.hs
+++ b/src/Text/Pandoc/Writers/ODT.hs
@@ -189,8 +189,8 @@ transformPicMath opts (Image attr@(id', cls, _) lab (src,t)) = catchError
        let dims =
              case (getDim Width, getDim Height) of
                (Just w, Just h)              -> [("width", show w), ("height", show h)]
-               (Just w@(Percent p), Nothing) -> [("width", show w), ("height", show (p / ratio) ++ "%")]
-               (Nothing, Just h@(Percent p)) -> [("width", show (p * ratio) ++ "%"), ("height", show h)]
+               (Just w@(Percent _), Nothing) -> [("rel-width", show w),("rel-height", "scale"),("width", show ptX ++ "pt"),("height", show ptY ++ "pt")]
+               (Nothing, Just h@(Percent _)) -> [("rel-width", "scale"),("rel-height", show h),("width", show ptX ++ "pt"),("height", show ptY ++ "pt")]
                (Just w@(Inch i), Nothing)    -> [("width", show w), ("height", show (i / ratio) ++ "in")]
                (Nothing, Just h@(Inch i))    -> [("width", show (i * ratio) ++ "in"), ("height", show h)]
                _                             -> [("width", show ptX ++ "pt"), ("height", show ptY ++ "pt")]

--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -506,7 +506,9 @@ inlineToOpenDocument o ils
                modify (\st -> st{ stImageId = id' + 1 })
                let getDims [] = []
                    getDims (("width", w) :xs) = ("svg:width", w)  : getDims xs
+                   getDims (("rel-width", w):xs) = ("style:rel-width", w) : getDims xs
                    getDims (("height", h):xs) = ("svg:height", h) : getDims xs
+                   getDims (("rel-height", w):xs) = ("style:rel-height", w) : getDims xs
                    getDims (_:xs) =                             getDims xs
                return $ inTags False "draw:frame"
                         (("draw:name", "img" ++ show id') : getDims kvs) $


### PR DESCRIPTION
Image scaling in ODT was broken when a width was set to
a percentage. The width was passed to the svg:width field
as a pecentage, which is not correct according to the ODT
standard.

Instead the real dimensions should be passed as width and
height and the style:rel-width attribute should be set to the
percentage while style:rel-heigh attribute should be set to
"scale". The converse is true if a percentage height is given.

This is now fixed and documents produced are now properly
scaled.