### PR TITLE
default.latex: Offer additional title page options from KOMA classes

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -945,7 +945,7 @@ Options affecting specific writers {.options}
 
 :   Use the [`listings`] package for LaTeX code blocks. The package
     does not support multi-byte encoding for source code. To handle UTF-8
-    you would need to use a custom template. This issue is fully 
+    you would need to use a custom template. This issue is fully
     documented here: [Encoding issue with the listings package].
 
 `-i`, `--incremental`
@@ -1533,7 +1533,7 @@ These variables change the appearance of PDF slides using [`beamer`].
 :   enables "title pages" for new sections (default is true)
 
 `theme`, `colortheme`, `fonttheme`, `innertheme`, `outertheme`
-:   beamer themes: 
+:   beamer themes
 
 `themeoptions`
 :   options for LaTeX beamer themes (a list).
@@ -1636,6 +1636,28 @@ Pandoc uses these variables when [creating a PDF] with a LaTeX engine.
 
 `microtypeoptions`
 :    options to pass to the microtype package
+
+### Additional title options (only with KOMA-classes)
+
+`titlehead`
+:    useful for logo names or similar. It occupies the entire textwidth,
+     at the top of the page.
+
+`subject`
+:    specifies the subject. Comes before the title.
+
+`publishers`
+:    useful to specify the publisher or similar information. Comes after the
+     `date` and before the `thanks`.
+
+`extratitle`
+:    an extra title that goes on a separate page before the titlepage.
+     Useful for information on the publisher, series number, copyrights etc.
+
+`dedication`
+:    useful for a dedication. Comes after the publisher. Goes on a separate
+     page on `scrbook`.
+
 
 ### Links
 
@@ -1931,7 +1953,7 @@ consecutive items:
 
     $for(author)$$author$$sep$, $endfor$
 
-Note that the separator needs to be specified immediately before the `$endfor` 
+Note that the separator needs to be specified immediately before the `$endfor`
 keyword.
 
 A dot can be used to select a field of a variable that takes
@@ -4721,7 +4743,7 @@ the [Beamer User's Guide] may also be used: `allowdisplaybreaks`,
 Background in reveal.js and beamer
 ----------------------------------
 
-Background images can be added to self-contained reveal.js slideshows and 
+Background images can be added to self-contained reveal.js slideshows and
 to beamer slideshows.
 
 For the same image on every slide, use the  configuration
@@ -4729,9 +4751,9 @@ option `background-image` either in the YAML metadata block
 or as a command-line variable. (There are no other options in
 beamer and the rest of this section concerns reveal.js slideshows.)
 
-For reveal.js, you can instead use the reveal.js-native option 
-`parallaxBackgroundImage`. You can also set `parallaxBackgroundHorizontal` 
-and `parallaxBackgroundVertical` the same way and must also set 
+For reveal.js, you can instead use the reveal.js-native option
+`parallaxBackgroundImage`. You can also set `parallaxBackgroundHorizontal`
+and `parallaxBackgroundVertical` the same way and must also set
 `parallaxBackgroundSize` to have your values take effect.
 
 To set an image for a particular reveal.js slide, add

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -391,6 +391,26 @@ $if(title)$
 $if(beamer)$
 \frame{\titlepage}
 $else$
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class do nothing
+}{% if KOMA class offer more titlepage options
+$if(titlehead)$
+  \titlehead{$titlehead$}
+$endif$
+$if(subject)$
+  \subject{$subject$}
+$endif$
+$if(publishers)$
+  \publishers{$publishers$}
+$endif$
+$if(extratitle)$
+  \extratitle{$extratitle$}
+$endif$
+$if(dedication)$
+  \dedication{$dedication$}
+$endif$
+}
+\makeatother
 \maketitle
 $endif$
 $if(abstract)$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -354,6 +354,26 @@ $endif$
 
 $if(title)$
 \title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+}{% if KOMA class
+$if(titlehead)$
+\titlehead{$titlehead$}
+$endif$
+$if(subject)$
+\subject{$subject$}
+$endif$
+$if(publishers)$
+\publishers{$publishers$}
+$endif$
+$if(extratitle)$
+\extratitle{$extratitle$}
+$endif$
+$if(dedication)$
+\dedication{$dedication$}
+$endif$
+}
+\makeatother
 $endif$
 $if(subtitle)$
 $if(beamer)$
@@ -381,26 +401,6 @@ $endif$
 $if(logo)$
 \logo{\includegraphics{$logo$}}
 $endif$
