### PR TITLE
LaTeX template: Add pandoc to PDF metadata

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -220,7 +220,7 @@ $if(colorlinks)$
 $else$
   hidelinks,
 $endif$
-}
+  pdfcreator={LaTeX via pandoc}}
 \urlstyle{same} % disable monospaced font for URLs
 $if(verbatim-in-note)$
 \VerbatimFootnotes % allows verbatim text in footnotes

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -37,7 +37,7 @@
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \hypersetup{
   hidelinks,
-}
+  pdfcreator={LaTeX via pandoc}}
 \urlstyle{same} % disable monospaced font for URLs
 \usepackage{color}
 \usepackage{fancyvrb}

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -37,7 +37,7 @@
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \hypersetup{
   hidelinks,
-}
+  pdfcreator={LaTeX via pandoc}}
 \urlstyle{same} % disable monospaced font for URLs
 \usepackage{listings}
 \newcommand{\passthrough}[1]{#1}

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -40,7 +40,7 @@
   pdftitle={Pandoc Test Suite},
   pdfauthor={John MacFarlane; Anonymous},
   hidelinks,
-}
+  pdfcreator={LaTeX via pandoc}}
 \urlstyle{same} % disable monospaced font for URLs
 \VerbatimFootnotes % allows verbatim text in footnotes
 \usepackage{graphicx,grffile}

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -38,7 +38,7 @@
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \hypersetup{
   hidelinks,
-}
+  pdfcreator={LaTeX via pandoc}}
 \urlstyle{same} % disable monospaced font for URLs
 \setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%


### PR DESCRIPTION
Credits pandoc in content creator metadata (the default is 'LaTeX with hyperref').