### PR TITLE
FIX #5183 : dokuwiki : remove automatic ':' prefix before internal image links

### DIFF
--- a/src/Text/Pandoc/Writers/DokuWiki.hs
+++ b/src/Text/Pandoc/Writers/DokuWiki.hs
@@ -130,9 +130,7 @@ blockToDokuWiki opts (Para [Image attr txt (src,'f':'i':'g':':':tit)]) = do
   let opt = if null txt
                then ""
                else "|" ++ if null tit then capt else tit ++ capt
-      -- Relative links fail isURI and receive a colon
-      prefix = if isURI src then "" else ":"
-  return $ "{{" ++ prefix ++ src ++ imageDims opts attr ++ opt ++ "}}\n"
+  return $ "{{" ++ src ++ imageDims opts attr ++ opt ++ "}}\n"
 
 blockToDokuWiki opts (Para inlines) = do
   indent <- asks stIndent
@@ -516,9 +514,7 @@ inlineToDokuWiki opts (Image attr alt (source, tit)) = do
               ("", []) -> ""
               ("", _ ) -> "|" ++ alt'
               (_ , _ ) -> "|" ++ tit
-      -- Relative links fail isURI and receive a colon
-      prefix = if isURI source then "" else ":"
-  return $ "{{" ++ prefix ++ source ++ imageDims opts attr ++ txt ++ "}}"
+  return $ "{{" ++ source ++ imageDims opts attr ++ txt ++ "}}"
 
 inlineToDokuWiki opts (Note contents) = do
   contents' <- blockListToDokuWiki opts contents

--- a/test/dokuwiki_external_images.dokuwiki
+++ b/test/dokuwiki_external_images.dokuwiki
@@ -1,1 +1,1 @@
-{{https://cooluri.com/image.png|HTTPS image}} {{http://cooluri.com/image.png|HTTP image}} {{ftp://ftp.cooluri.com/image.png|FTP image}} {{file:///tmp/coolimage.png|Filesystem image}} {{:/image.jpg|Relative image 1}} {{:image.jpg|Relative image 2}}
+{{https://cooluri.com/image.png|HTTPS image}} {{http://cooluri.com/image.png|HTTP image}} {{ftp://ftp.cooluri.com/image.png|FTP image}} {{file:///tmp/coolimage.png|Filesystem image}} {{/image.jpg|Relative image 1}} {{image.jpg|Relative image 2}}

--- a/test/writer.dokuwiki
+++ b/test/writer.dokuwiki
@@ -609,9 +609,9 @@ or here: <http://example.com/>
 
 From “Voyage dans la Lune” by Georges Melies (1902):
 
-{{:lalune.jpg|Voyage dans la Lune lalune}}
+{{lalune.jpg|Voyage dans la Lune lalune}}
 
-Here is a movie {{:movie.jpg|movie}} icon.
+Here is a movie {{movie.jpg|movie}} icon.
 
 
 ----


### PR DESCRIPTION
closes #5183

* `![](foo.png)` should be converted to `{{foo.png}}` (relative path)
* `![](/foo.png]` should be converted to `{{/foo.png}}` (absolute path)

Therefore the ':' prefix is useless and must be removed.
It blocks users from making relative image links.