### PR TITLE
Fix JATS issue with commas between editor name-part elements.

### DIFF
--- a/data/jats.csl
+++ b/data/jats.csl
@@ -37,9 +37,9 @@
     </names>
   </macro>
 
-  <macro name="editor">
+  <macro name="editor" delimiter=" ">
     <names variable="editor" prefix="{{jats}}&lt;person-group person-group-type=&quot;editor&quot;&gt;{{/jats}}" suffix="{{jats}}&lt;/person-group&gt;{{/jats}}">
-      <name prefix="{{jats}}&lt;name&gt;{{/jats}}" suffix="{{jats}}&lt;/name&gt;{{/jats}}" name-as-sort-order="all" sort-separator="">
+      <name prefix="{{jats}}&lt;name&gt;{{/jats}}" suffix="{{jats}}&lt;/name&gt;{{/jats}}" name-as-sort-order="all" sort-separator=" ">
         <name-part name="family" text-case="capitalize-first" prefix="{{jats}}&lt;surname&gt;{{/jats}}" suffix="{{jats}}&lt;/surname&gt;{{/jats}}"/>
         <name-part name="given" text-case="capitalize-first" prefix="{{jats}}&lt;given-names&gt;{{/jats}}" suffix="{{jats}}&lt;/given-names&gt;{{/jats}}"/>
       </name>


### PR DESCRIPTION
Related to #5397, if a bibtex entry has editor names, the current `jats.csl` allows punctuation between citations elements which are not allowed by the [PubMed Central validator](https://www.ncbi.nlm.nih.gov/pmc/tools/xmlchecker/).

**Steps to reproduce the current issue**

Pandoc v2.7.3

**Files**

[jats-example-files.zip](https://github.com/jgm/pandoc/files/3359726/jats-example-files.zip)

## Steps to reproduce

**Produce the JATS output using `jats.csl` from `master`**

```
pandoc -s --metadata-file metadata.json --bibliography bib.json --filter pandoc-citeproc --csl jats.csl.master --to jats example.md -o output.xml
```

Results in the following error using the online validator https://www.ncbi.nlm.nih.gov/pmc/tools/xmlchecker/

```
50:    <given-names>A.</given-names></name>, <name><surname>Second
>                                        ^
>  Element name content does not follow the DTD, expecting (((surname , given-names?) | given-names) , prefix? , suffix?), got (surname CDATA given-names)
>  Go to the next error
```

**Produce the JATS output using the fix included in this pull request**

```
pandoc -s --metadata-file metadata.json --bibliography bib.json --filter pandoc-citeproc --csl jats.csl.fixed --to jats example.md -o output.xml
```


