### PR TITLE
LaTeX template: Restrict `institute` to Beamer

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1362,10 +1362,6 @@ depending on the output format, but include the following:
 `subtitle`
 :   document subtitle, included in HTML, EPUB, LaTeX, ConTeXt, and Word docx
 
-`institute`
-:   author affiliations (in LaTeX and Beamer only).  Can be a
-    list, when there are multiple authors.
-
 `abstract`
 :   document summary, included in LaTeX, ConTeXt, AsciiDoc, and Word docx
 
@@ -1444,6 +1440,10 @@ including all [reveal.js configuration options].
 
 `logo`
 :   logo for Beamer documents
+
+`institute`
+:   author affiliations in Beamer.  Can be a
+    list when there are multiple authors.
 
 `slidy-url`
 :   base URL for Slidy documents (defaults to

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -370,7 +370,7 @@ $else$
 \makeatletter
 \providecommand{\institute}[1]{% add institute to \maketitle
   \apptocmd{\@author}{\end{tabular}
-    \vskip 1em
+    \par
     \begin{tabular}[t]{c}
     #1}{}{}
 }

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -364,7 +364,18 @@ $if(author)$
 \author{$for(author)$$author$$sep$ \and $endfor$}
 $endif$
 $if(institute)$
-\providecommand{\institute}[1]{}
+$if(beamer)$
+$else$
+\usepackage{etoolbox}
+\makeatletter
+\providecommand{\institute}[1]{% add institute to \maketitle
+  \apptocmd{\@author}{\end{tabular}
+    \vskip 1em
+    \begin{tabular}[t]{c}
+    #1}{}{}
+}
+\makeatother
+$endif$
 \institute{$for(institute)$$institute$$sep$ \and $endfor$}
 $endif$
 \date{$date$}

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -363,23 +363,11 @@ $endif$
 $if(author)$
 \author{$for(author)$$author$$sep$ \and $endfor$}
 $endif$
-$if(institute)$
-$if(beamer)$
-$else$
-\usepackage{etoolbox}
-\makeatletter
-\providecommand{\institute}[1]{% add institute to \maketitle
-  \apptocmd{\@author}{\end{tabular}
-    \par
-    \begin{tabular}[t]{c}
-    #1}{}{}
-}
-\makeatother
-$endif$
-\institute{$for(institute)$$institute$$sep$ \and $endfor$}
-$endif$
 \date{$date$}
 $if(beamer)$
+$if(institute)$
+\institute{$for(institute)$$institute$$sep$ \and $endfor$}
+$endif$
 $if(titlegraphic)$
 \titlegraphic{\includegraphics{$titlegraphic$}}
 $endif$


### PR DESCRIPTION
Use the `etoolbox` package (same technique as #5213) to add the `institute` variable to `\maketitle`. Verified to work with `article`, `book`, `report`, `memoir`, `scrartcl`. Closes #4209.

It's not the prettiest thing ever: the tabular environment of `\author` and `\and` is rather inflexible. I'm wondering if the `institute` variable was intended only to support Beamer users (in which case it could simply be excluded from normal LaTeX output), but the manual indicates that it's supposed to work in both LaTeX and Beamer.

Example:

```shell
pandoc -o institute.pdf << EOT

---
title: Test
subtitle: More tests
author:
- Tester 1
- Tester 2
institute:
- University of Testing
- University of Diagnostics
date:
- 2019
---

EOT
```

<img width="538" alt="screen shot 2019-01-12 at 23 09 27" src="https://user-images.githubusercontent.com/1084407/51081512-1ea1de00-16bf-11e9-9a12-3c4cd77433b1.png">