### PR TITLE
odt writer: fix typo in custom properties

### DIFF
--- a/src/Text/Pandoc/Writers/ODT.hs
+++ b/src/Text/Pandoc/Writers/ODT.hs
@@ -130,8 +130,8 @@ pandocToODT opts doc@(Pandoc meta _) = do
   let escapedText = text . escapeStringForXML
   let userDefinedMeta =
         map (\k -> inTags False "meta:user-defined"
-              [ ("meta_name", escapeStringForXML k)
-              ,("meta-value-type", "string")
+              [ ("meta:name", escapeStringForXML k)
+              ,("meta:value-type", "string")
               ] (escapedText $ lookupMetaString k meta)) userDefinedMetaFields
   let metaTag metafield = inTagsSimple metafield . escapedText
   let metaEntry = toEntry "meta.xml" epochtime


### PR DESCRIPTION
fixes #2839 

This is just a quick fix. I'd like to improve custom properties support like I'm doing for docx in https://github.com/jgm/pandoc/pull/5215 but I might do it there.