### PR TITLE
 LaTeX template: Render \subtitle

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -166,8 +166,7 @@ pandoc does not require them to be present:
 [`parskip`] (for better inter-paragraph spaces),
 [`xurl`] (for better line breaks in URLs),
 [`bookmark`] (for better PDF bookmarks),
-[`titling`] (if `subtitle` is specified), and
-[`footnote`] (to fix footnotes in tables).
+and [`footnote`] (to fix footnotes in tables).
 
 [TeX Live]: http://www.tug.org/texlive/
 [`amsfonts`]: https://ctan.org/pkg/amsfonts
@@ -199,7 +198,6 @@ pandoc does not require them to be present:
 [`polyglossia`]: https://ctan.org/pkg/polyglossia
 [`prince`]: https://www.princexml.com/
 [`setspace`]: https://ctan.org/pkg/setspace
-[`titling`]: https://ctan.org/pkg/titling
 [`ulem`]: https://ctan.org/pkg/ulem
 [`unicode-math`]: https://ctan.org/pkg/unicode-math
 [`upquote`]: https://ctan.org/pkg/upquote

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1361,10 +1361,7 @@ depending on the output format, but include the following:
         ...
 
 `subtitle`
-:   document subtitle, included in HTML, EPUB, LaTeX, ConTeXt, and Word docx;
-    renders in LaTeX only when using a document class that supports
-    `\subtitle`, such as `beamer` or the [KOMA-Script] series (`scrartcl`,
-    `scrreprt`, `scrbook`).[^subtitle]
+:   document subtitle, included in HTML, EPUB, LaTeX, ConTeXt, and Word docx
 
 `institute`
 :   author affiliations (in LaTeX and Beamer only).  Can be a
@@ -1402,15 +1399,6 @@ depending on the output format, but include the following:
 `meta-json`
 :   JSON representation of all of the document's metadata. Field
     values are transformed to the selected output format.
