### PR TITLE
Remove blank line

### DIFF
--- a/src/Text/Pandoc.hs
+++ b/src/Text/Pandoc.hs
@@ -28,7 +28,6 @@ inline links:
 > mdToRST txt = runIOorExplode $
 >   readMarkdown def txt
 >   >>= writeRST def{ writerReferenceLinks = True }
-
 >
 > main :: IO ()
 > main = do


### PR DESCRIPTION
This blank line was breaking the code block into two. Visible at http://hackage.haskell.org/package/pandoc-2.7.3/docs/Text-Pandoc.html