### PR TITLE
Markdown sequential table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 deb/.vagrant
 dist/*
+dist-newstyle/
 MANUAL.*
 !MANUAL.txt
 .configure-stamp

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3244,6 +3244,104 @@ you'll need to add colons as above.
 
 [PHP Markdown Extra tables]: https://michelf.ca/projects/php-markdown/extra/#table
 
+#### Extension: `sequential_tables` ####
+
+Sequential tables look like this:
+
+    ----sequentialtable
+    header
+    - One
+    - Two
+    align
+    - left
+    - right
+    width
+    - 10
+    - 10
+    row
+    - my
+    - table
+    row
+    - is
+    - nice
+    ----
+
+producing
+
+    One    Two
+    ----------
+    my   table
+    is    nice
+
+The most important advantage of this format over other markdown table
+parsers is that it makes handling complex or large table contents easy,
+without needing to resort to special editor functionality such as
+[Emacs table mode].
+
+----sequentialtable
+width
+- 10
+- 1
+- 10
+row
+- ~~~~.hs
+  test1 = evalContT $ do
+    resetT $ do
+      moveToNewThread
+      k -- must be `m ()` due to types
+    o   -- of resetT and moveToNewThread
+  ~~~~
+- ~
+- ~~~~.hs
+  test1 = do
+    void $ forkIO $ evalContT k
+    evalContT o
+  ~~~~
+----
+
+It might also be the only table format that allows nesting without much
+of a hassle:
+
+    ----sequentialtable
+    row
+    - ----sequentialtable
+      row
+      - a
+      - b
+      row
+      - c
+      - d
+      ----
+    - ----sequentialtable
+      row
+      - e
+      - f
+      row
+      - g
+      - h
+      ----
+    ----
+
+produces
+
+    a b  e f
+    c d  g h
+
+The parser for sequential tables is a bit strict (requires exactly
+`----sequentialtable` and `----`, and `- ` for list elements) but
+due to the approach of this table type, does not need to parse any
+of the contents, because indentation alone determines when the next
+cell starts.
+Everything to the right of the first two columns is part of the
+current cell and forwarded recursively to the markdown parser.
+
+parts of a table definition are be:
+
+  - zero or one `width` definitions with integer contents,
+  - zero or one `align` definitions which are `default|left|center|right`,
+  - zero or one `header`s with markdown content,
+  - one or more `row`s with markdown content.
+
 Metadata blocks
 ---------------
 

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -139,6 +139,7 @@ data Extension =
     | Ext_raw_attribute           -- ^ Allow explicit raw blocks/inlines
     | Ext_raw_html            -- ^ Allow raw HTML
     | Ext_raw_tex             -- ^ Allow raw TeX (other than math)
+    | Ext_sequential_tables   -- ^ Allow sequential tables
     | Ext_shortcut_reference_links -- ^ Shortcut reference links
     | Ext_simple_tables       -- ^ Pandoc-style simple tables
     | Ext_smart               -- ^ "Smart" quotes, apostrophes, ellipses, dashes
@@ -168,6 +169,7 @@ pandocExtensions = extensionsFromList
   , Ext_implicit_figures
   , Ext_simple_tables
   , Ext_multiline_tables
+  , Ext_sequential_tables
   , Ext_grid_tables
   , Ext_pipe_tables
   , Ext_citations
@@ -227,7 +229,7 @@ plainExtensions = extensionsFromList
   , Ext_strikeout
   ]
 
--- | Extensions to be used with github-flavored markdown.
+-- | Extensions to be used with php-flavored markdown.
 phpMarkdownExtraExtensions :: Extensions
 phpMarkdownExtraExtensions = extensionsFromList
   [ Ext_footnotes


### PR DESCRIPTION
This PR adds a new extension, named "sequential tables". See the included description in `Manual.txt`.

This implementation seems to do what it is supposed to, but I have not run the test-suite because `new-test` does not work. I'd have to re-compile the world, and I'd rather trust on your CI.

No test code was added either, because I could not find any for existing tables. Please point me in the direction if I have overlooked something. I think this also lacks some parsing code for the new extension. I hope you can point out necessary changes that I have overlooked.

I realize that I have somewhat skipped a step in your contributing guidelines, namely discussing this on pandoc-discuss. I do now know how to subscribe to that mailing list. But feel free to send me any sort of feedback to `hexagoxel@hexagoxel.de`.

I, the only copyright holder of the additions in this PR, release these additions under the GPL v2 license.

Thanks for creating and maintaining this great tool.