### PR TITLE
Change optMetadataFile type from Maybe to List

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -597,13 +597,13 @@ Reader options {.options}
 
 `--metadata-file=`*FILE*
 
-:   Read metadata from the supplied YAML (or JSON) file. Several file may be
-    provided. This option can be used with every input format, but string
-    scalars in the YAML file will always be parsed as Markdown.
-    Generally, the input will be handled the same as in
-    [YAML metadata blocks][Extension: `yaml_metadata_block`].
-    Metadata values specified inside the document, or by using `-M`,
-    overwrite values specified with this option.
+:   Read metadata from the supplied YAML (or JSON) file. This option can be used
+    with every input format, but string scalars in the YAML file will always be
+    parsed as Markdown. Generally, the input will be handled the same as in
+    [YAML metadata blocks][Extension: `yaml_metadata_block`]. This option can be
+    used repeatedly to include multiple metadata files. Metadata values
+    specified inside the document, or by using `-M`, overwrite values specified
+    with this option.
 
 `-p`, `--preserve-tabs`
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -597,8 +597,8 @@ Reader options {.options}
 
 `--metadata-file=`*FILE*
 
-:   Read metadata from the supplied YAML (or JSON) file.
-    This option can be used with every input format, but string
+:   Read metadata from the supplied YAML (or JSON) file. Several file may be
+    provided. This option can be used with every input format, but string
     scalars in the YAML file will always be parsed as Markdown.
     Generally, the input will be handled the same as in
     [YAML metadata blocks][Extension: `yaml_metadata_block`].
@@ -954,7 +954,7 @@ Options affecting specific writers {.options}
 
 :   Use the [`listings`] package for LaTeX code blocks. The package
     does not support multi-byte encoding for source code. To handle UTF-8
-    you would need to use a custom template. This issue is fully 
+    you would need to use a custom template. This issue is fully
     documented here: [Encoding issue with the listings package].
 
 `-i`, `--incremental`
@@ -1551,7 +1551,7 @@ These variables change the appearance of PDF slides using [`beamer`].
 :   enables "title pages" for new sections (default is true)
 
 `theme`, `colortheme`, `fonttheme`, `innertheme`, `outertheme`
-:   beamer themes: 
+:   beamer themes:
 
 `themeoptions`
 :   options for LaTeX beamer themes (a list).
@@ -2012,7 +2012,7 @@ consecutive items:
 
     $for(author)$$author$$sep$, $endfor$
 
-Note that the separator needs to be specified immediately before the `$endfor` 
+Note that the separator needs to be specified immediately before the `$endfor`
 keyword.
 
 A dot can be used to select a field of a variable that takes
