### PR TITLE
Treat `ly` as verbatim too

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1875,6 +1875,7 @@ environments = M.fromList
    , ("obeylines", obeylines)
    , ("tikzpicture", rawVerbEnv "tikzpicture")
    , ("lilypond", rawVerbEnv "lilypond")
+   , ("ly", rawVerbEnv "ly")
    -- etoolbox
    , ("ifstrequal", ifstrequal)
    , ("newtoggle", braced >>= newToggle)


### PR DESCRIPTION
According to https://github.com/jgm/pandoc/issues/4725#issuecomment-399772217 not only the `lilypond` environment but also `ly` should be included in the verbatim list.

@jperon
https://github.com/jperon/lyluatex/issues/203