### PR TITLE
odt: Add external option for native numbering

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2361,6 +2361,16 @@ input formats
 output formats
 :  `docx`, `odt`, `opendocument`, `html`
 
+#### Extension: `native_numbering` ####
+
+Enables native numbering of figures and tables. Enumeration
+starts at 1.
+
+This extension can be enabled/disabled for the following formats:
+
+output formats
+:  `odt`, `opendocument`
+
 #### Extension: `styles` #### {#ext-styles}
 
 When converting from docx, read all docx styles as divs (for

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -132,6 +132,7 @@ data Extension =
     | Ext_multiline_tables    -- ^ Pandoc-style multiline tables
     | Ext_native_divs             -- ^ Use Div blocks for contents of <div> tags
     | Ext_native_spans            -- ^ Use Span inlines for contents of <span>
+    | Ext_native_numbering    -- ^ Use output format's native numbering for figures and tables
     | Ext_ntb                 -- ^ ConTeXt Natural Tables
     | Ext_old_dashes          -- ^ -- = em, - before number = en
     | Ext_pandoc_title_block  -- ^ Pandoc title block

--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -397,9 +397,9 @@ blockToOpenDocument o bs
         captionDoc <- if null c
                       then return empty
                       else inlinesToOpenDocument o c >>=
-                             if True -- temporary: see #5474
-                                then unNumberedCaption "TableCaption"
-                                else numberedTableCaption
+                             if isEnabled Ext_native_numbering o
+                                then numberedTableCaption
+                                else unNumberedCaption "TableCaption"
         th <- if all null h
                  then return empty
                  else colHeadsToOpenDocument o (map fst paraHStyles) h
@@ -412,9 +412,9 @@ blockToOpenDocument o bs
                                   | otherwise    = do
         imageDoc <- withParagraphStyle o "FigureWithCaption" [Para [Image attr caption (source,title)]]
         captionDoc <- inlinesToOpenDocument o caption >>=
-                         if True -- temporary: see #5474
-                            then unNumberedCaption "FigureCaption"
-                            else numberedFigureCaption
+                         if isEnabled Ext_native_numbering o
+                            then numberedFigureCaption
+                            else unNumberedCaption "FigureCaption"
         return $ imageDoc $$ captionDoc
 
 
@@ -423,7 +423,7 @@ numberedTableCaption caption = do
     id' <- gets stTableCaptionId
     modify (\st -> st{ stTableCaptionId = id' + 1 })
     capterm <- translateTerm Term.Table
-    return $ numberedCaption "Table" capterm "Table" id' caption
+    return $ numberedCaption "TableCaption" capterm "Table" id' caption
 
 numberedFigureCaption :: PandocMonad m => Doc Text -> OD m (Doc Text)
 numberedFigureCaption caption = do

--- a/test/command/5474-figures.md
+++ b/test/command/5474-figures.md
@@ -1,0 +1,15 @@
+```
+% pandoc -t opendocument+native_numbering
+
+![First image](lalune.jpg)
+
+![Second image](lalune.jpg)
+
+^D
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureCaption">Figure <text:sequence text:ref-name="refIllustration0" text:name="Illustration" text:formula="ooow:Illustration+1" style:num-format="1">1</text:sequence>: First
+image</text:p>
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img2"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureCaption">Figure <text:sequence text:ref-name="refIllustration1" text:name="Illustration" text:formula="ooow:Illustration+1" style:num-format="1">2</text:sequence>: Second
+image</text:p>
+```

--- a/test/command/5474-tables.md
+++ b/test/command/5474-tables.md
@@ -1,0 +1,63 @@
+```
+% pandoc -t opendocument+native_numbering
+  Right     Left  
+-------     ------
+     12     11
+
+: First table
+
+  Right     Left  
+-------     ------
+     13     14    
+
+: Second Table
+^D
+<table:table table:name="Table1" table:style-name="Table1">
+  <table:table-column table:style-name="Table1.A" />
+  <table:table-column table:style-name="Table1.B" />
+  <table:table-header-rows>
+    <table:table-row>
+      <table:table-cell table:style-name="TableHeaderRowCell" office:value-type="string">
+        <text:p text:style-name="P1">Right</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="TableHeaderRowCell" office:value-type="string">
+        <text:p text:style-name="Table_20_Heading">Left</text:p>
+      </table:table-cell>
+    </table:table-row>
+  </table:table-header-rows>
+  <table:table-row>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="P2">12</text:p>
+    </table:table-cell>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="Table_20_Contents">11</text:p>
+    </table:table-cell>
+  </table:table-row>
+</table:table>
+<text:p text:style-name="TableCaption">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">1</text:sequence>: First
+table</text:p>
+<table:table table:name="Table2" table:style-name="Table2">
+  <table:table-column table:style-name="Table2.A" />
+  <table:table-column table:style-name="Table2.B" />
+  <table:table-header-rows>
+    <table:table-row>
+      <table:table-cell table:style-name="TableHeaderRowCell" office:value-type="string">
+        <text:p text:style-name="P3">Right</text:p>
+      </table:table-cell>
+      <table:table-cell table:style-name="TableHeaderRowCell" office:value-type="string">
+        <text:p text:style-name="Table_20_Heading">Left</text:p>
+      </table:table-cell>
+    </table:table-row>
+  </table:table-header-rows>
+  <table:table-row>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="P4">13</text:p>
+    </table:table-cell>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="Table_20_Contents">14</text:p>
+    </table:table-cell>
+  </table:table-row>
+</table:table>
+<text:p text:style-name="TableCaption">Table <text:sequence text:ref-name="refTable1" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">2</text:sequence>: Second
+Table</text:p>
+```


### PR DESCRIPTION
This adds an external options +native_numbering to the
ODT writer enabling enumeration of figures and tables in
ODT output.