### PR TITLE
fix handling of `file:` URL scheme in `downloadOrRead`

### DIFF
--- a/src/Text/Pandoc/Class.hs
+++ b/src/Text/Pandoc/Class.hs
@@ -572,10 +572,10 @@ downloadOrRead s = do
             Nothing -> openURL s' -- will throw error
     (Nothing, s') ->
        case parseURI s' of  -- requires absolute URI
-            -- We don't want to treat C:/ as a scheme:
-            Just u' | length (uriScheme u') > 2 -> openURL (show u')
             Just u' | uriScheme u' == "file:" ->
                  readLocalFile $ uriPathToPath (uriPath u')
+            -- We don't want to treat C:/ as a scheme:
+            Just u' | length (uriScheme u') > 2 -> openURL (show u')
             _ -> readLocalFile fp -- get from local file system
    where readLocalFile f = do
              resourcePath <- getResourcePath

--- a/test/command/5517.md
+++ b/test/command/5517.md
@@ -1,0 +1,26 @@
+Use epub output to trigger `downloadOrRead` in `Text.Pandoc.Class`
+in order to test `file:` URL-scheme handling.
+
+There are no relative `file:` URLs, so we cannot
+test with an actual file, since we don't know the
+current working directory. Instead, we use `/dev/null`
+as a file that certainly exists, redirect stderr
+to stdout and check that there is no warning.
+
+```
+% pandoc -M title=test -f native -t epub -o /dev/null 2>&1
+[Para [Image ("",[],[]) [] ("file:/dev/null","")]]
+^D
+```
+
+```
+% pandoc -M title=test -f native -t epub -o /dev/null 2>&1
+[Para [Image ("",[],[]) [] ("file:///dev/null","")]]
+^D
+```
+
+```
+% pandoc -M title=test -f native -t epub -o /dev/null 2>&1
+[Para [Image ("",[],[]) [] ("file://localhost/dev/null","")]]
+^D
+```


### PR DESCRIPTION
move up the pattern match to be reachable, closes #5517

seems this goes all the way back to https://github.com/jgm/pandoc/commit/4cb124d147790814cf2055afdfd17e500cece559