### PR TITLE
Lua filters: accept HTML-like attribute tables as Attr

### DIFF
--- a/test/lua/module/pandoc.lua
+++ b/test/lua/module/pandoc.lua
@@ -86,6 +86,22 @@ return {
         assert.are_equal(count, 3)
       end)
     },
+    group 'alternative representation' {
+      test('HTML-like attributes', function ()
+        local html_attributes = {
+          id = 'the-id',
+          class = 'class1 class2',
+          width = 11,
+          height = 12
+        }
+        local cloned = pandoc.types.clone.Attr(html_attributes)
+        assert.are_equal(cloned.identifier, 'the-id')
+        assert.are_equal(cloned.classes[1], 'class1')
+        assert.are_equal(cloned.classes[2], 'class2')
+        assert.are_equal(cloned.attributes.width, '11')
+        assert.are_equal(cloned.attributes.height, '12')
+      end)
+    }
   },
 
   group 'clone' {


### PR DESCRIPTION
Attr values can now be given as normal Lua tables; this can be used as
an alternative to constructing Attr values with `pandoc.Attr`.
Identifiers are taken from the `id` field, classes must be given as
space separated words in the `class` field. All remaining fields are
included as misc attributes.

With this change, the following lines now create equal elements:

    pandoc.Span('test', {id = 'test', class = 'a b', check = 1})
    pandoc.Span('test', pandoc.Attr('test', {'a','b'}, {check = 1}))

Note that the conversion from Lua table to Attr value is performed
during unmarshaling, _not_ during object construction:

    pandoc.Span('test', {id = 'test'}).identifier == nil
    pandoc.Span('test', pandoc.Attr('test')).identifier == 'test'
    -- equality is tested after unmarshaling
    pandoc.Span('x', {id = 'y'}) == pandoc.Span('x', pandoc.Attr('y')

Closes: #5744