### PR TITLE
let KOMA document class handle parskip when applicable

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -159,12 +159,13 @@ $endif$
 }{}
 $if(indent)$
 $else$
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
+\@ifundefined{KOMAClassName}{%
+  \IfFileExists{parskip.sty}{%
+  \usepackage{parskip}
+  }{% else
+  \setlength{\parindent}{0pt}
+  \setlength{\parskip}{6pt plus 2pt minus 1pt}
+  }}{\KOMAoptions{parskip=half}}
 $endif$
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -21,12 +21,13 @@
 \usepackage[]{microtype}
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
+\@ifundefined{KOMAClassName}{%
+  \IfFileExists{parskip.sty}{%
+  \usepackage{parskip}
+  }{% else
+  \setlength{\parindent}{0pt}
+  \setlength{\parskip}{6pt plus 2pt minus 1pt}
+  }}{\KOMAoptions{parskip=half}}
 \usepackage{hyperref}
 \hypersetup{
             pdfborder={0 0 0},

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -21,12 +21,13 @@
 \usepackage[]{microtype}
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
+\@ifundefined{KOMAClassName}{%
+  \IfFileExists{parskip.sty}{%
+  \usepackage{parskip}
+  }{% else
+  \setlength{\parindent}{0pt}
+  \setlength{\parskip}{6pt plus 2pt minus 1pt}
+  }}{\KOMAoptions{parskip=half}}
 \usepackage{hyperref}
 \hypersetup{
             pdfborder={0 0 0},

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -21,12 +21,13 @@
 \usepackage[]{microtype}
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
+\@ifundefined{KOMAClassName}{%
+  \IfFileExists{parskip.sty}{%
+  \usepackage{parskip}
+  }{% else
+  \setlength{\parindent}{0pt}
+  \setlength{\parskip}{6pt plus 2pt minus 1pt}
+  }}{\KOMAoptions{parskip=half}}
 \usepackage{fancyvrb}
 \usepackage{hyperref}
 \hypersetup{

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -21,12 +21,13 @@
 \usepackage[]{microtype}
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
+\@ifundefined{KOMAClassName}{%
+  \IfFileExists{parskip.sty}{%
+  \usepackage{parskip}
+  }{% else
+  \setlength{\parindent}{0pt}
+  \setlength{\parskip}{6pt plus 2pt minus 1pt}
+  }}{\KOMAoptions{parskip=half}}
 \usepackage{hyperref}
 \hypersetup{
             pdfborder={0 0 0},


### PR DESCRIPTION
As discussed in https://github.com/jgm/pandoc/issues/5131 it is better to let KOMA document classes handle parskip itself.

Please check the indentation of the added code, which might not be the style that should be adhered to.