### PR TITLE
man fix tableColFormat digit on the end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ windows/*.wixobj
 data/reference.docx
 data/reference.odt
 .stack-work
+.vscode
+.idea

--- a/src/Text/Pandoc/Readers/Roff.hs
+++ b/src/Text/Pandoc/Readers/Roff.hs
@@ -433,12 +433,13 @@ tableColFormat = do
                 else return ""
       return $ x : num
     pipeSuffix' <- option False $ True <$ string "|"
+    skipMany (letter <|> digit)
     return $ CellFormat
              { columnType     = c
              , pipePrefix     = pipePrefix'
              , pipeSuffix     = pipeSuffix'
              , columnSuffixes = numsuffixes ++ suffixes }
- 
+
 -- We don't fully handle the conditional.  But we do
 -- include everything under '.ie n', which occurs commonly
 -- in man pages.  We always skip the '.el' part.


### PR DESCRIPTION
relates to #5026 
Fixes cases like:
```
3-a/man3p//basename.3p

Error at "source" (line 105, column 3):
unexpected "5"
expecting lf new-line, ",", white space or "."
lf5 | lf5.
```