### PR TITLE
LaTeX template: Prevent scaling of main font

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -110,31 +110,30 @@ $if(mathspec)$
 $else$
   \usepackage{unicode-math}
 $endif$
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
-$for(fontfamilies)$
-  \newfontfamily{$fontfamilies.name$}[$for(fontfamilies.options)$$fontfamilies.options$$sep$,$endfor$]{$fontfamilies.font$}
-$endfor$
 $if(mainfont)$
   \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$
 $if(romanfont)$
-  \setromanfont[$for(romanfontoptions)$$romanfontoptions$$sep$,$endfor$]{$romanfont$}
+  \setromanfont[$if(romanfontoptions)$$for(romanfontoptions)$$romanfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$romanfont$}
 $endif$
 $if(sansfont)$
-  \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
+  \setsansfont[$if(sansfontoptions)$$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$sansfont$}
 $endif$
 $if(monofont)$
-  \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$endif$]{$monofont$}
+  \setmonofont[$if(monofontoptions)$$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$monofont$}
 $endif$
+$for(fontfamilies)$
+  \newfontfamily{$fontfamilies.name$}[$if(fontfamilies.options)$$for(fontfamilies.options)$$fontfamilies.options$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$fontfamilies.font$}
+$endfor$
 $if(mathfont)$
 $if(mathspec)$
   \ifxetex
-    \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+    \setmathfont(Digits,Latin,Greek)[$if(mathfontoptions)$$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$mathfont$}
   \else
-    \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+    \setmathfont[$if(mathfontoptions)$$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$mathfont$}
   \fi
 $else$
-  \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+  \setmathfont[$if(mathfontoptions)$$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$mathfont$}
 $endif$
 $endif$
 $if(CJKmainfont)$

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -12,7 +12,6 @@
   \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -12,7 +12,6 @@
   \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -12,7 +12,6 @@
   \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -13,7 +13,6 @@
   \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}


### PR DESCRIPTION
When `Scale=MatchLowercase` is set as a default font option, this scales `mainfont` against the old default, meaning that it resizes whatever is set as the main font to match the metrics of Latin Modern. This can result, for example, in a document set to 12pt appearing in 11pt or 13pt. Setting this option for individual families allows everything to scale against the main font, and permits the user to override the setting if desired. Note that it is not necessary to specify `Ligatures=TeX`, as this is already set by default for the appropriate families. See the `fontspec` manual: <https://ctan.org/pkg/fontspec>.