### PR TITLE
Pandoc mediabag extension

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -2450,6 +2450,18 @@ e.g.:
 
     local mb = require 'pandoc.mediabag'
 
+### delete {#mediabag-delete}
+
+`delete (filepath)`
+
+Removes a single entry from the media bag.
+
+Parameters:
+
+`filepath`:
+:   filename of the item to be deleted. The media bag will be
+    left unchanged if no entry with the given filename exists.
+
 ### empty {#mediabag-empty}
 
 `empty ()`

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -2448,8 +2448,13 @@ The module is loaded as part of module `pandoc` and can either be
 accessed via the `pandoc.mediabag` field, or explicitly required,
 e.g.:
 
-
     local mb = require 'pandoc.mediabag'
+
+### empty {#mediabag-empty}
+
+`empty ()`
+
+Clear-out the media bag, deleting all items.
 
 ### insert {#mediabag-insert}
 

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -2475,6 +2475,33 @@ Usage:
     local contents = "Hello, World!"
     pandoc.mediabag(fp, mt, contents)
 
+### iter {#mediabag-iter}
+
+`items ()`
+
+Returns an iterator triple to be used with Lua's generic `for`
+statement. The iterator returns the filepath, MIME type, and
+content of a media bag item on each invocation. Items are
+processed one-by-one to avoid excessive memory use.
+
+This function should be used only when full access to all items,
+including their contents, is required. For all other cases,
+[`list`](#mediabag-list) should be preferred.
+
+Returns:
+
+  - The iterator function; must be called with the iterator state
+    and the current iterator value.
+  - Iterator state – an opaque value to be passed to the iterator
+    function.
+  - Initial iterator value.
+
+Usage:
+
+    for fp, mt, contents in pandoc.mediabag.items() do
+      -- print(fp, mt, contents)
+    end
+
 ### list {#mediabag-list}
 
 `list ()`

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -591,6 +591,7 @@ library
                    Text.Pandoc.Lua.Marshaling.AST,
                    Text.Pandoc.Lua.Marshaling.AnyValue,
                    Text.Pandoc.Lua.Marshaling.CommonState,
+                   Text.Pandoc.Lua.Marshaling.MediaBag,
                    Text.Pandoc.Lua.Marshaling.ReaderOptions,
                    Text.Pandoc.Lua.Marshaling.Version,
                    Text.Pandoc.Lua.Module.MediaBag,

--- a/src/Text/Pandoc/Lua/Marshaling/MediaBag.hs
+++ b/src/Text/Pandoc/Lua/Marshaling/MediaBag.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE NoImplicitPrelude    #-}
+{- |
+   Module      : Text.Pandoc.Lua.Marshaling.MediaBag
+   Copyright   : © 2012-2019 John MacFarlane
+                 © 2017-2019 Albert Krewinkel
+   License     : GNU GPL, version 2 or above
+   Maintainer  : Albert Krewinkel <tarleb+pandoc@moltkeplatz.de>
+   Stability   : alpha
+
+Instances to marshal (push) and unmarshal (peek) media data.
+-}
+module Text.Pandoc.Lua.Marshaling.MediaBag (pushIterator) where
+
+import Prelude
+import Foreign.Ptr (Ptr)
+import Foreign.StablePtr (StablePtr, deRefStablePtr, newStablePtr)
+import Foreign.Lua (Lua, NumResults, Peekable, Pushable, StackIndex)
+import Foreign.Lua.Types.Peekable (reportValueOnFailure)
+import Foreign.Lua.Userdata (ensureUserdataMetatable, pushAnyWithMetatable,
+                             toAnyWithName)
+import Text.Pandoc.MediaBag (MediaBag, mediaItems)
+import Text.Pandoc.MIME (MimeType)
+import Text.Pandoc.Lua.Marshaling.AnyValue (AnyValue (..))
+
+import qualified Data.ByteString.Lazy as BL
+import qualified Foreign.Lua as Lua
+import qualified Foreign.Storable as Storable
+
+-- | A list of 'MediaBag' items.
+newtype MediaItems = MediaItems [(String, MimeType, BL.ByteString)]
+
+instance Pushable MediaItems where
+  push = pushMediaItems
+
+instance Peekable MediaItems where
+  peek = peekMediaItems
+
+-- | Push an iterator triple to be used with Lua's @for@ loop construct.
+-- Each iterator invokation returns a tripple consisting of an item's
+-- filename, MIME type, and content.
+pushIterator :: MediaBag -> Lua NumResults
+pushIterator mb = do
+  Lua.pushHaskellFunction nextItem
+  Lua.push (MediaItems $ mediaItems mb)
+  Lua.pushnil
+  return 3
+
+-- | Lua type name for @'MediaItems'@.
+mediaItemsTypeName :: String
+mediaItemsTypeName = "pandoc MediaItems"
+
+-- | Push a @MediaItems@ element to the stack.
+pushMediaItems :: MediaItems -> Lua ()
+pushMediaItems xs = pushAnyWithMetatable pushMT xs
+ where
+  pushMT = ensureUserdataMetatable mediaItemsTypeName (return ())
+
+-- | Retrieve a @MediaItems@ element from the stack.
+peekMediaItems :: StackIndex -> Lua MediaItems
+peekMediaItems = reportValueOnFailure mediaItemsTypeName
+                 (`toAnyWithName` mediaItemsTypeName)
+
+-- | Retrieve a list of items from an iterator state, return the first
+-- item (if present), and advance the state.
+nextItem :: Ptr (StablePtr MediaItems) -> AnyValue -> Lua NumResults
+nextItem ptr _ = do
+  (MediaItems items) <- Lua.liftIO $ deRefStablePtr =<< Storable.peek ptr
+  case items of
+    [] -> 2 <$ (Lua.pushnil *> Lua.pushnil)
+    (key, mt, content):xs -> do
+      Lua.liftIO $ Storable.poke ptr =<< newStablePtr (MediaItems xs)
+      Lua.push key
+      Lua.push mt
+      Lua.push content
+      return 3

--- a/src/Text/Pandoc/Lua/Module/MediaBag.hs
+++ b/src/Text/Pandoc/Lua/Module/MediaBag.hs
@@ -34,6 +34,7 @@ import qualified Text.Pandoc.MediaBag as MB
 pushModule :: Lua NumResults
 pushModule = do
   Lua.newtable
+  addFunction "empty" empty
   addFunction "insert" insertMediaFn
   addFunction "items" items
   addFunction "lookup" lookupMediaFn
@@ -60,6 +61,11 @@ setCommonState st = do
 modifyCommonState :: (CommonState -> CommonState) -> Lua ()
 modifyCommonState f = getCommonState >>= setCommonState . f
 
+-- | Delete all items from the media bag.
+empty :: Lua NumResults
+empty = 0 <$ modifyCommonState (\st -> st { stMediaBag = mempty })
+
+-- | Insert a new item into the media bag.
 insertMediaFn :: FilePath
               -> Optional MimeType
               -> BL.ByteString

--- a/src/Text/Pandoc/MediaBag.hs
+++ b/src/Text/Pandoc/MediaBag.hs
@@ -16,6 +16,7 @@ interface for interacting with it.
 -}
 module Text.Pandoc.MediaBag (
                      MediaBag,
+                     deleteMedia,
                      lookupMedia,
                      insertMedia,
                      mediaDirectory,
@@ -40,6 +41,14 @@ newtype MediaBag = MediaBag (M.Map [String] (MimeType, BL.ByteString))
 
 instance Show MediaBag where
   show bag = "MediaBag " ++ show (mediaDirectory bag)
+
+-- | Delete a media item from a 'MediaBag', or do nothing if no item corresponds
+-- to the given path.
+deleteMedia :: FilePath       -- ^ relative path and canonical name of resource
+            -> MediaBag
+            -> MediaBag
+deleteMedia fp (MediaBag mediamap) =
+  MediaBag $ M.delete (splitDirectories fp) mediamap
 
 -- | Insert a media item into a 'MediaBag', replacing any existing
 -- value with the same name.

--- a/src/Text/Pandoc/MediaBag.hs
+++ b/src/Text/Pandoc/MediaBag.hs
@@ -19,6 +19,7 @@ module Text.Pandoc.MediaBag (
                      lookupMedia,
                      insertMedia,
                      mediaDirectory,
+                     mediaItems
                      ) where
 import Prelude
 import qualified Data.ByteString.Lazy as BL
@@ -66,3 +67,8 @@ mediaDirectory :: MediaBag -> [(String, MimeType, Int)]
 mediaDirectory (MediaBag mediamap) =
   M.foldrWithKey (\fp (mime,contents) ->
       ((Posix.joinPath fp, mime, fromIntegral $ BL.length contents):)) [] mediamap
+
+mediaItems :: MediaBag -> [(String, MimeType, BL.ByteString)]
+mediaItems (MediaBag mediamap) =
+  M.foldrWithKey (\fp (mime,contents) ->
+      ((Posix.joinPath fp, mime, contents):)) [] mediamap

--- a/test/Tests/Lua/Module.hs
+++ b/test/Tests/Lua/Module.hs
@@ -19,9 +19,14 @@ import Tests.Lua (runLuaTest)
 
 tests :: [TestTree]
 tests =
-  [ testPandocLua "pandoc" ("lua" </> "module" </> "pandoc.lua")
-  , testPandocLua "pandoc.types" ("lua" </> "module" </> "pandoc-types.lua")
-  , testPandocLua "pandoc.util" ("lua" </> "module" </> "pandoc-utils.lua")
+  [ testPandocLua "pandoc"
+                  ("lua" </> "module" </> "pandoc.lua")
+  , testPandocLua "pandoc.mediabag"
+                  ("lua" </> "module" </> "pandoc-mediabag.lua")
+  , testPandocLua "pandoc.types"
+                  ("lua" </> "module" </> "pandoc-types.lua")
+  , testPandocLua "pandoc.util"
+                  ("lua" </> "module" </> "pandoc-utils.lua")
   ]
 
 testPandocLua :: TestName -> FilePath -> TestTree

--- a/test/lua/module/pandoc-mediabag.lua
+++ b/test/lua/module/pandoc-mediabag.lua
@@ -1,0 +1,72 @@
+local tasty = require 'tasty'
+
+local test = tasty.test_case
+local group = tasty.test_group
+local assert = tasty.assert
+
+local mediabag = require 'pandoc.mediabag'
+
+return {
+  group 'insert' {
+    test('insert adds an item to the mediabag', function ()
+      local fp = "media/hello.txt"
+      local mt = "text/plain"
+      local contents = "Hello, World!"
+      assert.are_same(mediabag.list(), {})
+      mediabag.insert(fp, mt, contents)
+      assert.are_same(
+        mediabag.list(),
+        {{['path'] = fp, ['type'] = mt, ['length'] = 13}}
+      )
+      mediabag.empty() -- clean up
+    end),
+    test('is idempotent', function ()
+      local fp = "media/hello.txt"
+      local mt = "text/plain"
+      local contents = "Hello, World!"
+      mediabag.insert(fp, mt, contents)
+      mediabag.insert(fp, mt, contents)
+      assert.are_same(
+        mediabag.list(),
+        {{['path'] = fp, ['type'] = mt, ['length'] = 13}}
+      )
+      mediabag.empty() -- clean up
+    end),
+  },
+
+  group 'delete' {
+    test('removes an item', function ()
+      assert.are_same(mediabag.list(), {})
+      mediabag.insert('test.html', 'text/html', '<aside>Who cares?</aside>')
+      mediabag.insert('test.css', 'text/plain', 'aside { color: red; }')
+      assert.are_equal(#mediabag.list(), 2)
+      mediabag.delete('test.html')
+      assert.are_same(
+        mediabag.list(),
+        {{['path'] = 'test.css', ['type'] = 'text/plain', ['length'] = 21}}
+      )
+      mediabag.empty() -- clean up
+    end),
+  },
+
+  group 'items' {
+    test('iterates over all items', function ()
+      local input_items = {
+        ['test.html'] = {'text/html', '<aside>Really?</aside>'},
+        ['test.css'] = {'text/plain', 'aside { color: red; }'},
+        ['test.js'] = {'application/javascript', 'alert("HI MOM!")'}
+      }
+      -- fill mediabag
+      for name, v in pairs(input_items) do
+        mediabag.insert(name, v[1], v[2])
+      end
+
+      local seen_items = {}
+      for fp, mt, c in mediabag.items() do
+        seen_items[fp] = {mt, c}
+      end
+      assert.are_same(seen_items, input_items)
+      mediabag.empty() -- clean up
+    end)
+  }
+}


### PR DESCRIPTION
This adds three functions to the `pandoc.mediabag` Lua module:

  - `delete`, which removes a single entry;
  - `empty`, which empties the whole bag;
  - `iter`, which simplifies iterating over the bag using Lua's generic `for` statement.
