### PR TITLE
Update LaTeX.hs

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -1051,7 +1051,10 @@ inlineToLaTeX (Code (_,classes,_) str) = do
         -- (defined in the default template) so that we don't have
         -- to change the way we escape characters depending on whether
         -- the lstinline is inside another command.  See #1629:
-        return $ text $ "\\passthrough{\\lstinline" ++ listingsopt ++ [chr] ++ str' ++ [chr] ++ "}"
+        -- works when lstset{mathescape=true}, See #4716
+        let originalLstinline = "\\lstinline" ++ listingsopt ++ [chr] ++ str ++ [chr]
+        let escapeLstinline = "\\lstinline" ++ listingsopt ++ [chr] ++ str' ++ [chr]
+        return $ text $ "\\ifdef{\\ifdisableEscapeString}{\\ifdisableEscapeString{" ++ originalLstinline ++ "}{" ++ escapeLstinline ++ "}}{" ++ escapeLstinline ++ "}"
   let rawCode = liftM (text . (\s -> "\\texttt{" ++ escapeSpaces s ++ "}"))
                  $ stringToLaTeX CodeString str
                 where escapeSpaces =  concatMap


### PR DESCRIPTION
Solve bug https://github.com/jgm/pandoc/issues/4716,

now, the old text can works, but it need `\usepackage{etoolbox}` for `\ifdef`.
if user want to use in mathescape=true for `listings` package, the following can be added to the template when needed.

```latex
\makeatletter
\newcommand{\ifmathescape}[2]{%
  \lst@ifmathescape #1\else #2\fi
}
\makeatother
\let\ifdisableEscapeString\ifmathescape
```

Sorry, I don't know haskwell language very well. Can it work?