### PR TITLE
Change treatment of `number-lines` directives.

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -189,6 +189,7 @@ extra-source-files:
                  test/command/*.md
                  test/command/3533-rst-csv-tables.csv
                  test/command/3880.txt
+                 test/command/5182.txt
                  test/command/abbrevs
                  test/command/SVG_logo-without-xml-declaration.svg
                  test/command/SVG_logo.svg

--- a/test/Tests/Readers/RST.hs
+++ b/test/Tests/Readers/RST.hs
@@ -112,7 +112,7 @@ tests = [ "line block with blank line" =:
                   "def func(x):\n  return y")
         , "Code directive with number-lines, no line specified" =: T.unlines
             [ ".. code::python"
-            , "   :number-lines: "
+            , "   :number-lines:"
             , ""
             , "  def func(x):"
             , "    return y"
@@ -120,7 +120,7 @@ tests = [ "line block with blank line" =:
               doc (codeBlockWith
                   ( ""
                   , ["python", "numberLines"]
-                  , [ ("startFrom", "") ]
+                  , []
                   )
                   "def func(x):\n  return y")
         , testGroup "literal / line / code blocks"

--- a/test/command/5182.md
+++ b/test/command/5182.md
@@ -1,0 +1,6 @@
+```
+pandoc -f rst -t native
+.. include:: command/5182.txt
+^D
+[CodeBlock ("",["python","numberLines"],[]) "def func(x):\n  return y"]
+```

--- a/test/command/5182.txt
+++ b/test/command/5182.txt
@@ -1,0 +1,5 @@
+.. code::python
+   :number-lines:
+
+  def func(x):
+    return y


### PR DESCRIPTION
Directives of this type without numeric inputs should not have a
`startFrom` attribute; with a blank value, the writers can produce
extra whitespace.

Also, the stuff around line 1000 is modified because previously, it failed to catch newlines.

Closes #5182.