### PR TITLE
parse rST inlines containing newlines closing #4912

### DIFF
--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -1315,7 +1315,6 @@ table = gridTable False <|> simpleTable False <|>
 inline :: PandocMonad m => RSTParser m Inlines
 inline = choice [ note          -- can start with whitespace, so try before ws
                 , link
-                , endline
                 , strong
                 , emph
                 , code
@@ -1328,6 +1327,7 @@ inline = choice [ note          -- can start with whitespace, so try before ws
 inlineContent :: PandocMonad m => RSTParser m Inlines
 inlineContent = choice [ whitespace
                        , str
+                       , endline
                        , smart
                        , hyphens
                        , escapedChar

--- a/test/Tests/Readers/RST.hs
+++ b/test/Tests/Readers/RST.hs
@@ -198,5 +198,8 @@ tests = [ "line block with blank line" =:
           , "bare URI parsing disabled inside emphasis (#4561)" =:
             "*http://location*" =?>
             para (emph (text "http://location"))
+          , "include newlines" =:
+            "**before\nafter**" =?>
+            para (strong (text "before\nafter"))
           ]
         ]


### PR DESCRIPTION
this eliminates a regression error introduced after pandoc 2.1.1,
affecting rST inline parsing. see the issue for details