### PR TITLE
Markdown Reader: yamlToMeta respects extensions

### DIFF
--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -211,10 +211,6 @@ convertWithOpts opts = do
                                          ("application/xml", jatsCSL)
                      return $ ("csl", jatsEncoded) : optMetadata opts
                    else return $ optMetadata opts
-    metadataFromFile <-
-      case optMetadataFile opts of
-        Nothing   -> return mempty
-        Just file -> readFileLazy file >>= yamlToMeta
 
     case lookup "lang" (optMetadata opts) of
            Just l  -> case parseBCP47 l of
@@ -234,6 +230,11 @@ convertWithOpts opts = do
           , readerExtensions = readerExts
           , readerStripComments = optStripComments opts
           }
+
+    metadataFromFile <-
+      case optMetadataFile opts of
+        Nothing   -> return mempty
+        Just file -> readFileLazy file >>= yamlToMeta readerOpts
 
     let transforms = (case optBaseHeaderLevel opts of
                           x | x > 1     -> (headerShift (x - 1) :)

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -249,12 +249,11 @@ yamlMetaBlock = try $ do
 
 -- | Read a YAML string and convert it to pandoc metadata.
 -- String scalars in the YAML are parsed as Markdown.
-yamlToMeta :: PandocMonad m => BS.ByteString -> m Meta
-yamlToMeta bstr = do
+yamlToMeta :: PandocMonad m => ReaderOptions -> BS.ByteString -> m Meta
+yamlToMeta opts bstr = do
   let parser = do
         meta <- yamlBsToMeta bstr
         return $ runF meta defaultParserState
-      opts = def{ readerExtensions = pandocExtensions }
   parsed <- readWithM parser def{ stateOptions = opts } ""
   case parsed of
     Right result -> return result


### PR DESCRIPTION
fixes #5272

Unfortunately, that's an API change. Meanwhile, we could use the default pandoc-markdown extensions as a stop-gap-measure instead:

    let opts = def{ readerExtensions = pandocExtensions }