### PR TITLE
EPUB Reader Cover

### DIFF
--- a/src/Text/Pandoc/Readers/EPUB.hs
+++ b/src/Text/Pandoc/Readers/EPUB.hs
@@ -135,7 +135,7 @@ parseManifest content = do
   return (cover, M.fromList r)
   where
     findCover e = maybe False (isInfixOf "cover")
-                  (findAttr (emptyName "properties") e)
+                  (findAttr (emptyName "id") e)
     parseItem e = do
       uid <- findAttrE (emptyName "id") e
       href <- findAttrE (emptyName "href") e

--- a/src/Text/Pandoc/Readers/EPUB.hs
+++ b/src/Text/Pandoc/Readers/EPUB.hs
@@ -134,7 +134,7 @@ parseManifest content = do
   let cover = findAttr (emptyName "href") =<< filterChild findCover manifest
   return (cover, M.fromList r)
   where
-    findCover e = maybe False (isInfixOf "cover-image")
+    findCover e = maybe False (isInfixOf "cover")
                   (findAttr (emptyName "properties") e)
     parseItem e = do
       uid <- findAttrE (emptyName "id") e

--- a/test/Tests/Readers/EPUB.hs
+++ b/test/Tests/Readers/EPUB.hs
@@ -44,10 +44,15 @@ featuresBag = [("img/check.gif","image/gif",1340)
               ,("img/multiscripts_and_greek_alphabet.png","image/png",10060)
               ]
 
+epub2CoverBag :: [(String, String, Int)]
+epub2CoverBag = [("wasteland-cover.jpg","image/jpeg",103477)]
+
 tests :: [TestTree]
 tests =
   [ testGroup "EPUB Mediabag"
     [ testCase "features bag"
-      (testMediaBag "epub/img.epub" featuresBag)
+      (testMediaBag "epub/img.epub" featuresBag),
+      testCase "EPUB2 cover bag"
+      (testMediaBag "epub/wasteland.epub" featuresBag)
     ]
   ]

--- a/test/Tests/Readers/EPUB.hs
+++ b/test/Tests/Readers/EPUB.hs
@@ -53,6 +53,6 @@ tests =
     [ testCase "features bag"
       (testMediaBag "epub/img.epub" featuresBag),
       testCase "EPUB2 cover bag"
-      (testMediaBag "epub/wasteland.epub" featuresBag)
+      (testMediaBag "epub/wasteland.epub" epub2CoverBag)
     ]
   ]


### PR DESCRIPTION
Fix #3992
Will now handle covers correctly of either EPUB2 or EPUB3 formatted files

Implemented during ZuriHac 2019 :smiley: 