### PR TITLE
Add JATS to output option on Try pandoc.

### DIFF
--- a/trypandoc/index.html
+++ b/trypandoc/index.html
@@ -132,6 +132,7 @@ $(document).ready(function() {
         <option value="html4">HTML 4</option>
         <option value="html5" selected>HTML 5</option>
         <option value="icml">ICML</option>
+        <option value="jats">JATS</option>
         <option value="json">JSON</option>
         <option value="latex">LaTeX</option>
         <option value="man">Man</option>


### PR DESCRIPTION
It's currently possible to craft a URL manually to convert to `jats` using the Try pandoc site [like this](http://pandoc.org/try/?text=!%5BFigure+1.+Citation+counts+for+PLOS+Biology+articles+published+in+2010.+Scopus+citation+counts+plotted+as+a+probability+distribution+for+all+197+*PLOS+Biology*+research+articles+published+in+2010.+Data+collected+May+20%2C+2013.+Median+19+citations%3B+10%25+of+papers+have+at+least+50+citations.%5D(%2Fimages%2F2013-12-11_figure_1.svg)%0A&from=markdown&to=jats)

This PR adds `jats` to the dropdown menu options.