### PR TITLE
OpenDocument writer: Implement figure numbering in captions

### DIFF
--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -411,9 +411,21 @@ blockToOpenDocument o bs
       figure attr caption source title | null caption =
         withParagraphStyle o "Figure" [Para [Image attr caption (source,title)]]
                                   | otherwise    = do
+        id' <- gets stImageId
         imageDoc <- withParagraphStyle o "FigureWithCaption" [Para [Image attr caption (source,title)]]
-        captionDoc <- withParagraphStyle o "FigureCaption" [Para caption]
+        captionDoc <- numberedFigureCaption id' <$> inlinesToOpenDocument o caption
         return $ imageDoc $$ captionDoc
+
+numberedFigureCaption :: Int -> Doc -> Doc
+numberedFigureCaption num caption =
+    let t = text "Figure "
+        r = num - 1
+        s = inTags False "text:sequence" [ ("text:ref-name", "refIllustration" ++ show r),
+                                           ("text:name", "Illustration"),
+                                           ("text:formula", "ooow:Illustration+1"),
+                                           ("style:num-format", "1") ] $ text $ show num
+        c = text ": "
+    in inParagraphTagsWithStyle "FigureCaption" $ hcat [ t, s, c, caption ]
 
 colHeadsToOpenDocument :: PandocMonad m
                        => WriterOptions -> [String] -> [[Block]]

--- a/test/writer.opendocument
+++ b/test/writer.opendocument
@@ -1880,7 +1880,7 @@ link in pointy braces</text:span></text:a>.</text:p>
 <text:p text:style-name="First_20_paragraph">From “Voyage dans la Lune” by
 Georges Melies (1902):</text:p>
 <text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
-<text:p text:style-name="FigureCaption">lalune</text:p>
+<text:p text:style-name="FigureCaption">Figure <text:sequence text:ref-name="refIllustration0" text:name="Illustration" text:formula="ooow:Illustration+1" style:num-format="1">1</text:sequence>: lalune</text:p>
 <text:p text:style-name="Text_20_body">Here is a movie
 <draw:frame draw:name="img2"><draw:image xlink:href="movie.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame>
 icon.</text:p>


### PR DESCRIPTION
Figure captions are now numbered 1, 2, 3, ... The format in
the caption is "Figure 1: <caption>" and so on.

This is necessary in order for libreoffice to generate an
Illustration Index (Table of Figures) for included figures.