### PR TITLE
New markdown to asciidoc tests

### DIFF
--- a/test/command/markdown-to-asciidoc-code.md
+++ b/test/command/markdown-to-asciidoc-code.md
@@ -2,109 +2,85 @@ converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a
 
 Render a code block without language
 
-```
-% pandoc -t asciidoc
-```
-summary(cars$dist)
-summary(cars$speed)
-```
-^D
-----
-summary(cars$dist)
-summary(cars$speed)
-----
-```
+    % pandoc -t asciidoc
+    ```
+    summary(cars$dist)
+    summary(cars$speed)
+    ```
+    ^D
+    ....
+    summary(cars$dist)
+    summary(cars$speed)
+    ....
 
 
 Render a code block without language containing HTML
 
-```
-% pandoc -t asciidoc
-```
-No language indicated, so no syntax highlighting.
-But let's throw in a <b>tag</b>.
-```
-^D
-----
-No language indicated, so no syntax highlighting.
-But let's throw in a <b>tag</b>.
-----
-```
+    % pandoc -t asciidoc
+    ```
+    No language indicated, so no syntax highlighting.
+    But let's throw in a <b>tag</b>.
+    ```
+    ^D
+    ....
+    No language indicated, so no syntax highlighting.
+    But let's throw in a <b>tag</b>.
+    ....
 
 
 Render a javascript code block
 
-```
-% pandoc -t asciidoc
-```javascript
-var s = "JavaScript syntax highlighting";
-alert(s);
-```
-^D
-[source,javascript]
-----
-var s = "JavaScript syntax highlighting";
-alert(s);
-----
-```
+  % pandoc -t asciidoc
+  ```javascript
+  var s = "JavaScript syntax highlighting";
+  alert(s);
+  ```
+  ^D
+  [source,javascript]
+  ----
+  var s = "JavaScript syntax highlighting";
+  alert(s);
+  ----
 
 
 Render a python code block
 
-```
-% pandoc -t asciidoc
-```python
-s = "Python syntax highlighting"
-print s
-```
-^D
-[source,python]
-----
-s = "Python syntax highlighting"
-print s
-----
-```
-
-
-Render an indented code block
-
-```
-% pandoc -t asciidoc
-    $ gem install asciidoctor
-^D
-----
-$ gem install asciidoctor
-----
-```
+  % pandoc -t asciidoc
+  ```python
+  s = "Python syntax highlighting"
+  print s
+  ```
+  ^D
+  [source,python]
+  ----
+  s = "Python syntax highlighting"
+  print s
+  ----
 
 
 Render code block adjacent to preceding paragraph
 
-```
-% pandoc -t asciidoc
-Here's an example:
-```javascript
-var s = "JavaScript syntax highlighting";
-alert(s);
-```
-^D
-Here's an example:
+    % pandoc -t asciidoc
+    An example:
 
-[source,javascript]
-----
-var s = "JavaScript syntax highlighting";
-alert(s);
-----
-```
+    ```javascript
+    var s = "JavaScript syntax highlighting";
+    alert(s);
+    ```
+    ^D
+    An example:
+
+    [source,javascript]
+    ----
+    var s = "JavaScript syntax highlighting";
+    alert(s);
+    ----
 
 
 Render inline code
 
-```
-% pandoc -t asciidoc
-We defined the `add` function to
-^D
-We defined the `add` function to
-```
-
+    % pandoc -t asciidoc
+    We defined the `add` function to
+    ^D
+    We defined the `+add+` function to
 

--- a/test/command/markdown-to-asciidoc-code.md
+++ b/test/command/markdown-to-asciidoc-code.md
@@ -1,0 +1,110 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/code.feature>
+
+Render a code block without language
+
+```
+% pandoc -t asciidoc
+```
+summary(cars$dist)
+summary(cars$speed)
+```
+^D
+----
+summary(cars$dist)
+summary(cars$speed)
+----
+```
+
+
+Render a code block without language containing HTML
+
+```
+% pandoc -t asciidoc
+```
+No language indicated, so no syntax highlighting.
+But let's throw in a <b>tag</b>.
+```
+^D
+----
+No language indicated, so no syntax highlighting.
+But let's throw in a <b>tag</b>.
+----
+```
+
+
+Render a javascript code block
+
+```
+% pandoc -t asciidoc
+```javascript
+var s = "JavaScript syntax highlighting";
+alert(s);
+```
+^D
+[source,javascript]
+----
+var s = "JavaScript syntax highlighting";
+alert(s);
+----
+```
+
+
+Render a python code block
+
+```
+% pandoc -t asciidoc
+```python
+s = "Python syntax highlighting"
+print s
+```
+^D
+[source,python]
+----
+s = "Python syntax highlighting"
+print s
+----
+```
+
+
+Render an indented code block
+
+```
+% pandoc -t asciidoc
+    $ gem install asciidoctor
+^D
+----
+$ gem install asciidoctor
+----
+```
+
+
+Render code block adjacent to preceding paragraph
+
+```
+% pandoc -t asciidoc
+Here's an example:
+```javascript
+var s = "JavaScript syntax highlighting";
+alert(s);
+```
+^D
+Here's an example:
+
+[source,javascript]
+----
+var s = "JavaScript syntax highlighting";
+alert(s);
+----
+```
+
+
+Render inline code
+
+```
+% pandoc -t asciidoc
+We defined the `add` function to
+^D
+We defined the `add` function to
+```
+
+

