### PR TITLE
Replace parseAttr with parseAttrs

### DIFF
--- a/src/Text/Pandoc/Readers/MediaWiki.hs
+++ b/src/Text/Pandoc/Readers/MediaWiki.hs
@@ -253,7 +253,7 @@ tableEnd = try $ guardColumnOne *> skipSpaces *> sym "|}"
 
 rowsep :: PandocMonad m => MWParser m ()
 rowsep = try $ guardColumnOne *> skipSpaces *> sym "|-" <*
-               many (char '-') <* optional parseAttr <* blanklines
+               many (char '-') <* optional parseAttrs <* blanklines
 
 cellsep :: PandocMonad m => MWParser m ()
 cellsep = try $ do
@@ -277,7 +277,7 @@ tableCaption = try $ do
   guardColumnOne
   skipSpaces
   sym "|+"
-  optional (try $ parseAttr *> skipSpaces *> char '|' *> blanklines)
+  optional (try $ parseAttrs *> skipSpaces *> char '|' *> blanklines)
   (trimInlines . mconcat) <$>
     many (notFollowedBy (cellsep <|> rowsep) *> inline)
 


### PR DESCRIPTION
Got similiar error with #2649

> Error at "source" (line 37, column 26):
> unexpected "c"
> expecting lf new-line
> |----- bgcolor="#DDDDFF" class="bottom"
>                          ^
> Pandoc could not convert successfully, error code: 65. Tried to run the following command: /usr/bin/pandoc --from=mediawiki --to=markdown_github /tmp/pandoc5cc73e2708042