### PR TITLE
Org writer: preserve line-numbering for example and code blocks.

### DIFF
--- a/test/command/5178.md
+++ b/test/command/5178.md
@@ -1,0 +1,41 @@
+```
+% pandoc -f rst -t org
+.. code:: haskell
+   :number-lines: 42
+
+   main = putStrLn "Hello World!"
+   unsafePerformIO main
+^D
+#+BEGIN_SRC haskell -n 42
+    main = putStrLn "Hello World!"
+    unsafePerformIO main
+#+END_SRC
+```
+
+```
+% pandoc -f org -t native
+#+BEGIN_SRC lisp -n 20
+    (+ 1 1)
+#+END_SRC
+
+#+BEGIN_SRC lisp +n 10
+    (+ 2 2)
+#+END_SRC
+^D
+[CodeBlock ("",["commonlisp","numberLines"],[("org-language","lisp"),("startFrom","20")]) "(+ 1 1)\n"
+,CodeBlock ("",["commonlisp","numberLines","continuedSourceBlock"],[("org-language","lisp"),("startFrom","10")]) "(+ 2 2)\n"]
+```
+
+```
+% pandoc -f native -t org
+[CodeBlock ("",["commonlisp","numberLines"],[("org-language","lisp"),("startFrom","20")]) "(+ 1 1)\n"
+,CodeBlock ("",["commonlisp","numberLines","continuedSourceBlock"],[("org-language","lisp"),("startFrom","10")]) "(+ 2 2)\n"]
+^D
+#+BEGIN_SRC lisp -n 20
+    (+ 1 1)
+#+END_SRC
+
+#+BEGIN_SRC lisp +n 10
+    (+ 2 2)
+#+END_SRC
+```


### PR DESCRIPTION
``` html
<div class="sourceCode" id="cb1" data-org-language="lisp" data-startFrom="20">
<pre class="sourceCode numberSource commonlisp numberLines">
<code class="sourceCode commonlisp">
<a class="sourceLine" id="cb1-20" title="20">(<span class="op">+</span> <span class="dv">1</span> <span class="dv">1</span>)
</a>
</code>
</pre>
</div>
```

I noticed that writing to HTML doesn't list the `startFrom` data as an attribute in `<pre>`; is this supposed to happen? If so I'll need to modify this patch slightly, since converting the above HTML back to Org does not write the `startFrom` data.

Closes #5178.