### PR TITLE
Implement task lists

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2612,6 +2612,13 @@ If default list markers are desired, use `#.`:
     #.  two
     #.  three
 
+#### Extension: `task_lists` ####
+
+Pandoc supports task lists, using the syntax of GitHub-Flavored Markdown.
+
+    - [ ] an unchecked task list item
+    - [x] checked item
+
 
 ### Definition lists ###
 
@@ -4223,7 +4230,7 @@ variants are supported:
 :   `pipe_tables`, `raw_html`, `fenced_code_blocks`, `auto_identifiers`,
     `gfm_auto_identifiers`, `backtick_code_blocks`,
     `autolink_bare_uris`, `space_in_atx_header`,
-    `intraword_underscores`, `strikeout`, `emoji`,
+    `intraword_underscores`, `strikeout`, `task_lists`, `emoji`,
     `shortcut_reference_links`, `angle_brackets_escapable`,
     `lists_without_preceding_blankline`.
 
@@ -4254,7 +4261,7 @@ Also, `raw_tex` only affects `gfm` output, not input.
 :   `pipe_tables`, `raw_html`, `fenced_code_blocks`, `auto_identifiers`,
     `gfm_auto_identifiers`, `backtick_code_blocks`,
     `autolink_bare_uris`, `space_in_atx_header`,
-    `intraword_underscores`, `strikeout`, `emoji`,
+    `intraword_underscores`, `strikeout`, `task_lists`, `emoji`,
     `shortcut_reference_links`, `angle_brackets_escapable`,
     `lists_without_preceding_blankline`.
 

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -167,6 +167,7 @@ data Extension =
     | Ext_subscript           -- ^ Subscript using ~this~ syntax
     | Ext_superscript         -- ^ Superscript using ^this^ syntax
     | Ext_styles              -- ^ Read styles that pandoc doesn't know
+    | Ext_task_lists          -- ^ Parse certain list items as task list items
     | Ext_table_captions      -- ^ Pandoc-style table captions
     | Ext_tex_math_dollars    -- ^ TeX math between $..$ or $$..$$
     | Ext_tex_math_double_backslash  -- ^ TeX math btw \\(..\\) \\[..\\]
@@ -215,6 +216,7 @@ pandocExtensions = extensionsFromList
   , Ext_strikeout
   , Ext_superscript
   , Ext_subscript
+  , Ext_task_lists
   , Ext_auto_identifiers
   , Ext_header_attributes
   , Ext_link_attributes
@@ -274,6 +276,7 @@ githubMarkdownExtensions = extensionsFromList
   , Ext_space_in_atx_header
   , Ext_intraword_underscores
   , Ext_strikeout
+  , Ext_task_lists
   , Ext_emoji
   , Ext_lists_without_preceding_blankline
   , Ext_shortcut_reference_links

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -958,7 +958,8 @@ listItem fourSpaceRule start = try $ do
   let raw = concat (first:continuations)
   contents <- parseFromString' parseBlocks raw
   updateState (\st -> st {stateParserContext = oldContext})
-  return contents
+  exts <- getOption readerExtensions
+  return $ B.fromList . taskListItemFromAscii exts . B.toList <$> contents
 
 orderedList :: PandocMonad m => MarkdownParser m (F Blocks)
 orderedList = try $ do

--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -765,7 +765,8 @@ itemEndsWithTightList bs =
 -- | Convert bullet list item (list of blocks) to markdown.
 bulletListItemToMarkdown :: PandocMonad m => WriterOptions -> [Block] -> MD m Doc
 bulletListItemToMarkdown opts bs = do
-  contents <- blockListToMarkdown opts bs
+  let exts = writerExtensions opts
+  contents <- blockListToMarkdown opts $ taskListItemToAscii exts bs
   let sps = replicate (writerTabStop opts - 2) ' '
   let start = text ('-' : ' ' : sps)
   -- remove trailing blank line if item ends with a tight list
@@ -781,7 +782,8 @@ orderedListItemToMarkdown :: PandocMonad m
                           -> [Block]       -- ^ list item (list of blocks)
                           -> MD m Doc
 orderedListItemToMarkdown opts marker bs = do
