### PR TITLE
Improve installation notes on associated software

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,10 +25,19 @@ under the heading for your operating system.
     to a directory of your choice.
     
   - Alternatively, you can install pandoc using
-    [chocolatey](https://chocolatey.org): `choco install pandoc`.
+    [Chocolatey](https://chocolatey.org):
+    
+        choco install pandoc
+    
+    Chocolatey can also install other software that integrates with Pandoc.
+    For example, to install `rsvg-convert` (from [librsvg], covering formats
+    without SVG support), [Python] (to use Pandoc filters), and
+    [MiKTeX] (to typeset PDFs with [LaTeX]):
+    
+        choco install rsvg-convert python miktex
 
-  - For PDF output, you'll also need to install LaTeX.
-    We recommend [MiKTeX](http://miktex.org/).
+  - By default, Pandoc creates PDFs using LaTeX.
+    We recommend installing it via [MiKTeX].
 
 ## macOS
 
@@ -38,22 +47,35 @@ under the heading for your operating system.
     and running it with `perl uninstall-pandoc.pl`.
 
   - Alternatively, you can install pandoc using
-    [homebrew](http://brew.sh): `brew install pandoc`.
-    Note: If you are using macOS < 10.10, this method installs 
-    pandoc from source, so it will take a long time and a lot of 
-    disk space for the ghc compiler and dependent Haskell libraries.
+    [Homebrew](http://brew.sh):
+     
+         brew install pandoc
+
+    To include pandoc's citation parser:
+     
+         brew install pandoc-citeproc
+    
+    Homebrew can also install other software that integrates with Pandoc.
+    For example, to install [librsvg] (its `rsvg-convert` covers formats
+    without SVG support), [Python] (to use Pandoc filters), and
+    [BasicTeX] (to typeset PDFs with [LaTeX]):
+    
+         brew install librsvg python homebrew/cask/basictex
+    
+    Note: On unsupported versions of macOS (more than three releases old),
+    Homebrew from source, which takes additional time and disk space
+    for the `ghc` compiler and dependent Haskell libraries.
     
   - We also provide a zip file containing the binaries and man
     pages, for those who prefer not to use the installer.  Simply
     unzip the file and move the binaries and man pages to
     whatever directory you like.
 
-  - For PDF output, you'll also need LaTeX.  Because a full [MacTeX]
-    installation takes more than a gigabyte of disk space, we recommend
-    installing [BasicTeX](http://www.tug.org/mactex/morepackages.html)
-    (64M) or [TinyTeX](https://yihui.name/tinytex/)
+  - By default, Pandoc creates PDFs using LaTeX.  Because a full [MacTeX]
+    installation uses four gigabytes of disk space, we recommend
+    [BasicTeX] or [TinyTeX](https://yihui.name/tinytex/)
     and using the `tlmgr` tool to install additional packages
-    as needed.  If you get errors warning of fonts not found, try
+    as needed.  If you receive errors warning of fonts not found:
 
         tlmgr install collection-fontsrecommended
 
@@ -362,6 +384,11 @@ To run just the markdown benchmarks:
 [Haskell platform]: http://hackage.haskell.org/platform/
 [MacPorts]: http://trac.macports.org/browser/trunk/dports/textproc/pandoc/Portfile
 [MacTeX]: https://tug.org/mactex/
+[BasicTeX]: http://www.tug.org/mactex/morepackages.html
+[LaTeX]: https://www.latex-project.org
+[MiKTeX]: http://miktex.org/
+[librsvg]: https://wiki.gnome.org/Projects/LibRsvg
+[Python]: https://www.python.org
 [NetBSD]: http://pkgsrc.se/wip/pandoc
 [NixOS]: https://nixos.org/nixos/packages.html
 [Slackware]: https://www.slackbuilds.org/result/?search=pandoc&sv=

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,7 +63,7 @@ under the heading for your operating system.
          brew install librsvg python homebrew/cask/basictex
     
     Note: On unsupported versions of macOS (more than three releases old),
-    Homebrew from source, which takes additional time and disk space
+    Homebrew instals from source, which takes additional time and disk space
     for the `ghc` compiler and dependent Haskell libraries.
     
   - We also provide a zip file containing the binaries and man


### PR DESCRIPTION
Includes explanation of how to install related tools with package managers (since the method of installing `rsvg-convert` is not obvious).