### PR TITLE
LaTeX reader: add support for `nolinkurl` command.

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -988,6 +988,8 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList
   , ("Verb", doverb)
   , ("url", ((unescapeURL . T.unpack . untokenize) <$> bracedUrl) >>= \url ->
                   pure (link url "" (str url)))
+  , ("nolinkurl", ((unescapeURL . T.unpack . untokenize) <$> bracedUrl) >>= \url ->
+                  pure (code url))
   , ("href", (unescapeURL . toksToString <$>
                  bracedUrl <* optional sp) >>= \url ->
                    tok >>= \lab -> pure (link url "" lab))

--- a/test/command/4306.md
+++ b/test/command/4306.md
@@ -1,0 +1,10 @@
+```
+pandoc -f latex -t native
+\documentclass{article}
+\usepackage{hyperref}
+\begin{document}
+The file id is \nolinkurl{ESP_123_5235}.
+\end{document}
+^D
+[Para [Str "The",Space,Str "file",Space,Str "id",Space,Str "is",Space,Code ("",[],[]) "ESP_123_5235",Str "."]]
+```


### PR DESCRIPTION
Closes #4306.