### PR TITLE
add variable hyperrefoptions to default latex template to pass options to the hyperref package

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -1,4 +1,4 @@
-\PassOptionsToPackage{unicode=true}{hyperref} % options for packages loaded elsewhere
+\PassOptionsToPackage{unicode=true,$for(hyperrefoptions)$$hyperrefoptions$$sep$,$endfor$}{hyperref} % options for packages loaded elsewhere
 \PassOptionsToPackage{hyphens}{url}
 $if(colorlinks)$
 \PassOptionsToPackage{dvipsnames,svgnames*,x11names*}{xcolor}


### PR DESCRIPTION
Introduces a new variable `hyperrefoptions` which can be used to pass options to the hyperref package. For instance, it allows to specify `hyperrefoptions: linktoc=all` in a YAML block to enable linked page numbers in the table of content.