### PR TITLE
Manual: document `date-meta` template variable

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1813,6 +1813,16 @@ on the output format, and include the following:
 `body`
 :   body of document
 
+`date-meta`
+:   the `date` variable converted to ISO 8601 YYYY-MM-DD,
+    included in all HTML based formats (dzslides, epub,
+    html, html4, html5, revealjs, s5, slideous, slidy).
+    The recognized formats for `date` are: `mm/dd/yyyy`,
+    `mm/dd/yy`, `yyyy-mm-dd` (ISO 8601), `dd MM yyyy`
+    (e.g. either `02 Apr 2018` or `02 April 2018`),
+    `MM dd, yyyy` (e.g. `Apr. 02, 2018` or `April 02, 2018),
+    `yyyy[mm[dd]]]` (e.g. `20180402, `201804` or `2018`)
+
 `header-includes`
 :   contents specified by `-H/--include-in-header` (may have multiple
     values)

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1821,7 +1821,7 @@ on the output format, and include the following:
     `mm/dd/yy`, `yyyy-mm-dd` (ISO 8601), `dd MM yyyy`
     (e.g. either `02 Apr 2018` or `02 April 2018`),
     `MM dd, yyyy` (e.g. `Apr. 02, 2018` or `April 02, 2018),
-    `yyyy[mm[dd]]]` (e.g. `20180402, `201804` or `2018`)
+    `yyyy[mm[dd]]]` (e.g. `20180402, `201804` or `2018`).
 
 `header-includes`
 :   contents specified by `-H/--include-in-header` (may have multiple


### PR DESCRIPTION
In HTML based formats the `date` metadata variable is converted to ISO 8601 and available as `$date-meta$`, but it's not documented at the moment. This PR adds a block with all allowed date formats.