### PR TITLE
LaTeX template: Respect `numbersections` for books

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -277,7 +277,7 @@ $endif$
 $if(numbersections)$
 \setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$5$endif$}
 $else$
-\setcounter{secnumdepth}{0}
+\setcounter{secnumdepth}{-2}
 $endif$
 $if(beamer)$
 $else$

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -79,7 +79,7 @@
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\setcounter{secnumdepth}{0}
+\setcounter{secnumdepth}{-2}
 % Redefines (sub)paragraphs to behave more like sections
 \ifx\paragraph\undefined\else
   \let\oldparagraph\paragraph

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -44,7 +44,7 @@
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\setcounter{secnumdepth}{0}
+\setcounter{secnumdepth}{-2}
 % Redefines (sub)paragraphs to behave more like sections
 \ifx\paragraph\undefined\else
   \let\oldparagraph\paragraph

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -57,7 +57,7 @@
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\setcounter{secnumdepth}{0}
+\setcounter{secnumdepth}{-2}
 % Redefines (sub)paragraphs to behave more like sections
 \ifx\paragraph\undefined\else
   \let\oldparagraph\paragraph

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -42,7 +42,7 @@
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
-\setcounter{secnumdepth}{0}
+\setcounter{secnumdepth}{-2}
 % Redefines (sub)paragraphs to behave more like sections
 \ifx\paragraph\undefined\else
   \let\oldparagraph\paragraph


### PR DESCRIPTION
Ensure that `\part` and `\chapter` are only numbered if `numbersections` is set. To return to the previous behaviour, use `-V numbersections -V secnumdepth=0`.

With the Pandoc 2.5 template, one has to set `numbersections` to remove part/chapter numbering:

```markdown
pandoc -o chnum.pdf << EOT

---
documentclass: book
numbersections: true
secnumdepth: -2
---

# Test

# Test

EOT
```