### PR TITLE
HTML writer: ensure TeX formulas are rendered correctly

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -1064,7 +1064,7 @@ inlineToHtml opts inline = do
               let imtag = if html5 then H5.img else H.img
               let s = case t of
                            InlineMath  -> "\\textstyle "
-                           DisplayMath -> ""
+                           DisplayMath -> "\\displaystyle "
               let m = imtag ! A.style "vertical-align:middle"
                             ! A.src (toValue $ url ++ urlEncode (s ++ str))
                             ! A.alt (toValue str)

--- a/test/command/5655.md
+++ b/test/command/5655.md
@@ -9,6 +9,6 @@ $T_n={n+1 \choose 2}$
 % pandoc --webtex
 $$T_n={n+1 \choose 2}$$
 ^D
-<p><br /><img style="vertical-align:middle" src="https://latex.codecogs.com/png.latex?T_n%3D%7Bn%2B1%20%5Cchoose%202%7D" alt="T_n={n+1 \choose 2}" title="T_n={n+1 \choose 2}" /><br /></p>
+<p><br /><img style="vertical-align:middle" src="https://latex.codecogs.com/png.latex?%5Cdisplaystyle%20T_n%3D%7Bn%2B1%20%5Cchoose%202%7D" alt="T_n={n+1 \choose 2}" title="T_n={n+1 \choose 2}" /><br /></p>
 ````
 


### PR DESCRIPTION
The web service passed in to `--webtex` may render formulas using inline
or display style by default. Prefixing formulas with the appropriate
command ensures they are rendered correctly.

This is a followup to the discussion in #5656.