### PR TITLE
Org reader: modify handling of example blocks.

### DIFF
--- a/src/Text/Pandoc/Readers/Org/ParserState.hs
+++ b/src/Text/Pandoc/Readers/Org/ParserState.hs
@@ -117,6 +117,7 @@ data OrgParserState = OrgParserState
   , orgStateSelectTags           :: Set.Set Tag
   , orgStateSelectTagsChanged    :: Bool
   , orgStateTodoSequences        :: [TodoSequence]
+  , orgStateTrimLeadBlkIndent    :: Bool
   , orgLogMessages               :: [LogMessage]
   , orgMacros                    :: M.Map Text Macro
   }
@@ -184,6 +185,7 @@ defaultOrgParserState = OrgParserState
   , orgStateParserContext = NullState
   , orgStateSelectTags = Set.singleton $ Tag "export"
   , orgStateSelectTagsChanged = False
+  , orgStateTrimLeadBlkIndent = True
   , orgStateTodoSequences = []
   , orgLogMessages = []
   , orgMacros = M.empty

--- a/test/command/4186.md
+++ b/test/command/4186.md
@@ -1,0 +1,60 @@
+```
+% pandoc -f org -t native
+#+BEGIN_EXAMPLE -i
+    This should retain the four leading spaces
+#+END_EXAMPLE
+^D
+[CodeBlock ("",["example"],[]) "    This should retain the four leading spaces\n"]
+```
+
+```
+% pandoc -f org -t html
+- depth 1
+  #+NAME: bob
+  #+BEGIN_EXAMPLE -i
+    Vertical alignment is four spaces beyond the appearance of the word "depth".
+  #+END_EXAMPLE
+       - depth 2
+         #+begin_example
+                          Vertically aligned with the second appearance of the word "depth".
+         #+end_example
+              #+begin_example -i
+    Vertical alignment is four spaces beyond the second
+    appearance of the word "depth".
+    The "begin" portion is a component of
+    this deeper list element, so that guarantees
+    that the entire block must be a component of the
+    inner list element.
+    #+end_example
+         Still inside the inner list element
+   #+NAME: carrie
+                         #+BEGIN_EXAMPLE
+                           This belongs to the outer list element, and is aligned accordingly, since the NAME attribute is not indented deeply enough. It is not enough for the BEGIN alone to be aligned deeply if the block is meant to have a NAME.
+                           #+END_EXAMPLE
+                 Still in the shallower list element since the preceding example
+                 block forced the deeper list element to terminate.
+Outside all lists.
+^D
+<ul>
+<li><p>depth 1</p>
+<pre id="bob" class="example"><code>    Vertical alignment is four spaces beyond the appearance of the word &quot;depth&quot;.
+</code></pre>
+<ul>
+<li><p>depth 2</p>
+<pre class="example"><code>Vertically aligned with the second appearance of the word &quot;depth&quot;.
+</code></pre>
+<pre class="example"><code>    Vertical alignment is four spaces beyond the second
+    appearance of the word &quot;depth&quot;.
+    The &quot;begin&quot; portion is a component of
+    this deeper list element, so that guarantees
+    that the entire block must be a component of the
+    inner list element.
+</code></pre>
+<p>Still inside the inner list element</p></li>
+</ul>
+<pre id="carrie" class="example"><code>This belongs to the outer list element, and is aligned accordingly, since the NAME attribute is not indented deeply enough. It is not enough for the BEGIN alone to be aligned deeply if the block is meant to have a NAME.
+</code></pre>
+<p>Still in the shallower list element since the preceding example block forced the deeper list element to terminate.</p></li>
+</ul>
+<p>Outside all lists.</p>
+```


### PR DESCRIPTION
Closes #4186.

I'm pretty sure Emacs' built-in Org-to-Markdown conversion is wrong; it doesn't respect the `-i` switch at all, for example. For this reason, I chose to use HTML instead for the test. It looks to me that Org's native HTML conversion (`org-html-export-to-html`) is consistent with what this PR suggests. I also tested by exporting to a PDF (`org-latex-export-to-pdf`) and eyeballing.