### PR TITLE
Add current directory as template variable

### DIFF
--- a/src/Text/Pandoc/App/OutputSettings.hs
+++ b/src/Text/Pandoc/App/OutputSettings.hs
@@ -28,6 +28,7 @@ import Data.List (find, isPrefixOf, isSuffixOf)
 import Data.Maybe (fromMaybe)
 import Skylighting (defaultSyntaxMap)
 import Skylighting.Parser (addSyntaxDefinition, parseSyntaxDefinition)
+import System.Directory (getCurrentDirectory)
 import System.Exit (exitSuccess)
 import System.FilePath
 import System.IO (stdout)
@@ -133,6 +134,9 @@ optToOutputSettings opts = do
              (optIncludeInHeader opts)
     >>=
     withList (addStringAsVariable "css") (optCss opts)
+    >>=
+    maybe return (addStringAsVariable "pwd")
+                 (getCurrentDirectory opts)
     >>=
     maybe return (addStringAsVariable "title-prefix")
                  (optTitlePrefix opts)


### PR DESCRIPTION
As described in #5464, this adds `$pwd$` as template variable so files in the current path can be used e.g. even if a tex file is compiled in another folder.