### PR TITLE
Update diff-zip to support windows

### DIFF
--- a/tools/diff-zip.sh
+++ b/tools/diff-zip.sh
@@ -9,7 +9,7 @@ f2="$2"
 test -f "$f1" -a -f "$f2" || {
     echo "Usage: diff-zip firstfile secondfile" && exit 1
 }
-WORKDIR=$(mktemp -d -t diff-zip)
+WORKDIR=$(mktemp -d -t diff-zip.XXX)
 trap "{ rm -r $WORKDIR; }" EXIT
 unzip -q -d "$WORKDIR/a" "$f1"
 unzip -q -d "$WORKDIR/b" "$f2"
@@ -17,10 +17,10 @@ cd "$WORKDIR"
 mkdir tidy
 for x in a b; do
     cp -r $x tidy/
-    find -E $x -iregex '.*\.(xhtml|xml|rdf|rels)' -exec sh -c 'mkdir -p "$(dirname tidy/$1)" && tidy -q -xml -utf8 -i "$1" > "tidy/$1"' _ {} \;
+    find $x -regextype posix-extended -iregex '.*\.(xhtml|xml|rdf|rels)' -exec sh -c 'mkdir -p "$(dirname tidy/$1)" && tidy -q -xml -utf8 -i "$1" > "tidy/$1"' _ {} \;
 done
 cd tidy
 mkdir c
 cp -r a/* c/
 cp -r b/* c/
-find c -type f -exec sh -c 'echo "\033[1m=== ${1#*/} ===\033[0m" ; diff -u "a/${1#*/}" "b/${1#*/}" 2>&1' _ {} \;
+find c -type f -exec sh -c 'echo -e "\033[1m=== ${1#*/} ===\033[0m" ; diff -u "a/${1#*/}" "b/${1#*/}" 2>&1' _ {} \;


### PR DESCRIPTION
Trying to use this script on windows (git-bash) gave several errors:

- *mktemp* complained about missing XXXs in the template (fixed by adding XXX)
- *find* didn't understand the -E switch (fixed by using the equivalent arguments)
- *terminal codes* were not being recognized by the console (-e added to echo)