### PR TITLE
Add Reader support for HTML <samp> element

### DIFF
--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -782,8 +782,9 @@ pImage = do
   return $ B.imageWith (uid, cls, kvs) (escapeURI url) title (B.text alt)
 
 pCode :: PandocMonad m => TagParser m Inlines
+-- pSatisfy :: PandocMonad m => (Tag Text -> Bool) -> TagParser m (Tag Text)
 pCode = try $ do
-  (TagOpen open attr') <- pSatisfy $ tagOpen (`elem` ["code","tt"]) (const True)
+  (TagOpen open attr') <- pSatisfy $ tagOpen (`elem` ["code","tt","samp"]) (const True)
   let attr = toStringAttr attr'
   result <- manyTill pAny (pCloses open)
   return $ B.codeWith (mkAttr attr) $ unwords $ lines $ T.unpack $

--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -782,7 +782,6 @@ pImage = do
   return $ B.imageWith (uid, cls, kvs) (escapeURI url) title (B.text alt)
 
 pCode :: PandocMonad m => TagParser m Inlines
--- pSatisfy :: PandocMonad m => (Tag Text -> Bool) -> TagParser m (Tag Text)
 pCode = try $ do
   (TagOpen open attr') <- pSatisfy $ tagOpen (`elem` ["code","tt","samp"]) (const True)
   let attr = toStringAttr attr'

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -93,7 +93,7 @@ tests = [ testGroup "base tag"
           [
             test html "inline samp block" $ 
             "<samp>Answer is 42</samp>" =?> 
-            plain (code "Answer is 42")
+            plain (codeWith ("",["sample"],[]) "Answer is 42")
           ]
         , askOption $ \(QuickCheckTests numtests) ->
             testProperty "Round trip" $

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -89,6 +89,12 @@ tests = [ testGroup "base tag"
           , test htmlNativeDivs "<main> followed by text" $ "<main>main content</main>non-main content" =?>
             doc (divWith ("", [], [("role", "main")]) (plain (text "main content")) <> plain (text "non-main content"))
           ]
+        , testGroup "samp"
+          [
+            test html "inline samp block" $ 
+            "<samp>Answer is 42</samp>" =?> 
+            plain (code "Answer is 42")
+          ]
         , askOption $ \(QuickCheckTests numtests) ->
             testProperty "Round trip" $
               withMaxSuccess (if QuickCheckTests numtests == defaultValue


### PR DESCRIPTION
Parsing support for `<samp>`  HTML element as requested in #5792 .

**Before**
```
➜  pandoc git:(issue5792) ✗ pandoc -f html -t markdown    
Output <samp>Answer is 42</samp> was printed.
Output Answer is 42 was printed.
```

**After**
```
➜  pandoc git:(issue5792) ✗ pandoc -f html -t markdown    
Output <samp>Answer is 42</samp> was printed.
Output `Answer is 42`{.sample} was printed.
```