### PR TITLE
LaTeX reader: `\underline` now outputs interior text directly rather …

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -866,7 +866,7 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList
   , ("slash", lit "/")
   , ("textbf", extractSpaces strong <$> tok)
   , ("textnormal", extractSpaces (spanWith ("",["nodecor"],[])) <$> tok)
-  , ("textunderline", inlines)
+  , ("underline", underlineSpan <$> tok)
   , ("ldots", lit "…")
   , ("vdots", lit "\8942")
   , ("dots", lit "…")
@@ -1123,6 +1123,10 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList
   , ("foreignlanguage", foreignlanguage)
   -- include
   , ("input", include "input")
+  -- soul package
+  , ("ul", underlineSpan <$> tok)
+  -- ulem package
+  , ("uline", underlineSpan <$> tok)
   -- plain tex stuff that should just be passed through as raw tex
   , ("ifdim", ifdim)
   ]

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -866,6 +866,7 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList
   , ("slash", lit "/")
   , ("textbf", extractSpaces strong <$> tok)
   , ("textnormal", extractSpaces (spanWith ("",["nodecor"],[])) <$> tok)
+  , ("textunderline", inlines)
   , ("ldots", lit "…")
   , ("vdots", lit "\8942")
   , ("dots", lit "…")


### PR DESCRIPTION
…than ignoring it

Previously, any text in an `\underline` command in LaTeX would be ignored when being read by the LaTeX reader. Now, it simply pushes the text through without doing anything else to it. This is likely preferable to losing the text completely, even though it won't have the same formatting.
