### PR TITLE
default.revealjs: css loading follows the latest revealjs

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -16,6 +16,7 @@ $endif$
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
+  <link rel="stylesheet" href="$revealjs-url$/css/reset.css">
   <link rel="stylesheet" href="$revealjs-url$/css/reveal.css">
   <style>
       code{white-space: pre-wrap;}


### PR DESCRIPTION
The latest Reveal.js (3.8.0) loads reset.css before loading reveal.css to remove the browser's default css.

https://github.com/hakimel/reveal.js/blob/3da09f1fef1fa3c140d2daa5bdee2a32683dd964/index.html#L9
