### PR TITLE
Updates MathJax URL to work with version 3

### DIFF
--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -676,7 +676,7 @@ options =
                  (OptArg
                   (\arg opt -> do
                       let url' = fromMaybe (defaultMathJaxURL ++
-                                  "MathJax.js?config=TeX-AMS_CHTML-full") arg
+                                  "tex-mml-chtml.js") arg
                       return opt { optHTMLMathMethod = MathJax url'})
                   "URL")
                  "" -- "Use MathJax for HTML math"

--- a/src/Text/Pandoc/Writers/Math.hs
+++ b/src/Text/Pandoc/Writers/Math.hs
@@ -52,7 +52,7 @@ convertMath writer mt str =
                    InlineMath  -> DisplayInline
 
 defaultMathJaxURL :: String
-defaultMathJaxURL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/"
+defaultMathJaxURL = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/"
 
 defaultKaTeXURL :: String
 defaultKaTeXURL = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/"

--- a/trypandoc/trypandoc.hs
+++ b/trypandoc/trypandoc.hs
@@ -72,7 +72,7 @@ writerOpts :: WriterOptions
 writerOpts = def { writerReferenceLinks = True,
                    writerEmailObfuscation = NoObfuscation,
                    writerHTMLMathMethod = MathJax (defaultMathJaxURL ++
-                       "MathJax.js?config=TeX-AMS_CHTML-full"),
+                       "tex-mml-chtml.js"),
                    writerHighlightStyle = Just pygments }
 
 readerOpts :: ReaderOptions


### PR DESCRIPTION
This updates the URL and filenames to work with MathJax version 3.
The only problem is the  `--standalone` option, where loading SRE and the initial fonts fail. That should change in the near future, once v3 can webpack SRE properly. 

On the other hand for v2.7.2 the option did also not work as expected, as loading of fonts,  Menu and Zoom fails. So I feel there is not that much change there.