### PR TITLE
Fix multiline table for XWiki writer

### DIFF
--- a/src/Text/Pandoc/Writers/XWiki.hs
+++ b/src/Text/Pandoc/Writers/XWiki.hs
@@ -139,9 +139,11 @@ formRow row = do
 tableCellXWiki :: PandocMonad m => Bool -> [Block] -> XWikiReader m Text
 tableCellXWiki isHeader cell = do
   contents <- blockListToXWiki cell
+  let isMultiline = (length . split (== '\n')) contents > 1
+  let contents' = intercalate contents $ if isMultiline then [pack "(((", pack ")))"] else [mempty, mempty]
   let cellBorder = if isHeader then "|=" else "|"
-  return $ cellBorder <> contents
-  
+  return $ cellBorder <> contents'
+
 
 inlineListToXWiki :: PandocMonad m => [Inline] -> XWikiReader m Text
 inlineListToXWiki lst =


### PR DESCRIPTION
Details at https://groups.google.com/forum/#!topic/pandoc-discuss/c861tTdCFTg

TL;DR:

Fix XWiki output for

```markdown
+----------+----------+
| Col A    | Col B    |
+==========+==========+
| Row A    | * Item A |
|          | * Item B |
+----------+----------+
```

from (notice that the following XWiki code renders as a table followed by a singleton list)

```
|=Col A|=Col B
|Row A|*. Item A
*. Item B
```

to

```
|=Col A|=Col B
|Row A|(((*. Item A
*. Item B
)))
```
