### PR TITLE
Updating JATS template to v1.1dtd

### DIFF
--- a/data/templates/default.jats
+++ b/data/templates/default.jats
@@ -2,12 +2,12 @@
 $if(xml-stylesheet)$
 <?xml-stylesheet type="text/xsl" href="$xml-stylesheet$"?>
 $endif$
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN"
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN"
                   "JATS-journalpublishing1.dtd">
 $if(article.type)$
-<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.0" article-type="$article.type$">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1" article-type="$article.type$">
 $else$
-<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.0" article-type="other">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1" article-type="other">
 $endif$
 <front>
 <journal-meta>

--- a/test/writer.jats
+++ b/test/writer.jats
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN"
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN"
                   "JATS-journalpublishing1.dtd">
-<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.0" article-type="other">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1" article-type="other">
 <front>
 <journal-meta>
 <journal-title-group>


### PR DESCRIPTION
JATS v1.0 (and below) don't support `code` tags with attributes such as `language`. This means that a standard code snippet in a Markdown document produces JATS output that is invalid in the v1.0 JATS DTD.

This pull request simply updates the DTD for the JATS template to `v1.1` which makes the outputted JATS XML v1.1 compliant.

## Steps to reproduce the issue

Pandoc v2.7.3

**Files**

[jats-example-files.zip](https://github.com/jgm/pandoc/files/3363134/jats-example-files.zip)

The Markdown file has a code snippet beginning with:

```r
# Load the "insight" package
install.packages("insight")
library(insight)
```

**Produce JATS XML using the current `default.jats` from `master`**

```
pandoc -s --metadata-file metadata.json  --template v1.0default.jats --to jats example.md -o outputv1.0.xml
```

Results in the following error using the online validator https://www.ncbi.nlm.nih.gov/pmc/tools/xmlchecker/

```
30:    <code language="r script"># Load the &quot;insight&quot; package
>                             ^
>  No declaration for attribute language of element code
>  Go to the next error
```

**Produce JATS XML using the updated `default.jats` in this pull request**

(Named `v1.1default.jats` in the zipped up files above):

```
pandoc -s --metadata-file metadata.json  --template v1.1default.jats --to jats example.md -o outputv1.1.xml
```

Validates successfully.

Note, I did try bumping the [DTD to v1.2](https://jats.nlm.nih.gov/publishing/tag-library/1.2/chapter/root.html) (which I believe is the latest), but the PMC validator doesn't seem to be able to handle JATS XML at that version.