### PR TITLE
[LaTeX Writer] Don't convert unicode quotes to TeX ligatures

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -380,10 +380,6 @@ stringToLaTeX context zs = do
          '\x200B' -> emits "\\hspace{0pt}"  -- zero-width space
          '\x202F' -> emits "\\,"
          '\x2026' -> emitcseq "\\ldots"
-         '\x2018' | ligatures -> emitquote "`"
-         '\x2019' | ligatures -> emitquote "'"
-         '\x201C' | ligatures -> emitquote "``"
-         '\x201D' | ligatures -> emitquote "''"
          '\x2014' | ligatures -> emits "---"
          '\x2013' | ligatures -> emits "--"
          _ | writerPreferAscii opts


### PR DESCRIPTION
Converting unicode ligatures to TeX ligatures may kick in unexpectedly,
such as when specifying pdf metadata. Consider the following YAML:

    title-meta: Lorem „ipsum“

Running pandoc and later `pdfinfo *.pdf|grep Title` will produce the
following output:

    Title:          Lorem „ipsum``

Rather than the expected:

    Title:          Lorem „ipsum“

Since LaTeX handles unicode quotes quite well by itself already (either
through `\usepackage[utf8]{inputenc}` or through native support in Xe-
and LuaLaTeX), there is no need to convert unicode quotes. I would thus
suggest to leave unicode quotes the way they were entered in markdown.