### PR TITLE
Fix broken links in documents

### DIFF
--- a/doc/customizing-pandoc.md
+++ b/doc/customizing-pandoc.md
@@ -111,9 +111,9 @@ use an interface built directly into pandoc, and must be written
 in the Lua language).  If you are writing your own filters, it
 is best to use Lua filters, which are more portable (they
 require only pandoc itself) and more efficient.  See [Lua
-filters](lua-filters.html) for documentation and examples.  If
+filters](https://pandoc.org/lua-filters.html) for documentation and examples.  If
 you would prefer to write your filter in another language, see
-[Filters](filters.html) for a gentle introduction to JSON
+[Filters](https://pandoc.org/filters.html) for a gentle introduction to JSON
 filters.
 
 There's a repository of lua filters at

--- a/doc/customizing-pandoc.md
+++ b/doc/customizing-pandoc.md
@@ -46,14 +46,14 @@ There are several ways to set template variables:
 | accessible by filters: | no        | yes               | yes                         |
 
 
-[`--variable`]:      http://pandoc.org/MANUAL.html#option--variable
-[`--metadata`]:      http://pandoc.org/MANUAL.html#option--metadata
-[YAML metadata]:     http://pandoc.org/MANUAL.html#extension-yaml_metadata_block
-[`--metadata-file`]: http://pandoc.org/MANUAL.html#option--metadata-file
+[`--variable`]:      https://pandoc.org/MANUAL.html#option--variable
+[`--metadata`]:      https://pandoc.org/MANUAL.html#option--metadata
+[YAML metadata]:     https://pandoc.org/MANUAL.html#extension-yaml_metadata_block
+[`--metadata-file`]: https://pandoc.org/MANUAL.html#option--metadata-file
 
 
 
-For more information, see [Templates](http://pandoc.org/MANUAL.html#templates) in
+For more information, see [Templates](https://pandoc.org/MANUAL.html#templates) in
 the pandoc manual.
 
 ### Example: adding structured author data to HTML
@@ -73,7 +73,7 @@ For `docx`, `pptx` or `odt` documents, things are a bit more
 complicated. Instead of a single template file, you need to
 provide a customized `reference.docx/pptx/odt`.
 See the manual for the
-[`--reference-doc`](http://pandoc.org/MANUAL.html#option--reference-doc) option.
+[`--reference-doc`](https://pandoc.org/MANUAL.html#option--reference-doc) option.
 
 ### Example: changing the font and line spacing in a Word docx
 
@@ -136,7 +136,7 @@ TODO
 ## Generic Divs and Spans
 
 TODO
-[Divs and Spans](http://pandoc.org/MANUAL.html#divs-and-spans): generic blocks
+[Divs and Spans](https://pandoc.org/MANUAL.html#divs-and-spans): generic blocks
 that can be transformed with filters
 
 ### Example: colored text
@@ -144,23 +144,23 @@ that can be transformed with filters
 
 ### Example: custom styles in docx
 
-[Custom Styles in Docx](http://pandoc.org/MANUAL.html#custom-styles-in-docx)
+[Custom Styles in Docx](https://pandoc.org/MANUAL.html#custom-styles-in-docx)
 
 ## Raw attributes
 
 TODO
-[Generic raw attributes](http://pandoc.org/MANUAL.html#generic-raw-attribute):
+[Generic raw attributes](https://pandoc.org/MANUAL.html#generic-raw-attribute):
 to include raw snippets
 
 ## Custom writers
 
 TODO
-[Custom writers](http://pandoc.org/MANUAL.html#custom-writers)
+[Custom writers](https://pandoc.org/MANUAL.html#custom-writers)
 
 ## Custom syntax highlighting
 
 TODO
-[Custom syntax highlighting](http://pandoc.org/MANUAL.html#syntax-highlighting),
+[Custom syntax highlighting](https://pandoc.org/MANUAL.html#syntax-highlighting),
 provided by the [skylighting
 library](https://github.com/jgm/skylighting)
 

--- a/doc/customizing-pandoc.md
+++ b/doc/customizing-pandoc.md
@@ -53,7 +53,7 @@ There are several ways to set template variables:
 
 
 
-For more information, see [Templates](/MANUAL.html#templates) in
+For more information, see [Templates](http://pandoc.org/MANUAL.html#templates) in
 the pandoc manual.
 
 ### Example: adding structured author data to HTML
@@ -73,7 +73,7 @@ For `docx`, `pptx` or `odt` documents, things are a bit more
 complicated. Instead of a single template file, you need to
 provide a customized `reference.docx/pptx/odt`.
 See the manual for the
-[`--reference-doc`](/MANUAL.html#option--reference-doc) option.
+[`--reference-doc`](http://pandoc.org/MANUAL.html#option--reference-doc) option.
 
 ### Example: changing the font and line spacing in a Word docx
 
@@ -136,7 +136,7 @@ TODO
 ## Generic Divs and Spans
 
 TODO
-[Divs and Spans](/MANUAL.html#divs-and-spans): generic blocks
+[Divs and Spans](http://pandoc.org/MANUAL.html#divs-and-spans): generic blocks
 that can be transformed with filters
 
 ### Example: colored text
@@ -144,23 +144,23 @@ that can be transformed with filters
 
 ### Example: custom styles in docx
 
-[Custom Styles in Docx](/MANUAL.html#custom-styles-in-docx)
+[Custom Styles in Docx](http://pandoc.org/MANUAL.html#custom-styles-in-docx)
 
 ## Raw attributes
 
 TODO
-[Generic raw attributes](/MANUAL.html#generic-raw-attribute):
+[Generic raw attributes](http://pandoc.org/MANUAL.html#generic-raw-attribute):
 to include raw snippets
 
 ## Custom writers
 
 TODO
-[Custom writers](/MANUAL.html#custom-writers)
+[Custom writers](http://pandoc.org/MANUAL.html#custom-writers)
 
 ## Custom syntax highlighting
 
 TODO
-[Custom syntax highlighting](/MANUAL.html#syntax-highlighting),
+[Custom syntax highlighting](http://pandoc.org/MANUAL.html#syntax-highlighting),
 provided by the [skylighting
 library](https://github.com/jgm/skylighting)
 

--- a/doc/epub.md
+++ b/doc/epub.md
@@ -144,7 +144,7 @@ Of course, this isn't much help if you want EPUB2 output (`pandoc -t epub2`)
 or target readers that don't support MathML. Then you should try using the
 `--webtex` option, which will use a web service to convert the TeX to an image.
 
-[KindleGen]: https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000234621
+[KindleGen]: https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211
 [EPUB]:  https://en.wikipedia.org/wiki/EPUB
 [Pro Git]: https://git-scm.com/book/en/v2
 [Creative Commons]: https://creativecommons.org/

--- a/doc/epub.md
+++ b/doc/epub.md
@@ -53,7 +53,7 @@ please consider [buying a copy] to help support his excellent work.)
 You can find the markdown source for the book on its
 [github site].  Let's get a copy of the whole repository:[^1]
 
-    git clone http://github.com/progit/progit.git
+    git clone https://github.com/progit/progit.git
 
 [^1]: If you don't have [git], you can browse to the [github site] and
 click "Download Source" to get the same files in a zip or tar archive.
@@ -105,7 +105,7 @@ language: en-US
 ...
 ```
 
-See the [User's Guide](http://pandoc.org/MANUAL.html#epub-metadata) for more information
+See the [User's Guide](https://pandoc.org/MANUAL.html#epub-metadata) for more information
 above these fields.
 
 Now run pandoc to make the ebook, using our title page and modified
@@ -144,13 +144,13 @@ Of course, this isn't much help if you want EPUB2 output (`pandoc -t epub2`)
 or target readers that don't support MathML. Then you should try using the
 `--webtex` option, which will use a web service to convert the TeX to an image.
 
-[KindleGen]: http://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000234621
-[EPUB]:  http://en.wikipedia.org/wiki/EPUB
+[KindleGen]: https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000234621
+[EPUB]:  https://en.wikipedia.org/wiki/EPUB
 [Pro Git]: https://git-scm.com/book/en/v2
-[Creative Commons]: http://creativecommons.org/
+[Creative Commons]: https://creativecommons.org/
 [buying a copy]: https://git-scm.com/book/en/v2
-[github site]: http://github.com/progit/progit
-[git]: http://git-scm.com
-[Dublin Core metadata elements]: http://dublincore.org/documents/dces/
-[User's Guide]: http://pandoc.org/MANUAL.html
+[github site]: https://github.com/progit/progit
+[git]: https://git-scm.com
+[Dublin Core metadata elements]: https://dublincore.org/documents/dces/
+[User's Guide]: https://pandoc.org/MANUAL.html
 

--- a/doc/epub.md
+++ b/doc/epub.md
@@ -105,7 +105,7 @@ language: en-US
 ...
 ```
 
-See the [User's Guide](MANUAL.html#epub-metadata) for more information
+See the [User's Guide](http://pandoc.org/MANUAL.html#epub-metadata) for more information
 above these fields.
 
 Now run pandoc to make the ebook, using our title page and modified
@@ -152,5 +152,5 @@ or target readers that don't support MathML. Then you should try using the
 [github site]: http://github.com/progit/progit
 [git]: http://git-scm.com
 [Dublin Core metadata elements]: http://dublincore.org/documents/dces/
-[User's Guide]: MANUAL.html
+[User's Guide]: http://pandoc.org/MANUAL.html
 

--- a/doc/filters.md
+++ b/doc/filters.md
@@ -104,7 +104,7 @@ metadata like title, authors, and date) and a list of `Block`
 Each has as its content a list of `Inline` elements.  For more details on
 the pandoc AST, see the [haddock documentation for `Text.Pandoc.Definition`].
 
-[haddock documentation for `Text.Pandoc.Definition`]: http://hackage.haskell.org/package/pandoc-types
+[haddock documentation for `Text.Pandoc.Definition`]: https://hackage.haskell.org/package/pandoc-types
 
 Here's a short Haskell script that reads markdown, changes level
 2+ headers to regular paragraphs, and writes the result as markdown.
@@ -141,7 +141,7 @@ our `behead` function (a function from `Block` to `Block`) to
 a transformation on whole `Pandoc` documents.
 (See the [haddock documentation for `Text.Pandoc.Walk`].)
 
-[haddock documentation for `Text.Pandoc.Walk`]: http://hackage.haskell.org/package/pandoc-types
+[haddock documentation for `Text.Pandoc.Walk`]: https://hackage.haskell.org/package/pandoc-types
 
 # Queries: listing URLs
 
@@ -307,10 +307,10 @@ Note that, although these parameters are not used in this example,
 the document's metadata.
 
 There are many examples of python filters in [the pandocfilters
-repository](http://github.com/jgm/pandocfilters).
+repository](https://github.com/jgm/pandocfilters).
 
 For a more Pythonic alternative to pandocfilters, see
-the [panflute](http://scorreia.com/software/panflute/) library.
+the [panflute](https://scorreia.com/software/panflute/) library.
 Don't like Python?   There are also ports of pandocfilters in
 [PHP](https://github.com/vinai/pandocfilters-php),
 [perl](https://metacpan.org/pod/Pandoc::Filter),
@@ -382,7 +382,7 @@ from an `Inline` element to a list of `Inline` elements.
 # A filter for ruby text
 
 Finally, here's a nice real-world example, developed on the
-[pandoc-discuss](http://groups.google.com/group/pandoc-discuss/browse_thread/thread/7baea325565878c8) list.  Qubyte wrote:
+[pandoc-discuss](https://groups.google.com/group/pandoc-discuss/browse_thread/thread/7baea325565878c8) list.  Qubyte wrote:
 
 > I'm interested in using pandoc to turn my markdown notes on Japanese
 > into nicely set HTML and (Xe)LaTeX. With HTML5, ruby (typically used to

--- a/doc/filters.md
+++ b/doc/filters.md
@@ -322,7 +322,7 @@ Starting with pandoc 2.0, pandoc includes built-in support for
 writing filters in lua.  The lua interpreter is built in to
 pandoc, so a lua filter does not require any additional software
 to run.  See the [documentation on lua
-filters](lua-filters.html).
+filters](https://pandoc.org/lua-filters.html).
 
 # Include files
 

--- a/doc/filters.md
+++ b/doc/filters.md
@@ -310,7 +310,7 @@ There are many examples of python filters in [the pandocfilters
 repository](https://github.com/jgm/pandocfilters).
 
 For a more Pythonic alternative to pandocfilters, see
-the [panflute](https://scorreia.com/software/panflute/) library.
+the [panflute](https://pypi.org/project/panflute) library.
 Don't like Python?   There are also ports of pandocfilters in
 [PHP](https://github.com/vinai/pandocfilters-php),
 [perl](https://metacpan.org/pod/Pandoc::Filter),

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -10,7 +10,7 @@ Guide](https://pandoc.org/MANUAL.html) or the pandoc man page.
 # Step 1:  Install pandoc
 
 First, install pandoc, following the [instructions for
-your platform](installing.html).
+your platform](https://pandoc.org/installing.html).
 
 # Step 2:  Open a terminal
 
@@ -281,7 +281,7 @@ package in linux.)  Then do
 
 You now know the basics.  Pandoc has a lot of options.  At this point
 you can start to learn more about them by reading the
-[User's Guide](README.html).
+[User's Guide](https://pandoc.org/MANUAL.html).
 
 Here's an example.  The `--mathml` option causes pandoc to
 convert TeX math into MathML.  Type
@@ -312,7 +312,7 @@ in the User's Guide.
 
 If you get stuck, you can always ask questions on the
 [pandoc-discuss](https://groups.google.com/group/pandoc-discuss)
-mailing list.  But be sure to check the [FAQs](faqs.html) first,
+mailing list.  But be sure to check the [FAQs](https://pandoc.org/faqs.html) first,
 and search through the mailing list to see if your question has
 been answered before.
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -5,7 +5,7 @@ author: John MacFarlane
 
 This document is for people who are unfamiliar with command line
 tools.  Command-line experts can go straight to the [User's
-Guide](README.html) or the pandoc man page.
+Guide](http://pandoc.org/MANUAL.html) or the pandoc man page.
 
 # Step 1:  Install pandoc
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -5,7 +5,7 @@ author: John MacFarlane
 
 This document is for people who are unfamiliar with command line
 tools.  Command-line experts can go straight to the [User's
-Guide](http://pandoc.org/MANUAL.html) or the pandoc man page.
+Guide](https://pandoc.org/MANUAL.html) or the pandoc man page.
 
 # Step 1:  Install pandoc
 
@@ -212,9 +212,9 @@ Now save your file as `test1.md` in the directory
 
 Note:  If you use plain text a lot, you'll want a better editor than
 `Notepad` or `TextEdit`.  You might want to look at
-[Sublime Text](http://www.sublimetext.com/) or (if you're willing
+[Sublime Text](https://www.sublimetext.com/) or (if you're willing
 to put in some time learning an unfamiliar interface)
-[Vim](http://www.vim.org) or [Emacs](http://www.gnu.org/software/emacs).
+[Vim](https://www.vim.org) or [Emacs](https://www.gnu.org/software/emacs).
 
 # Step 6:  Converting a file
 
@@ -271,8 +271,8 @@ Pandoc knows you're trying to create a LaTeX document, because of the
 Now try creating a Word document (with extension `docx`).
 
 If you want to create a PDF, you'll need to have LaTeX installed.
-(See [MacTeX](http://tug.org/mactex/) on OS X,
-[MiKTeX](http://miktex.org) on Windows, or install the texlive
+(See [MacTeX](https://tug.org/mactex/) on OS X,
+[MiKTeX](https://miktex.org) on Windows, or install the texlive
 package in linux.)  Then do
 
     pandoc test1.md -s -o test1.pdf
@@ -311,7 +311,7 @@ to get the pandoc manual page.  All of this information is also
 in the User's Guide.
 
 If you get stuck, you can always ask questions on the
-[pandoc-discuss](http://groups.google.com/group/pandoc-discuss)
+[pandoc-discuss](https://groups.google.com/group/pandoc-discuss)
 mailing list.  But be sure to check the [FAQs](faqs.html) first,
 and search through the mailing list to see if your question has
 been answered before.

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -11,7 +11,7 @@ title: Pandoc Lua Filters
 Pandoc has long supported filters, which allow the pandoc
 abstract syntax tree (AST) to be manipulated between the parsing
 and the writing phase. [Traditional pandoc
-filters](filters.html) accept a JSON representation of the
+filters](https://pandoc.org/filters.html) accept a JSON representation of the
 pandoc AST and produce an altered JSON representation of the
 AST. They may be written in any programming language, and
 invoked from pandoc using the `--filter` option.

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -508,7 +508,7 @@ end
 This filter replaces code blocks with class `abc` with images
 created by running their contents through `abcm2ps` and
 ImageMagick's `convert`. (For more on ABC notation, see
-<http://abcnotation.com>.)
+<https://abcnotation.com>.)
 
 Images are added to the mediabag. For output to binary formats,
 pandoc will use images in the mediabag. For textual formats, use

--- a/doc/using-the-pandoc-api.md
+++ b/doc/using-the-pandoc-api.md
@@ -459,4 +459,4 @@ structure and calling this function.
 [Text.Pandoc.Logging]: https://hackage.haskell.org/package/pandoc/docs/Text-Pandoc-Logging.html
 [Text.Pandoc.App]: https://hackage.haskell.org/package/pandoc/docs/Text-Pandoc-App.html
 [Text.Pandoc.Error]: https://hackage.haskell.org/package/pandoc/docs/Text-Pandoc-Error.html
-[Text.Pandoc.Writers.Shared]: https://hackage.haskell.org/package/pandoc/docs/Text-Pandoc-Writers.Shared.html
+[Text.Pandoc.Writers.Shared]: https://hackage.haskell.org/package/pandoc/docs/Text-Pandoc-Writers-Shared.html


### PR DESCRIPTION
"User's Guide" links are pointing to MANUAL.html which gives 404 page.
This replaces them with http://pandoc.org/MANUAL.html.