### PR TITLE
Remove reference to head.min.js

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -89,7 +89,6 @@ $body$
     </div>
   </div>
 
-  <script src="$revealjs-url$/lib/js/head.min.js"></script>
   <script src="$revealjs-url$/js/reveal.js"></script>
 
   <script>


### PR DESCRIPTION
This file has been removed in 3.8.0: https://github.com/hakimel/reveal.js/commit/29b0e86089eb3ec0d4bb5811c9b723dfcf36703c