### PR TITLE
Don't advertise base-4.8 support anymore

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -360,7 +360,7 @@ flag trypandoc
   Default:       False
 
 library
-  build-depends: base >= 4.8 && < 5,
+  build-depends: base >= 4.9 && < 5,
                  syb >= 0.1 && < 0.8,
                  containers >= 0.4.2.1 && < 0.7,
                  unordered-containers >= 0.2 && < 0.3,


### PR DESCRIPTION
As can be seen at

https://matrix.hackage.haskell.org/package/pandoc@1555514886

the build fails for base-4.8 due to `blaze-html` unfortunately providing the Semigroup instance for `Html` conditionally only for base >= 4.9 (see below)

There's now immediate action required on your part as I've already fixed up the metadata of the three affected releases on Hackage:

- https://hackage.haskell.org/package/pandoc-2.7.2/revisions/
- https://hackage.haskell.org/package/pandoc-2.7.1/revisions/
- https://hackage.haskell.org/package/pandoc-2.7/revisions/

----

```
[101 of 149] Compiling Text.Pandoc.Writers.HTML ( src/Text/Pandoc/Writers/HTML.hs, /tmp/matrix-worker/1555517101/dist-newstyle/build/x86_64-linux/ghc-7.10.3/pandoc-2.7/build/Text/Pandoc/Writers/HTML.o )

src/Text/Pandoc/Writers/HTML.hs:480:52:
    Could not deduce (Semigroup Html) arising from a use of ‘<>’
    from the context (PandocMonad m)
      bound by the type signature for
                 elementToHtml :: PandocMonad m =>
                                  Maybe Int
                                  -> Int -> WriterOptions -> Element -> StateT WriterState m Html
      at src/Text/Pandoc/Writers/HTML.hs:(420,18)-(421,42)
    In the second argument of ‘($)’, namely ‘header' <> titleContents’
    In the second argument of ‘($)’, namely
      ‘secttag $ header' <> titleContents’
    In a stmt of a 'do' block:
      t <- addAttrs opts attr $ secttag $ header' <> titleContents
<<ghc: 223673459600 bytes, 3771 GCs, 299831631/657798880 avg/max bytes residency (33 samples), 1444M in use, 0.001 INIT (0.001 elapsed), 175.810 MUT (187.985 elapsed), 51.274 GC (51.275 elapsed) :ghc>>
cabal: Failed to build pandoc-2.7 (which is required by exe:pandoc from pandoc-2.7).
```