### PR TITLE
Remove unused head.min.js link from revealjs

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -89,7 +89,6 @@ $body$
     </div>
   </div>
 
-  <script src="$revealjs-url$/lib/js/head.min.js"></script>
   <script src="$revealjs-url$/js/reveal.js"></script>
 
   <script>


### PR DESCRIPTION
As [lib/js/head.min.js has been removed in the latest version of reveal.js](https://github.com/hakimel/reveal.js/commit/29b0e86089eb3ec0d4bb5811c9b723dfcf36703c#diff-d6453d319d952303b6752f08260dcb0d), the inclusion of that script needs to be removed.

Otherwise, an error occurs when you try to output `revelajs` presentation (**File ./reveal.js/lib/js/head.min.js not found in resource path**).