### PR TITLE
LaTeX writer: Add classes for frontmatter support

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -137,8 +137,8 @@ pandocToLaTeX options (Pandoc meta blocks) = do
               (fmap render' . blockListToLaTeX)
               (fmap render' . inlineListToLaTeX)
               meta
-  let chaptersClasses = ["memoir","book","report","scrreprt","scrbook"]
-  let frontmatterClasses = ["memoir","book","scrbook"]
+  let chaptersClasses = ["memoir","book","report","scrreprt","scrbook","extreport","extbook","tufte-book"]
+  let frontmatterClasses = ["memoir","book","scrbook","extbook","tufte-book"]
   -- these have \frontmatter etc.
   beamer <- gets stBeamer
   let documentClass =

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -138,7 +138,7 @@ pandocToLaTeX options (Pandoc meta blocks) = do
               (fmap render' . inlineListToLaTeX)
               meta
   let chaptersClasses = ["memoir","book","report","scrreprt","scrbook"]
-  let frontmatterClasses = ["memoir","book","scrreprt","scrbook"]
+  let frontmatterClasses = ["memoir","book","scrbook"]
   -- these have \frontmatter etc.
   beamer <- gets stBeamer
   let documentClass =


### PR DESCRIPTION
The KOMA-Script `scrreprt` class follows the pattern of `report`, and does not support `\frontmatter`.