### PR TITLE
Add YAML to list of languages in source blocks

### DIFF
--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -408,5 +408,5 @@ orgLangIdentifiers =
   , "calc", "emacs-lisp", "fortran", "gnuplot", "haskell", "java", "js"
   , "latex", "ledger", "lisp", "lilypond", "matlab", "mscgen", "ocaml"
   , "octave", "org", "oz", "perl", "plantuml", "processing", "python", "R"
-  , "ruby", "sass", "scheme", "screen", "sed", "sh", "sql", "sqlite"
+  , "ruby", "sass", "scheme", "screen", "sed", "sh", "sql", "sqlite", "yaml"
   ]

--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -405,7 +405,7 @@ pandocLangToOrg cs =
 orgLangIdentifiers :: [String]
 orgLangIdentifiers =
   [ "asymptote", "awk", "C", "C++", "clojure", "css", "d", "ditaa", "dot"
-  , "calc", "diff", "emacs-lisp", "fortran", "gnuplot", "go", "haskell", "java", "js"
+  , "calc", "emacs-lisp", "fortran", "gnuplot", "haskell", "java", "js"
   , "latex", "ledger", "lisp", "lilypond", "matlab", "mscgen", "ocaml"
   , "octave", "org", "oz", "perl", "plantuml", "processing", "python", "R"
   , "ruby", "sass", "scheme", "screen", "sed", "sh", "sql", "sqlite", "yaml"

--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -405,7 +405,7 @@ pandocLangToOrg cs =
 orgLangIdentifiers :: [String]
 orgLangIdentifiers =
   [ "asymptote", "awk", "C", "C++", "clojure", "css", "d", "ditaa", "dot"
-  , "calc", "emacs-lisp", "fortran", "gnuplot", "haskell", "java", "js"
+  , "calc", "diff", "emacs-lisp", "fortran", "gnuplot", "go", "haskell", "java", "js"
   , "latex", "ledger", "lisp", "lilypond", "matlab", "mscgen", "ocaml"
   , "octave", "org", "oz", "perl", "plantuml", "processing", "python", "R"
   , "ruby", "sass", "scheme", "screen", "sed", "sh", "sql", "sqlite", "yaml"


### PR DESCRIPTION
Add YAML to languages creating source blocks rather than example blocks.  Supported by `yaml-mode` in Emacs

From markdown to Org:
\`\`\`yaml
servers:
  host: example.com
  port: 8080
\`\`\`

#+BEGIN_SRC yaml
  servers:
    hostname: example.com
    port: 8080
#+END_SRC

And back to markdown:
\`\`\`{.yaml}
servers:
  hostname: example.com
  port: 8080
\`\`\`
