### PR TITLE
Cleanup Text.Pandoc.Lua module

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -427,6 +427,7 @@ library
                    Text.Pandoc.Shared,
                    Text.Pandoc.MediaBag,
                    Text.Pandoc.Error,
+                   Text.Pandoc.Filter,
                    Text.Pandoc.Readers,
                    Text.Pandoc.Readers.HTML,
                    Text.Pandoc.Readers.LaTeX,
@@ -504,8 +505,7 @@ library
                    Text.Pandoc.ImageSize,
                    Text.Pandoc.BCP47,
                    Text.Pandoc.Class
-  other-modules:   Text.Pandoc.Filter,
-                   Text.Pandoc.Filter.JSON,
+  other-modules:   Text.Pandoc.Filter.JSON,
                    Text.Pandoc.Filter.Lua,
                    Text.Pandoc.Filter.Path,
                    Text.Pandoc.Readers.Docx.Lists,

--- a/src/Text/Pandoc/Filter.hs
+++ b/src/Text/Pandoc/Filter.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell   #-}
 {-
-Copyright (C) 2006-2017 John MacFarlane <jgm@berkeley.edu>
+Copyright (C) 2006-2018 John MacFarlane <jgm@berkeley.edu>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -16,11 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -}
-{-# LANGUAGE TemplateHaskell     #-}
-
 {- |
    Module      : Text.Pandoc.Filter
-   Copyright   : Copyright (C) 2006-2017 John MacFarlane
+   Copyright   : Copyright (C) 2006-2018 John MacFarlane
    License     : GNU GPL, version 2 or above
 
    Maintainer  : John MacFarlane <jgm@berkeley@edu>

--- a/src/Text/Pandoc/Filter/JSON.hs
+++ b/src/Text/Pandoc/Filter/JSON.hs
@@ -44,7 +44,6 @@ import System.FilePath ((</>), takeExtension)
 import Text.Pandoc.Class (PandocIO)
 import Text.Pandoc.Error (PandocError (PandocFilterError))
 import Text.Pandoc.Definition (Pandoc)
-import Text.Pandoc.Filter.Path (expandFilterPath)
 import Text.Pandoc.Options (ReaderOptions)
 import Text.Pandoc.Process (pipeProcess)
 import Text.Pandoc.Shared (pandocVersion)
@@ -56,9 +55,7 @@ apply :: ReaderOptions
       -> FilePath
       -> Pandoc
       -> PandocIO Pandoc
-apply ropts args f d = do
-  f' <- expandFilterPath f
-  liftIO $ externalFilter ropts f' args d
+apply ropts args f = liftIO . externalFilter ropts f args
 
 externalFilter :: MonadIO m
                => ReaderOptions -> FilePath -> [String] -> Pandoc -> m Pandoc

--- a/src/Text/Pandoc/Filter/Lua.hs
+++ b/src/Text/Pandoc/Filter/Lua.hs
@@ -32,24 +32,55 @@ module Text.Pandoc.Filter.Lua (apply) where
 
 import Prelude
 import Control.Exception (throw)
+import Control.Monad ((>=>))
+import Foreign.Lua (Lua)
 import Text.Pandoc.Class (PandocIO)
 import Text.Pandoc.Definition (Pandoc)
 import Text.Pandoc.Error (PandocError (PandocFilterError))
 import Text.Pandoc.Filter.Path (expandFilterPath)
-import Text.Pandoc.Lua (LuaException (..), runLuaFilter)
+import Text.Pandoc.Lua (LuaException (..), runPandocLua)
+import Text.Pandoc.Lua.Filter (LuaFilter, walkMWithLuaFilter)
+import Text.Pandoc.Lua.Global (Global (..), setGlobals)
+import Text.Pandoc.Lua.Util (dofileWithTraceback)
 import Text.Pandoc.Options (ReaderOptions)
 
+import qualified Foreign.Lua as Lua
+
+-- | Run the Lua filter in @filterPath@ for a transformation to the
+-- target format (first element in args). Pandoc uses Lua init files to
+-- setup the Lua interpreter.
 apply :: ReaderOptions
       -> [String]
       -> FilePath
       -> Pandoc
       -> PandocIO Pandoc
-apply ropts args f d = do
-  f' <- expandFilterPath f
+apply ropts args f doc = do
+  filterPath <- expandFilterPath f
   let format = case args of
                  (x:_) -> x
-                 _     -> error "Format not supplied for lua filter"
-  res <- runLuaFilter ropts f' format d
-  case res of
-    Right x               -> return x
-    Left (LuaException s) -> throw (PandocFilterError f s)
+                 _     -> error "Format not supplied for Lua filter"
+  runPandocLua >=> forceResult filterPath $ do
+    setGlobals [ FORMAT format
+               , PANDOC_READER_OPTIONS ropts
+               , PANDOC_SCRIPT_FILE filterPath
+               ]
+    top <- Lua.gettop
+    stat <- dofileWithTraceback filterPath
+    if stat /= Lua.OK
+      then Lua.throwTopMessage
+      else do
+        newtop <- Lua.gettop
+        -- Use the returned filters, or the implicitly defined global
+        -- filter if nothing was returned.
+        luaFilters <- if newtop - top >= 1
+                      then Lua.peek Lua.stackTop
+                      else Lua.pushglobaltable *> fmap (:[]) Lua.popValue
+        runAll luaFilters doc
+
+forceResult :: FilePath -> Either LuaException Pandoc -> PandocIO Pandoc
+forceResult fp eitherResult = case eitherResult of
+  Right x               -> return x
+  Left (LuaException s) -> throw (PandocFilterError fp s)
+
+runAll :: [LuaFilter] -> Pandoc -> Lua Pandoc
+runAll = foldr ((>=>) . walkMWithLuaFilter) return

--- a/src/Text/Pandoc/Filter/Lua.hs
+++ b/src/Text/Pandoc/Filter/Lua.hs
@@ -38,7 +38,7 @@ import Text.Pandoc.Class (PandocIO)
 import Text.Pandoc.Definition (Pandoc)
 import Text.Pandoc.Error (PandocError (PandocFilterError))
 import Text.Pandoc.Filter.Path (expandFilterPath)
-import Text.Pandoc.Lua (LuaException (..), runPandocLua)
+import Text.Pandoc.Lua (LuaException (..), runLua)
 import Text.Pandoc.Lua.Filter (LuaFilter, walkMWithLuaFilter)
 import Text.Pandoc.Lua.Global (Global (..), setGlobals)
 import Text.Pandoc.Lua.Util (dofileWithTraceback)
@@ -59,7 +59,7 @@ apply ropts args f doc = do
   let format = case args of
                  (x:_) -> x
                  _     -> error "Format not supplied for Lua filter"
-  runPandocLua >=> forceResult filterPath $ do
+  runLua >=> forceResult filterPath $ do
     setGlobals [ FORMAT format
                , PANDOC_READER_OPTIONS ropts
                , PANDOC_SCRIPT_FILE filterPath

--- a/src/Text/Pandoc/Filter/Lua.hs
+++ b/src/Text/Pandoc/Filter/Lua.hs
@@ -36,7 +36,6 @@ import Control.Monad ((>=>))
 import Text.Pandoc.Class (PandocIO)
 import Text.Pandoc.Definition (Pandoc)
 import Text.Pandoc.Error (PandocError (PandocFilterError))
-import Text.Pandoc.Filter.Path (expandFilterPath)
 import Text.Pandoc.Lua (Global (..), LuaException (..),
                         runLua, runFilterFile, setGlobals)
 import Text.Pandoc.Options (ReaderOptions)
@@ -49,17 +48,16 @@ apply :: ReaderOptions
       -> FilePath
       -> Pandoc
       -> PandocIO Pandoc
-apply ropts args f doc = do
-  filterPath <- expandFilterPath f
+apply ropts args fp doc = do
   let format = case args of
                  (x:_) -> x
                  _     -> error "Format not supplied for Lua filter"
-  runLua >=> forceResult filterPath $ do
+  runLua >=> forceResult fp $ do
     setGlobals [ FORMAT format
                , PANDOC_READER_OPTIONS ropts
-               , PANDOC_SCRIPT_FILE filterPath
+               , PANDOC_SCRIPT_FILE fp
                ]
-    runFilterFile filterPath doc
+    runFilterFile fp doc
 
 forceResult :: FilePath -> Either LuaException Pandoc -> PandocIO Pandoc
 forceResult fp eitherResult = case eitherResult of

--- a/src/Text/Pandoc/Lua.hs
+++ b/src/Text/Pandoc/Lua.hs
@@ -28,8 +28,8 @@ Running pandoc Lua filters.
 -}
 module Text.Pandoc.Lua
   ( LuaException (..)
-  , runPandocLua
+  , runLua
   ) where
 
-import Text.Pandoc.Lua.Init (LuaException (..), runPandocLua)
+import Text.Pandoc.Lua.Init (LuaException (..), runLua)
 

--- a/src/Text/Pandoc/Lua.hs
+++ b/src/Text/Pandoc/Lua.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 {-
 Copyright © 2017–2018 Albert Krewinkel <tarleb+pandoc@moltkeplatz.de>
 
@@ -15,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -}
-{-# LANGUAGE NoImplicitPrelude #-}
 {- |
    Module      : Text.Pandoc.Lua
    Copyright   : Copyright © 2017–2018 Albert Krewinkel
@@ -27,9 +27,17 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 Running pandoc Lua filters.
 -}
 module Text.Pandoc.Lua
-  ( LuaException (..)
-  , runLua
+  ( runLua
+  , LuaException (..)
+  -- * Lua globals
+  , Global (..)
+  , setGlobals
+  -- * Filters
+  , runFilterFile
   ) where
 
+import Text.Pandoc.Lua.Filter (runFilterFile)
+import Text.Pandoc.Lua.Global (Global (..), setGlobals)
 import Text.Pandoc.Lua.Init (LuaException (..), runLua)
+import Text.Pandoc.Lua.StackInstances ()
 

--- a/src/Text/Pandoc/Lua/Init.hs
+++ b/src/Text/Pandoc/Lua/Init.hs
@@ -29,7 +29,7 @@ Functions to initialize the Lua interpreter.
 module Text.Pandoc.Lua.Init
   ( LuaException (..)
   , LuaPackageParams (..)
-  , runPandocLua
+  , runLua
   , initLuaState
   , luaPackageParams
   ) where
@@ -56,8 +56,8 @@ newtype LuaException = LuaException String deriving (Show)
 
 -- | Run the lua interpreter, using pandoc's default way of environment
 -- initialization.
-runPandocLua :: Lua a -> PandocIO (Either LuaException a)
-runPandocLua luaOp = do
+runLua :: Lua a -> PandocIO (Either LuaException a)
+runLua luaOp = do
   luaPkgParams <- luaPackageParams
   globals <- defaultGlobals
   enc <- liftIO $ getForeignEncoding <* setForeignEncoding utf8

--- a/src/Text/Pandoc/Lua/Init.hs
+++ b/src/Text/Pandoc/Lua/Init.hs
@@ -30,7 +30,6 @@ module Text.Pandoc.Lua.Init
   ( LuaException (..)
   , LuaPackageParams (..)
   , runLua
-  , initLuaState
   , luaPackageParams
   ) where
 
@@ -94,7 +93,7 @@ luaPackageParams = do
     , luaPkgMediaBag = mbRef
     }
 
--- Initialize the lua state with all required values
+-- | Initialize the lua state with all required values
 initLuaState :: LuaPackageParams -> Lua ()
 initLuaState luaPkgParams = do
   Lua.openlibs

--- a/src/Text/Pandoc/Writers/Custom.hs
+++ b/src/Text/Pandoc/Writers/Custom.hs
@@ -43,9 +43,8 @@ import Foreign.Lua (Lua, Pushable)
 import Text.Pandoc.Class (PandocIO)
 import Text.Pandoc.Definition
 import Text.Pandoc.Error
-import Text.Pandoc.Lua.Global (Global (..), setGlobals)
-import Text.Pandoc.Lua.Init (LuaException (LuaException), runLua)
-import Text.Pandoc.Lua.StackInstances ()
+import Text.Pandoc.Lua (Global (..), LuaException (LuaException),
+                        runLua, setGlobals)
 import Text.Pandoc.Lua.Util (addField, dofileWithTraceback)
 import Text.Pandoc.Options
 import Text.Pandoc.Templates

--- a/src/Text/Pandoc/Writers/Custom.hs
+++ b/src/Text/Pandoc/Writers/Custom.hs
@@ -44,7 +44,7 @@ import Text.Pandoc.Class (PandocIO)
 import Text.Pandoc.Definition
 import Text.Pandoc.Error
 import Text.Pandoc.Lua.Global (Global (..), setGlobals)
-import Text.Pandoc.Lua.Init (LuaException (LuaException), runPandocLua)
+import Text.Pandoc.Lua.Init (LuaException (LuaException), runLua)
 import Text.Pandoc.Lua.StackInstances ()
 import Text.Pandoc.Lua.Util (addField, dofileWithTraceback)
 import Text.Pandoc.Options
@@ -111,7 +111,7 @@ writeCustom luaFile opts doc@(Pandoc meta _) = do
   let globals = [ PANDOC_DOCUMENT doc
                 , PANDOC_SCRIPT_FILE luaFile
                 ]
-  res <- runPandocLua $ do
+  res <- runLua $ do
     setGlobals globals
     stat <- dofileWithTraceback luaFile
     -- check for error in lua script (later we'll change the return type

--- a/test/Tests/Lua.hs
+++ b/test/Tests/Lua.hs
@@ -18,7 +18,7 @@ import Text.Pandoc.Class (runIOorExplode, setUserDataDir)
 import Text.Pandoc.Definition (Block (BlockQuote, Div, Para), Inline (Emph, Str),
                                Attr, Meta, Pandoc, pandocTypesVersion)
 import Text.Pandoc.Filter (Filter (LuaFilter), applyFilters)
-import Text.Pandoc.Lua (runPandocLua)
+import Text.Pandoc.Lua (runLua)
 import Text.Pandoc.Options (def)
 import Text.Pandoc.Shared (pandocVersion)
 
@@ -128,7 +128,7 @@ tests = map (localOption (QuickCheckTests 20))
       (doc $ para "ignored")
       (doc $ para (str $ "lua" </> "script-name.lua"))
 
-  , testCase "Pandoc version is set" . runPandocLua' $ do
+  , testCase "Pandoc version is set" . runLua' $ do
       Lua.getglobal' "table.concat"
       Lua.getglobal "PANDOC_VERSION"
       Lua.push ("." :: String) -- separator
@@ -136,13 +136,13 @@ tests = map (localOption (QuickCheckTests 20))
       Lua.liftIO . assertEqual "pandoc version is wrong" pandocVersion
         =<< Lua.peek Lua.stackTop
 
-  , testCase "Pandoc types version is set" . runPandocLua' $ do
+  , testCase "Pandoc types version is set" . runLua' $ do
       let versionNums = versionBranch pandocTypesVersion
       Lua.getglobal "PANDOC_API_VERSION"
       Lua.liftIO . assertEqual "pandoc-types version is wrong" versionNums
         =<< Lua.peek Lua.stackTop
 
-  , testCase "Allow singleton inline in constructors" . runPandocLua' $ do
+  , testCase "Allow singleton inline in constructors" . runLua' $ do
       Lua.liftIO . assertEqual "Not the exptected Emph" (Emph [Str "test"])
         =<< Lua.callFunc "pandoc.Emph" (Str "test")
       Lua.liftIO . assertEqual "Unexpected element" (Para [Str "test"])
@@ -156,14 +156,14 @@ tests = map (localOption (QuickCheckTests 20))
           Lua.peek Lua.stackTop
         )
 
-  , testCase "Elements with Attr have `attr` accessor" . runPandocLua' $ do
+  , testCase "Elements with Attr have `attr` accessor" . runLua' $ do
       Lua.push (Div ("hi", ["moin"], [])
                 [Para [Str "ignored"]])
       Lua.getfield Lua.stackTop "attr"
       Lua.liftIO . assertEqual "no accessor" (("hi", ["moin"], []) :: Attr)
         =<< Lua.peek Lua.stackTop
 
-  , testCase "informative error messages" . runPandocLua' $ do
+  , testCase "informative error messages" . runLua' $ do
       Lua.pushboolean True
       err <- Lua.peekEither Lua.stackTop
       case (err :: Either String Pandoc) of
@@ -185,7 +185,7 @@ roundtripEqual :: (Eq a, Lua.Peekable a, Lua.Pushable a) => a -> IO Bool
 roundtripEqual x = (x ==) <$> roundtripped
  where
   roundtripped :: (Lua.Peekable a, Lua.Pushable a) => IO a
-  roundtripped = runPandocLua' $ do
+  roundtripped = runLua' $ do
     oldSize <- Lua.gettop
     Lua.push x
     size <- Lua.gettop
@@ -196,10 +196,10 @@ roundtripEqual x = (x ==) <$> roundtripped
       Left e -> error (show e)
       Right y -> return y
 
-runPandocLua' :: Lua.Lua a -> IO a
-runPandocLua' op = runIOorExplode $ do
+runLua' :: Lua.Lua a -> IO a
+runLua' op = runIOorExplode $ do
   setUserDataDir (Just "../data")
-  res <- runPandocLua op
+  res <- runLua op
   case res of
     Left e -> error (show e)
     Right x -> return x


### PR DESCRIPTION
Expose more useful functions via `Text.Pandoc.Lua`.

The `Text.Pandoc.Filter` is now also exposed, as importing `Text.Pandoc.App` just for its filtering features seems like overkill. This also helps with testing.