### PR TITLE
clone of pandoc-citeproc is not used

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -5,7 +5,6 @@ RUN apk add alpine-sdk git ca-certificates ghc gmp-dev zlib-dev bash dpkg fakero
 RUN mkdir -p /usr/src/
 WORKDIR /usr/src/
 RUN git clone https://github.com/jgm/pandoc
-RUN git clone https://github.com/jgm/pandoc-citeproc
 WORKDIR /usr/src/pandoc
 RUN cabal update && \
     cabal install cabal-install-2.4.0.0 && \


### PR DESCRIPTION
This is what we discussed on the dockerfile repo.  I'm a little turned around about how cabal actually works, but right now the clones produce the directory structure

```
/usr/src
    pandoc-citeproc/
    pandoc/
        < build . pandoc-citeproc runs from here >
```

That's why when the tag for `pandoc-citeproc` was missing the builds failed, the `clone` isn't being used, the `cabal.project` definition is.  The build setup over there derived from here, and we want to make the same decision there as here.

@tarleb proposed an alternative which is to clone to `/usr/src/pandoc/pandoc-citeproc` so that when we have build `. pandoc-citeproc` from `/usr/src/pandoc` directory it (in theory?) builds the cloned version.  It's unclear to me what cabal actually does though.  Ref: https://github.com/pandoc/dockerfiles/pull/34