### PR TITLE
HTML reader: Handle cite attribute for quotes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -67,6 +67,11 @@
 
     + Add RTL support (Alexander Krotov, #5551).
 
+  * HTML reader:
+
+    + If `cite` attribute is present on a `<q>` tag, represent it as a
+      link around a quote.
+
   * JIRA writer:
 
     + Remove escapeStringForJira for code blocks (Jan-Otto Kröpke).

--- a/changelog.md
+++ b/changelog.md
@@ -67,11 +67,6 @@
 
     + Add RTL support (Alexander Krotov, #5551).
 
-  * HTML reader:
-
-    + If `cite` attribute is present on a `<q>` tag, represent it as a
-      link around a quote.
-
   * JIRA writer:
 
     + Remove escapeStringForJira for code blocks (Jan-Otto Kröpke).

--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -703,13 +703,12 @@ pQ = try $ do
   case maybeFromAttrib "cite" tag of
        Nothing   -> quote
        Just url' -> do
-         let title = T.unpack $ fromAttrib "title" tag
          -- take id from id attribute if present, otherwise name
          let uid = fromMaybe (T.unpack $ fromAttrib "name" tag) $
                       maybeFromAttrib "id" tag
          let cls = words $ T.unpack $ fromAttrib "class" tag
          url <- canonicalizeUrl url'
-         extractSpaces (B.linkWith (uid, cls, []) (escapeURI url) title) <$> quote
+         extractSpaces (B.spanWith (uid, cls, [("cite", escapeURI url)])) <$> quote
 
 pEmph :: PandocMonad m => TagParser m Inlines
 pEmph = pInlinesInTags "em" B.emph <|> pInlinesInTags "i" B.emph

--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -685,7 +685,6 @@ pSelfClosing f g = do
 pQ :: PandocMonad m => TagParser m Inlines
 pQ = try $ do
   tag <- pSatisfy $ tagOpenLit "q" (const True)
-  lab <- mconcat <$> manyTill inline (pCloses "q")
 
   context <- asks quoteContext
   let quoteType = case context of
@@ -697,7 +696,8 @@ pQ = try $ do
   let constructor = case quoteType of
                             SingleQuote -> B.singleQuoted
                             DoubleQuote -> B.doubleQuoted
-  let quote = withQuoteContext innerQuoteContext $ return (extractSpaces constructor lab)
+  lab <- withQuoteContext innerQuoteContext $ mconcat <$> manyTill inline (pCloses "q")
+  let quote = return (extractSpaces constructor lab)
 
   -- check for cite; if cite, then a link with inner quote, otherwise a quote
   case maybeFromAttrib "cite" tag of

--- a/test/Tests/Writers/HTML.hs
+++ b/test/Tests/Writers/HTML.hs
@@ -14,7 +14,9 @@ html :: (ToPandoc a) => a -> String
 html = unpack . purely (writeHtml4String def{ writerWrapText = WrapNone }) . toPandoc
 
 htmlQTags :: (ToPandoc a) => a -> String
-htmlQTags = unpack . purely (writeHtml4String def{ writerWrapText = WrapNone, writerHtmlQTags = True }) . toPandoc
+htmlQTags = unpack
+  . purely (writeHtml4String def{ writerWrapText = WrapNone, writerHtmlQTags = True })
+  . toPandoc
 
 {-
   "my test" =: X =?> Y
@@ -32,11 +34,6 @@ infix 4 =:
 (=:) :: (ToString a, ToPandoc a)
      => String -> (a, String) -> TestTree
 (=:) = test html
-
-infix 4 =::
-(=::) :: (ToString a, ToPandoc a)
-     => String -> (a, String) -> TestTree
-(=::) = test htmlQTags
 
 tests :: [TestTree]
 tests = [ testGroup "inline code"
@@ -59,9 +56,13 @@ tests = [ testGroup "inline code"
         , testGroup "quotes"
           [ "quote with cite attribute (without q-tags)" =:
             doubleQuoted (spanWith ("", [], [("cite", "http://example.org")]) (str "examples"))
-            =?> "“examples”"
-          , "quote with cite attribute (with q-tags)" =::
+            =?> "“<span cite=\"http://example.org\">examples</span>”"
+          , tQ "quote with cite attribute (with q-tags)" $
             doubleQuoted (spanWith ("", [], [("cite", "http://example.org")]) (str "examples"))
             =?> "<q cite=\"http://example.org\">examples</q>"
           ]
         ]
+        where
+          tQ :: (ToString a, ToPandoc a)
+               => String -> (a, String) -> TestTree
+          tQ = test htmlQTags

--- a/test/html-reader.html
+++ b/test/html-reader.html
@@ -81,6 +81,10 @@ span.pandocNoteMarker { }
 </blockquote>
 <p>And a following paragraph.</p>
 <hr />
+<h1>Inline quotes</h1>
+<p>Normal text but then a <q cite="https://www.imdb.com/title/tt0062622/quotes/qt0396921">inline quote</q>.</p>
+<p><q>Missing a cite attribute means its just normal text</q></p>
+<hr />
 <h1>Code Blocks</h1>
 <p>Code:</p>
 <pre><code>---- (should be four hyphens)

--- a/test/html-reader.native
+++ b/test/html-reader.native
@@ -51,6 +51,10 @@ Pandoc (Meta {unMeta = fromList [("generator",MetaInlines [Str "pandoc"]),("titl
   [Para [Str "Don't",Space,Str "quote",Space,Str "me."]]]
 ,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
 ,HorizontalRule
+,Header 1 ("inline-quotes",[],[]) [Str "Inline",Space,Str "quotes"]
+,Para [Str "Normal",Space,Str "text",Space,Str "but",Space,Str "then",Space,Str "a",Space,Link ("",[],[]) [Quoted DoubleQuote [Str "inline",Space,Str "quote"]] ("https://www.imdb.com/title/tt0062622/quotes/qt0396921",""),Str "."]
+,Para [Quoted DoubleQuote [Str "Missing",Space,Str "a",Space,Str "cite",Space,Str "attribute",Space,Str "means",Space,Str "its",Space,Str "just",Space,Str "normal",Space,Str "text"]]
+,HorizontalRule
 ,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
 ,Para [Str "Code:"]
 ,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"

--- a/test/html-reader.native
+++ b/test/html-reader.native
@@ -52,7 +52,7 @@ Pandoc (Meta {unMeta = fromList [("generator",MetaInlines [Str "pandoc"]),("titl
 ,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
 ,HorizontalRule
 ,Header 1 ("inline-quotes",[],[]) [Str "Inline",Space,Str "quotes"]
-,Para [Str "Normal",Space,Str "text",Space,Str "but",Space,Str "then",Space,Str "a",Space,Link ("",[],[]) [Quoted DoubleQuote [Str "inline",Space,Str "quote"]] ("https://www.imdb.com/title/tt0062622/quotes/qt0396921",""),Str "."]
+,Para [Str "Normal",Space,Str "text",Space,Str "but",Space,Str "then",Space,Str "a",Space,Span ("",[],[("cite","https://www.imdb.com/title/tt0062622/quotes/qt0396921")]) [Quoted DoubleQuote [Str "inline",Space,Str "quote"]],Str "."]
 ,Para [Quoted DoubleQuote [Str "Missing",Space,Str "a",Space,Str "cite",Space,Str "attribute",Space,Str "means",Space,Str "its",Space,Str "just",Space,Str "normal",Space,Str "text"]]
 ,HorizontalRule
 ,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]

--- a/test/html-reader.native
+++ b/test/html-reader.native
@@ -52,7 +52,7 @@ Pandoc (Meta {unMeta = fromList [("generator",MetaInlines [Str "pandoc"]),("titl
 ,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
 ,HorizontalRule
 ,Header 1 ("inline-quotes",[],[]) [Str "Inline",Space,Str "quotes"]
-,Para [Str "Normal",Space,Str "text",Space,Str "but",Space,Str "then",Space,Str "a",Space,Span ("",[],[("cite","https://www.imdb.com/title/tt0062622/quotes/qt0396921")]) [Quoted DoubleQuote [Str "inline",Space,Str "quote"]],Str "."]
+,Para [Str "Normal",Space,Str "text",Space,Str "but",Space,Str "then",Space,Str "a",Space,Quoted DoubleQuote [Span ("",[],[("cite","https://www.imdb.com/title/tt0062622/quotes/qt0396921")]) [Str "inline",Space,Str "quote"]],Str "."]
 ,Para [Quoted DoubleQuote [Str "Missing",Space,Str "a",Space,Str "cite",Space,Str "attribute",Space,Str "means",Space,Str "its",Space,Str "just",Space,Str "normal",Space,Str "text"]]
 ,HorizontalRule
 ,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]


### PR DESCRIPTION
If a `<q>` tag has a `cite` attribute, we interpret it as a link with an
inner quote.

Closes #5798