@@ -4806,7 +4806,7 @@ the [Beamer User's Guide] may also be used: `allowdisplaybreaks`,
 Background in reveal.js and beamer
 ----------------------------------
 
-Background images can be added to self-contained reveal.js slideshows and 
+Background images can be added to self-contained reveal.js slideshows and
 to beamer slideshows.
 
 For the same image on every slide, use the  configuration
@@ -4814,9 +4814,9 @@ option `background-image` either in the YAML metadata block
 or as a command-line variable. (There are no other options in
 beamer and the rest of this section concerns reveal.js slideshows.)
 
-For reveal.js, you can instead use the reveal.js-native option 
-`parallaxBackgroundImage`. You can also set `parallaxBackgroundHorizontal` 
-and `parallaxBackgroundVertical` the same way and must also set 
+For reveal.js, you can instead use the reveal.js-native option
+`parallaxBackgroundImage`. You can also set `parallaxBackgroundHorizontal`
+and `parallaxBackgroundVertical` the same way and must also set
 `parallaxBackgroundSize` to have your values take effect.
 
 To set an image for a particular reveal.js slide, add

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -601,7 +601,8 @@ Reader options {.options}
     with every input format, but string scalars in the YAML file will always be
     parsed as Markdown. Generally, the input will be handled the same as in
     [YAML metadata blocks][Extension: `yaml_metadata_block`]. This option can be
-    used repeatedly to include multiple metadata files. Metadata values
+    used repeatedly to include multiple metadata files; values in files specified
+    first will be preferred over those specified in later files. Metadata values
     specified inside the document, or by using `-M`, overwrite values specified
     with this option.
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -954,7 +954,7 @@ Options affecting specific writers {.options}
 
 :   Use the [`listings`] package for LaTeX code blocks. The package
     does not support multi-byte encoding for source code. To handle UTF-8
-    you would need to use a custom template. This issue is fully
+    you would need to use a custom template. This issue is fully 
     documented here: [Encoding issue with the listings package].
 
 `-i`, `--incremental`
@@ -1551,7 +1551,7 @@ These variables change the appearance of PDF slides using [`beamer`].
 :   enables "title pages" for new sections (default is true)
 
 `theme`, `colortheme`, `fonttheme`, `innertheme`, `outertheme`
-:   beamer themes:
+:   beamer themes: 
 
 `themeoptions`
 :   options for LaTeX beamer themes (a list).
@@ -2012,7 +2012,7 @@ consecutive items:
 
     $for(author)$$author$$sep$, $endfor$
 
-Note that the separator needs to be specified immediately before the `$endfor`
+Note that the separator needs to be specified immediately before the `$endfor` 
 keyword.
 
 A dot can be used to select a field of a variable that takes
@@ -4806,7 +4806,7 @@ the [Beamer User's Guide] may also be used: `allowdisplaybreaks`,
 Background in reveal.js and beamer
 ----------------------------------
 
-Background images can be added to self-contained reveal.js slideshows and
+Background images can be added to self-contained reveal.js slideshows and 
 to beamer slideshows.
 
 For the same image on every slide, use the  configuration
@@ -4814,9 +4814,9 @@ option `background-image` either in the YAML metadata block
 or as a command-line variable. (There are no other options in
 beamer and the rest of this section concerns reveal.js slideshows.)
 
-For reveal.js, you can instead use the reveal.js-native option
-`parallaxBackgroundImage`. You can also set `parallaxBackgroundHorizontal`
-and `parallaxBackgroundVertical` the same way and must also set
+For reveal.js, you can instead use the reveal.js-native option 
+`parallaxBackgroundImage`. You can also set `parallaxBackgroundHorizontal` 
+and `parallaxBackgroundVertical` the same way and must also set 
 `parallaxBackgroundSize` to have your values take effect.
 
 To set an image for a particular reveal.js slide, add

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -198,6 +198,8 @@ extra-source-files:
                  test/command/3533-rst-csv-tables.csv
                  test/command/3880.txt
                  test/command/5182.txt
+                 test/command/5700-metadata-file-1.yml
+                 test/command/5700-metadata-file-2.yml
                  test/command/abbrevs
                  test/command/SVG_logo-without-xml-declaration.svg
                  test/command/SVG_logo.svg

--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -226,8 +226,9 @@ convertWithOpts opts = do
 
     metadataFromFile <-
       case optMetadataFile opts of
-        Nothing   -> return mempty
-        Just file -> readFileLazy file >>= yamlToMeta readerOpts
+        []    -> return mempty
+        paths -> mapM readFileLazy paths >>= mapM (yamlToMeta readerOpts)
+                   >>= return . (foldr1 (<>))
 
     let transforms = (case optBaseHeaderLevel opts of
                           x | x > 1     -> (headerShift (x - 1) :)

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -181,7 +181,7 @@ options =
     , Option "" ["metadata-file"]
                  (ReqArg
                   (\arg opt -> return opt{ optMetadataFile =
-                                   Just (normalizePath arg) })
+                    (optMetadataFile opt) <> [normalizePath arg] })
                   "FILE")
                  ""
 

--- a/src/Text/Pandoc/App/Opt.hs
+++ b/src/Text/Pandoc/App/Opt.hs
@@ -54,7 +54,7 @@ data Opt = Opt
     , optTemplate              :: Maybe FilePath  -- ^ Custom template
     , optVariables             :: [(String,String)] -- ^ Template variables to set
     , optMetadata              :: [(String, String)] -- ^ Metadata fields to set
-    , optMetadataFile          :: Maybe FilePath  -- ^ Name of YAML metadata file
+    , optMetadataFile          :: [FilePath]  -- ^ Name of YAML metadata file
     , optOutputFile            :: Maybe FilePath  -- ^ Name of output file
     , optInputFiles            :: [FilePath] -- ^ Names of input files
     , optNumberSections        :: Bool    -- ^ Number sections in LaTeX
@@ -128,7 +128,7 @@ defaultOpts = Opt
     , optTemplate              = Nothing
     , optVariables             = []
     , optMetadata              = []
-    , optMetadataFile          = Nothing
+    , optMetadataFile          = []
     , optOutputFile            = Nothing
     , optInputFiles            = []
     , optNumberSections        = False

--- a/test/command/5700-metadata-file-1.yml
+++ b/test/command/5700-metadata-file-1.yml
@@ -1,0 +1,1 @@
+title: Multiple metadata files test

--- a/test/command/5700-metadata-file-2.yml
+++ b/test/command/5700-metadata-file-2.yml
@@ -1,0 +1,1 @@
+desc: Both of these files should be loaded.

--- a/test/command/5700-metadata-file-2.yml
+++ b/test/command/5700-metadata-file-2.yml
@@ -1,1 +1,2 @@
+title: This title should be overridden by 5700-metadta-file-2.yml
 desc: Both of these files should be loaded.

--- a/test/command/5700.md
+++ b/test/command/5700.md
@@ -1,0 +1,6 @@
+```
+% pandoc -t native -s --metadata-file command/5700-metadata-file-1.yml --metadata-file command/5700-metadata-file-2.yml
+^D
+Pandoc (Meta {unMeta = fromList [("desc",MetaInlines [Str "Both",Space,Str "of",Space,Str "these",Space,Str "files",Space,Str "should",Space,Str "be",Space,Str "loaded."]),("title",MetaInlines [Str "Multiple",Space,Str "metadata",Space,Str "files",Space,Str "test"])]})
+[]
+```


### PR DESCRIPTION
Changed optMetadataFile from Maybe FilePath to [FilePath]. This allows
for multiple YAML metadata files to be added. The new default value has
been changed from Nothing to [].

To account for this change in Text.Pandoc.App, metaDataFromFile now
operates on two mapM calls (for readFileLazy and yamlToMeta) and a fold.

Added a test (command/5700.md) which tests this functionality and
updated MANUAL.txt, as per the contributing guidelines.

This would fix #5700.