### PR TITLE
KaTeX: fleqn option

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1988,6 +1988,12 @@ ODT or pptx.
 [Unicode Bidirectional Algorithm]: http://www.w3.org/International/articles/inline-bidi-markup/uba-basics
 [Language subtag lookup]: https://r12a.github.io/app-subtags/
 
+### Variables for HTML math
+
+`classoption`
+:   when using [KaTeX](#option--katex), you can render display math equations
+    flush left using [YAML metadata](#layout) or with `-M classoption=fleqn`.
+
 ### Variables for HTML slides
 
 These affect HTML output when [producing slide shows with pandoc].

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -313,7 +313,7 @@ defaultMathJaxURL :: String
 defaultMathJaxURL = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/"
 
 defaultKaTeXURL :: String
-defaultKaTeXURL = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0/"
+defaultKaTeXURL = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/"
 
 $(deriveJSON defaultOptions ''ReaderOptions)
 

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -281,8 +281,12 @@ pandocToHtml opts (Pandoc meta blocks) = do
                          H.script !
                            A.src (toValue $ url ++ "katex.min.js") $ mempty
                          nl opts
-                         H.script
-                            "document.addEventListener(\"DOMContentLoaded\", function () {\n  var mathElements = document.getElementsByClassName(\"math\");\n  for (var i = 0; i < mathElements.length; i++) {\n    var texText = mathElements[i].firstChild;\n    if (mathElements[i].tagName == \"SPAN\") { katex.render(texText.data, mathElements[i], { displayMode: mathElements[i].classList.contains(\"display\"), throwOnError: false } );\n  }}});"
+                         let katexFlushLeft =
+                               case lookupContext "classoption" metadata of
+                                 Just clsops | "fleqn" `elem` (clsops :: [Text]) -> "true"
+                                 _ -> "false"
+                         H.script $
+                            "document.addEventListener(\"DOMContentLoaded\", function () {\n  var mathElements = document.getElementsByClassName(\"math\");\n  for (var i = 0; i < mathElements.length; i++) {\n    var texText = mathElements[i].firstChild;\n    if (mathElements[i].tagName == \"SPAN\") { katex.render(texText.data, mathElements[i], { displayMode: mathElements[i].classList.contains(\"display\"), throwOnError: false, fleqn: " <> katexFlushLeft <> " } );\n  }}});"
                          nl opts
                          H.link ! A.rel "stylesheet" !
                            A.href (toValue $ url ++ "katex.min.css")


### PR DESCRIPTION
closes #5815

Is there a better way to write this? Do we have an analogue of `lookupMetaBool` for `Context` somewhere?