--- a/test/command/markdown-to-asciidoc-description-lists.md
+++ b/test/command/markdown-to-asciidoc-description-lists.md
@@ -1,0 +1,33 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/descriptionlists.feature>
+
+Render a description list
+
+```
+% pandoc -t asciidoc
+Apple
+:   Pomaceous fruit of plants of the genus Malus in
+the family Rosaceae.
+^D
+Apple::
+  Pomaceous fruit of plants of the genus Malus in the family Rosaceae.
+```
+
+
+Render a multiple description lists
+
+```
+% pandoc -t asciidoc
+Apple
+:   Pomaceous fruit of plants of the genus Malus in
+the family Rosaceae.
+
+Orange
+:   The fruit of an evergreen tree of the genus Citrus.
+^D
+Apple::
+  Pomaceous fruit of plants of the genus Malus in the family Rosaceae.
+Orange::
+  The fruit of an evergreen tree of the genus Citrus.
+```
+
+

--- a/test/command/markdown-to-asciidoc-headings.md
+++ b/test/command/markdown-to-asciidoc-headings.md
@@ -1,0 +1,94 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/headings.feature>
+
+Render a level 1 heading
+
+```
+% pandoc -t asciidoc
+# Title #
+^D
+= Title
+```
+
+
+Render a level 1 underscored heading
+
+```
+% pandoc -t asciidoc
+Title
+=====
+^D
+= Title
+```
+
+
+Render a level 2 heading
+
+```
+% pandoc -t asciidoc
+## Title
+^D
+== Title
+```
+
+
+Render a level 2 underscored heading
+
+```
+% pandoc -t asciidoc
+Title
+-----
+^D
+== Title
+```
+
+
+Render a level 3 heading
+
+```
+% pandoc -t asciidoc
+## Title
+^D
+== Title
+```
+
+
+Render a level 4 heading
+
+```
+% pandoc -t asciidoc
+#### Title
+^D
+==== Title
+```
+
+
+Render a level 5 heading
+
+```
+% pandoc -t asciidoc
+##### Title
+^D
+===== Title
+```
+
+
+Render a level 6 heading
+
+```
+% pandoc -t asciidoc
+###### Title
+^D
+====== Title
+```
+
+
+Render a heading with different styling
+
+```
+% pandoc -t asciidoc
+# Title ####
+^D
+= Title
+```
+
+

--- a/test/command/markdown-to-asciidoc-lines.md
+++ b/test/command/markdown-to-asciidoc-lines.md
@@ -1,0 +1,21 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/lines.feature>
+
+Create 4 horizontal lines
+
+```
+% pandoc -t asciidoc
+---
+
+- - -
+
+***
+
+* * *
+^D
+'''
+'''
+'''
+'''
+```
+
+

