### PR TITLE
Add to other-extensions field for use by cabal solver

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -441,6 +441,7 @@ library
      other-modules: Text.Pandoc.Data
   if flag(derive_json_via_th)
      cpp-options:   -DDERIVE_JSON_VIA_TH
+     other-extensions: TemplateHaskell
   if os(windows)
     cpp-options:      -D_WINDOWS
   ghc-options:     -Wall -fno-warn-unused-do-bind


### PR DESCRIPTION
As of `cabal-install` 3.0, the solver can use the `other-extensions` field to set flags - with this commit, pandoc should cross-compile out of the box :)