### PR TITLE
Add option to include source files in ConTeXt PDFs

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1828,6 +1828,9 @@ Pandoc uses these variables when [creating a PDF] with ConTeXt.
 `whitespace`
 :   spacing between paragraphs, e.g. `none`, `small` (using [`setupwhitespace`])
 
+`includesource`
+:   include all source documents as file attachments in the PDF file
+
 [ConTeXt Paper Setup]: https://wiki.contextgarden.net/PaperSetup
 [ConTeXt Layout]: https://wiki.contextgarden.net/Layout
 [ConTeXt Font Switching]: https://wiki.contextgarden.net/Font_Switching

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -105,6 +105,11 @@ $endif$
 \setupxtable[body][]
 \setupxtable[foot][bottomframe=on]
 
+$if(includesource)$
+$for(sourcefile)$
+\attachment[file=$curdir$/$sourcefile$,method=hidden]
+$endfor$
+$endif$
 $for(header-includes)$
 $header-includes$
 $endfor$


### PR DESCRIPTION
Most conversions can be reversed (with some formattings lost, though).
Generally, this isn't possible with conversions to PDFs.

This PR adds a metadata variable to include the source files in the resulting PDF so they can be extracted from the PDF afterwards (e.g. with `pdfdetach -saveall`).

Test case:

`test.md`:

```
---
title: Attachment test
includesource: true
...

Your PDF should include this source document as attachment to the file.
```

```
$ echo 'And this one (`test2.md`) too.' > test2.md
$ pandoc -t context test.md test2.md -o test.pdf
$ pdfdetach -list test.pdf
2 embedded files
1: test.md
2: test2.md
```

![visual result](https://user-images.githubusercontent.com/920936/59418072-a738bd80-8dc8-11e9-9a73-d237ac3bed46.png)
