### PR TITLE
[Docx Reader] Only honour the last seen paragraph style

### DIFF
--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -65,7 +65,6 @@ import Control.Monad.Reader
 import Control.Monad.State.Strict
 import qualified Data.ByteString.Lazy as B
 import Data.Default (Default)
-import Data.List (delete, intersect)
 import Data.Char (isSpace)
 import qualified Data.Map as M
 import Data.Maybe (isJust, fromMaybe)
@@ -152,8 +151,8 @@ sepBodyParts :: [BodyPart] -> ([BodyPart], [BodyPart])
 sepBodyParts = span (\bp -> isMetaPar bp || isEmptyPar bp)
 
 isMetaPar :: BodyPart -> Bool
-isMetaPar (Paragraph pPr _) =
-  not $ null $ intersect (getStyleNames $ pStyle pPr) (M.keys metaStyles)
+isMetaPar (Paragraph pPr _) = or $
+  (`elem` M.keys metaStyles) . getStyleName <$> pStyle pPr
 isMetaPar _ = False
 
 isEmptyPar :: BodyPart -> Bool
@@ -170,7 +169,8 @@ bodyPartsToMeta' :: PandocMonad m => [BodyPart] -> DocxContext m (M.Map String M
 bodyPartsToMeta' [] = return M.empty
 bodyPartsToMeta' (bp : bps)
   | (Paragraph pPr parParts) <- bp
-  , (c : _)<- getStyleNames (pStyle pPr) `intersect` M.keys metaStyles
+  , Just c <- getStyleName <$> pStyle pPr
+  , c `elem` M.keys metaStyles
   , (Just metaField) <- M.lookup c metaStyles = do
     inlines <- smushInlines <$> mapM parPartToInlines parParts
     remaining <- bodyPartsToMeta' bps
@@ -208,9 +208,6 @@ isInheritedFromStyles names sty
 
 hasStylesInheritedFrom :: [ParaStyleName] -> ParagraphStyle -> Bool
 hasStylesInheritedFrom ns s = any (isInheritedFromStyles ns) $ pStyle s
-
-removeStyleNamed :: ParaStyleName -> ParagraphStyle -> ParagraphStyle
-removeStyleNamed sn ps = ps{pStyle = filter (\psd -> getStyleName psd /= sn) $ pStyle ps}
 
 isCodeCharStyle :: CharStyle -> Bool
 isCodeCharStyle = isInheritedFromStyles ["Verbatim Char"]
@@ -529,22 +526,21 @@ extraInfo f s = do
 
 parStyleToTransform :: PandocMonad m => ParagraphStyle -> DocxContext m (Blocks -> Blocks)
 parStyleToTransform pPr
-  | (c:cs) <- pStyle pPr
+  | Just c <- pStyle pPr
   , getStyleName c `elem` divsToKeep = do
-      let pPr' = pPr { pStyle = cs }
+      let pPr' = pPr { pStyle = Nothing }
       transform <- parStyleToTransform pPr'
       return $ divWith ("", [normalizeToClassName $ getStyleName c], []) . transform
-  | (c:cs) <- pStyle pPr,
-    getStyleName c `elem` listParagraphStyles = do
-      let pPr' = pPr { pStyle = cs, indentation = Nothing}
+  | isListPara pPr = do
+      let pPr' = pPr { isListPara = False, indentation = Nothing}
       transform <- parStyleToTransform pPr'
-      return $ divWith ("", [normalizeToClassName $ getStyleName c], []) . transform
-  | (c:cs) <- pStyle pPr = do
-      let pPr' = pPr { pStyle = cs }
+      return $ divWith ("", listParagraphDivs, []) . transform
+  | Just c <- pStyle pPr = do
+      let pPr' = pPr { pStyle = Nothing }
       transform <- parStyleToTransform pPr'
       ei <- extraInfo divWith c
       return $ ei . (if isBlockQuote c then blockQuote else id) . transform
-  | null (pStyle pPr)
+  | Nothing <- pStyle pPr
   , Just left <- indentation pPr >>= leftParIndent = do
     let pPr' = pPr { indentation = Nothing }
         hang = fromMaybe 0 $ indentation pPr >>= hangingParIndent
@@ -568,17 +564,21 @@ bodyPartToBlocks (Paragraph pPr parparts)
         codeBlock $
         concatMap parPartToString parparts
   | Just (style, n) <- pHeading pPr = do
