### PR TITLE
Epub3 stylesheet link compatible with kindlegen

### DIFF
--- a/data/templates/default.epub3
+++ b/data/templates/default.epub3
@@ -20,7 +20,7 @@ $highlighting-css$
   </style>
 $endif$
 $for(css)$
-  <link rel="stylesheet" href="$css$" />
+  <link rel="stylesheet" type="text/css" href="$css$" />
 $endfor$
 $for(header-includes)$
   $header-includes$


### PR DESCRIPTION
It’s seems that the commit https://github.com/daamien/pandoc/commit/411119b603509d9c9c42e48a661a61bc33eb6a24 removes the `type="text/css"` from both `<style>` and `<rel="stylesheet">` elements in all templates. The rationale for the change is described in https://github.com/jgm/pandoc/issues/5146 — the elements are optional and can cause HTML validators to complain.

However, this change causes Amazon’s [Kindlegen](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211]) (MAC OSX V2.9 build 1028-0897292) to not pick up the stylesheet when converting a Pandoc generated ePub3 to Mobi. No styles! This is probably a bug on Amazon’s end 😳—Epub3 uses XHTML5, so I think the type attribute should indeed be optional. But it is probably much easier reverting the change at Pandoc’s end, at least for the epub3 template.

One can verify the issue by running the [Toy example](https://pandoc.org/epub.html#a-toy-example) from Pandoc’s documentation, then running `kindlegen mybook.epub` and then use [`kindleunpack.py mybook.mobi`](https://github.com/kevinhendricks/KindleUnpack). You will find the default pandoc stylesheet not to be included. I could work around the issue by copying pandoc’s epub3 template and adding the attribute to the link tag. I suggest doing this change in the default template.

Whether or not I added the type attribute had no effect on the inline `<style>` tag which Pandoc places in the header by default—these get added regardless, as separate stylesheets for each page. Since the validators mentioned by @crystalfp in https://github.com/jgm/pandoc/issues/5146 complained only about the `<style>` tag, and only in the context of standalone HTML5, it seems save to suggest that adding the `type` attribute only to the link tag of the epub3 template is not very intrusive.

BTW I wonder why is there an inline style tag in the epub template, these could be part of the default css right?
