### PR TITLE
Customizable type of PDF/A for the ConTeXt writer (issue #5608)

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1799,7 +1799,9 @@ Pandoc uses these variables when [creating a PDF] with ConTeXt.
     repeat for multiple options
 
 `pdfa`
-:   adds to the preamble the setup necessary to generate PDF/A-1b:2005.
+:   adds to the preamble the setup necessary to generate PDF/A of the type
+    specified, e.g. `1a:2005`, `2a`. If no type is specified (i.e. the value
+    is set to True), `1b:2005` will be used as default.
     To successfully generate PDF/A the required ICC color profiles have to
     be available and the content and all included files (such as images)
     have to be standard conforming.  The ICC profiles can be obtained

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -27,7 +27,6 @@ $endif$
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
 \setupinteractionscreen[option=bookmark]
-\setuptagging[state=start]
 
 $if(papersize)$
 \setuppapersize[$for(papersize)$$papersize$$sep$,$endfor$]
@@ -41,10 +40,13 @@ $endif$
 $if(pdfa)$
 % attempt to generate PDF/A
 \setupbackend
-  [format=PDF/A-1b:2005,
+  [format=PDF/A-$pdfa$,
    intent=sRGB IEC61966-2.1,
    profile=sRGB.icc]
 $endif$
+
+\setupbackend[export=yes]
+\setupstructure[state=start,method=auto]
 
 % use microtypography
 \definefontfeature[default][default][script=latn, protrusion=quality, expansion=quality, itlc=yes, textitalics=yes, onum=yes, pnum=yes]

--- a/src/Text/Pandoc/Writers/ConTeXt.hs
+++ b/src/Text/Pandoc/Writers/ConTeXt.hs
@@ -93,6 +93,9 @@ pandocToConTeXt options (Pandoc meta blocks) = do
                         Just (('a':d:ds) :: String)
                           | all isDigit (d:ds) -> resetField "papersize"
                                                      (('A':d:ds) :: String)
+                        _                     -> id)
+                $ (case getField "pdfa" metadata of
+                        Just ("true" :: String) -> resetField "pdfa" ("1b:2005" :: String)
                         _                     -> id) metadata
   let context' = defField "context-dir" (toContextDir
                                          $ getField "dir" context) context


### PR DESCRIPTION
The user can choose type of PDF/A ouptut, e.g. `pdfa=2a` for PDF/A-2A. If no value is given `1b:2005` will be used as fallback (the old behaviour), as suggested under [issue #5608](https://github.com/jgm/pandoc/issues/5608). Se  the formats starting with `pdf/a` in the [ConTeXt source](https://source.contextgarden.net/tex/context/base/mkiv/lpdf-fmt.lua?search=pdf-fmt) for available types. Moreover, the options for tagged PDF in the ConTeXt template have been changed to give better structure, as suggested under [comment to #5409](https://github.com/jgm/pandoc/issues/5409#issuecomment-504637400).