### PR TITLE
Improve pdfSize in ImageSize by ignoring all whitespace in /MediaBox command

### DIFF
--- a/src/Text/Pandoc/ImageSize.hs
+++ b/src/Text/Pandoc/ImageSize.hs
@@ -278,16 +278,16 @@ pPdfSize = do
   A.skipWhile (/='/')
   A.char8 '/'
   (do A.string "MediaBox"
-      A.skipWhile (==' ')
+      A.skipSpace
       A.char8 '['
-      A.skipWhile (==' ')
+      A.skipSpace
       [x1,y1,x2,y2] <- A.count 4 $ do
-        A.skipWhile (==' ')
+        A.skipSpace
         raw <- A.many1 $ A.satisfy (\c -> isDigit c || c == '.')
         case safeRead raw of
           Just (r :: Double) -> return $ floor r
           Nothing            -> mzero
-      A.skipWhile (==' ')
+      A.skipSpace
       A.char8 ']'
       return $ ImageSize{
               pxX  = x2 - x1

--- a/src/Text/Pandoc/ImageSize.hs
+++ b/src/Text/Pandoc/ImageSize.hs
@@ -278,13 +278,16 @@ pPdfSize = do
   A.skipWhile (/='/')
   A.char8 '/'
   (do A.string "MediaBox"
+      A.skipWhile (==' ')
       A.char8 '['
+      A.skipWhile (==' ')
       [x1,y1,x2,y2] <- A.count 4 $ do
         A.skipWhile (==' ')
         raw <- A.many1 $ A.satisfy (\c -> isDigit c || c == '.')
         case safeRead raw of
           Just (r :: Double) -> return $ floor r
           Nothing            -> mzero
+      A.skipWhile (==' ')
       A.char8 ']'
       return $ ImageSize{
               pxX  = x2 - x1


### PR DESCRIPTION
This is a small improvement to commit [9573141](https://github.com/jgm/pandoc/commit/957314143faec08b4687822557dac6ac32216cb9). That commit fixed PDF image sizes for PDFs created with Illustrator, but it was not working with PDFs created using Figma. The fix for this was to ignore all of the whitespace in the /MediaBox line. 

This fix ignores all whitespace in the PDF /MediaBox line so that a wider range of PDF sizes can be read. This improves fix to #4322.