### PR TITLE
Org reader: handle `minlevel` option differently.

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Blocks.hs
+++ b/src/Text/Pandoc/Readers/Org/Blocks.hs
@@ -547,9 +547,7 @@ include = try $ do
 
   shiftHeader :: Int -> Block -> Block
   shiftHeader shift blk =
-    if shift <= 0
-    then blk
-    else case blk of
+    case blk of
       (Header lvl attr content) -> Header (lvl - shift) attr content
       _ -> blk
 

--- a/test/Tests/Readers/Org/Directive.hs
+++ b/test/Tests/Readers/Org/Directive.hs
@@ -192,9 +192,14 @@ tests =
        headerWith ("level3", [], []) 3 "Level3")
 
     , testWithFiles [("./level3.org", "*** Level3\n\n")]
-      "Minlevel shifts level"
+      "Minlevel shifts level leftward"
       (T.unlines [ "#+include: \"level3.org\" :minlevel 1" ] =?>
        headerWith ("level3", [], []) 1 "Level3")
+
+    , testWithFiles [("./level1.org", "* Level1\n\n")]
+      "Minlevel shifts level rightward"
+      (T.unlines [ "#+include: \"level1.org\" :minlevel 3" ] =?>
+       headerWith ("level1", [], []) 3 "Level1")
 
     , testWithFiles [("./src.hs", "putStrLn outString\n")]
       "Include file as source code snippet"


### PR DESCRIPTION
When `minlevel` exceeds the original minimum level observed in the
file to be included, every heading should be shifted rightward.

Closes #5188.