### PR TITLE
EPUB writer: use metadata field `css` instead of `stylesheet`

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -976,8 +976,8 @@ Options affecting specific writers {.options}
     include multiple files. They will be included in the order specified.
 
     A stylesheet is required for generating EPUB.  If none is
-    provided using this option (or the deprecated `stylesheet`
-    metadata field), pandoc will look for a file `epub.css` in the
+    provided using this option (or the `css` or `stylesheet`
+    metadata fields), pandoc will look for a file `epub.css` in the
     user data directory (see `--data-dir`).  If it is not
     found there, sensible defaults will be used.
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -976,8 +976,8 @@ Options affecting specific writers {.options}
     include multiple files. They will be included in the order specified.
 
     A stylesheet is required for generating EPUB.  If none is
-    provided using this option (or the `stylesheet` metadata
-    field), pandoc will look for a file `epub.css` in the
+    provided using this option (or the deprecated `stylesheet`
+    metadata field), pandoc will look for a file `epub.css` in the
     user data directory (see `--data-dir`).  If it is not
     found there, sensible defaults will be used.
 
@@ -4613,7 +4613,7 @@ The following fields are recognized:
 `cover-image`
   ~ A string value (path to cover image).
 
-`stylesheet`
+`css` (or legacy: `stylesheet`)
   ~ A string value (path to CSS stylesheet).
 
 `page-progression-direction`

--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -36,6 +36,7 @@ module Text.Pandoc.Writers.EPUB ( writeEPUB2, writeEPUB3 ) where
 import Prelude
 import Codec.Archive.Zip (Entry, addEntryToArchive, eRelativePath, emptyArchive,
                           fromArchive, fromEntry, toEntry)
+import Control.Applicative ( (<|>) )
 import Control.Monad (mplus, unless, when, zipWithM)
 import Control.Monad.Except (catchError, throwError)
 import Control.Monad.State.Strict (State, StateT, evalState, evalStateT, get,
@@ -351,9 +352,9 @@ metadataFromMeta opts meta = EPUBMetadata{
         rights = metaValueToString <$> lookupMeta "rights" meta
         coverImage = lookup "epub-cover-image" (writerVariables opts) `mplus`
              (metaValueToString <$> lookupMeta "cover-image" meta)
-        stylesheets = fromMaybe []
-                        (metaValueToPaths <$> lookupMeta "stylesheet" meta) ++
-                      [f | ("css",f) <- writerVariables opts]
+        mCss = lookupMeta "css" meta <|> lookupMeta "stylesheet" meta
+        stylesheets = fromMaybe [] (metaValueToPaths <$> mCss) ++
+                        [f | ("css",f) <- writerVariables opts]
         pageDirection = case map toLower . metaValueToString <$>
                              lookupMeta "page-progression-direction" meta of
                               Just "ltr" -> Just LTR


### PR DESCRIPTION
closes #4990