### PR TITLE
HTML Reader/Writer - Add support for <var> and <samp>

### DIFF
--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -788,7 +788,7 @@ pCodeWithClass elemToClass = try $ do
   TagOpen open attr' <- pSatisfy $ tagOpen tagTest (const True)
   result <- manyTill pAny (pCloses open)
   let (ids,cs,kvs) = mkAttr . toStringAttr $ attr'
-      cs'          = maybe cs id . fmap (:cs) . lookup open $ elemToClass
+      cs'          = maybe cs (:cs) . lookup open $ elemToClass
   return . B.codeWith (ids,cs',kvs) .
     unwords . lines . T.unpack . innerText $ result
 

--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -38,7 +38,7 @@ import Data.Foldable (for_)
 import Data.List (isPrefixOf)
 import Data.List.Split (wordsBy, splitWhen)
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe, isJust, isNothing, fromJust)
+import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Monoid (First (..))
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -784,10 +784,12 @@ pImage = do
 
 pCodeWithClass :: PandocMonad m => [(T.Text,String)] -> TagParser m Inlines 
 pCodeWithClass elemToClass = try $ do 
-  TagOpen open attr' <- pSatisfy $ tagOpen (flip elem . fmap fst $ elemToClass) (const True)
+  let tagTest = flip elem . fmap fst $ elemToClass
+  TagOpen open attr' <- pSatisfy $ tagOpen tagTest (const True)
   result <- manyTill pAny (pCloses open)
   let (ids,cs,kvs) = mkAttr . toStringAttr $ attr'
-  return . B.codeWith (ids,fromJust (lookup open elemToClass) : cs,kvs) .
+      cs'          = maybe cs id . fmap (:cs) . lookup open $ elemToClass
+  return . B.codeWith (ids,cs',kvs) .
     unwords . lines . T.unpack . innerText $ result
 
 pCode :: PandocMonad m => TagParser m Inlines

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -31,7 +31,7 @@ module Text.Pandoc.Writers.HTML (
   ) where
 import Control.Monad.State.Strict
 import Data.Char (ord, toLower)
-import Data.List (intercalate, intersperse, isPrefixOf, partition, elem, delete)
+import Data.List (intercalate, intersperse, isPrefixOf, partition, delete)
 import Data.List.Split (splitWhen)
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import qualified Data.Set as Set

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -95,6 +95,12 @@ tests = [ testGroup "base tag"
             "<samp>Answer is 42</samp>" =?> 
             plain (codeWith ("",["sample"],[]) "Answer is 42")
           ]
+        , testGroup "var"
+        [
+          test html "inline var block" $ 
+          "<var>result</var>" =?> 
+          plain (codeWith ("",["variable"],[]) "result")
+        ]
         , askOption $ \(QuickCheckTests numtests) ->
             testProperty "Round trip" $
               withMaxSuccess (if QuickCheckTests numtests == defaultValue

--- a/test/Tests/Writers/HTML.hs
+++ b/test/Tests/Writers/HTML.hs
@@ -71,6 +71,18 @@ tests = [ testGroup "inline code"
             plain (codeWith ("",["variable"],[]) "result") =?>
             "<var>result</var>"
           ]
+        , testGroup "sample with style"
+          [ "samp should wrap highlighted code" =:
+            codeWith ("",["sample","haskell"],[]) ">>="
+            =?> ("<samp><code class=\"sourceCode haskell\">" ++ 
+                "<span class=\"op\">&gt;&gt;=</span></code></samp>")
+          ]
+        , testGroup "variable with style"
+          [ "var should wrap highlighted code" =:
+            codeWith ("",["haskell","variable"],[]) ">>="
+            =?> ("<var><code class=\"sourceCode haskell\">" ++ 
+                "<span class=\"op\">&gt;&gt;=</span></code></var>")
+          ]
         ]
         where
           tQ :: (ToString a, ToPandoc a)

--- a/test/Tests/Writers/HTML.hs
+++ b/test/Tests/Writers/HTML.hs
@@ -61,6 +61,16 @@ tests = [ testGroup "inline code"
             doubleQuoted (spanWith ("", [], [("cite", "http://example.org")]) (str "examples"))
             =?> "<q cite=\"http://example.org\">examples</q>"
           ]
+        , testGroup "sample"
+          [ "sample should be rendered correctly" =:
+            plain (codeWith ("",["sample"],[]) "Answer is 42") =?>
+            "<samp>Answer is 42</samp>"
+          ]
+        , testGroup "variable"
+          [ "variable should be rendered correctly" =:
+            plain (codeWith ("",["variable"],[]) "result") =?>
+            "<var>result</var>"
+          ]
         ]
         where
           tQ :: (ToString a, ToPandoc a)


### PR DESCRIPTION
Change for #5799. Adds Reader/Writer support for `<var>` HTML element and Writer support for `<samp>` HTML element.

Before - 
```
➜  pandoc git:(issue5799) ✗ pandoc -t markdown -f html
<var>result</var>
result
➜  pandoc git:(issue5799) ✗ pandoc -f markdown -t html
`result`{.sample}
<p><code class="sample">result</code></p>
➜  pandoc git:(issue5799) ✗ pandoc -f markdown -t html
`result`{.variable}
<p><code class="variable">result</code></p>
```

After - 
```
➜  pandoc git:(issue5799) ✗ pandoc -t markdown -f html
<var>result</var>
`result`{.variable}
➜  pandoc git:(issue5799) ✗ pandoc -f markdown -t html
`result`{.sample}
<p><samp>result</samp></p>
➜  pandoc git:(issue5799) ✗ pandoc -f markdown -t html
`result`{.variable}
<p><var>result</var></p>
```