### PR TITLE
LaTeX template: Fix subtitle spacing

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -354,7 +354,7 @@ $else$
 \usepackage{etoolbox}
 \makeatletter
 \providecommand{\subtitle}[1]{% add subtitle to \maketitle
-  \apptocmd{\@title}{\par {\large #1}}{}{}
+  \apptocmd{\@title}{\par {\large #1 \par}}{}{}
 }
 \makeatother
 $endif$


### PR DESCRIPTION
The `\large` command does not reset the spacing without adding `\par` to the end, which caused `\subtitle` to use the same line spacing as `\title`.

(I missed this earlier because it is only visible in multi-line subtitles.)