### PR TITLE
RTF writer: Fix build failure with ghc-8.6.1 caused by missing MonadFail instance.

### DIFF
--- a/src/Text/Pandoc/Writers/RTF.hs
+++ b/src/Text/Pandoc/Writers/RTF.hs
@@ -341,8 +341,10 @@ listItemToRTF :: PandocMonad m
 listItemToRTF alignment indent marker [] = return $
   rtfCompact (indent + listIncrement) (negate listIncrement) alignment
              (marker ++ "\\tx" ++ show listIncrement ++ "\\tab ")
-listItemToRTF alignment indent marker list = do
-  (first:rest) <- mapM (blockToRTF (indent + listIncrement) alignment) list
+listItemToRTF alignment indent marker (listFirst:listRest) = do
+  let f = blockToRTF (indent + listIncrement) alignment
+  first <- f listFirst
+  rest <- mapM f listRest
   let listMarker = "\\fi" ++ show (negate listIncrement) ++ " " ++ marker ++
                    "\\tx" ++ show listIncrement ++ "\\tab"
   let insertListMarker ('\\':'f':'i':'-':d:xs) | isDigit d =


### PR DESCRIPTION
Building with ghc-8.6.1 causes the following error:

```
src/Text/Pandoc/Writers/RTF.hs:345:3: error:
    • Could not deduce (Control.Monad.Fail.MonadFail m)
        arising from a do statement
        with the failable pattern ‘(first : rest)’
      from the context: PandocMonad m
        bound by the type signature for:
                   listItemToRTF :: forall (m :: * -> *).
                                    PandocMonad m =>
                                    Alignment -> Int -> String -> [Block] -> m String
        at src/Text/Pandoc/Writers/RTF.hs:(335,1)-(340,25)
      Possible fix:
        add (Control.Monad.Fail.MonadFail m) to the context of
          the type signature for:
            listItemToRTF :: forall (m :: * -> *).
                             PandocMonad m =>
                             Alignment -> Int -> String -> [Block] -> m String
    • In a stmt of a 'do' block:
        (first : rest) <- mapM
                            (blockToRTF (indent + listIncrement) alignment) list
      In the expression:
        do (first : rest) <- mapM
                               (blockToRTF (indent + listIncrement) alignment) list
           let listMarker
                 = "\\fi"
                     ++
                       show (negate listIncrement)
                         ++ " " ++ marker ++ "\\tx" ++ show listIncrement ++ "\\tab"
           let insertListMarker ('\\' : 'f' : 'i' : '-' : d : xs)
                 | isDigit d = listMarker ++ dropWhile isDigit xs
               insertListMarker ('\\' : 'f' : 'i' : d : xs)
                 | isDigit d = listMarker ++ dropWhile isDigit xs
               insertListMarker (x : xs) = x : insertListMarker xs
               insertListMarker [] = ...
           return $ insertListMarker first ++ concat rest
      In an equation for ‘listItemToRTF’:
          listItemToRTF alignment indent marker list
            = do (first : rest) <- mapM
                                     (blockToRTF (indent + listIncrement) alignment) list
                 let listMarker = ...
                 let insertListMarker ('\\' : 'f' : 'i' : '-' : d : xs)
                       | isDigit d = ...
                     insertListMarker ('\\' : 'f' : 'i' : d : xs) | isDigit d = ...
                     insertListMarker (x : xs) = ...
                     insertListMarker [] = ...
                 ....
    |
345 |   (first:rest) <- mapM (blockToRTF (indent + listIncrement) alignment) list
    |   ^^^
```

My commit avoids generating the MonadFail reference and thus the error. With it, I can build pandoc again with ghc-8.6.1, although I need to manually install fixed versions of memory and texmath first.