### PR TITLE
[LaTeX] Enable user-override for hyphenations.

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -390,6 +390,9 @@ $if(logo)$
 \logo{\includegraphics{$logo$}}
 $endif$
 $endif$
+$if(hyphenation)$
+\hyphenation{$hyphenation$}
+$endif§
 
 \begin{document}
 $if(has-frontmatter)$


### PR DESCRIPTION
User can specify `hyphenation: every-where` in YAML section.