### PR TITLE
RST reader: keep `name` property in `imgAttr`.

### DIFF
--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -645,7 +645,7 @@ directive' = do
       name = trim $ fromMaybe "" (lookup "name" fields)
       classes = words $ maybe "" trim (lookup "class" fields)
       keyvals = [(k, trim v) | (k, v) <- fields, k /= "name", k /= "class"]
-      imgAttr cl = ("", classes ++ alignClasses, widthAttr ++ heightAttr)
+      imgAttr cl = (name, classes ++ alignClasses, widthAttr ++ heightAttr)
         where
           alignClasses = words $ maybe "" trim (lookup cl fields) ++
                           maybe "" (\x -> "align-" ++ trim x)

--- a/test/command/5619.md
+++ b/test/command/5619.md
@@ -1,0 +1,10 @@
+```
+% pandoc -f rst -t native
+.. figure:: img1.jpg
+  :width: 1in
+  :name: test
+
+  The caption. Here's what piggybacking on caption would look like {#fig:1}
+^D
+[Para [Image ("test",[],[("width","1in")]) [Str "The",Space,Str "caption.",Space,Str "Here's",Space,Str "what",Space,Str "piggybacking",Space,Str "on",Space,Str "caption",Space,Str "would",Space,Str "look",Space,Str "like",Space,Str "{#fig:1}"] ("img1.jpg","fig:")]]
+```


### PR DESCRIPTION
Closes #5619.