-  contents <- blockListToMarkdown opts bs
+  let exts = writerExtensions opts
+  contents <- blockListToMarkdown opts $ taskListItemToAscii exts bs
   let sps = case length marker - writerTabStop opts of
                    n | n > 0 -> text $ replicate n ' '
                    _ -> text " "

--- a/test/command/gfm.md
+++ b/test/command/gfm.md
@@ -101,3 +101,32 @@ hi
 ^D
 [Para [Str "hi",LineBreak,Str "hi"]]
 ```
+
+```
+% pandoc -f gfm -t native
+- [ ] foo
+- [x] bar
+^D
+[BulletList
+ [[Plain [Str "\9744",Space,Str "foo"]]
+ ,[Plain [Str "\9746",Space,Str "bar"]]]]
+```
+
+```
+% pandoc -f gfm-task_lists -t native
+- [ ] foo
+- [x] bar
+^D
+[BulletList
+ [[Plain [Str "[",Space,Str "]",Space,Str "foo"]]
+ ,[Plain [Str "[x]",Space,Str "bar"]]]]
+```
+
+```
+% pandoc -f gfm -t gfm
+- [ ] foo
+- [x] bar
+^D
+  - [ ] foo
+  - [x] bar
+```

--- a/test/command/tasklist.md
+++ b/test/command/tasklist.md
@@ -1,0 +1,113 @@
+tests adapted from <https://github.github.com/gfm/#task-list-items-extension->
+
+```
+% pandoc
+- [ ] foo
+- [x] bar
+^D
+<ul>
+<li><input type="checkbox" disabled="" />
+foo</li>
+<li><input type="checkbox" disabled="" checked="" />
+bar</li>
+</ul>
+```
+
+
+```
+% pandoc
+- [x] foo
+  - [ ] bar
+  - [x] baz
+- [ ] bim
+^D
+<ul>
+<li><input type="checkbox" disabled="" checked="" />
+foo<ul>
+<li><input type="checkbox" disabled="" />
+bar</li>
+<li><input type="checkbox" disabled="" checked="" />
+baz</li>
+</ul></li>
+<li><input type="checkbox" disabled="" />
+bim</li>
+</ul>
+```
+
+
+custom html task list test:
+
+```
+% pandoc
+- [ ]  unchecked
+- plain item
+-  [x] checked
+
+paragraph
+
+1. [ ] ordered unchecked
+2. [] plain item
+3. [x] ordered checked
+
+paragraph
+
+- [ ] list item with a
+
+    second paragraph
+
+- [x] checked
+^D
+<ul>
+<li><input type="checkbox" disabled="" />
+unchecked</li>
+<li>plain item</li>
+<li><input type="checkbox" disabled="" checked="" />
+checked</li>
+</ul>
+<p>paragraph</p>
+<ol type="1">
+<li><input type="checkbox" disabled="" />
+ordered unchecked</li>
+<li>[] plain item</li>
+<li><input type="checkbox" disabled="" checked="" />
+ordered checked</li>
+</ol>
+<p>paragraph</p>
+<ul>
+<li><p><input type="checkbox" disabled="" />
+list item with a</p><p>second paragraph</p></li>
+<li><p><input type="checkbox" disabled="" checked="" />
+checked</p></li>
+</ul>
+```
+
+latex task list test:
+
+```
+% pandoc -t latex
+- [ ] foo bar
+
+  baz
+
+- [x] ok
+^D
+\begin{itemize}
+\item[$\square$]
+  foo bar
+
+  baz
+\item[$\boxtimes$]
+  ok
+\end{itemize}
+```
+
+round trip:
+
+```
+% pandoc -f markdown -t markdown
+- [ ] foo
+- [x] bar
+^D
+-   [ ] foo
+-   [x] bar
+```


### PR DESCRIPTION
closes #3051 

rationale:

- basis for the markdown syntax is [GFM task list items spec](https://github.github.com/gfm/#task-list-items-extension-)
- checkboxes in HTML output are [disabled on GitHub](https://blog.github.com/2014-04-28-task-lists-in-all-markdown-documents/) as well

This currently does not create an extra span, but matches directly on the unicode characters. The code seems reasonably concise to me, but if you think going with a span is a better solution, I can change it of course...

~~TODO: adjust GFM reader/writer~~