### PR TITLE
Default latex template: patch for fixing spacing problem on CJK language.

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -137,7 +137,7 @@ $endif$
 $endif$
 $if(CJKmainfont)$
   \ifxetex
-    \usepackage{xeCJK}
+    \usepackage[space]{xeCJK}
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
   \fi
 $endif$


### PR DESCRIPTION
Issue and solution is from below.
https://tex.stackexchange.com/questions/17292/how-to-write-spaces-between-korean-words-with-xecjk