--- a/test/command/markdown-to-asciidoc-links.md
+++ b/test/command/markdown-to-asciidoc-links.md
@@ -26,7 +26,7 @@ Render linked text with comma
 % pandoc -t asciidoc
 This is [a very, very cool](http://example.com/) inline link.
 ^D
-This is http://example.com/["a very, very cool"] inline link.
+This is http://example.com/[a very, very cool] inline link.
 ```
 
 
@@ -34,11 +34,12 @@ Render a reference style link with link definition
 
 ```
 % pandoc -t asciidoc
-The [syntax page] [s] provides complete, detailed documentation for
+The [syntax page][s] provides complete, detailed documentation for
 
 [s]: /projects/markdown/syntax  "Markdown Syntax"
 ^D
-The link:/projects/markdown/syntax[syntax page] provides complete, detailed documentation for
+The link:/projects/markdown/syntax[syntax page] provides complete,
+detailed documentation for
 ```
 
 
@@ -46,21 +47,21 @@ Render a reference style link with link text
 
 ```
 % pandoc -t asciidoc
-The [syntax page] provides complete, detailed documentation for
+The [syntax page] provides documentation
 
 [syntax page]: http://www.syntaxpage.com
 ^D
-The http://www.syntaxpage.com[syntax page] provides complete, detailed documentation for
+The http://www.syntaxpage.com[syntax page] provides documentation
 ```
 
 
-Render an internal link using the cross reference syntax
+Render an internal link
 
 ```
 % pandoc -t asciidoc
 Refer to [Quick start](#quick-start) to learn how to get started.
 ^D
-Refer to <<quick-start,Quick start>> to learn how to get started.
+Refer to link:#quick-start[Quick start] to learn how to get started.
 ```
 
 

--- a/test/command/markdown-to-asciidoc-links.md
+++ b/test/command/markdown-to-asciidoc-links.md
@@ -1,0 +1,122 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/links.feature>
+
+Render an implicit inline link
+
+```
+% pandoc -t asciidoc
+Use [http://example.com](http://example.com) for sample links in documentation.
+^D
+Use http://example.com for sample links in documentation.
+```
+
+
+Render an inline link
+
+```
+% pandoc -t asciidoc
+This is [an example](http://example.com/) inline link.
+^D
+This is http://example.com/[an example] inline link.
+```
+
+
+Render linked text with comma
+
+```
+% pandoc -t asciidoc
+This is [a very, very cool](http://example.com/) inline link.
+^D
+This is http://example.com/["a very, very cool"] inline link.
+```
+
+
+Render a reference style link with link definition
+
+```
+% pandoc -t asciidoc
+The [syntax page] [s] provides complete, detailed documentation for
+
+[s]: /projects/markdown/syntax  "Markdown Syntax"
+^D
+The link:/projects/markdown/syntax[syntax page] provides complete, detailed documentation for
+```
+
+
+Render a reference style link with link text
+
+```
+% pandoc -t asciidoc
+The [syntax page] provides complete, detailed documentation for
+
+[syntax page]: http://www.syntaxpage.com
+^D
+The http://www.syntaxpage.com[syntax page] provides complete, detailed documentation for
+```
+
+
+Render an internal link using the cross reference syntax
+
+```
+% pandoc -t asciidoc
+Refer to [Quick start](#quick-start) to learn how to get started.
+^D
+Refer to <<quick-start,Quick start>> to learn how to get started.
+```
+
+
+Render an reference style image
+
+```
+% pandoc -t asciidoc
+![Alt text][logo]
+
+[logo]: images/icons/home.png
+^D
+image:images/icons/home.png[Alt text]
+```
+
+
+Render an inline image with parameters
+
+```
+% pandoc -t asciidoc
+![Alt text](images/icons/home.png)
+
+![Alt text](images/icons/home.png?width=100)
+^D
+image:images/icons/home.png[Alt text]
+
+image:images/icons/home.png?width=100[Alt text]
+```
+
+
+Render an inline image with comma in alt text
+
+```
+% pandoc -t asciidoc
+![Alt,text](images/icons/home.png)
+^D
+image:images/icons/home.png["Alt,text"]
+```
+
+
+Render a hyperlinked inline image with alt text
+
+```
+% pandoc -t asciidoc
+[![Build Status](https://travis-ci.org/asciidoctor/asciidoctor.png)](https://travis-ci.org/asciidoctor/asciidoctor)
+^D
+image:https://travis-ci.org/asciidoctor/asciidoctor.png[Build Status,link=https://travis-ci.org/asciidoctor/asciidoctor]
+```
+
+
+Render a hyperlinked inline image with no alt text
+
+```
+% pandoc -t asciidoc
+[![](https://travis-ci.org/asciidoctor/asciidoctor.png)](https://travis-ci.org/asciidoctor/asciidoctor)
+^D
+image:https://travis-ci.org/asciidoctor/asciidoctor.png[link=https://travis-ci.org/asciidoctor/asciidoctor]
+```
+
+

--- a/test/command/markdown-to-asciidoc-lists.md
+++ b/test/command/markdown-to-asciidoc-lists.md
@@ -1,0 +1,181 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/lists.feature>
+
+Render an unordered list
+
+```
+% pandoc -t asciidoc
+* Item 1
+* Item 2
+* Item 3
+^D
+* Item 1
+* Item 2
+* Item 3
+```
+
+
+Render an unordered list of paragraphs
+
+```
+% pandoc -t asciidoc
+* Paragraph 1
+
+* Paragraph 2
+^D
+* Paragraph 1
+
+* Paragraph 2
+```
+
+
+Render an unordered nested list
+
+```
+% pandoc -t asciidoc
+* Item 1
+    * Item 1_1
+    * Item 1_2
+^D
+* Item 1
+** Item 1_1
+** Item 1_2
+```
+
+
+Render an ordered list
+
+```
+% pandoc -t asciidoc
+1. Item 1
+1. Item 2
+1. Item 3
+^D
+. Item 1
+. Item 2
+. Item 3
+```
+
+
+Render a nested ordered list
+
+```
+% pandoc -t asciidoc
+1. Item 1
+    1. Item 1.1
+    1. Item 1.2
+^D
+. Item 1
+.. Item 1.1
+.. Item 1.2
+```
+
+
+Render a nested ordered list combined with unordered list
+
+```
+% pandoc -t asciidoc
+1. Item 1
+    1. Item 11
+        * bullet 111
+        * bullet 112
+            * bullet 1121
+                1. Item 11211
+    1. Item 12
+1. Item 2
+^D
+. Item 1
+.. Item 11
+*** bullet 111
+*** bullet 112
+**** bullet 1121
+..... Item 11211
+.. Item 12
+. Item 2
+```
+
+
+Render an ordered list combined with a nested unordered list
+
+```
+% pandoc -t asciidoc
+1. Item 1
+
+2. Item 2
+
+    * Subitem of Item 2
+
+3. Item 3
+^D
+. Item 1
+
+. Item 2
+
+** Subitem of Item 2
+
+. Item 3
+```
+
+
+Render an ordered list of paragraphs
+
+```
+% pandoc -t asciidoc
+. Paragraph 1
+
+. Paragraph 2
+^D
+. Paragraph 1
+
+. Paragraph 2
+```
+
+
+Render an unordered list with a link
+
+```
+% pandoc -t asciidoc
+There is a Maven example project available.
+
+* [http://github.com/geb/geb-example-maven](https://github.com/geb/geb-example-maven)
+^D
+There is a Maven example project available.
+
+* https://github.com/geb/geb-example-maven[http://github.com/geb/geb-example-maven]
+```
+
+
+Render 4 numbered items with a code block
+
+```
+% pandoc -t asciidoc
+1. Use the `browser` object explicitly (made available by the testing adapters)
+2. Use the page instance returned by the `to()` and `at()` methods instead of calling through the browser
+3. Use methods on the `Page` classes instead of the `content {}` block and dynamic properties
+4. If you need to use content definition options like `required:` and `wait:` then you can still reference content elements defined using the DSL in methods on `Page` and `Module` classes as usual, e.g.:
+
+    static content = {
+        async(wait: true) { $(".async") }
+    }
+
+    String asyncText() {
+        async.text() // Wait here for the async definition to return a non-empty Navigator...
+    }
+Using this “typed” style is not an all or nothing proposition.
+^D
+. Use the `browser` object explicitly (made available by the testing adapters)
+. Use the page instance returned by the `to()` and `at()` methods instead of calling through the browser
+. Use methods on the `Page` classes instead of the `content {}` block and dynamic properties
+. If you need to use content definition options like `required:` and `wait:` then you can still reference content elements defined using the DSL in methods on `Page` and `Module` classes as usual, e.g.:
+
+    static content = {
+        async(wait: true) { $(".async") }
+    }
+
+    String asyncText() {
+        async.text() // Wait here for the async definition to return a non-empty Navigator...
+    }
+
+Using this “typed” style is not an all or nothing proposition.
+```
+
+

--- a/test/command/markdown-to-asciidoc-lists.md
+++ b/test/command/markdown-to-asciidoc-lists.md
@@ -14,20 +14,6 @@ Render an unordered list
 ```
 
 
-Render an unordered list of paragraphs
-
-```
-% pandoc -t asciidoc
-* Paragraph 1
-
-* Paragraph 2
-^D
-* Paragraph 1
-
-* Paragraph 2
-```
-
-
 Render an unordered nested list
 
 ```
@@ -107,11 +93,8 @@ Render an ordered list combined with a nested unordered list
 3. Item 3
 ^D
 . Item 1
-
 . Item 2
-
 ** Subitem of Item 2
-
 . Item 3
 ```
 
@@ -147,34 +130,41 @@ There is a Maven example project available.
 Render 4 numbered items with a code block
 
 ```
-% pandoc -t asciidoc
+% pandoc -f markdown-smart -t asciidoc
 1. Use the `browser` object explicitly (made available by the testing adapters)
 2. Use the page instance returned by the `to()` and `at()` methods instead of calling through the browser
 3. Use methods on the `Page` classes instead of the `content {}` block and dynamic properties
 4. If you need to use content definition options like `required:` and `wait:` then you can still reference content elements defined using the DSL in methods on `Page` and `Module` classes as usual, e.g.:
 
-    static content = {
-        async(wait: true) { $(".async") }
-    }
+       static content = {
+           async(wait: true) { $(".async") }
+       }
 
-    String asyncText() {
-        async.text() // Wait here for the async definition to return a non-empty Navigator...
-    }
+       String asyncText() {
+           async.text() // Wait here for the async definition to return a non-empty Navigator...
+       }
 Using this “typed” style is not an all or nothing proposition.
 ^D
-. Use the `browser` object explicitly (made available by the testing adapters)
-. Use the page instance returned by the `to()` and `at()` methods instead of calling through the browser
-. Use methods on the `Page` classes instead of the `content {}` block and dynamic properties
-. If you need to use content definition options like `required:` and `wait:` then you can still reference content elements defined using the DSL in methods on `Page` and `Module` classes as usual, e.g.:
+. Use the `+browser+` object explicitly (made available by the testing
+adapters)
+. Use the page instance returned by the `+to()+` and `+at()+` methods
+instead of calling through the browser
+. Use methods on the `+Page+` classes instead of the `+content {}+`
+block and dynamic properties
+. If you need to use content definition options like `+required:+` and
+`+wait:+` then you can still reference content elements defined using
+the DSL in methods on `+Page+` and `+Module+` classes as usual, e.g.:
++
+....
+static content = {
+    async(wait: true) { $(".async") }
+}
 
-    static content = {
-        async(wait: true) { $(".async") }
-    }
-
-    String asyncText() {
-        async.text() // Wait here for the async definition to return a non-empty Navigator...
-    }
-
+String asyncText() {
+    async.text() // Wait here for the async definition to return a non-empty Navigator...
+}
+....
++
 Using this “typed” style is not an all or nothing proposition.
 ```
 

--- a/test/command/markdown-to-asciidoc-markup.md
+++ b/test/command/markdown-to-asciidoc-markup.md
@@ -1,0 +1,320 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/markup.feature>
+
+Don't apply formatting
+
+```
+% pandoc -t asciidoc
+Normal text
+^D
+Normal text
+```
+
+
+Don't apply formatting for one line over multiple lines
+
+```
+% pandoc -t asciidoc
+Normal text
+Normal text
+^D
+Normal text
+Normal text
+```
+
+
+Don't apply formatting for multiple lines
+
+```
+% pandoc -t asciidoc
+Normal text
+
+Normal text
+^D
+Normal text
+
+Normal text
+```
+
+
+Text, lists, text
+
+```
+% pandoc -t asciidoc
+The support provides:
+
+* Understanding of implicit browser methods (e.g. `to()`, `at()`) in test classes (e.g. `extends GebSpec`)
+* Understanding of content defined via the Content DSL (within `Page` and `Module` classes only)
+* Completion in `at {}` and `content {}` blocks
+
+This effectively enables more authoring support with less explicit type information. The Geb development team would like to thank the good folks at JetBrains for adding this explicit support for Geb to IDEA.
+^D
+The support provides:
+
+* Understanding of implicit browser methods (e.g. `to()`, `at()`) in test classes (e.g. `extends GebSpec`)
+* Understanding of content defined via the Content DSL (within `Page` and `Module` classes only)
+* Completion in `at {}` and `content {}` blocks
+
+This effectively enables more authoring support with less explicit type information. The Geb development team would like to thank the good folks at JetBrains for adding this explicit support for Geb to IDEA.
+```
+
+
+Escaped characters
+
+```
+% pandoc -t asciidoc
+\*this text is surrounded by literal asterisks\*
+^D
++++*this text is surrounded by literal asterisks*+++
+```
+
+
+Make text bold
+
+```
+% pandoc -t asciidoc
+**Bold text**
+__Bold text__
+^D
+*Bold text*
+*Bold text*
+```
+
+
+Make text italic
+
+```
+% pandoc -t asciidoc
+*Italic text*
+_Italic text_
+^D
+_Italic text_
+_Italic text_
+```
+
+
+Make text mono
+
+```
+% pandoc -t asciidoc
+`Mono text`
+^D
+`Mono text`
+```
+
+
+Make text bold and italic
+
+```
+% pandoc -t asciidoc
+This is ***bold and italic*** text
+^D
+This is *_bold and italic_* text
+```
+
+
+Blockquotes
+
+```
+% pandoc -t asciidoc
+> Blockquotes are very handy in email to emulate reply text.
+> This line is part of the same quote.
+
+Quote break.
+
+> This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
+^D
+____
+
+Blockquotes are very handy in email to emulate reply text.
+This line is part of the same quote.
+
+____
+
+Quote break.
+
+____
+
+This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can _put_ *Markdown* into a blockquote.
+
+____
+```
+
+
+Nested Blockquotes
+
+```
+% pandoc -t asciidoc
+> > What's new?
+>
+> I've got Markdown in my AsciiDoc!
+>
+> > Like what?
+>
+> * Blockquotes
+> * Headings
+> * Fenced code blocks
+>
+> > Is there more?
+>
+> Yep. AsciiDoc and Markdown share a lot of common syntax already.
+^D
+____
+
+________
+
+What's new?
+
+________
+
+I've got Markdown in my AsciiDoc!
+
+________
+
+Like what?
+
+________
+
+* Blockquotes
+* Headings
+* Fenced code blocks
+
+________
+
+Is there more?
+
+________
+
+Yep. AsciiDoc and Markdown share a lot of common syntax already.
+
+____
+```
+
+
+Superscript
+
+```
+% pandoc -t asciidoc
+superscript^2^
+^D
+superscript^2^
+```
+
+
+Subscript
+
+```
+% pandoc -t asciidoc
+CO~2~
+^D
+CO~2~
+```
+
+
+Double angle bracket quoting
+
+```
+% pandoc -t asciidoc
+<<hello>>
+^D
+«hello»
+```
+
+
+Double quoting
+
+```
+% pandoc -t asciidoc
+"hello"
+^D
+"hello"
+```
+
+
+Single quoting
+
+```
+% pandoc -t asciidoc
+'hello'
+^D
+'hello'
+```
+
+
+Apostroph
+
+```
+% pandoc -t asciidoc
+a'a
+^D
+a'a
+```
+
+
+Ellipsis two
+
+```
+% pandoc -t asciidoc
+a...a
+a. . .a
+^D
+a…a
+a…a
+```
+
+
+Em Dash
+
+```
+% pandoc -t asciidoc
+a---a
+^D
+a—a
+```
+
+
+En Dash
+
+```
+% pandoc -t asciidoc
+a--a
+^D
+a–a
+```
+
+
+Nbsp
+
+```
+% pandoc -t asciidoc
+<< a a >>
+^D
+«{nbsp}a a{nbsp}»
+```
+
+
+Should recognize a hard line break
+
+```
+% pandoc -t asciidoc
+Roses are red,{sp}{sp}
+Violets are blue.{sp}
+Sort of blue.
+More like violet.
+^D
+Roses are red, +
+Violets are blue.
+Sort of blue.
+More like violet.
+```
+
+
+Strikethrough
+
+```
+% pandoc -t asciidoc
+This is ~~striked~~ text
+^D
+This is [line-through]#striked# text
+```
+
+

--- a/test/command/markdown-to-asciidoc-markup.md
+++ b/test/command/markdown-to-asciidoc-markup.md
@@ -1,41 +1,5 @@
 converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/markup.feature>
 
-Don't apply formatting
-
-```
-% pandoc -t asciidoc
-Normal text
-^D
-Normal text
-```
-
-
-Don't apply formatting for one line over multiple lines
-
-```
-% pandoc -t asciidoc
-Normal text
-Normal text
-^D
-Normal text
-Normal text
-```
-
-
-Don't apply formatting for multiple lines
-
-```
-% pandoc -t asciidoc
-Normal text
-
-Normal text
-^D
-Normal text
-
-Normal text
-```
-
-
 Text, lists, text
 
 ```
@@ -50,11 +14,15 @@ This effectively enables more authoring support with less explicit type informat
 ^D
 The support provides:
 
-* Understanding of implicit browser methods (e.g. `to()`, `at()`) in test classes (e.g. `extends GebSpec`)
-* Understanding of content defined via the Content DSL (within `Page` and `Module` classes only)
-* Completion in `at {}` and `content {}` blocks
+* Understanding of implicit browser methods (e.g. `+to()+`, `+at()+`) in
+test classes (e.g. `+extends GebSpec+`)
+* Understanding of content defined via the Content DSL (within `+Page+`
+and `+Module+` classes only)
+* Completion in `+at {}+` and `+content {}+` blocks
 
-This effectively enables more authoring support with less explicit type information. The Geb development team would like to thank the good folks at JetBrains for adding this explicit support for Geb to IDEA.
+This effectively enables more authoring support with less explicit type
+information. The Geb development team would like to thank the good folks
+at JetBrains for adding this explicit support for Geb to IDEA.
 ```
 
 
@@ -73,9 +41,7 @@ Make text bold
 ```
 % pandoc -t asciidoc
 **Bold text**
-__Bold text__
 ^D
-*Bold text*
 *Bold text*
 ```
 
@@ -85,9 +51,7 @@ Make text italic
 ```
 % pandoc -t asciidoc
 *Italic text*
-_Italic text_
 ^D
-_Italic text_
 _Italic text_
 ```
 
@@ -98,7 +62,7 @@ Make text mono
 % pandoc -t asciidoc
 `Mono text`
 ^D
-`Mono text`
+`+Mono text+`
 ```
 
 
@@ -115,7 +79,7 @@ This is *_bold and italic_* text
 Blockquotes
 
 ```
-% pandoc -t asciidoc
+% pandoc -f markdown-smart -t asciidoc
 > Blockquotes are very handy in email to emulate reply text.
 > This line is part of the same quote.
 
@@ -124,18 +88,17 @@ Quote break.
 > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
 ^D
 ____
-
-Blockquotes are very handy in email to emulate reply text.
-This line is part of the same quote.
-
+Blockquotes are very handy in email to emulate reply text. This line is
+part of the same quote.
 ____
 
 Quote break.
 
 ____
-
-This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can _put_ *Markdown* into a blockquote.
-
+This is a very long line that will still be quoted properly when it
+wraps. Oh boy let's keep writing to make sure this is long enough to
+actually wrap for everyone. Oh, you can _put_ *Markdown* into a
+blockquote.
 ____
 ```
 
@@ -143,7 +106,7 @@ ____
 Nested Blockquotes
 
 ```
-% pandoc -t asciidoc
+% pandoc -f markdown-smart -t asciidoc
 > > What's new?
 >
 > I've got Markdown in my AsciiDoc!
@@ -210,20 +173,11 @@ CO~2~
 ```
 
 
-Double angle bracket quoting
-
-```
-% pandoc -t asciidoc
-<<hello>>
-^D
-«hello»
-```
-
 
 Double quoting
 
 ```
-% pandoc -t asciidoc
+% pandoc -f markdown-smart -t asciidoc
 "hello"
 ^D
 "hello"
@@ -233,7 +187,7 @@ Double quoting
 Single quoting
 
 ```
-% pandoc -t asciidoc
+% pandoc -f markdown-smart -t asciidoc
 'hello'
 ^D
 'hello'
@@ -243,7 +197,7 @@ Single quoting
 Apostroph
 
 ```
-% pandoc -t asciidoc
+% pandoc -f markdown-smart -t asciidoc
 a'a
 ^D
 a'a
@@ -255,9 +209,7 @@ Ellipsis two
 ```
 % pandoc -t asciidoc
 a...a
-a. . .a
 ^D
-a…a
 a…a
 ```
 
@@ -296,15 +248,11 @@ Should recognize a hard line break
 
 ```
 % pandoc -t asciidoc
-Roses are red,{sp}{sp}
-Violets are blue.{sp}
-Sort of blue.
-More like violet.
+Roses are red,\
+Violets are blue.
 ^D
 Roses are red, +
 Violets are blue.
-Sort of blue.
-More like violet.
 ```
 
 

--- a/test/command/markdown-to-asciidoc-paragraphs.md
+++ b/test/command/markdown-to-asciidoc-paragraphs.md
@@ -10,18 +10,6 @@ A paragraph with a single line.
 ```
 
 
-Render a paragraph with multiple lines
-
-```
-% pandoc -t asciidoc
-First line of paragraph.
-Second line of paragraph.
-^D
-First line of paragraph.
-Second line of paragraph.
-```
-
-
 Render multiple paragraphs seperated by a blank line
 
 ```

--- a/test/command/markdown-to-asciidoc-paragraphs.md
+++ b/test/command/markdown-to-asciidoc-paragraphs.md
@@ -1,0 +1,38 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/paragraphs.feature>
+
+Render a paragraph with a single line
+
+```
+% pandoc -t asciidoc
+A paragraph with a single line.
+^D
+A paragraph with a single line.
+```
+
+
+Render a paragraph with multiple lines
+
+```
+% pandoc -t asciidoc
+First line of paragraph.
+Second line of paragraph.
+^D
+First line of paragraph.
+Second line of paragraph.
+```
+
+
+Render multiple paragraphs seperated by a blank line
+
+```
+% pandoc -t asciidoc
+First paragraph.
+
+Second paragraph.
+^D
+First paragraph.
+
+Second paragraph.
+```
+
+

--- a/test/command/markdown-to-asciidoc-tables.md
+++ b/test/command/markdown-to-asciidoc-tables.md
@@ -1,0 +1,106 @@
+converted from: <https://github.com/bodiam/markdown-to-asciidoc/tree/9bd90bc405a7d25b03822cc91154bcb315ab39bf/src/test/resources/nl/jworks/markdown_to_asciidoc/tables.feature>
+
+Render a table
+
+```
+% pandoc -t asciidoc
+| Name of Column 1 | Name of Column 2|
+| ---------------- | --------------- |
+| Cell in column 1, row 1 | Cell in column 2, row 1|
+| Cell in column 1, row 2 | Cell in column 2, row 2|
+^D
+|===
+|Name of Column 1 |Name of Column 2
+
+|Cell in column 1, row 1 |Cell in column 2, row 1
+|Cell in column 1, row 2 |Cell in column 2, row 2
+|===
+```
+
+
+Leave a trailing space at the end of each adjacent cell
+
+```
+% pandoc -t asciidoc
+| Browser | Tablet |  Smartphone |
+| ------- | ------ | ---------- |
+| Safari 5.1+| iPad 2+ |  iOS 6+ |
+^D
+|===
+|Browser |Tablet |Smartphone
+
+|Safari 5.1+ |iPad 2+ |iOS 6+
+|===
+```
+
+
+Render a table with left, center and right align columns
+
+```
+% pandoc -t asciidoc
+| Tables        | Are           |  Cool|
+| ------------- |:-------------:| ----:|
+| col 3 is      | right-aligned | $1600|
+| col 2 is      | centered      |   $12|
+| zebra stripes | are neat      |    $1|
+^D
+[cols="<,^,>"]
+|===
+|Tables |Are |Cool
+
+|col 3 is |right-aligned |$1600
+|col 2 is |centered |$12
+|zebra stripes |are neat |$1
+|===
+```
+
+
+Render a markdown HTML table
+
+```
+% pandoc -t asciidoc
+Care must be taken with slashes when specifying both the base URL and the relative URL as trailing and leading slashes have significant meaning. The following table illustrates the resolution of different types of URLs.
+
+<table class="graybox" border="0" cellspacing="0" cellpadding="5">
+    <tr><th>Base</th><th>Navigating To</th><th>Result</th></tr>
+    <tr><td>http://myapp.com/</td><td>abc</td><td>http://myapp.com/abc</td></tr>
+    <tr><td>http://myapp.com</td><td>abc</td><td>http://myapp.comabc</td></tr>
+</table>
+
+It is usually most desirable to define your base urls with trailing slashes and not to use leading slashes on relative URLs.
+^D
+Care must be taken with slashes when specifying both the base URL and the relative URL as trailing and leading slashes have significant meaning. The following table illustrates the resolution of different types of URLs.
+
+|===
+|Base |Navigating To |Result
+
+|http://myapp.com/ |abc |http://myapp.com/abc
+|http://myapp.com |abc |http://myapp.comabc
+|===
+
+It is usually most desirable to define your base urls with trailing slashes and not to use leading slashes on relative URLs.
+```
+
+
+Render a table with left, center and right align columns
+
+```
+% pandoc -t asciidoc
+|              | Grouping                    ||
+| First Header | Second Header | Third Header |
+| ------------ | :-----------: | -----------: |
+| Content      | *Long Cell*                 ||
+| Content      | **Cell**      | Cell         |
+| New section  | More          | Data         |
+^D
+[cols="<,^,>"]
+|===
+|  2+| Grouping
+
+| Content 2+| _Long Cell_
+| Content   | *Cell* | Cell
+| New section | More | Data
+|===
+```
+
+

--- a/test/command/markdown-to-asciidoc-tables.md
+++ b/test/command/markdown-to-asciidoc-tables.md
@@ -55,33 +55,6 @@ Render a table with left, center and right align columns
 ```
 
 
-Render a markdown HTML table
-
-```
-% pandoc -t asciidoc
-Care must be taken with slashes when specifying both the base URL and the relative URL as trailing and leading slashes have significant meaning. The following table illustrates the resolution of different types of URLs.
-
-<table class="graybox" border="0" cellspacing="0" cellpadding="5">
-    <tr><th>Base</th><th>Navigating To</th><th>Result</th></tr>
-    <tr><td>http://myapp.com/</td><td>abc</td><td>http://myapp.com/abc</td></tr>
-    <tr><td>http://myapp.com</td><td>abc</td><td>http://myapp.comabc</td></tr>
-</table>
-
-It is usually most desirable to define your base urls with trailing slashes and not to use leading slashes on relative URLs.
-^D
-Care must be taken with slashes when specifying both the base URL and the relative URL as trailing and leading slashes have significant meaning. The following table illustrates the resolution of different types of URLs.
-
-|===
-|Base |Navigating To |Result
-
-|http://myapp.com/ |abc |http://myapp.com/abc
-|http://myapp.com |abc |http://myapp.comabc
-|===
-
-It is usually most desirable to define your base urls with trailing slashes and not to use leading slashes on relative URLs.
-```
-
-
 Render a table with left, center and right align columns
 
 ```


### PR DESCRIPTION
I've written a script (not included) and transformed the tests from https://github.com/bodiam/markdown-to-asciidoc/tree/master/src/test/resources/nl/jworks/markdown_to_asciidoc to our test format.

There are also another two files in that repo we could look at named `testsuite.[adoc|md]`: https://github.com/bodiam/markdown-to-asciidoc/tree/master/src/test/resources

To execute only the new tests:

    stack test  --test-arguments='-p markdown-to-asciidoc'

After fixing quite a few tests manually (insignificant changes like word-wrapping), we are at:

    23 out of 61 tests failed (2.45s)

Those are somewhat interesting cases where I'm not sure whether pandoc is wrong or the test is wrong. 

Also a few places where it should be possible to improve pandoc to output nicer asciidoc. I'll see whether I get to that as well...