### PR TITLE
default.latex: Define subtitle only for non-KOMA classes

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -358,11 +358,12 @@ $endif$
 $if(subtitle)$
 $if(beamer)$
 $else$
-\usepackage{etoolbox}
 \makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA classes
+\usepackage{etoolbox}
 \providecommand{\subtitle}[1]{% add subtitle to \maketitle
   \apptocmd{\@title}{\par {\large #1 \par}}{}{}
-}
+}}
 \makeatother
 $endif$
 \subtitle{$subtitle$}


### PR DESCRIPTION
KOMA has already a definition of subtitle.