-    ils <-local (\s-> s{docxInHeaderBlock=True})
+    ils <- local (\s-> s{docxInHeaderBlock=True})
            (smushInlines <$> mapM parPartToInlines parparts)
+    let headercls = case getStyleName <$> pStyle pPr of
+          Just st | st /= style -> [normalizeToClassName st]
+          _ -> []
     makeHeaderAnchor $
-      headerWith ("", map normalizeToClassName . delete style $ getStyleNames (pStyle pPr), []) n ils
+      headerWith ("", headercls, []) n ils
   | otherwise = do
     ils <- trimSps . smushInlines <$> mapM parPartToInlines parparts
     prevParaIls <- gets docxPrevPara
     dropIls <- gets docxDropCap
     let ils' = dropIls <> ils
     let (paraOrPlain, pPr')
-          | hasStylesInheritedFrom ["Compact"] pPr = (plain, removeStyleNamed "Compact" pPr)
+          | hasStylesInheritedFrom ["Compact"] pPr
+          = (plain, pPr{pStyle = mfilter ((/="Compact") . getStyleName) $ pStyle pPr})
           | otherwise = (para, pPr)
     if dropCap pPr'
       then do modify $ \s -> s { docxDropCap = ils' }
@@ -644,7 +644,7 @@ bodyPartToBlocks (ListItem pPr numId lvl (Just levelInfo) parparts) = do
   blks <- bodyPartToBlocks (Paragraph pPr parparts)
   return $ divWith ("", ["list-item"], kvs) blks
 bodyPartToBlocks (ListItem pPr _ _ _ parparts) =
-  let pPr' = pPr {pStyle = constructBogusParStyleData "list-paragraph": pStyle pPr}
+  let pPr' = pPr {isListPara = True}
   in
     bodyPartToBlocks $ Paragraph pPr' parparts
 bodyPartToBlocks (Tbl _ _ _ []) =

--- a/src/Text/Pandoc/Readers/Docx/Lists.hs
+++ b/src/Text/Pandoc/Readers/Docx/Lists.hs
@@ -15,16 +15,13 @@ Functions for converting flat docx paragraphs into nested lists.
 module Text.Pandoc.Readers.Docx.Lists ( blocksToBullets
                                       , blocksToDefinitions
                                       , listParagraphDivs
-                                      , listParagraphStyles
                                       ) where
 
 import Prelude
 import Data.List
 import Data.Maybe
-import Data.String (fromString)
 import Text.Pandoc.Generic (bottomUp)
 import Text.Pandoc.JSON
-import Text.Pandoc.Readers.Docx.Parse (ParaStyleName)
 import Text.Pandoc.Shared (trim, safeRead)
 
 isListItem :: Block -> Bool
@@ -84,9 +81,6 @@ getListType _ = Nothing
 
 listParagraphDivs :: [String]
 listParagraphDivs = ["list-paragraph"]
-
-listParagraphStyles :: [ParaStyleName]
-listParagraphStyles = map fromString listParagraphDivs
 
 -- This is a first stab at going through and attaching meaning to list
 -- paragraphs, without an item marker, following a list item. We


### PR DESCRIPTION
**:construction: :warning: :rotating_light: Do not merge :rotating_light: :warning: :construction:**

This PR is mostly intended for discussion related to #5738. The issue is, Word doesn't allow multiple paragraph styles being applied to a single paragraph. In my tests, both LibreOffice and Word (2013 and 2019) ignored all styles defined on the paragraph except the _last one_.

This PR basically makes Docx Reader do the same. **The main question** is, do we actually want to do that? This does actually simplify the code a tiny bit, but due to Writer writing multiple styles per paragraph in some cases, round-tripping through docx will sometimes create weird inconsistencies. This arguably is not a big issue, since opening and saving Writer's output with Word will lead to the same weird inconsistencies.

One test is failing. I chose not to update it. Technically, that test is not actually testing for anything particularly meaningful: only pandoc can produce a paragraph that has both `Definition` and `Source Code` styles, and such documents won't survive being edited by Word or LibreOffice. So the thing that test is supposed to test for is, well, frankly, not a real thing <sub>under a particular definition of "real"</sub>. So I'm not sure how to update that test correctly, provided we decide this should be merged.

/cc @jkr 
/cc @conklech (I believe you said something about actually round-tripping through docx in your workflow, so your input here might be enlightening)