### PR TITLE
Customizable type of PDF/A for the ConTeXt writer (issue #5608)

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1,6 +1,6 @@
 % Pandoc User's Guide
 % John MacFarlane
-% June 25, 2019
+% July 6, 2019
 
 Synopsis
 ========
@@ -1801,7 +1801,9 @@ Pandoc uses these variables when [creating a PDF] with ConTeXt.
 `pdfa`
 :   adds to the preamble the setup necessary to generate PDF/A of the type
     specified, e.g. `1a:2005`, `2a`. If no type is specified (i.e. the value
-    is set to True), `1b:2005` will be used as default.
+    is set to True, by e.g. `--metadata=pdfa` or `pdfa: true` in a YAML metadata
+    block), `1b:2005` will be used as default, for reasons of backwards
+    compatibility. Using `--variable=pdfa` without specified value is not supported.
     To successfully generate PDF/A the required ICC color profiles have to
     be available and the content and all included files (such as images)
     have to be standard conforming.  The ICC profiles and output intent

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1,6 +1,6 @@
 % Pandoc User's Guide
 % John MacFarlane
-% June 11, 2019
+% June 25, 2019
 
 Synopsis
 ========
@@ -1804,9 +1804,21 @@ Pandoc uses these variables when [creating a PDF] with ConTeXt.
     is set to True), `1b:2005` will be used as default.
     To successfully generate PDF/A the required ICC color profiles have to
     be available and the content and all included files (such as images)
-    have to be standard conforming.  The ICC profiles can be obtained
-    from [ConTeXt ICC Profiles].  See also [ConTeXt PDFA] for more
-    details.
+    have to be standard conforming.  The ICC profiles and output intent
+    may be specified using the variables `pdfaiccprofile` and `pdfaintent'.
+    See also [ConTeXt PDFA] for more details.
+
+`pdfaiccprofile`
+:   when used in conjunction with `pdfa', specifies the ICC profile to use
+    in the PDF, e.g. `default.cmyk'. If left unspecified, `sRGB.icc' is
+    used as default. May be repeated to include multiple profiles. Note that
+    the profiles have to be available on the system. They can be obtained
+    from [ConTeXt ICC Profiles].
+
+`pdfaintent'
+:   when used in conjunction with `pdfa', specifies the output intent for
+    the colors, e.g. `ISO coated v2 300\letterpercent\space (ECI)'
+    If left unspecified, `sRGB IEC61966-2.1' is used as default.
 
 `toc`
 :   include table of contents (can also be set using `--toc/--table-of-contents`)

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1799,7 +1799,9 @@ Pandoc uses these variables when [creating a PDF] with ConTeXt.
     repeat for multiple options
 
 `pdfa`
-:   adds to the preamble the setup necessary to generate PDF/A-1b:2005.
+:   adds to the preamble the setup necessary to generate PDF/A of the type
+    specified, e.g. `1a:2005`, `2a`. If no type is specified (i.e. the value
+    is set to True), `1b:2005` will be used as default.
     To successfully generate PDF/A the required ICC color profiles have to
     be available and the content and all included files (such as images)
     have to be standard conforming.  The ICC profiles can be obtained

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -27,7 +27,6 @@ $endif$
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
 \setupinteractionscreen[option=bookmark]
-\setuptagging[state=start]
 
 $if(papersize)$
 \setuppapersize[$for(papersize)$$papersize$$sep$,$endfor$]
@@ -41,10 +40,13 @@ $endif$
 $if(pdfa)$
 % attempt to generate PDF/A
 \setupbackend
-  [format=PDF/A-1b:2005,
+  [format=PDF/A-$pdfa$,
    intent=sRGB IEC61966-2.1,
    profile=sRGB.icc]
 $endif$
+
+\setupbackend[export=yes]
+\setupstructure[state=start,method=auto]
 
 % use microtypography
 \definefontfeature[default][default][script=latn, protrusion=quality, expansion=quality, itlc=yes, textitalics=yes, onum=yes, pnum=yes]

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -44,7 +44,6 @@ $if(pdfa)$
    intent=sRGB IEC61966-2.1,
    profile=sRGB.icc]
 $endif$
