### PR TITLE
Emit warning on `-f latex -o out.pdf`

### DIFF
--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -147,6 +147,14 @@ convertWithOpts opts = do
 
     let pdfOutput = map toLower (takeExtension outputFile) == ".pdf"
 
+    when (pdfOutput && readerName == "latex") $
+      case (optInputFiles opts) of
+        (inputFile:_) -> report $ UnusualConversion $
+          "to convert a .tex file to PDF, you get better results by using pdflatex "
+            <> "(or lualatex or xelatex) directly, try `pdflatex " <> inputFile
+            <> "` instead of `pandoc " <> inputFile <> " -o " <> outputFile <> "`."
+        _ -> return ()
+
     (reader, readerExts) <-
              case getReader readerName of
                   Right (r, es) -> return (r :: Reader PandocIO, es)

--- a/src/Text/Pandoc/Logging.hs
+++ b/src/Text/Pandoc/Logging.hs
@@ -86,6 +86,7 @@ data LogMessage =
   | Deprecated String String
   | NoTranslation String
   | CouldNotLoadTranslations String String
+  | UnusualConversion String
   | UnexpectedXmlElement String String
   | UnknownOrgExportOption String
   | UnknownExtensions [String] String
@@ -203,6 +204,8 @@ instance ToJSON LogMessage where
       CouldNotLoadTranslations lang msg ->
            ["lang" .= Text.pack lang,
             "message" .= Text.pack msg]
+      UnusualConversion msg ->
+           ["message" .= Text.pack msg]
       UnexpectedXmlElement element parent ->
            ["element" .= Text.pack element,
             "parent" .= Text.pack parent]
@@ -310,6 +313,8 @@ showLogMessage msg =
        CouldNotLoadTranslations lang m ->
          "Could not load translations for " ++ lang ++
            if null m then "" else '\n' : m
+       UnusualConversion m ->
+         "Unusual conversion: " ++ m
        UnexpectedXmlElement element parent ->
          "Unexpected XML element " ++ element ++ " in " ++ parent
        UnknownOrgExportOption option ->
@@ -357,6 +362,7 @@ messageVerbosity msg =
        Deprecated{}                 -> WARNING
        NoTranslation{}              -> WARNING
        CouldNotLoadTranslations{}   -> WARNING
+       UnusualConversion {}         -> WARNING
        UnexpectedXmlElement {}      -> WARNING
        UnknownOrgExportOption {}    -> WARNING
        UnknownExtensions{}          -> WARNING


### PR DESCRIPTION
add UnusualConversion to LogMessage [API change]

see https://github.com/jgm/pandoc/issues/5730#issuecomment-529086055