-
-[^subtitle]: To make `subtitle` work with other LaTeX
-    document classes, you can add the following to `header-includes`:
-
-        \providecommand{\subtitle}[1]{%
-          \usepackage{titling}
-          \posttitle{%
-            \par\large#1\end{center}}
-        }
 
 Language variables
 ------------------

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -166,47 +166,48 @@ pandoc does not require them to be present:
 [`parskip`] (for better inter-paragraph spaces),
 [`xurl`] (for better line breaks in URLs),
 [`bookmark`] (for better PDF bookmarks),
+[`titling`] (if `subtitle` is specified), and
 [`footnote`] (to fix footnotes in tables).
 
+[TeX Live]: http://www.tug.org/texlive/
 [`amsfonts`]: https://ctan.org/pkg/amsfonts
 [`amsmath`]: https://ctan.org/pkg/amsmath
-[`lm`]: https://ctan.org/pkg/lm
-[`ifxetex`]: https://ctan.org/pkg/ifxetex
-[`ifluatex`]: https://ctan.org/pkg/ifluatex
-[`listings`]: https://ctan.org/pkg/listings
-[`fancyvrb`]: https://ctan.org/pkg/fancyvrb
-[`longtable`]: https://ctan.org/pkg/longtable
-[`booktabs`]: https://ctan.org/pkg/booktabs
-[`graphicx`]: https://ctan.org/pkg/graphicx
-[`grffile`]: https://ctan.org/pkg/grffile
-[`geometry`]: https://ctan.org/pkg/geometry
-[`setspace`]: https://ctan.org/pkg/setspace
-[`xecjk`]: https://ctan.org/pkg/xecjk
-[`hyperref`]: https://ctan.org/pkg/hyperref
-[`ulem`]: https://ctan.org/pkg/ulem
 [`babel`]: https://ctan.org/pkg/babel
-[`bidi`]: https://ctan.org/pkg/bidi
-[`mathspec`]: https://ctan.org/pkg/mathspec
-[`unicode-math`]: https://ctan.org/pkg/unicode-math
-[`polyglossia`]: https://ctan.org/pkg/polyglossia
-[`fontspec`]: https://ctan.org/pkg/fontspec
-[`upquote`]: https://ctan.org/pkg/upquote
-[`microtype`]: https://ctan.org/pkg/microtype
-[`csquotes`]: https://ctan.org/pkg/csquotes
-[`natbib`]: https://ctan.org/pkg/natbib
+[`biber`]: https://ctan.org/pkg/biber
 [`biblatex`]: https://ctan.org/pkg/biblatex
 [`bibtex`]: https://ctan.org/pkg/bibtex
-[`biber`]: https://ctan.org/pkg/biber
-[TeX Live]: http://www.tug.org/texlive/
-[`wkhtmltopdf`]: https://wkhtmltopdf.org
-[`weasyprint`]: http://weasyprint.org
-[`prince`]: https://www.princexml.com/
-[`upquote`]: https://ctan.org/pkg/upquote
-[`microtype`]: https://ctan.org/pkg/microtype
-[`parskip`]: https://ctan.org/pkg/parskip
-[`xurl`]: https://ctan.org/pkg/xurl
+[`bidi`]: https://ctan.org/pkg/bidi
 [`bookmark`]: https://ctan.org/pkg/bookmark
+[`booktabs`]: https://ctan.org/pkg/booktabs
+[`csquotes`]: https://ctan.org/pkg/csquotes
+[`fancyvrb`]: https://ctan.org/pkg/fancyvrb
+[`fontspec`]: https://ctan.org/pkg/fontspec
 [`footnote`]: https://ctan.org/pkg/footnote
+[`geometry`]: https://ctan.org/pkg/geometry
+[`graphicx`]: https://ctan.org/pkg/graphicx
+[`grffile`]: https://ctan.org/pkg/grffile
+[`hyperref`]: https://ctan.org/pkg/hyperref
+[`ifluatex`]: https://ctan.org/pkg/ifluatex
+[`ifxetex`]: https://ctan.org/pkg/ifxetex
+[`listings`]: https://ctan.org/pkg/listings
+[`lm`]: https://ctan.org/pkg/lm
+[`longtable`]: https://ctan.org/pkg/longtable
+[`mathspec`]: https://ctan.org/pkg/mathspec
+[`microtype`]: https://ctan.org/pkg/microtype
+[`natbib`]: https://ctan.org/pkg/natbib
+[`parskip`]: https://ctan.org/pkg/parskip
+[`polyglossia`]: https://ctan.org/pkg/polyglossia
+[`prince`]: https://www.princexml.com/
+[`setspace`]: https://ctan.org/pkg/setspace
+[`titling`]: https://ctan.org/pkg/titling
+[`ulem`]: https://ctan.org/pkg/ulem
+[`unicode-math`]: https://ctan.org/pkg/unicode-math
+[`upquote`]: https://ctan.org/pkg/upquote
+[`weasyprint`]: http://weasyprint.org
+[`wkhtmltopdf`]: https://wkhtmltopdf.org
+[`xecjk`]: https://ctan.org/pkg/xecjk
+[`xurl`]: https://ctan.org/pkg/xurl
+
 
 
 Reading from the Web

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -352,11 +352,12 @@ $endif$
 $if(subtitle)$
 $if(beamer)$
 $else$
-\providecommand{\subtitle}[1]{%
-	\usepackage{titling}
-	\posttitle{%
-    \par\large#1\end{center}}
+\makeatletter
+\providecommand{\subtitle}[1]{% add subtitle to \maketitle
+  \usepackage{etoolbox}
+  \apptocmd{\@title}{\par \large #1}{}{}
 }
+\makeatother
 $endif$
 \subtitle{$subtitle$}
 $endif$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -352,10 +352,10 @@ $endif$
 $if(subtitle)$
 $if(beamer)$
 $else$
+\usepackage{etoolbox}
 \makeatletter
 \providecommand{\subtitle}[1]{% add subtitle to \maketitle
-  \usepackage{etoolbox}
-  \apptocmd{\@title}{\par \large #1}{}{}
+  \apptocmd{\@title}{\par {\large #1}}{}{}
 }
 \makeatother
 $endif$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -354,12 +354,10 @@ $if(beamer)$
 $else$
 \makeatletter
 \@ifundefined{KOMAClassName}{% if non-KOMA class
-	\usepackage{titling}
 	\providecommand{\subtitle}[1]{%
+  	\usepackage{titling}
 	  \posttitle{%
-	    \par\end{center}
-	    \begin{center}\large#1\end{center}
-	    \vskip0.5em}%
+	    \par\large#1\end{center}}
 	}
 }{}% KOMA-Script provides \subtitle
 \makeatother

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -350,7 +350,20 @@ $if(title)$
 \title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
 $endif$
 $if(subtitle)$
-\providecommand{\subtitle}[1]{}
+$if(beamer)$
+$else$
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+	\usepackage{titling}
+	\providecommand{\subtitle}[1]{%
+	  \posttitle{%
+	    \par\end{center}
+	    \begin{center}\large#1\end{center}
+	    \vskip0.5em}%
+	}
+}{}% KOMA-Script provides \subtitle
+\makeatother
+$endif$
 \subtitle{$subtitle$}
 $endif$
 $if(author)$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -352,15 +352,11 @@ $endif$
 $if(subtitle)$
 $if(beamer)$
 $else$
-\makeatletter
-\@ifundefined{KOMAClassName}{% if non-KOMA class
-	\providecommand{\subtitle}[1]{%
-  	\usepackage{titling}
-	  \posttitle{%
-	    \par\large#1\end{center}}
-	}
-}{}% KOMA-Script provides \subtitle
-\makeatother
+\providecommand{\subtitle}[1]{%
+	\usepackage{titling}
+	\posttitle{%
+    \par\large#1\end{center}}
+}
 $endif$
 \subtitle{$subtitle$}
 $endif$


### PR DESCRIPTION
This renders `\subtitle` without requiring a different document class such as `scrartcl`, ~~using the `titling` package. This integrates the solution in the manual, which I believe was based on an example from Enrico Gregorio, <https://tex.stackexchange.com/a/50186> but is simplified.~~ The matter has come up several times (#4675, #3896, #1327 and on pandoc-discuss), so it seems worthwhile to include it by default even if requiring `titling` isn't ideal.

The blank command was added in <https://github.com/jgm/pandoc/commit/4ac59af2429d97c1bb1f54088453a97205c0fcdc> to avoid problems with packages that define `\subtitle`. I've verified that this solution will not load with Beamer or KOMA (I was initially using a separate test for KOMA, but `\providecommand` is sufficient to stop `titling` from loading).

~~I'm not using a test for the presence of `titling` on the principle of providing an error rather than silently changing key aspects of the document's appearance, but there are some distributions that omit it (which was why I didn't add this code to the template earlier), so this could be added.~~