### PR TITLE
Markdown reader: handle inline code more eagerly within lists.

### DIFF
--- a/test/command/5627.md
+++ b/test/command/5627.md
@@ -1,0 +1,83 @@
+```
+% pandoc -t html
+## Example
+
+1. One
+2. Two `-->something<!--`
+3. Three
+
+~~~html
+--><!--<script>alert('Escaped!')</script>
+~~~
+
+~~~html
+Something
+~~~
+^D
+<h2 id="example">Example</h2>
+<ol type="1">
+<li>One</li>
+<li>Two <code>--&gt;something&lt;!--</code></li>
+<li>Three</li>
+</ol>
+<div class="sourceCode" id="cb1"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb1-1"><a href="#cb1-1"></a>--&gt;<span class="co">&lt;!--&lt;script&gt;alert(&#39;Escaped!&#39;)&lt;/script&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb2-1"><a href="#cb2-1"></a>Something</span></code></pre></div>
+```
+
+```
+% pandoc -t html
+## Example 2
+
+- `-->something<!--`
+- `-->something<!--`
+- bye `-->something else<!--`
+
+~~~html
+--><!--<script>alert('Escaped!')</script>
+~~~
+
+~~~html
+Something
+~~~
+^D
+<h2 id="example-2">Example 2</h2>
+<ul>
+<li><code>--&gt;something&lt;!--</code></li>
+<li><code>--&gt;something&lt;!--</code></li>
+<li>bye <code>--&gt;something else&lt;!--</code></li>
+</ul>
+<div class="sourceCode" id="cb1"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb1-1"><a href="#cb1-1"></a>--&gt;<span class="co">&lt;!--&lt;script&gt;alert(&#39;Escaped!&#39;)&lt;/script&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode html"><code class="sourceCode html"><span id="cb2-1"><a href="#cb2-1"></a>Something</span></code></pre></div>
+```
+
+```
+% pandoc -t html
+## Example 3
+
+1. `-->one<!--`
+5. bye `-->two <!--`
+3. ` three, not in block
+1. four, not in block  `
+2. five
+5. six
+6. seven `
+-  separate unordered list `
+42. forty-two, separate ordered list
+^D
+<h2 id="example-3">Example 3</h2>
+<ol type="1">
+<li><code>--&gt;one&lt;!--</code></li>
+<li>bye <code>--&gt;two &lt;!--</code></li>
+<li>` three, not in block</li>
+<li>four, not in block `</li>
+<li>five</li>
+<li>six</li>
+<li>seven `</li>
+</ol>
+<ul>
+<li>separate unordered list `</li>
+</ul>
+<ol start="42" type="1">
+<li>forty-two, separate ordered list</li>
+</ol>
+```


### PR DESCRIPTION
Closes #5627.