### PR TITLE
default.latex: Do not apply linestretch to title

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -391,7 +391,13 @@ $if(title)$
 $if(beamer)$
 \frame{\titlepage}
 $else$
+$if(linestretch)$
+\begin{spacing}{1}
 \maketitle
+\end{spacing}
+$else$
+\maketitle
+$endif$
 $endif$
 $if(abstract)$
 \begin{abstract}


### PR DESCRIPTION
See: Kohm, M. (2018). KOMA-Script. p45.