-
 \setupbackend[export=yes]
 \setupstructure[state=start,method=auto]
 

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -41,8 +41,8 @@ $if(pdfa)$
 % attempt to generate PDF/A
 \setupbackend
   [format=PDF/A-$pdfa$,
-   intent=sRGB IEC61966-2.1,
-   profile=sRGB.icc]
+   profile={default_cmyk.icc,default_rgb.icc,default_gray.icc},
+   intent=ISO coated v2 300\letterpercent\space (ECI)]
 $endif$
 \setupbackend[export=yes]
 \setupstructure[state=start,method=auto]

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -41,8 +41,8 @@ $if(pdfa)$
 % attempt to generate PDF/A
 \setupbackend
   [format=PDF/A-$pdfa$,
-   profile={default_cmyk.icc,default_rgb.icc,default_gray.icc},
-   intent=ISO coated v2 300\letterpercent\space (ECI)]
+   profile={$if(pdfaiccprofile)$$for(pdfaiccprofile)$$pdfaiccprofile$$sep$,$endfor$$else$sRGB.icc$endif$},
+   intent=$if(pdfaintent)$$pdfaintent$$else$sRGB IEC61966-2.1$endif$]
 $endif$
 \setupbackend[export=yes]
 \setupstructure[state=start,method=auto]

--- a/src/Text/Pandoc/Writers/ConTeXt.hs
+++ b/src/Text/Pandoc/Writers/ConTeXt.hs
@@ -15,7 +15,7 @@ Conversion of 'Pandoc' format into ConTeXt.
 module Text.Pandoc.Writers.ConTeXt ( writeConTeXt ) where
 import Prelude
 import Control.Monad.State.Strict
-import Data.Char (ord, isDigit)
+import Data.Char (ord, isDigit, toLower)
 import Data.List (intercalate, intersperse)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
@@ -94,8 +94,8 @@ pandocToConTeXt options (Pandoc meta blocks) = do
                           | all isDigit (d:ds) -> resetField "papersize"
                                                      (('A':d:ds) :: String)
                         _                     -> id)
-                $ (case getField "pdfa" metadata of
-                        Just ("true" :: String) -> resetField "pdfa" ("1b:2005" :: String)
+                $ (case toLower <$> lookupMetaString "pdfa" meta of
+                        "true" -> resetField "pdfa" ("1b:2005" :: String)
                         _                     -> id) metadata
   let context' = defField "context-dir" (toContextDir
                                          $ getField "dir" context) context

--- a/src/Text/Pandoc/Writers/ConTeXt.hs
+++ b/src/Text/Pandoc/Writers/ConTeXt.hs
@@ -93,6 +93,9 @@ pandocToConTeXt options (Pandoc meta blocks) = do
                         Just (('a':d:ds) :: String)
                           | all isDigit (d:ds) -> resetField "papersize"
                                                      (('A':d:ds) :: String)
+                        _                     -> id)
+                $ (case getField "pdfa" metadata of
+                        Just ("true" :: String) -> resetField "pdfa" ("1b:2005" :: String)
                         _                     -> id) metadata
   let context' = defField "context-dir" (toContextDir
                                          $ getField "dir" context) context

--- a/test/writer.context
+++ b/test/writer.context
@@ -10,8 +10,9 @@
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
 \setupinteractionscreen[option=bookmark]
-\setuptagging[state=start]
 
+\setupbackend[export=yes]
+\setupstructure[state=start,method=auto]
 
 % use microtypography
 \definefontfeature[default][default][script=latn, protrusion=quality, expansion=quality, itlc=yes, textitalics=yes, onum=yes, pnum=yes]

--- a/test/writers-lang-and-dir.context
+++ b/test/writers-lang-and-dir.context
@@ -8,8 +8,9 @@
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]
 \setupinteractionscreen[option=bookmark]
-\setuptagging[state=start]
 
+\setupbackend[export=yes]
+\setupstructure[state=start,method=auto]
 
 % use microtypography
 \definefontfeature[default][default][script=latn, protrusion=quality, expansion=quality, itlc=yes, textitalics=yes, onum=yes, pnum=yes]


### PR DESCRIPTION
The type of PDF/A produced by the ConTeXt writer can be changed so that e.g. a PDF/A-2A can be produced by giving `pdfa=2a`, as discussed under [#5608](https://github.com/jgm/pandoc/issues/5608). If `pdfa` is given without value, a PDF/A-1B is produced, in accordance with the old behavior of the variable. For a list of supported types of PDF/A, see the formats beginning with `pdf/a` in [the ConTeXt source](https://source.contextgarden.net/tex/context/base/mkiv/lpdf-fmt.lua?search=pdf-fmt).

To  fix issues with tagging (which is a requirement for level A PDF/A conformance), the ConTeXt template is changed according to [discussion under #5409](https://github.com/jgm/pandoc/issues/5409#issuecomment-504637400).