### PR TITLE
Add viz. to abbreviations file

### DIFF
--- a/data/abbreviations
+++ b/data/abbreviations
@@ -46,5 +46,6 @@ Sept.
 Sgt.
 Sr.
 St.
+viz.
 vol.
 vs.


### PR DESCRIPTION
A less commonly used abbreviation, but one that is always used sentence-internally and where we want a non-breaking space after.