### PR TITLE
MANUAL: reveal.js flags

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1502,7 +1502,9 @@ Variables for HTML slides
 -------------------------
 
 These affect HTML output when [producing slide shows with pandoc].
+
 All [reveal.js configuration options] are available as variables.
+To turn off boolean flags that default to true in reveal.js, use `0`.
 
 `revealjs-url`
 :   base URL for reveal.js documents (defaults to `reveal.js`)


### PR DESCRIPTION
Unless anybody has a better idea?

The thing is, the revealjs template contains things like:

```
$if(controls)$
        // Display controls in the bottom right corner
        controls: $controls$,
$endif$
```

Since `0` is truthy in pandoc templates but falsy in JavaScript, this allows us to override [revealjs' default](https://github.com/hakimel/reveal.js#configuration).