### PR TITLE
Output HTML5 video and audio elements

### DIFF
--- a/src/Text/Pandoc/MIME.hs
+++ b/src/Text/Pandoc/MIME.hs
@@ -55,9 +55,13 @@ reverseMimeTypes = M.fromList $ map (\(k,v) -> (v,k)) mimeTypesList
 mimeTypes :: M.Map String MimeType
 mimeTypes = M.fromList mimeTypesList
 
+-- | Collection of common mime types.
+-- Except for first entry, list borrowed from
+-- <https://github.com/Happstack/happstack-server/blob/master/src/Happstack/Server/FileServe/BuildingBlocks.hs happstack-server>
 mimeTypesList :: [(String, MimeType)]
-mimeTypesList = -- List borrowed from happstack-server.
-           [("gz","application/x-gzip")
+mimeTypesList =
+           [("cpt","image/x-corelphotopaint")
+           ,("gz","application/x-gzip")
            ,("cabal","application/x-cabal")
            ,("%","application/x-trash")
            ,("323","text/h323")

--- a/src/Text/Pandoc/MIME.hs
+++ b/src/Text/Pandoc/MIME.hs
@@ -11,12 +11,13 @@
 Mime type lookup for ODT writer.
 -}
 module Text.Pandoc.MIME ( MimeType, getMimeType, getMimeTypeDef,
-                          extensionFromMimeType )where
+                          extensionFromMimeType, mediaCategory ) where
 import Prelude
 import Data.Char (toLower)
 import Data.List (isPrefixOf, isSuffixOf)
+import Data.List.Split (splitOn)
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import System.FilePath
 
 type MimeType = String
@@ -41,6 +42,12 @@ extensionFromMimeType :: MimeType -> Maybe String
 extensionFromMimeType mimetype =
   M.lookup (takeWhile (/=';') mimetype) reverseMimeTypes
   -- note:  we just look up the basic mime type, dropping the content-encoding etc.
+
+-- | Determine general media category for file path, e.g.
+--
+-- prop> mediaCategory "foo.jpg" = Just "image"
+mediaCategory :: FilePath -> Maybe String
+mediaCategory fp = getMimeType fp >>= listToMaybe . splitOn "/"
 
 reverseMimeTypes :: M.Map MimeType String
 reverseMimeTypes = M.fromList $ map (\(k,v) -> (v,k)) mimeTypesList

--- a/test/command/2662.md
+++ b/test/command/2662.md
@@ -7,5 +7,5 @@
    :scale: 300 %
    :alt: alternate text
 ^D
-<p><img src="http://url.to.image/foo.png" alt="alternate text" class="align-left" width="600" height="300" /></p>
+<p><img src="http://url.to.image/foo.png" class="align-left" width="600" height="300" alt="alternate text" /></p>
 ```

--- a/test/command/3450.md
+++ b/test/command/3450.md
@@ -2,7 +2,7 @@
 % pandoc -fmarkdown-implicit_figures
 ![image](lalune.jpg){height=2em}
 ^D
-<p><img src="lalune.jpg" alt="image" style="height:2em" /></p>
+<p><img src="lalune.jpg" style="height:2em" alt="image" /></p>
 ```
 ```
 % pandoc -fmarkdown-implicit_figures -t latex

--- a/test/command/4012.md
+++ b/test/command/4012.md
@@ -4,5 +4,5 @@ pandoc -f markdown-implicit_figures
 
 [image]: http://example.com/image.jpg {height=35mm}
 ^D
-<p><img src="http://example.com/image.jpg" alt="image" style="height:35mm" /></p>
+<p><img src="http://example.com/image.jpg" style="height:35mm" alt="image" /></p>
 ```

--- a/test/command/4677.md
+++ b/test/command/4677.md
@@ -3,6 +3,6 @@
 ![Caption](img.png){#img:1}
 ^D
 <figure>
-<img src="img.png" alt="" id="img:1" /><figcaption>Caption</figcaption>
+<img src="img.png" id="img:1" alt="" /><figcaption>Caption</figcaption>
 </figure>
 ```

--- a/test/command/5121.md
+++ b/test/command/5121.md
@@ -5,7 +5,7 @@
 ## Header 2
 ^D
 <figure>
-<img src="./my-figure.jpg" alt="" width="500" /><figcaption>My caption</figcaption>
+<img src="./my-figure.jpg" width="500" alt="" /><figcaption>My caption</figcaption>
 </figure>
 
 Header 2

--- a/test/command/video-audio.md
+++ b/test/command/video-audio.md
@@ -1,0 +1,19 @@
+```
+% pandoc -f markdown-implicit_figures -t html
+![](./test.mp4)
+
+![Your browser does not support video.](foo/test.webm){width=300}
+
+![](test.mp3)
+
+![](./test.pdf)
+
+![](./test.jpg)
+^D
+<p><video src="./test.mp4" controls=""><a href="./test.mp4">Video</a></video></p>
+<p><video src="foo/test.webm" width="300" controls=""><a href="foo/test.webm">Your browser does not support video.</a></video></p>
+<p><audio src="test.mp3" controls=""><a href="test.mp3">Audio</a></audio></p>
+<p><embed src="./test.pdf" /></p>
+<p><img src="./test.jpg" /></p>
+```
+


### PR DESCRIPTION
As requested on [pandoc-discuss](https://groups.google.com/forum/#!topic/pandoc-discuss/BkBPXQ8pb3A) and also discussed in a [commonmark thread](https://talk.commonmark.org/t/embedded-audio-and-video/441/25), so I gave it a try.

Some tests needed to be changed slightly because the `alt` attribute comes last now.

---

I was also thinking of adding a way to disable the media player controls (which I enabled by default), like:

    ![](./test.mp4){controls=false}

But the equivalent HTML would actually show the controls, since it doesn't take the value of the attribute into account, only the key. We could of course still implement it this way, but it sort of sets a precedent that the string `"false"` is somehow special in pandoc markdown attribute values. Or alternatively something like `{.no-controls}`.

---

About the list of image file extensions: we're loosing a few obscure ones in this pull. I was about to put the following in, but no browser can read them anyway. And `.raw` is not even guaranteed to be a raw image, could also be some other form of raw data used in science...

    -- following from https://stackoverflow.com/a/47612661/214446
    ,("arw","image/x-sony-arw")
    ,("cr2","image/x-canon-cr2")
    ,("crw","image/x-canon-crw")
    ,("dng","image/x-adobe-dng")
    ,("erf","image/x-epson-erf")
    ,("k25","image/x-kodak-k25")
    ,("KDC","image/x-kodak-kdc")
    ,("MRW","image/x-minolta-mrw")
    ,("NEF","image/x-nikon-nef")
    ,("ORF","image/x-olympus-orf")
    ,("PEF","image/x-pentax-pef")
    ,("RAF","image/x-fuji-raf")
    ,("RAW","image/x-panasonic-raw")
    ,("SR2","image/x-sony-sr2")
    ,("SRF","image/x-sony-srf")
    ,("X3F","image/x-sigma-x3f")
