### PR TITLE
consolidate simple-table detection

### DIFF
--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -61,7 +61,7 @@ import Text.Pandoc.Options (
     extensionEnabled)
 import Text.Pandoc.Parsing hiding ((<|>))
 import Text.Pandoc.Shared (addMetaField, blocksToInlines', crFilter, escapeURI,
-                           extractSpaces, safeRead, underlineSpan)
+    extractSpaces, onlySimpleTableCells, safeRead, underlineSpan)
 import Text.Pandoc.Walk
 import Text.Parsec.Error
 import Text.TeXMath (readMathML, writeTeX)
@@ -488,14 +488,9 @@ pTable = try $ do
   TagClose _ <- pSatisfy (matchTagClose "table")
   let rows'' = concat rowsLs <> topfoot <> bottomfoot
   let rows''' = map (map snd) rows''
-  -- let rows''' = map (map snd) rows''
   -- fail on empty table
   guard $ not $ null head' && null rows'''
-  let isSinglePlain x = case B.toList x of
-                             []        -> True
-                             [Plain _] -> True
-                             _         -> False
-  let isSimple = all isSinglePlain $ concat (head':rows''')
+  let isSimple = onlySimpleTableCells $ fmap B.toList <$> head':rows'''
   let cols = if null head'
                 then maximum (map length rows''')
                 else length head'

--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -27,7 +27,6 @@ import Data.List (find, group, intersperse, sortBy, stripPrefix, transpose,
                   isPrefixOf)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
-import Data.Monoid (Any (..))
 import Data.Ord (comparing)
 import qualified Data.Set as Set
 import qualified Data.Scientific as Scientific
@@ -574,14 +573,7 @@ blockToMarkdown' opts t@(Table caption aligns widths headers rows) =  do
   let caption'' = if null caption || not (isEnabled Ext_table_captions opts)
                      then blankline
                      else blankline $$ (": " <> caption') $$ blankline
-  let isLineBreak LineBreak = Any True
-      isLineBreak _         = Any False
-  let hasLineBreak = getAny . query isLineBreak
-  let isSimpleCell [Plain ils] = not (hasLineBreak ils)
-      isSimpleCell [Para ils ] = not (hasLineBreak ils)
-      isSimpleCell []          = True
-      isSimpleCell _           = False
-  let hasSimpleCells = all isSimpleCell (concat (headers:rows))
+  let hasSimpleCells = onlySimpleTableCells $ headers:rows
   let isSimple = hasSimpleCells && all (==0) widths
   let isPlainBlock (Plain _) = True
       isPlainBlock _         = False

--- a/src/Text/Pandoc/Writers/Muse.hs
+++ b/src/Text/Pandoc/Writers/Muse.hs
@@ -31,7 +31,6 @@ import Control.Monad.State.Strict
 import Data.Char (isAlphaNum, isAsciiLower, isAsciiUpper, isDigit, isSpace)
 import Data.Default
 import Data.List (intersperse, isInfixOf, transpose)
-import Data.Monoid (Any (..))
 import qualified Data.Set as Set
 import Data.Text (Text)
 import System.FilePath (takeExtension)
@@ -44,7 +43,6 @@ import Text.Pandoc.Shared
 import Text.Pandoc.Templates (renderTemplate')
 import Text.Pandoc.Writers.Math
 import Text.Pandoc.Writers.Shared
-import Text.Pandoc.Walk
 
 type Notes = [[Block]]
 
@@ -269,15 +267,7 @@ blockToMuse (Table caption aligns widths headers rows) =
     blocksToDoc opts blocks =
       local (\env -> env { envOptions = opts }) $ blockListToMuse blocks
     numcols = maximum (length aligns : length widths : map length (headers:rows))
-    hasSimpleCells = all isSimpleCell (concat (headers:rows))
-    isLineBreak LineBreak = Any True
-    isLineBreak _         = Any False
-    hasLineBreak = getAny . query isLineBreak
-    isSimple = hasSimpleCells && all (== 0) widths
-    isSimpleCell [Plain ils] = not (hasLineBreak ils)
-    isSimpleCell [Para ils ] = not (hasLineBreak ils)
-    isSimpleCell []          = True
-    isSimpleCell _           = False
+    isSimple = onlySimpleTableCells (headers:rows) && all (== 0) widths
 blockToMuse (Div _ bs) = flatBlockListToMuse bs
 blockToMuse Null = return empty
 

--- a/test/html-reader.native
+++ b/test/html-reader.native
@@ -415,7 +415,7 @@ Pandoc (Meta {unMeta = fromList [("generator",MetaInlines [Str "pandoc"]),("titl
   ,[Plain [Str "5"]]
   ,[Plain [Str "6"]]]]
 ,HorizontalRule
-,Table [] [AlignDefault,AlignDefault,AlignDefault] [0.3333333333333333,0.3333333333333333,0.3333333333333333]
+,Table [] [AlignDefault,AlignDefault,AlignDefault] [0.0,0.0,0.0]
  [[Plain [Str "X"]]
  ,[Plain [Str "Y"]]
  ,[Plain [Str "Z"]]]


### PR DESCRIPTION
add `onlySimpleTableCells` to Text.Pandoc.Shared

[API change]

Motivation was an inconsistency in the HTML reader, which only checked for `Plain`, but not `Para` in table cells (thus the change in the test). Via https://groups.google.com/forum/#!topic/pandoc-discuss/99dNIjLLQaE.