### PR TITLE
LaTeX template: Simplify fontspec usage

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1527,13 +1527,12 @@ LaTeX variables are used when [creating a PDF].
     `fontfamily` set to [`mathpazo`] provides Palatino with old-style
     figures and true small caps; may be repeated for multiple options
 
-`mainfont`, `romanfont`, `sansfont`, `monofont`, `mathfont`, `CJKmainfont`
+`mainfont`, `sansfont`, `monofont`, `mathfont`, `CJKmainfont`
 :   font families for use with `xelatex` or
     `lualatex`: take the name of any system font, using the
-    [`fontspec`] package.  Note that if `CJKmainfont` is used,
-    the [`xecjk`] package must be available.
+    [`fontspec`] package.  `CJKmainfont` uses the [`xecjk`] package.
 
-`mainfontoptions`, `romanfontoptions`, `sansfontoptions`, `monofontoptions`, `mathfontoptions`, `CJKoptions`
+`mainfontoptions`, `sansfontoptions`, `monofontoptions`, `mathfontoptions`, `CJKoptions`
 :   options to use with `mainfont`, `sansfont`, `monofont`, `mathfont`,
     `CJKmainfont` in `xelatex` and `lualatex`.  Allow for any choices
     available through [`fontspec`], such as the OpenType features

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -110,30 +110,29 @@ $if(mathspec)$
 $else$
   \usepackage{unicode-math}
 $endif$
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
 $if(mainfont)$
   \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
 $endif$
-$if(romanfont)$
-  \setromanfont[$if(romanfontoptions)$$for(romanfontoptions)$$romanfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$romanfont$}
-$endif$
 $if(sansfont)$
-  \setsansfont[$if(sansfontoptions)$$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$sansfont$}
+  \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
 $endif$
 $if(monofont)$
-  \setmonofont[$if(monofontoptions)$$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$monofont$}
+  \setmonofont[$for(monofontoptions)$$monofontoptions$$sep$,$endfor$]{$monofont$}
 $endif$
 $for(fontfamilies)$
-  \newfontfamily{$fontfamilies.name$}[$if(fontfamilies.options)$$for(fontfamilies.options)$$fontfamilies.options$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$fontfamilies.font$}
+  \newfontfamily{$fontfamilies.name$}[$for(fontfamilies.options)$$fontfamilies.options$$sep$,$endfor$]{$fontfamilies.font$}
 $endfor$
 $if(mathfont)$
 $if(mathspec)$
   \ifxetex
-    \setmathfont(Digits,Latin,Greek)[$if(mathfontoptions)$$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$mathfont$}
+    \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
   \else
-    \setmathfont[$if(mathfontoptions)$$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$mathfont$}
+    \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
   \fi
 $else$
-  \setmathfont[$if(mathfontoptions)$$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$$else$Scale=MatchLowercase$endif$]{$mathfont$}
+  \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
 $endif$
 $endif$
 $if(CJKmainfont)$

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -12,6 +12,8 @@
   \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -12,6 +12,8 @@
   \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -12,6 +12,8 @@
   \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -13,6 +13,8 @@
   \usepackage{textcomp} % provides euro and other symbols
 \else % if luatex or xelatex
   \usepackage{unicode-math}
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
 \fi
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}


### PR DESCRIPTION
Simplify the approach of #5212, ensuring that `mainfont` is used as the base font for scaling and that LuaLaTeX does not display the mono font with TeX ligatures (as it does not use the `Mapping=tex-ansi` option).

With this modified version of `\defaultfontfeatures`, fontspec erroneously reports scaling against the old default font in the log (this had confused me earlier, hence my previous approach), but it nonetheless displays the main font at the specified size. Using this rather than setting `Scale=MatchLowercase` for each family individually means that users will not lose scaling when upgrading to the new template if they were using other font options. Scaling can be disabled for an individual family by adding the option `Scale=1` to `sansfontoptions`, `monofontoptions`, etc.

Remove the `\setromanfont` command added in #4665, as this is not documented in the fontspec manual and appears to be a deprecated alias for `\setmainfont`.

As I neglected to include it in #5212, this illustrates the differences between this version of the template and the one in pandoc 2.5, using the [Adobe Source](https://github.com/adobe-fonts) series of fonts:

```latex
pandoc -o fonttest.pdf --pdf-engine=lualatex << EOT

---
fontsize: 12pt
mainfont: Source Serif Pro
sansfont: Source Sans Pro
monofont: Source Code Pro
---

"The quick fox --- \the\fontdimen6\font\relax"

\sffamily "The quick fox --- \the\fontdimen6\font\relax"

\ttfamily "The quick fox --- \the\fontdimen6\font\relax"

EOT
````

Pandoc 2.5 template:

<img width="324" alt="screen shot 2019-01-12 at 19 51 22" src="https://user-images.githubusercontent.com/1084407/51080090-72063300-16a3-11e9-80d0-32ec91194c8c.png">

Compare the results of the Pandoc 2.5 template with XeLaTeX:

<img width="365" alt="screen shot 2019-01-12 at 19 57 23" src="https://user-images.githubusercontent.com/1084407/51080146-4a639a80-16a4-11e9-940c-e0c470c336ab.png">

Updated template with either XeLaTeX or LuaLaTeX:

<img width="405" alt="screen shot 2019-01-12 at 19 51 50" src="https://user-images.githubusercontent.com/1084407/51080094-821e1280-16a3-11e9-926c-339b32aba5c0.png">