### PR TITLE
LaTeX template: Ensure correct heading/table order

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -436,7 +436,7 @@ General options {.options}
 [XHTML]: http://www.w3.org/TR/xhtml1/
 [LaTeX]: http://latex-project.org
 [`beamer`]: https://ctan.org/pkg/beamer
-[Beamer User's Guide]: http://ctan.math.utah.edu/ctan/tex-archive/macros/latex/contrib/beamer/doc/beameruserguide.pdf
+[Beamer User's Guide]: http://mirrors.ctan.org/macros/latex/contrib/beamer/doc/beameruserguide.pdf
 [ConTeXt]: http://www.contextgarden.net/
 [Rich Text Format]: http://en.wikipedia.org/wiki/Rich_Text_Format
 [DocBook]: http://docbook.org
@@ -1548,17 +1548,51 @@ Pandoc uses these variables when [creating a PDF] with a LaTeX engine.
 
 ### Layout
 
+`block-headings`
+:   make `\paragraph` and `\subparagraph` (fourth- and fifth-level headings, or
+    fifth- and sixth-level with book classes) free-standing rather than run-in;
+    requires further formatting to distinguish from `\subsubsection` (third- or
+    fourth-level headings). Instead of using this option, [KOMA-Script] can adjust
+    headings more extensively:
+
+        ---
+        documentclass: scrartcl
+        header-includes: |
+          \RedeclareSectionCommand[
+            beforeskip=-10pt plus -2pt minus -1pt,
+            afterskip=1sp plus -1sp minus 1sp,
+            font=\normalfont\itshape]{paragraph}
+          \RedeclareSectionCommand[
+            beforeskip=-10pt plus -2pt minus -1pt,
+            afterskip=1sp plus -1sp minus 1sp,
+            font=\normalfont\scshape,
+            indent=0pt]{subparagraph}
+        ...
+
 `classoption`
-:   option for document class, e.g. `oneside`; repeat for multiple options
+:   option for document class, e.g. `oneside`; repeat for multiple options:
+
+        ---
+        classoption:
+        - twocolumn
+        - landscape
+        ...
 
 `documentclass`
-:   document class: usually one of the standard classes, [`article`], [`report`],
-    and [`book`]; the [KOMA-Script] equivalents, `scrartcl`, `scrreprt`,
-    and `scrbook`, which default to smaller margins; or [`memoir`]
+:   document class: usually one of the standard classes, [`article`], [`book`],
+    and [`report`]; the [KOMA-Script] equivalents, `scrartcl`, `scrbook`,
+    and `scrreprt`, which default to smaller margins; or [`memoir`]
 
 `geometry`
 :   option for [`geometry`] package, e.g. `margin=1in`;
-    repeat for multiple options
+    repeat for multiple options:
+
+        ---
+        geometry:
+        - top=30mm
+        - left=20mm
+        - heightrounded
+        ...
 
 `indent`
 :   uses document class settings for indentation (the default LaTeX template
@@ -1583,10 +1617,6 @@ Pandoc uses these variables when [creating a PDF] with a LaTeX engine.
 `secnumdepth`
 :   numbering depth for sections (with `--number-sections` option
     or `numbersections` variable)
-
-`subparagraph`
-:   disables default behavior of LaTeX template that redefines (sub)paragraphs
-    as sections, changing the appearance of nested headings in some classes
 
 ### Fonts
 

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -99,7 +99,7 @@ $endif$
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
   \usepackage[utf8]{inputenc}
-  \usepackage{textcomp} % provides euro and other symbols
+  \usepackage{textcomp} % provide euro and other symbols
 \else % if luatex or xetex
 $if(mathspec)$
   \ifxetex
@@ -223,7 +223,7 @@ $endif$
   pdfcreator={LaTeX via pandoc}}
 \urlstyle{same} % disable monospaced font for URLs
 $if(verbatim-in-note)$
-\VerbatimFootnotes % allows verbatim text in footnotes
+\VerbatimFootnotes % allow verbatim text in footnotes
 $endif$
 $if(geometry)$
 \usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
@@ -252,6 +252,11 @@ $if(beamer)$
 \def\fnum@table{\tablename~\thetable}
 \makeatother
 $else$
+% Correct order of tables after \paragraph or \subparagraph
+\usepackage{etoolbox}
+\makeatletter
+\patchcmd\longtable{\par}{\if@noskipsec\mbox{}\fi\par}{}{}
+\makeatother
 % Allow footnotes in longtable head/foot
 \IfFileExists{footnotehyper.sty}{\usepackage{footnotehyper}}{\usepackage{footnote}}
 \makesavenoteenv{longtable}
@@ -291,9 +296,8 @@ $else$
 $endif$
 $if(beamer)$
 $else$
-$if(subparagraph)$
-$else$
-% Redefines (sub)paragraphs to behave more like sections
+$if(block-headings)$
+% Make \paragraph and \subparagraph free-standing
 \ifx\paragraph\undefined\else
   \let\oldparagraph\paragraph
   \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
@@ -307,7 +311,6 @@ $endif$
 $if(pagestyle)$
 \pagestyle{$pagestyle$}
 $endif$
-
 $for(header-includes)$
 $header-includes$
 $endfor$

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -10,7 +10,7 @@
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
-  \usepackage{textcomp} % provides euro and other symbols
+  \usepackage{textcomp} % provide euro and other symbols
 \else % if luatex or xetex
   \usepackage{unicode-math}
   \defaultfontfeatures{Scale=MatchLowercase}
@@ -81,16 +81,6 @@
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
-% Redefines (sub)paragraphs to behave more like sections
-\ifx\paragraph\undefined\else
-  \let\oldparagraph\paragraph
-  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
-\fi
-\ifx\subparagraph\undefined\else
-  \let\oldsubparagraph\subparagraph
-  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
-\fi
-
 
 \date{}
 

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -10,7 +10,7 @@
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
-  \usepackage{textcomp} % provides euro and other symbols
+  \usepackage{textcomp} % provide euro and other symbols
 \else % if luatex or xetex
   \usepackage{unicode-math}
   \defaultfontfeatures{Scale=MatchLowercase}
@@ -48,16 +48,6 @@
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
-% Redefines (sub)paragraphs to behave more like sections
-\ifx\paragraph\undefined\else
-  \let\oldparagraph\paragraph
-  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
-\fi
-\ifx\subparagraph\undefined\else
-  \let\oldsubparagraph\subparagraph
-  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
-\fi
-
 
 \date{}
 

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -10,7 +10,7 @@
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
-  \usepackage{textcomp} % provides euro and other symbols
+  \usepackage{textcomp} % provide euro and other symbols
 \else % if luatex or xetex
   \usepackage{unicode-math}
   \defaultfontfeatures{Scale=MatchLowercase}
@@ -42,7 +42,7 @@
   hidelinks,
   pdfcreator={LaTeX via pandoc}}
 \urlstyle{same} % disable monospaced font for URLs
-\VerbatimFootnotes % allows verbatim text in footnotes
+\VerbatimFootnotes % allow verbatim text in footnotes
 \usepackage{graphicx,grffile}
 \makeatletter
 \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
@@ -63,16 +63,6 @@
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
-% Redefines (sub)paragraphs to behave more like sections
-\ifx\paragraph\undefined\else
-  \let\oldparagraph\paragraph
-  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
-\fi
-\ifx\subparagraph\undefined\else
-  \let\oldsubparagraph\subparagraph
-  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
-\fi
-
 
 \title{Pandoc Test Suite}
 \author{John MacFarlane \and Anonymous}

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -11,7 +11,7 @@
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
-  \usepackage{textcomp} % provides euro and other symbols
+  \usepackage{textcomp} % provide euro and other symbols
 \else % if luatex or xetex
   \usepackage{unicode-math}
   \defaultfontfeatures{Scale=MatchLowercase}
@@ -44,16 +44,6 @@
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
-% Redefines (sub)paragraphs to behave more like sections
-\ifx\paragraph\undefined\else
-  \let\oldparagraph\paragraph
-  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
-\fi
-\ifx\subparagraph\undefined\else
-  \let\oldsubparagraph\subparagraph
-  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
-\fi
-
 \ifxetex
   % Load polyglossia as late as possible: uses bidi with RTL langages (e.g. Hebrew, Arabic)
   \usepackage{polyglossia}


### PR DESCRIPTION
Improve the workaround for #1658, adapting a solution by @u-fischer in <https://github.com/latex3/latex2e/issues/131> that works whether or not the `indent` variable is enabled. Rename the previous approach under the `subparagraph` variable as `block-headings`. This is no longer enabled by default, as it gives headings 3–5 an identical appearance. Provide an example in the manual of reformatting the appearance of headings more thoroughly using KOMA-Script. Closes #5365.