### PR TITLE
ICML writer: support custom-styles

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2051,7 +2051,7 @@ output formats
 Read all docx styles as divs (for paragraph styles) and spans (for
 character styles) regardless of whether pandoc understands the meaning
 of these styles. This can be used with [docx custom
-styles](#custom-styles-in-docx). Disabled by default.
+styles](#custom-styles). Disabled by default.
 
 input formats
 :  `docx`
@@ -4763,8 +4763,10 @@ To disable highlighting, use the `--no-highlight` option.
 
 [skylighting]: https://github.com/jgm/skylighting
 
-Custom Styles in Docx
-=====================
+Custom Styles
+=============
+
+Custom styles can be used in the docx and ICML formats.
 
 Input
 -----
@@ -4817,8 +4819,8 @@ same styles in your input and output files.
 Output
 ------
 
-By default, pandoc's docx output applies a predefined set of styles for
-blocks such as paragraphs and block quotes, and uses largely default
+By default, pandoc's docx and ICML output applies a predefined set of styles
+for blocks such as paragraphs and block quotes, and uses largely default
 formatting (italics, bold) for inlines. This will work for most
 purposes, especially alongside a `reference.docx` file. However, if you
 need to apply your own styles to blocks, or match a preexisting set of
@@ -4843,9 +4845,9 @@ style `Emphatically`. Similarly, using the `fenced_divs` syntax,
 
 would style the two contained lines with the `Poetry` paragraph style.
 
-If the styles are not yet in your reference.docx, they will be defined
-in the output file as inheriting from normal text. If they are already
-defined, pandoc will not alter the definition.
+For docx output, styles will be defined in the output file as inheriting
+from normal text, if the styles are not yet in your reference.docx.
+If they are already defined, pandoc will not alter the definition.
 
 This feature allows for greatest customization in conjunction with
 [pandoc filters]. If you want all paragraphs after block quotes to be

--- a/src/Text/Pandoc/Writers/ICML.hs
+++ b/src/Text/Pandoc/Writers/ICML.hs
@@ -21,7 +21,7 @@ import Prelude
 import Control.Monad.Except (catchError)
 import Control.Monad.State.Strict
 import Data.List (intersperse, isInfixOf, isPrefixOf, stripPrefix)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, maybeToList)
 import qualified Data.Set as Set
 import Data.Text as Text (breakOnAll, pack)
 import Data.Text (Text)
@@ -287,6 +287,9 @@ hyperlinksToDoc (x:xs) = hyp x $$ hyperlinksToDoc xs
                   $ inTags False "BorderColor" [("type","enumeration")] (text "Black")
                   $$ inTags False "Destination" [("type","object")] (text $ "HyperlinkURLDestination/"++escapeColons (escapeStringForXML url)) -- HyperlinkURLDestination with more than one colon crashes CS6
 
+-- | Key for specifying user-defined styles
+dynamicStyleKey :: String
+dynamicStyleKey = "custom-style"
 
 -- | Convert a list of Pandoc blocks to ICML.
 blocksToICML :: PandocMonad m => WriterOptions -> Style -> [Block] -> WS m Doc
@@ -362,7 +365,9 @@ blockToICML opts style (Table caption aligns widths headers rows) =
                        , ("ColumnCount", show nrCols)
                        ] (colDescs $$ cells)
       liftM2 ($$) tableDoc $ parStyle opts (tableCaptionName:style) caption
-blockToICML opts style (Div _ lst) = blocksToICML opts style lst
+blockToICML opts style (Div (_, _, kvs) lst) =
+  let dynamicStyle = maybeToList $ lookup dynamicStyleKey kvs
+  in  blocksToICML opts (dynamicStyle <> style) lst
 blockToICML _ _ Null = return empty
 
 -- | Convert a list of lists of blocks to ICML list items.
@@ -460,7 +465,9 @@ inlineToICML opts style (Link _ lst (url, title)) = do
             in  (cont, newst)
 inlineToICML opts style (Image attr _ target) = imageICML opts style attr target
 inlineToICML opts style (Note lst) = footnoteToICML opts style lst
-inlineToICML opts style (Span _ lst) = inlinesToICML opts style lst
+inlineToICML opts style (Span (_, _, kvs) lst) =
+  let dynamicStyle = maybeToList $ lookup dynamicStyleKey kvs
+  in  inlinesToICML opts (dynamicStyle <> style) lst
 
 -- | Convert a list of block elements to an ICML footnote.
 footnoteToICML :: PandocMonad m => WriterOptions -> Style -> [Block] -> WS m Doc


### PR DESCRIPTION
see #2106 

This turned out to be a lot easier than expected. For better or worse (this time for the better), the ICML writer implements styles simply as a list of Strings that are being passed around.