-\makeatletter
-\@ifundefined{KOMAClassName}{% if non-KOMA class
-}{% if KOMA class
-$if(titlehead)$
-\titlehead{$titlehead$}
-$endif$
-$if(subject)$
-\subject{$subject$}
-$endif$
-$if(publishers)$
-\publishers{$publishers$}
-$endif$
-$if(extratitle)$
-\extratitle{$extratitle$}
-$endif$
-$if(dedication)$
-\dedication{$dedication$}
-$endif$
-}
-\makeatother
 $endif$
 
 \begin{document}

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -381,7 +381,6 @@ $endif$
 $if(logo)$
 \logo{\includegraphics{$logo$}}
 $endif$
-$endif$
 \makeatletter
 \@ifundefined{KOMAClassName}{% if non-KOMA class
 }{% if KOMA class
@@ -402,6 +401,7 @@ $if(dedication)$
 $endif$
 }
 \makeatother
+$endif$
 
 \begin{document}
 $if(has-frontmatter)$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -392,8 +392,8 @@ $if(beamer)$
 \frame{\titlepage}
 $else$
 \makeatletter
-\@ifundefined{KOMAClassName}{% if non-KOMA class do nothing
-}{% if KOMA class offer more titlepage options
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+}{% if KOMA class
 $if(titlehead)$
   \titlehead{$titlehead$}
 $endif$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -382,6 +382,26 @@ $if(logo)$
 \logo{\includegraphics{$logo$}}
 $endif$
 $endif$
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+}{% if KOMA class
+$if(titlehead)$
+\titlehead{$titlehead$}
+$endif$
+$if(subject)$
+\subject{$subject$}
+$endif$
+$if(publishers)$
+\publishers{$publishers$}
+$endif$
+$if(extratitle)$
+\extratitle{$extratitle$}
+$endif$
+$if(dedication)$
+\dedication{$dedication$}
+$endif$
+}
+\makeatother
 
 \begin{document}
 $if(has-frontmatter)$
@@ -391,26 +411,6 @@ $if(title)$
 $if(beamer)$
 \frame{\titlepage}
 $else$
-\makeatletter
-\@ifundefined{KOMAClassName}{% if non-KOMA class
-}{% if KOMA class
-$if(titlehead)$
-  \titlehead{$titlehead$}
-$endif$
-$if(subject)$
-  \subject{$subject$}
-$endif$
-$if(publishers)$
-  \publishers{$publishers$}
-$endif$
-$if(extratitle)$
-  \extratitle{$extratitle$}
-$endif$
-$if(dedication)$
-  \dedication{$dedication$}
-$endif$
-}
-\makeatother
 \maketitle
 $endif$
 $if(abstract)$

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -98,11 +98,6 @@
 
 
 \date{}
-\makeatletter
-\@ifundefined{KOMAClassName}{% if non-KOMA class
-}{% if KOMA class
-}
-\makeatother
 
 \begin{document}
 

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -98,6 +98,11 @@
 
 
 \date{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+}{% if KOMA class
+}
+\makeatother
 
 \begin{document}
 

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -76,6 +76,11 @@
 
 
 \title{Pandoc Test Suite}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+}{% if KOMA class
+}
+\makeatother
 \author{John MacFarlane \and Anonymous}
 \date{July 17, 2006}
 

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -78,11 +78,6 @@
 \title{Pandoc Test Suite}
 \author{John MacFarlane \and Anonymous}
 \date{July 17, 2006}
-\makeatletter
-\@ifundefined{KOMAClassName}{% if non-KOMA class
-}{% if KOMA class
-}
-\makeatother
 
 \begin{document}
 \maketitle

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -78,6 +78,11 @@
 \title{Pandoc Test Suite}
 \author{John MacFarlane \and Anonymous}
 \date{July 17, 2006}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+}{% if KOMA class
+}
+\makeatother
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
[http://texdoc.net/texmf-dist/doc/latex/koma-script/scrguien.pdf](http://texdoc.net/texmf-dist/doc/latex/koma-script/scrguien.pdf)

See p.66ff

This is important for all types of documents that need more information in the title, eg. Dissertations, Bachelor Thesis, Books, etc.

e.g.

```LATEX
\documentclass{scrartcl}
\usepackage[english]{babel}
\begin{document}
\titlehead{{\LargeUnseen University\hfillSS~2019\\}
Higher Analytical Institute\\
Mythological Rd\\
34567 Etherworld}
\subject{Dissertation}
\title{Digital space simulation with the DSP\,56004}
\subtitle{Short but sweet?}
\author{Fuzzy George}
\date{30. February 2019}
\publishers{Adviser Prof. John Eccentric Doe}
\dedication{To my friend}
\maketitle
\end{document}
```

This PR is generalizing PR [#4536](https://github.com/jgm/pandoc/pull/4536)