### PR TITLE
HTML writer: emit empty alt tag in figures

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -681,7 +681,7 @@ figure :: PandocMonad m
        => WriterOptions -> Attr -> [Inline] -> (String, String)
        -> StateT WriterState m Html
 figure opts attr txt (s,tit) = do
-  img <- inlineToHtml opts (Image attr txt (s,tit))
+  img <- inlineToHtml opts (Image attr [Str ""] (s,tit))
   html5 <- gets stHtml5
   let tocapt = if html5
                   then H5.figcaption

--- a/test/command/3577.md
+++ b/test/command/3577.md
@@ -16,10 +16,10 @@
 \end{figure}
 ^D
 <figure>
-<img src="img1.jpg" alt="Caption 1" /><figcaption>Caption 1</figcaption>
+<img src="img1.jpg" alt="" /><figcaption>Caption 1</figcaption>
 </figure>
 <figure>
-<img src="img2.jpg" alt="Caption 2" /><figcaption>Caption 2</figcaption>
+<img src="img2.jpg" alt="" /><figcaption>Caption 2</figcaption>
 </figure>
 ```
 ```
@@ -30,6 +30,6 @@
 \end{figure}
 ^D
 <figure>
-<img src="img1.jpg" alt="Caption 3" /><figcaption>Caption 3</figcaption>
+<img src="img1.jpg" alt="" /><figcaption>Caption 3</figcaption>
 </figure>
 ```

--- a/test/command/4677.md
+++ b/test/command/4677.md
@@ -3,6 +3,6 @@
 ![Caption](img.png){#img:1}
 ^D
 <figure>
-<img src="img.png" alt="Caption" id="img:1" /><figcaption>Caption</figcaption>
+<img src="img.png" alt="" id="img:1" /><figcaption>Caption</figcaption>
 </figure>
 ```

--- a/test/command/5121.md
+++ b/test/command/5121.md
@@ -5,7 +5,7 @@
 ## Header 2
 ^D
 <figure>
-<img src="./my-figure.jpg" alt="My caption" width="500" /><figcaption>My caption</figcaption>
+<img src="./my-figure.jpg" alt="" width="500" /><figcaption>My caption</figcaption>
 </figure>
 
 Header 2

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -518,7 +518,7 @@ Blah
 <h1 id="images">Images</h1>
 <p>From “Voyage dans la Lune” by Georges Melies (1902):</p>
 <div class="figure">
-<img src="lalune.jpg" title="Voyage dans la Lune" alt="lalune" />
+<img src="lalune.jpg" title="Voyage dans la Lune" alt="" />
 <p class="caption">lalune</p>
 </div>
 <p>Here is a movie <img src="movie.jpg" alt="movie" /> icon.</p>

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -521,7 +521,7 @@ Blah
 <h1 id="images">Images</h1>
 <p>From “Voyage dans la Lune” by Georges Melies (1902):</p>
 <figure>
-<img src="lalune.jpg" title="Voyage dans la Lune" alt="lalune" /><figcaption>lalune</figcaption>
+<img src="lalune.jpg" title="Voyage dans la Lune" alt="" /><figcaption>lalune</figcaption>
 </figure>
 <p>Here is a movie <img src="movie.jpg" alt="movie" /> icon.</p>
 <hr />


### PR DESCRIPTION
The same alt text is already in the `<figcaption>` and screen-readers would read it twice, see #4737

Note: `Image attr [] (s,tit)` wouldn't work, since this would emit no alt tag which is invalid HTML.