### PR TITLE
LaTeX template: Move \setstretch after front matter

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -93,7 +93,6 @@ $else$
 $endif$
 $if(linestretch)$
 \usepackage{setspace}
-\setstretch{$linestretch$}
 $endif$
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
@@ -430,6 +429,9 @@ $if(lot)$
 $endif$
 $if(lof)$
 \listoffigures
+$endif$
+$if(linestretch)$
+\setstretch{$linestretch$}
 $endif$
 $if(has-frontmatter)$
 \mainmatter


### PR DESCRIPTION
Ensures that `\maketitle`, `\tableofcontents`, and so forth are not affected by changes to line spacing. Closes #5179 by partially working around <https://github.com/reutenauer/polyglossia/issues/218>.

I haven't been able to find a major drawback to moving `\setstretch` outside the preamble, but have put up a [StackExchange question](https://tex.stackexchange.com/questions/480143/is-there-a-drawback-to-using-setstretch-outside-the-preamble) to see whether I'm missing anything.