### PR TITLE
sample.lua: Fix some minor issues

### DIFF
--- a/data/sample.lua
+++ b/data/sample.lua
@@ -332,7 +332,7 @@ function Table(caption, aligns, widths, headers, rows)
     end
     add('</tr>')
   end
-  add('</table')
+  add('</table>')
   return table.concat(buffer,'\n')
 end
 


### PR DESCRIPTION
* The closing tag ' </table' was missing a '>'.
* The content of list items was not escaped.