### PR TITLE
Rendering of LineBreak as "\hfill\break" instead of "\\"in the LaTeX writer

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -623,7 +623,7 @@ blockToLaTeX (Para [Str ".",Space,Str ".",Space,Str "."]) = do
      then blockToLaTeX (RawBlock "latex" "\\pause")
      else inlineListToLaTeX [Str ".",Space,Str ".",Space,Str "."]
 blockToLaTeX (Para lst) =
-  inlineListToLaTeX $ dropWhile isLineBreakOrSpace lst
+  inlineListToLaTeX $ lst
 blockToLaTeX (LineBlock lns) =
   blockToLaTeX $ linesToPara lns
 blockToLaTeX (BlockQuote lst) = do
@@ -1240,7 +1240,7 @@ inlineToLaTeX il@(RawInline f str) = do
 inlineToLaTeX LineBreak = do
   emptyLine <- gets stEmptyLine
   setEmptyLine True
-  return $ (if emptyLine then "~" else "") <> "\\\\" <> cr
+  return $ (if emptyLine then "~" else "") <> "\\hfill\\break" <> cr
 inlineToLaTeX SoftBreak = do
   wrapText <- gets (writerWrapText . stOptions)
   case wrapText of

--- a/test/command/2874.md
+++ b/test/command/2874.md
@@ -3,12 +3,12 @@
 <a></a>
 <br/>
 ^D
-{}~\\
+{}~\hfill\break
 ```
 
 ```
 % pandoc -f html -t latex
 <a name="foo"></a><br/>
 ^D
-\protect\hypertarget{foo}{}{}~\\
+\protect\hypertarget{foo}{}{}~\hfill\break
 ```

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -123,7 +123,7 @@ item.
 
 Here's one with a bullet. * criminey.
 
-There should be a hard line break\\
+There should be a hard line break\hfill\break
 here.
 
 \begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}


### PR DESCRIPTION
LineBreak is now "\hfill\break" for LaTeX.
LaTeX writer no longer strips line breaks that occur at the beginning of paragraphs (that LaTeX would choke on). -> fixes #3324 