### PR TITLE
FIX #5183 : zimwiki : remove automatic colon prefix before internal  images

### DIFF
--- a/src/Text/Pandoc/Writers/ZimWiki.hs
+++ b/src/Text/Pandoc/Writers/ZimWiki.hs
@@ -109,9 +109,7 @@ blockToZimWiki opts (Para [Image attr txt (src,'f':'i':'g':':':tit)]) = do
   let opt = if null txt
                then ""
                else "|" ++ if null tit then capt else tit ++ capt
-      -- Relative links fail isURI and receive a colon
-      prefix = if isURI src then "" else ":"
-  return $ "{{" ++ prefix ++ src ++ imageDims opts attr ++ opt ++ "}}\n"
+  return $ "{{" ++ src ++ imageDims opts attr ++ opt ++ "}}\n"
 
 blockToZimWiki opts (Para inlines) = do
   indent <- gets stIndent
@@ -383,9 +381,7 @@ inlineToZimWiki opts (Image attr alt (source, tit)) = do
               ("", _, False ) -> "|" ++ alt'
               (_ , _, False ) -> "|" ++ tit
               (_ , _, True )  -> ""
-      -- Relative links fail isURI and receive a colon
-      prefix = if isURI source then "" else ":"
-  return $ "{{" ++ prefix ++ source ++ imageDims opts attr ++ txt ++ "}}"
+  return $ "{{" ++ source ++ imageDims opts attr ++ txt ++ "}}"
 
 inlineToZimWiki opts (Note contents) = do
   -- no concept of notes in zim wiki, use a text block

--- a/test/writer.zimwiki
+++ b/test/writer.zimwiki
@@ -52,22 +52,22 @@ E-mail style:
 > This is a block quote. It is pretty short.
 
 > Code in a block quote:
->
+> 
 > '''
 > sub status {
 >     print "working";
 > }
 > '''
->
+> 
 > A list:
->
+> 
 > 1. item one
 > 2. item two
->
+> 
 > Nested block quotes:
->
+> 
 > > nested
->
+> 
 > > nested
 
 This should not be a block quote: 2 > 1.
@@ -435,7 +435,7 @@ Ellipses…and…and….
 
 ====== LaTeX ======
 
-*
+* 
 * $2+2=4$
 * $x \in y$
 * $\alpha \wedge \omega$

--- a/test/writer.zimwiki
+++ b/test/writer.zimwiki
@@ -52,22 +52,22 @@ E-mail style:
 > This is a block quote. It is pretty short.
 
 > Code in a block quote:
-> 
+>
 > '''
 > sub status {
 >     print "working";
 > }
 > '''
-> 
+>
 > A list:
-> 
+>
 > 1. item one
 > 2. item two
-> 
+>
 > Nested block quotes:
-> 
+>
 > > nested
-> 
+>
 > > nested
 
 This should not be a block quote: 2 > 1.
@@ -435,7 +435,7 @@ Ellipses…and…and….
 
 ====== LaTeX ======
 
-* 
+*
 * $2+2=4$
 * $x \in y$
 * $\alpha \wedge \omega$
@@ -593,9 +593,9 @@ or here: <http://example.com/>
 
 From “Voyage dans la Lune” by Georges Melies (1902):
 
-{{:lalune.jpg|Voyage dans la Lune lalune}}
+{{lalune.jpg|Voyage dans la Lune lalune}}
 
-Here is a movie {{:movie.jpg|movie}} icon.
+Here is a movie {{movie.jpg|movie}} icon.
 
 
 ----


### PR DESCRIPTION
This is patch is similar to the PR #5184
https://github.com/jgm/pandoc/pull/5184

* `![](foo.png)` should be converted to `{{foo.png}}` (relative path)
* `![](/foo.png)` should be converted to `{{/foo.png}}` (absolute path)

Therefore the ':' prefix is useless and must be removed.

I never used the zimwiki, but i submitted the similar dokuwiki fix.

1. The zimwiki syntax is inspired by dokuwiki
2. The zimwiki documentation does not mention the colon character for images
3. The pandoc zimwiki writer seems to be a copy-paste for the dokuwiki writer

http://zim-wiki.org/manual/Help/Wiki_Syntax.html

If the PR #5184 is applied, I think this one should be applied too.