### PR TITLE
Update Lua function names in pandoc.system

### DIFF
--- a/src/Text/Pandoc/Lua/Module/System.hs
+++ b/src/Text/Pandoc/Lua/Module/System.hs
@@ -27,8 +27,8 @@ pushModule = do
   addField "arch" arch
   addField "os" os
   addFunction "environment" env
-  addFunction "get_current_directory" getwd
+  addFunction "get_working_directory" getwd
   addFunction "with_environment" with_env
-  addFunction "with_temp_directory" with_tmpdir
+  addFunction "with_temporary_directory" with_tmpdir
   addFunction "with_working_directory" with_wd
   return 1


### PR DESCRIPTION
Fixed function names of pandoc.system.get_working_directory() and
pandoc.system.with_temporary_directory() which are written in the
manual of lua filter. This PR is for fixing of #5594.