### PR TITLE
Translations/ru

### DIFF
--- a/data/translations/ru.yaml
+++ b/data/translations/ru.yaml
@@ -1,20 +1,20 @@
-Abstract: Аннотація
-Appendix: Приложеніе
+Abstract: Аннотация
+Appendix: Приложение
 Author: Именной указатель
-Bibliography: Библіографія
+Bibliography: Литература
 Cc: исх.
 Chapter: Глава
-Contents: Оглавленіе
+Contents: Оглавление
 Encl: вкл.
 Figure: Рис.
-Index: Предмѣтный указатель
-ListOfFigures: Списокъ иллюстрацій
-ListOfTables: Списокъ таблицъ
+Index: Предметный указатель
+ListOfFigures: Список иллюстраций
+ListOfTables: Список таблиц
 Page: с.
 Part: Часть
-Preface: Предисловіе
+Preface: Предисловие
 Proof: Доказательство
-References: Примѣчанія
+References: Список литературы
 See: см.
 SeeAlso: см. также
 Table: Таблица


### PR DESCRIPTION
I suppose that you've copy-pasted the Russian translations from babel[1] package. Actually, it has two versions — `\captionsrussian@ancient` and `\captionsrussian@modern`, the former contains translations with pre-Revolutionary (1918) orthography.

This PR replaces the ancient Russian with modern. :)

[1]: http://ctan.math.utah.edu/ctan/tex-archive/macros/latex/contrib/babel-contrib/russian/russianb.ldf