### PR TITLE
Lua filters: allow passing of HTML-like tables instead of Attr

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -1247,7 +1247,19 @@ Superscripted text
 
 ### Attr {#type-ref-Attr}
 
-A set of element attributes
+A set of element attributes. Values of this type can be created
+with the [`pandoc.Attr`](#Attr) constructor. For convenience, it
+is usually not necessary to construct the value directly if it is
+part of an element, and it is sufficient to pass an HTML-like
+table. E.g., to create a span with identifier "text" and classes
+"a" and "b", on can write:
+
+    local span = pandoc.Span('text', {id = 'text', class = 'a b'})
+
+This also works when using the `attr` setter:
+
+    local span = pandoc.Span 'text'
+    span.attr = {id = 'text', class = 'a b', other_attribute = '1'}
 
 Object equality is determined via
 [`pandoc.utils.equals`](#utils-equals).

--- a/test/lua/module/pandoc.lua
+++ b/test/lua/module/pandoc.lua
@@ -86,6 +86,47 @@ return {
         assert.are_equal(count, 3)
       end)
     },
+    group 'HTML-like attribute tables' {
+      test('in element constructor', function ()
+        local html_attributes = {
+          id = 'the-id',
+          class = 'class1 class2',
+          width = '11',
+          height = '12'
+        }
+        local attr = pandoc.Span('test', html_attributes).attr
+        assert.are_equal(attr.identifier, 'the-id')
+        assert.are_equal(attr.classes[1], 'class1')
+        assert.are_equal(attr.classes[2], 'class2')
+        assert.are_equal(attr.attributes.width, '11')
+        assert.are_equal(attr.attributes.height, '12')
+      end),
+      test('element attr setter', function ()
+        local html_attributes = {
+          id = 'the-id',
+          class = 'class1 class2',
+          width = "11",
+          height = "12"
+        }
+        local span = pandoc.Span 'test'
+        span.attr = html_attributes
+        assert.are_equal(span.attr.identifier, 'the-id')
+        assert.are_equal(span.attr.classes[1], 'class1')
+        assert.are_equal(span.attr.classes[2], 'class2')
+        assert.are_equal(span.attr.attributes.width, '11')
+        assert.are_equal(span.attr.attributes.height, '12')
+      end),
+      test('element attrbutes setter', function ()
+        local attributes = {
+          width = "11",
+          height = "12"
+        }
+        local span = pandoc.Span 'test'
+        span.attributes = attributes
+        assert.are_equal(span.attr.attributes.width, '11')
+        assert.are_equal(span.attr.attributes.height, '12')
+      end)
+    }
   },
 
   group 'clone' {


### PR DESCRIPTION
Attr values can now be given as normal Lua tables; this can be used as a
convenient alternative to define Attr values, instead of constructing
values with `pandoc.Attr`. Identifiers are taken from the *id* field,
classes must be given as space separated words in the *class* field. All
remaining fields are included as misc attributes.

With this change, the following lines now create equal elements:

    pandoc.Span('test', {id = 'test', class = 'a b', check = 1})
    pandoc.Span('test', pandoc.Attr('test', {'a','b'}, {check = 1}))

This also works when using the *attr* setter:

    local span = pandoc.Span 'text'
    span.attr = {id = 'test', class = 'a b', check = 1}

Furthermore, the *attributes* field of AST elements can now be a plain
key-value table even when using the `attributes` accessor:

    local span = pandoc.Span 'test'
    span.attributes = {check = 1}   -- works as expected now

Closes: #5744