### PR TITLE
add support for <kbd>

### DIFF
--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -62,7 +62,8 @@ import Text.Pandoc.Options (
     extensionEnabled)
 import Text.Pandoc.Parsing hiding ((<|>))
 import Text.Pandoc.Shared (addMetaField, blocksToInlines', crFilter, escapeURI,
-    extractSpaces, onlySimpleTableCells, safeRead, underlineSpan)
+                           extractSpaces, htmlSpanLikeElements,
+                           onlySimpleTableCells, safeRead, underlineSpan)
 import Text.Pandoc.Walk
 import Text.Parsec.Error
 import Text.TeXMath (readMathML, writeTeX)
@@ -643,6 +644,7 @@ inline = choice
            , pStrong
            , pSuperscript
            , pSubscript
+           , pSpanLike
            , pSmall
            , pStrikeout
            , pUnderline
@@ -706,6 +708,12 @@ pSuperscript = pInlinesInTags "sup" B.superscript
 
 pSubscript :: PandocMonad m => TagParser m Inlines
 pSubscript = pInlinesInTags "sub" B.subscript
+
+pSpanLike :: PandocMonad m => TagParser m Inlines
+pSpanLike = Set.foldr
+  (\tag acc -> acc <|> pInlinesInTags tag (B.spanWith ("",[T.unpack tag],[])))
+  mzero
+  htmlSpanLikeElements
 
 pSmall :: PandocMonad m => TagParser m Inlines
 pSmall = pInlinesInTags "small" (B.spanWith ("",["small"],[]))

--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -67,6 +67,7 @@ module Text.Pandoc.Shared (
                      makeMeta,
                      eastAsianLineBreakFilter,
                      underlineSpan,
+                     htmlSpanLikeElements,
                      splitSentences,
                      filterIpynbOutput,
                      -- * TagSoup HTML handling
@@ -693,6 +694,11 @@ eastAsianLineBreakFilter = bottomUp go
 -- Will be replaced once Underline is an element.
 underlineSpan :: Inlines -> Inlines
 underlineSpan = B.spanWith ("", ["underline"], [])
+
+-- | Set of HTML elements that are represented as Span with a class equal as
+-- the element tag itself.
+htmlSpanLikeElements :: Set.Set T.Text
+htmlSpanLikeElements = Set.fromList [T.pack "kbd"]
 
 -- | Returns the first sentence in a list of inlines, and the rest.
 breakSentence :: [Inline] -> ([Inline], [Inline])

--- a/test/command/5805.md
+++ b/test/command/5805.md
@@ -1,0 +1,20 @@
+```
+% pandoc -f html -t html
+<kbd>Ctrl-C</kbd>
+^D
+<kbd>Ctrl-C</kbd>
+```
+
+```
+% pandoc -f html -t native
+<kbd>Ctrl-C</kbd>
+^D
+[Plain [Span ("",["kbd"],[]) [Str "Ctrl-C"]]]
+```
+
+```
+% pandoc -f native -t html
+[Plain [Span ("",["kbd"],[]) [Str "Ctrl-C"]]]
+^D
+<kbd>Ctrl-C</kbd>
+```


### PR DESCRIPTION
Closes #5796 .

I'm a bit unsure about adding a special case in the writer for a span with a "kbd" class because it means that any "<span class="kbd">content</span>" will be written as a `<kbd>` element which is unexpected I'd say. Moreover there are other elements like <small> that are represented as spans with a special class, just like kbd, that are not converted back to the original element.