### PR TITLE
ConTeXt writer: Fix floats

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2060,6 +2060,18 @@ In the `context` output format this enables the use of [Natural Tables
 Natural tables allow more fine-grained global customization but come
 at a performance penalty compared to extreme tables.
 
+#### Extension: `nofloat` ####
+
+Some document processing system, mostly those derived from TeX, place
+tables and images in so called “inserts”.  These inserts float around
+the page to achieve optimal placement of elements in the text with
+regards to pagebreaking.  Sometimes however, this behavior can be
+undesirable and floats should be fixed at the position at which they
+appear in the source.  If you are sure that you know what you are
+doing and are certain that you want to take the risk of extremely poor
+pagebreaks, you can add this extension to the writer.  Currently only
+the ConTeXt writer is supported.
+
 
 Pandoc's Markdown
 =================

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -141,6 +141,7 @@ data Extension =
     | Ext_multiline_tables    -- ^ Pandoc-style multiline tables
     | Ext_native_divs             -- ^ Use Div blocks for contents of <div> tags
     | Ext_native_spans            -- ^ Use Span inlines for contents of <span>
+    | Ext_nofloat                 -- ^ Fix floats (currently only for ConTeXt)
     | Ext_ntb                 -- ^ ConTeXt Natural Tables
     | Ext_old_dashes          -- ^ -- = em, - before number = en
     | Ext_pandoc_title_block  -- ^ Pandoc title block

--- a/test/Tests/Writers/ConTeXt.hs
+++ b/test/Tests/Writers/ConTeXt.hs
@@ -17,6 +17,9 @@ context = unpack . purely (writeConTeXt def) . toPandoc
 context' :: (ToPandoc a) => a -> String
 context' = unpack . purely (writeConTeXt def{ writerWrapText = WrapNone }) . toPandoc
 
+contextNofloat :: (ToPandoc a) => a -> String
+contextNofloat = unpack . purely (writeConTeXt def{ writerExtensions = enableExtension Ext_nofloat pandocExtensions }) . toPandoc
+
 contextNtb :: (ToPandoc a) => a -> String
 contextNtb = unpack . purely (writeConTeXt def{ writerExtensions = enableExtension Ext_ntb pandocExtensions }) . toPandoc
 
@@ -147,5 +150,29 @@ tests = [ testGroup "inline code"
                           , "\\stopTABLEfoot"
                           , "\\stopTABLE"
                           , "\\stopplacetable" ]
+            ]
+        , testGroup "nofloat"
+            [ test contextNofloat "table with header and caption" $
+              let caption = text "Table 1"
+                  aligns = [(AlignDefault, 0.0)]
+                  headers = [plain $ text "Test"]
+              in table caption aligns headers []
+              =?> unlines [ "\\startplacetable[location={force},title={Table 1}]"
+                          , "\\startxtable"
+                          , "\\startxtablehead[head]"
+                          , "\\startxrow"
+                          , "\\startxcell Test \\stopxcell"
+                          , "\\stopxrow"
+                          , "\\stopxtablehead"
+                          , "\\stopxtable"
+                          , "\\stopplacetable" ]
+            , test contextNofloat "image with caption" $
+              let caption = text "Caption"
+                  uri = "image.jpg"
+                  reference = "fig:label"
+              in para (image uri reference caption)
+              =?> unlines [ "\\startplacefigure[location={force},title={Caption}]"
+                          , "\\externalfigure[image.jpg]"
+                          , "\\stopplacefigure" ]
             ]
         ]

--- a/test/tables.context
+++ b/test/tables.context
@@ -37,7 +37,7 @@ Simple table with caption:
 
 Simple table without caption:
 
-\startplacetable[location=none]
+\startplacetable[location={none}]
 \startxtable
 \startxtablehead[head]
 \startxrow
@@ -144,7 +144,7 @@ blank line between rows. \stopxcell
 
 Multiline table without caption:
 
-\startplacetable[location=none]
+\startplacetable[location={none}]
 \startxtable
 \startxtablehead[head]
 \startxrow
@@ -177,7 +177,7 @@ blank line between rows. \stopxcell
 
 Table without column headers:
 
-\startplacetable[location=none]
+\startplacetable[location={none}]
 \startxtable
 \startxtablebody[body]
 \startxrow
@@ -206,7 +206,7 @@ Table without column headers:
 
 Multiline table without column headers:
 
-\startplacetable[location=none]
+\startplacetable[location={none}]
 \startxtable
 \startxtablebody[body]
 \startxrow

--- a/test/writer.context
+++ b/test/writer.context
@@ -866,9 +866,11 @@ or here: <http://example.com/>
 
 From \quotation{Voyage dans la Lune} by Georges Melies (1902):
 
-\placefigure{lalune}{\externalfigure[lalune.jpg]}
+\startplacefigure[title={lalune}]
+\externalfigure[lalune.jpg]
+\stopplacefigure
 
-Here is a movie {\externalfigure[movie.jpg]} icon.
+Here is a movie \externalfigure[movie.jpg] icon.
 
 \thinrule
 


### PR DESCRIPTION
In #4915 it was voiced that it would be nice to fix tables and figures rather than having them float around the page.  I'm not really sure whether that is a wise idea, from a document design point of view, but I hope that people have good reasons for horrible page breaks.

Fixes #4915