### PR TITLE
Make Math produced by Asciidoc writer work with both Asciidoc and Asciidoctor

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -279,7 +279,7 @@ General options {.options}
 :   Specify output format.  *FORMAT* can be:
 
     ::: {#output-formats}
-    - `asciidoc` ([AsciiDoc])
+    - `asciidoc` ([AsciiDoc]) or `asciidoctor` ([AsciiDoctor])
     - `beamer` ([LaTeX beamer][`beamer`] slide show)
     - `commonmark` ([CommonMark] Markdown)
     - `context` ([ConTeXt])
@@ -465,6 +465,7 @@ General options {.options}
 [GNU Texinfo]: http://www.gnu.org/software/texinfo/
 [Emacs Org mode]: http://orgmode.org
 [AsciiDoc]: http://www.methods.co.nz/asciidoc/
+[AsciiDoctor]: https://asciidoctor.org/
 [DZSlides]: http://paulrouget.com/dzslides/
 [Word docx]: https://en.wikipedia.org/wiki/Office_Open_XML
 [PDF]: https://www.adobe.com/pdf/
@@ -3513,7 +3514,11 @@ reStructuredText
   ~ It will be rendered using an [interpreted text role `:math:`].
 
 AsciiDoc
-  ~ It will be rendered as `latexmath:[...]` when inline and `[latexmath]++++....++++` when in display mode.
+  ~ For AsciiDoc output format (`-t asciidoc`) it will appear verbatim
+    surrounded by `latexmath:[$...$]` (for inline math) or
+    `[latexmath]++++\[...\]+++` (for display math).
+    For AsciiDoctor output format (`-t asciidoctor`) the LaTex delimiters
+    (`$..$` and `\[..\]`) are omitted.
 
 Texinfo
   ~ It will be rendered inside a `@math` command.

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3513,7 +3513,7 @@ reStructuredText
   ~ It will be rendered using an [interpreted text role `:math:`].
 
 AsciiDoc
-  ~ It will be rendered as `latexmath:[...]`.
+  ~ It will be rendered as `latexmath:[...]` when inline and `[latexmath]++++....++++` when in display mode.
 
 Texinfo
   ~ It will be rendered inside a `@math` command.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ It can convert *to*
 
 <div id="output-formats">
 
-  - `asciidoc` ([AsciiDoc](http://www.methods.co.nz/asciidoc/))
+  - `asciidoc` ([AsciiDoc](http://www.methods.co.nz/asciidoc/)) or `asciidoctor` ([AsciiDoctor](https://asciidoctor.org/))
   - `beamer` ([LaTeX beamer](https://ctan.org/pkg/beamer) slide show)
   - `commonmark` ([CommonMark](http://commonmark.org) Markdown)
   - `context` ([ConTeXt](http://www.contextgarden.net/))

--- a/data/templates/default.asciidoctor
+++ b/data/templates/default.asciidoctor
@@ -1,0 +1,38 @@
+$if(titleblock)$
+= $title$
+$if(author)$
+$for(author)$$author$$sep$; $endfor$
+$endif$
+$if(date)$
+$date$
+$endif$
+$if(keywords)$
+:keywords: $for(keywords)$$keywords$$sep$, $endfor$
+$endif$
+$if(lang)$
+:lang: $lang$
+$endif$
+$if(toc)$
+:toc:
+$endif$
+
+$endif$
+$if(abstract)$
+[abstract]
+== Abstract
+$abstract$
+
+$endif$
+$for(header-includes)$
+$header-includes$
+
+$endfor$
+$for(include-before)$
+$include-before$
+
+$endfor$
+$body$
+$for(include-after)$
+
+$include-after$
+$endfor$

--- a/data/templates/default.asciidoctor
+++ b/data/templates/default.asciidoctor
@@ -15,6 +15,9 @@ $endif$
 $if(toc)$
 :toc:
 $endif$
+$if(math)$
+:stem: latexmath
+$endif$
 
 $endif$
 $if(abstract)$

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -70,6 +70,7 @@ data-files:
                  data/templates/default.revealjs
                  data/templates/default.dzslides
                  data/templates/default.asciidoc
+                 data/templates/default.asciidoctor
                  data/templates/default.haddock
                  data/templates/default.textile
                  data/templates/default.org

--- a/src/Text/Pandoc/Writers.hs
+++ b/src/Text/Pandoc/Writers.hs
@@ -37,6 +37,7 @@ module Text.Pandoc.Writers
       Writer(..)
     , writers
     , writeAsciiDoc
+    , writeAsciiDoctor
     , writeBeamer
     , writeCommonMark
     , writeConTeXt
@@ -178,6 +179,7 @@ writers = [
   ,("rtf"          , TextWriter writeRTF)
   ,("org"          , TextWriter writeOrg)
   ,("asciidoc"     , TextWriter writeAsciiDoc)
+  ,("asciidoctor"  , TextWriter writeAsciiDoctor)
   ,("haddock"      , TextWriter writeHaddock)
   ,("commonmark"   , TextWriter writeCommonMark)
   ,("gfm"          , TextWriter writeCommonMark)

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -414,7 +414,10 @@ inlineToAsciiDoc _ (Str str) = return $ text $ escapeString str
 inlineToAsciiDoc _ (Math InlineMath str) =
   return $ "latexmath:[$" <> text str <> "$]"
 inlineToAsciiDoc _ (Math DisplayMath str) =
-  return $ "latexmath:[\\[" <> text str <> "\\]]"
+  return $
+      blankline <> "[latexmath]" $$ "++++" $$
+      "\\[" <> text str <> "\\]"
+      $$ "++++" $$ blankline
 inlineToAsciiDoc _ il@(RawInline f s)
   | f == "asciidoc" = return $ text s
   | otherwise         = do

--- a/test/Tests/Old.hs
+++ b/test/Tests/Old.hs
@@ -159,7 +159,7 @@ tests pandocPath =
         "tikiwiki-reader.tikiwiki" "tikiwiki-reader.native" ]
   , testGroup "other writers" $ map (\f -> testGroup f $ writerTests' f)
     [ "opendocument" , "context" , "texinfo", "icml", "tei"
-    , "man" , "plain" , "rtf", "org", "asciidoc", "zimwiki"
+    , "man" , "plain" , "rtf", "org", "asciidoc", "asciidoctor", "zimwiki"
     ]
   , testGroup "writers-lang-and-dir"
     [ test' "latex" ["-f", "native", "-t", "latex", "-s"]

--- a/test/tables.asciidoctor
+++ b/test/tables.asciidoctor
@@ -1,0 +1,67 @@
+Simple table with caption:
+
+.Demonstration of simple table syntax.
+[cols=">,<,^,",options="header",]
+|===
+|Right |Left |Center |Default
+|12 |12 |12 |12
+|123 |123 |123 |123
+|1 |1 |1 |1
+|===
+
+Simple table without caption:
+
+[cols=">,<,^,",options="header",]
+|===
+|Right |Left |Center |Default
+|12 |12 |12 |12
+|123 |123 |123 |123
+|1 |1 |1 |1
+|===
+
+Simple table indented two spaces:
+
+.Demonstration of simple table syntax.
+[cols=">,<,^,",options="header",]
+|===
+|Right |Left |Center |Default
+|12 |12 |12 |12
+|123 |123 |123 |123
+|1 |1 |1 |1
+|===
+
+Multiline table with caption:
+
+.Here’s the caption. It may span multiple lines.
+[width="80%",cols="^20%,<17%,>20%,<43%",options="header",]
+|===
+|Centered Header |Left Aligned |Right Aligned |Default aligned
+|First |row |12.0 |Example of a row that spans multiple lines.
+|Second |row |5.0 |Here’s another one. Note the blank line between rows.
+|===
+
+Multiline table without caption:
+
+[width="80%",cols="^20%,<17%,>20%,<43%",options="header",]
+|===
+|Centered Header |Left Aligned |Right Aligned |Default aligned
+|First |row |12.0 |Example of a row that spans multiple lines.
+|Second |row |5.0 |Here’s another one. Note the blank line between rows.
+|===
+
+Table without column headers:
+
+[cols=">,<,^,>",]
+|===
+|12 |12 |12 |12
+|123 |123 |123 |123
+|1 |1 |1 |1
+|===
+
+Multiline table without column headers:
+
+[width="80%",cols="^20%,<17%,>20%,43%",]
+|===
+|First |row |12.0 |Example of a row that spans multiple lines.
+|Second |row |5.0 |Here’s another one. Note the blank line between rows.
+|===

--- a/test/writer.asciidoc
+++ b/test/writer.asciidoc
@@ -466,7 +466,11 @@ Ellipses…and…and….
 * latexmath:[$223$]
 * latexmath:[$p$]-Tree
 * Here’s some display math:
-latexmath:[\[\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}\]]
+
+[latexmath]
+++++
+\[\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}\]
+++++
 * Here’s one that has a line break in it:
 latexmath:[$\alpha + \omega \times x^2$].
 

--- a/test/writer.asciidoctor
+++ b/test/writer.asciidoctor
@@ -1,6 +1,7 @@
 = Pandoc Test Suite
 John MacFarlane; Anonymous
 July 17, 2006
+:stem: latexmath
 
 This is a set of tests for pandoc. Most of them are adapted from John Gruber’s
 markdown test suite.

--- a/test/writer.asciidoctor
+++ b/test/writer.asciidoctor
@@ -1,0 +1,648 @@
+= Pandoc Test Suite
+John MacFarlane; Anonymous
+July 17, 2006
+
+This is a set of tests for pandoc. Most of them are adapted from John Gruber’s
+markdown test suite.
+
+'''''
+
+== Headers
+
+=== Level 2 with an link:/url[embedded link]
+
+==== Level 3 with _emphasis_
+
+===== Level 4
+
+====== Level 5
+
+== Level 1
+
+=== Level 2 with _emphasis_
+
+==== Level 3
+
+with no blank line
+
+=== Level 2
+
+with no blank line
+
+'''''
+
+== Paragraphs
+
+Here’s a regular paragraph.
+
+In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item.
+Because a hard-wrapped line in the middle of a paragraph looked like a list
+item.
+
+Here’s one with a bullet. * criminey.
+
+There should be a hard line break +
+here.
+
+'''''
+
+== Block Quotes
+
+E-mail style:
+
+____
+This is a block quote. It is pretty short.
+____
+
+____
+--
+Code in a block quote:
+
+....
+sub status {
+    print "working";
+}
+....
+
+A list:
+
+[arabic]
+. item one
+. item two
+
+Nested block quotes:
+
+____
+nested
+____
+
+____
+nested
+____
+
+--
+____
+
+This should not be a block quote: 2 > 1.
+
+And a following paragraph.
+
+'''''
+
+== Code Blocks
+
+Code:
+
+....
+---- (should be four hyphens)
+
+sub status {
+    print "working";
+}
+
+this code block is indented by one tab
+....
+
+And:
+
+....
+    this code block is indented by two tabs
+
+These should not be escaped:  \$ \\ \> \[ \{
+....
+
+'''''
+
+== Lists
+
+=== Unordered
+
+Asterisks tight:
+
+* asterisk 1
+* asterisk 2
+* asterisk 3
+
+Asterisks loose:
+
+* asterisk 1
+* asterisk 2
+* asterisk 3
+
+Pluses tight:
+
+* Plus 1
+* Plus 2
+* Plus 3
+
+Pluses loose:
+
+* Plus 1
+* Plus 2
+* Plus 3
+
+Minuses tight:
+
+* Minus 1
+* Minus 2
+* Minus 3
+
+Minuses loose:
+
+* Minus 1
+* Minus 2
+* Minus 3
+
+=== Ordered
+
+Tight:
+
+[arabic]
+. First
+. Second
+. Third
+
+and:
+
+[arabic]
+. One
+. Two
+. Three
+
+Loose using tabs:
+
+[arabic]
+. First
+. Second
+. Third
+
+and using spaces:
+
+[arabic]
+. One
+. Two
+. Three
+
+Multiple paragraphs:
+
+[arabic]
+. Item 1, graf one.
++
+Item 1. graf two. The quick brown fox jumped over the lazy dog’s back.
+. Item 2.
+. Item 3.
+
+=== Nested
+
+* Tab
+** Tab
+*** Tab
+
+Here’s another:
+
+[arabic]
+. First
+. Second:
+* Fee
+* Fie
+* Foe
+. Third
+
+Same thing but with paragraphs:
+
+[arabic]
+. First
+. Second:
+* Fee
+* Fie
+* Foe
+. Third
+
+=== Tabs and spaces
+
+* this is a list item indented with tabs
+* this is a list item indented with spaces
+** this is an example list item indented with tabs
+** this is an example list item indented with spaces
+
+=== Fancy list markers
+
+[arabic, start=2]
+. begins with 2
+. and now 3
++
+with a continuation
+[lowerroman, start=4]
+.. sublist with roman numerals, starting with 4
+.. more items
+[upperalpha]
+... a subsublist
+... a subsublist
+
+Nesting:
+
+[upperalpha]
+. Upper Alpha
+[upperroman]
+.. Upper Roman.
+[arabic, start=6]
+... Decimal start with 6
+[loweralpha, start=3]
+.... Lower alpha with paren
+
+Autonumbering:
+
+. Autonumber.
+. More.
+.. Nested.
+
+Should not be a list item:
+
+M.A. 2007
+
+B. Williams
+
+'''''
+
+== Definition Lists
+
+Tight using spaces:
+
+apple::
+  red fruit
+orange::
+  orange fruit
+banana::
+  yellow fruit
+
+Tight using tabs:
+
+apple::
+  red fruit
+orange::
+  orange fruit
+banana::
+  yellow fruit
+
+Loose:
+
+apple::
+  red fruit
+orange::
+  orange fruit
+banana::
+  yellow fruit
+
+Multiple blocks with italics:
+
+_apple_::
+  red fruit
+  +
+  contains seeds, crisp, pleasant to taste
+_orange_::
+  orange fruit
+  +
+....
+{ orange code block }
+....
+  +
+  ____
+  orange block quote
+  ____
+
+Multiple definitions, tight:
+
+apple::
+  red fruit
+  +
+  computer
+orange::
+  orange fruit
+  +
+  bank
+
+Multiple definitions, loose:
+
+apple::
+  red fruit
+  +
+  computer
+orange::
+  orange fruit
+  +
+  bank
+
+Blank line after term, indented marker, alternate markers:
+
+apple::
+  red fruit
+  +
+  computer
+orange::
+  orange fruit
+  +
+  [arabic]
+  . sublist
+  . sublist
+
+== HTML Blocks
+
+Simple block on one line:
+
+foo
+
+And nested without indentation:
+
+foo
+
+bar
+
+Interpreted markdown in a table:
+
+This is _emphasized_
+
+And this is *strong*
+
+Here’s a simple block:
+
+foo
+
+This should be a code block, though:
+
+....
+<div>
+    foo
+</div>
+....
+
+As should this:
+
+....
+<div>foo</div>
+....
+
+Now, nested:
+
+foo
+
+This should just be an HTML comment:
+
+Multiline:
+
+Code block:
+
+....
+<!-- Comment -->
+....
+
+Just plain comment, with trailing spaces on the line:
+
+Code:
+
+....
+<hr />
+....
+
+Hr’s:
+
+'''''
+
+== Inline Markup
+
+This is _emphasized_, and so _is this_.
+
+This is *strong*, and so *is this*.
+
+An _link:/url[emphasized link]_.
+
+*_This is strong and em._*
+
+So is *_this_* word.
+
+*_This is strong and em._*
+
+So is *_this_* word.
+
+This is code: `>`, `$`, `\`, `\$`, `<html>`.
+
+[line-through]*This is _strikeout_.*
+
+Superscripts: a^bc^d a^_hello_^ a^hello there^.
+
+Subscripts: H~2~O, H~23~O, H~many of them~O.
+
+These should not be superscripts or subscripts, because of the unescaped
+spaces: a^b c^d, a~b c~d.
+
+'''''
+
+== Smart quotes, ellipses, dashes
+
+``Hello,'' said the spider. ```Shelob' is my name.''
+
+`A', `B', and `C' are letters.
+
+`Oak,' `elm,' and `beech' are names of trees. So is `pine.'
+
+`He said, ``I want to go.''' Were you alive in the 70’s?
+
+Here is some quoted ``code`' and a ``http://example.com/?foo=1&bar=2[quoted
+link]''.
+
+Some dashes: one—two — three—four — five.
+
+Dashes between numbers: 5–7, 255–66, 1987–1999.
+
+Ellipses…and…and….
+
+'''''
+
+== LaTeX
+
+* 
+* latexmath:[2+2=4]
+* latexmath:[x \in y]
+* latexmath:[\alpha \wedge \omega]
+* latexmath:[223]
+* latexmath:[p]-Tree
+* Here’s some display math:
+
+[latexmath]
+++++
+\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}
+++++
+* Here’s one that has a line break in it:
+latexmath:[\alpha + \omega \times x^2].
+
+These shouldn’t be math:
+
+* To get the famous equation, write `$e = mc^2$`.
+* $22,000 is a _lot_ of money. So is $34,000. (It worked if ``lot'' is
+emphasized.)
+* Shoes ($20) and socks ($5).
+* Escaped `$`: $73 _this should be emphasized_ 23$.
+
+Here’s a LaTeX table:
+
+'''''
+
+== Special Characters
+
+Here is some unicode:
+
+* I hat: Î
+* o umlaut: ö
+* section: §
+* set membership: ∈
+* copyright: ©
+
+AT&T has an ampersand in their name.
+
+AT&T is another way to write it.
+
+This & that.
+
+4 < 5.
+
+6 > 5.
+
+Backslash: \
+
+Backtick: `
+
+Asterisk: *
+
+Underscore: _
+
+Left brace: \{
+
+Right brace: }
+
+Left bracket: [
+
+Right bracket: ]
+
+Left paren: (
+
+Right paren: )
+
+Greater-than: >
+
+Hash: #
+
+Period: .
+
+Bang: !
+
+Plus: +
+
+Minus: -
+
+'''''
+
+== Links
+
+=== Explicit
+
+Just a link:/url/[URL].
+
+link:/url/[URL and title].
+
+link:/url/[URL and title].
+
+link:/url/[URL and title].
+
+link:/url/[URL and title]
+
+link:/url/[URL and title]
+
+link:/url/with_underscore[with_underscore]
+
+mailto:nobody@nowhere.net[Email link]
+
+link:[Empty].
+
+=== Reference
+
+Foo link:/url/[bar].
+
+With link:/url/[embedded [brackets]].
+
+link:/url/[b] by itself should be a link.
+
+Indented link:/url[once].
+
+Indented link:/url[twice].
+
+Indented link:/url[thrice].
+
+This should [not][] be a link.
+
+....
+[not]: /url
+....
+
+Foo link:/url/[bar].
+
+Foo link:/url/[biz].
+
+=== With ampersands
+
+Here’s a http://example.com/?foo=1&bar=2[link with an ampersand in the URL].
+
+Here’s a link with an amersand in the link text: http://att.com/[AT&T].
+
+Here’s an link:/script?foo=1&bar=2[inline link].
+
+Here’s an link:/script?foo=1&bar=2[inline link in pointy braces].
+
+=== Autolinks
+
+With an ampersand: http://example.com/?foo=1&bar=2
+
+* In a list?
+* http://example.com/
+* It should.
+
+An e-mail address: nobody@nowhere.net
+
+____
+Blockquoted: http://example.com/
+____
+
+Auto-links should not occur here: `<http://example.com/>`
+
+....
+or here: <http://example.com/>
+....
+
+'''''
+
+== Images
+
+From ``Voyage dans la Lune'' by Georges Melies (1902):
+
+image:lalune.jpg[lalune,title="Voyage dans la Lune"]
+
+Here is a movie image:movie.jpg[movie] icon.
+
+'''''
+
+== Footnotes
+
+Here is a footnote reference,footnote:[Here is the footnote. It can go
+anywhere after the footnote reference. It need not be placed at the end of the
+document.] and another.[multiblock footnote omitted] This should _not_ be a
+footnote reference, because it contains a space.[^my note] Here is an inline
+note.footnote:[This is _easier_ to type. Inline notes may contain
+http://google.com[links] and `]` verbatim characters, as well as [bracketed
+text].]
+
+____
+Notes can go in quotes.footnote:[In quote.]
+____
+
+[arabic]
+. And in list items.footnote:[In list.]
+
+This paragraph should not be part of the note, as it is not indented.


### PR DESCRIPTION
Feature request discussed here:
https://groups.google.com/forum/#!topic/pandoc-discuss/Hz-XBuNhMA8

Adds a tex_math_bare extension for which the latexmath is written without delimiters (`$` or `\[`)