### PR TITLE
Parse empty argument array in inline org-mode src blocks.

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -525,7 +525,8 @@ inlineCodeBlock :: PandocMonad m => OrgParser m (F Inlines)
 inlineCodeBlock = try $ do
   string "src_"
   lang <- many1 orgArgWordChar
-  opts <- option [] $ enclosedByPair '[' ']' inlineBlockOption
+  opts <- option [] $ try (enclosedByPair '[' ']' inlineBlockOption)
+                        <|> (mempty <$ string "[]")
   inlineCode <- enclosedByPair '{' '}' (noneOf "\n\r")
   let attrClasses = [translateLang lang]
   let attrKeyVal  = originalLang lang <> opts

--- a/test/Tests/Readers/Org/Inline.hs
+++ b/test/Tests/Readers/Org/Inline.hs
@@ -280,6 +280,13 @@ tests =
                        )
                        "echo 'Hello, World'")
 
+  , "Inline code block with a blank argument array" =:
+      "src_sh[]{echo 'Hello, World'}" =?>
+    para (codeWith ( ""
+                       , [ "bash" ]
+                       , [ ("org-language", "sh") ])
+                       "echo 'Hello, World'")
+
   , "Inline code block with toggle" =:
       "src_sh[:toggle]{echo $HOME}" =?>
     para (codeWith ( ""


### PR DESCRIPTION
This allows `src_emacs-lisp[]{(+ 1 1)}` to be handled like `src_emacs-lisp{(+ 1 1)}`, which wasn't the case previously.