### PR TITLE
FB2 writer: do not wrap note references into <sup> and brackets

### DIFF
--- a/src/Text/Pandoc/Writers/FB2.hs
+++ b/src/Text/Pandoc/Writers/FB2.hs
@@ -444,7 +444,7 @@ toXml (Note bs) = do
   let fn_id = footnoteID n
   fn_desc <- cMapM blockToXml bs
   modify (\s -> s { footnotes = (n, fn_id, fn_desc) : fns })
-  let fn_ref = el "sup" . txt $ "[" ++ show n ++ "]"
+  let fn_ref = txt $ "[" ++ show n ++ "]"
   return . list $ el "a" ( [ attr ("l","href") ('#':fn_id)
                            , uattr "type" "note" ]
                          , fn_ref )

--- a/test/fb2/basic.fb2
+++ b/test/fb2/basic.fb2
@@ -55,9 +55,7 @@ citatons.</p>
 <empty-line />
 <p>
 <strikethrough>Strikeout</strikethrough> is Pandoc’s extension.
-Superscript and subscripts too: H<sub>2</sub>O is a liquid<a l:href="#n1" type="note">
-<sup>[1]</sup>
-</a>.
+Superscript and subscripts too: H<sub>2</sub>O is a liquid<a l:href="#n1" type="note">[1]</a>.
 2<sup>10</sup> is 1024.</p>
 <p>Math is another Pandoc extension: <code>E = m c^2</code>.</p>
 </section>

--- a/test/writer.fb2
+++ b/test/writer.fb2
@@ -696,25 +696,15 @@ So is ‘pine.’</p>
 <title>
 <p>Footnotes</p>
 </title>
-<p>Here is a footnote reference,<a l:href="#n1" type="note">
-<sup>[1]</sup>
-</a> and another.<a l:href="#n2" type="note">
-<sup>[2]</sup>
-</a>
+<p>Here is a footnote reference,<a l:href="#n1" type="note">[1]</a> and another.<a l:href="#n2" type="note">[2]</a>
 This should <emphasis>not</emphasis> be a footnote reference, because it
-contains a space.[^my note] Here is an inline note.<a l:href="#n3" type="note">
-<sup>[3]</sup>
-</a>
+contains a space.[^my note] Here is an inline note.<a l:href="#n3" type="note">[3]</a>
 </p>
 <cite>
-<p>Notes can go in quotes.<a l:href="#n4" type="note">
-<sup>[4]</sup>
-</a>
+<p>Notes can go in quotes.<a l:href="#n4" type="note">[4]</a>
 </p>
 </cite>
-<p>1. And in list items.<a l:href="#n5" type="note">
-<sup>[5]</sup>
-</a>
+<p>1. And in list items.<a l:href="#n5" type="note">[5]</a>
 </p>
 <p>This paragraph should not be part of the note, as it is not indented.</p>
 </section>


### PR DESCRIPTION
Existing FB2 readers, such as FBReader, already display links with type="note" as a superscript.

As for brackets, "official" FB2 converters add their own brackets, so they would be duplicated:
https://github.com/gribuser/fb2any/blob/c4a8b96d616f901d737f457e6d06daaad19836d6/FB_2_txt/fb2txt_engine.pas#L311