### PR TITLE
revealjs: typo in the socket.io javascript plugin

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -263,7 +263,7 @@ $endif$
           { src: '$revealjs-url$/lib/js/classList.js', condition: function() { return !document.body.classList; } },
           { src: '$revealjs-url$/plugin/zoom-js/zoom.js', async: true },
 $if(notes-server)$
-          { src: '$revealjs-url$/socket.io/socker.io.js', async: true },
+          { src: '$revealjs-url$/socket.io/socket.io.js', async: true },
           { src: '$revealjs-url$/plugin/notes-server/client.js', async: true },
 $endif$
 $if(mathjax)$


### PR DESCRIPTION
so `% pandoc -V notes-server=true` works again.