### PR TITLE
Place caption before table in OpenDocument format.

### DIFF
--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -404,9 +404,11 @@ blockToOpenDocument o bs
                  then return empty
                  else colHeadsToOpenDocument o (map fst paraHStyles) h
         tr <- mapM (tableRowToOpenDocument o (map fst paraStyles)) r
-        return $ inTags True "table:table" [ ("table:name"      , name)
-                                           , ("table:style-name", name)
-                                           ] (vcat columns $$ th $$ vcat tr) $$ captionDoc
+        let tableDoc = inTags True "table:table" [
+                            ("table:name"      , name)
+                          , ("table:style-name", name)
+                          ] (vcat columns $$ th $$ vcat tr)
+        return $ captionDoc $$ tableDoc
       figure attr caption source title | null caption =
         withParagraphStyle o "Figure" [Para [Image attr caption (source,title)]]
                                   | otherwise    = do

--- a/test/command/5474-tables.md
+++ b/test/command/5474-tables.md
@@ -12,6 +12,8 @@
 
 : Second Table
 ^D
+<text:p text:style-name="TableCaption">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">1</text:sequence>: First
+table</text:p>
 <table:table table:name="Table1" table:style-name="Table1">
   <table:table-column table:style-name="Table1.A" />
   <table:table-column table:style-name="Table1.B" />
@@ -34,8 +36,8 @@
     </table:table-cell>
   </table:table-row>
 </table:table>
-<text:p text:style-name="TableCaption">Table <text:sequence text:ref-name="refTable0" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">1</text:sequence>: First
-table</text:p>
+<text:p text:style-name="TableCaption">Table <text:sequence text:ref-name="refTable1" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">2</text:sequence>: Second
+Table</text:p>
 <table:table table:name="Table2" table:style-name="Table2">
   <table:table-column table:style-name="Table2.A" />
   <table:table-column table:style-name="Table2.B" />
@@ -58,6 +60,4 @@ table</text:p>
     </table:table-cell>
   </table:table-row>
 </table:table>
-<text:p text:style-name="TableCaption">Table <text:sequence text:ref-name="refTable1" text:name="Table" text:formula="ooow:Table+1" style:num-format="1">2</text:sequence>: Second
-Table</text:p>
 ```

--- a/test/tables.opendocument
+++ b/test/tables.opendocument
@@ -1,4 +1,6 @@
 <text:p text:style-name="Text_20_body">Simple table with caption:</text:p>
+<text:p text:style-name="TableCaption">Demonstration of simple table
+syntax.</text:p>
 <table:table table:name="Table1" table:style-name="Table1">
   <table:table-column table:style-name="Table1.A" />
   <table:table-column table:style-name="Table1.B" />
@@ -63,8 +65,6 @@
     </table:table-cell>
   </table:table-row>
 </table:table>
-<text:p text:style-name="TableCaption">Demonstration of simple table
-syntax.</text:p>
 <text:p text:style-name="First_20_paragraph">Simple table without
 caption:</text:p>
 <table:table table:name="Table2" table:style-name="Table2">
@@ -133,6 +133,8 @@ caption:</text:p>
 </table:table>
 <text:p text:style-name="First_20_paragraph">Simple table indented two
 spaces:</text:p>
+<text:p text:style-name="TableCaption">Demonstration of simple table
+syntax.</text:p>
 <table:table table:name="Table3" table:style-name="Table3">
   <table:table-column table:style-name="Table3.A" />
   <table:table-column table:style-name="Table3.B" />
@@ -197,10 +199,10 @@ spaces:</text:p>
     </table:table-cell>
   </table:table-row>
 </table:table>
-<text:p text:style-name="TableCaption">Demonstration of simple table
-syntax.</text:p>
 <text:p text:style-name="First_20_paragraph">Multiline table with
 caption:</text:p>
+<text:p text:style-name="TableCaption">Here’s the caption. It may span
+multiple lines.</text:p>
 <table:table table:name="Table4" table:style-name="Table4">
   <table:table-column table:style-name="Table4.A" />
   <table:table-column table:style-name="Table4.B" />
@@ -253,8 +255,6 @@ caption:</text:p>
     </table:table-cell>
   </table:table-row>
 </table:table>
-<text:p text:style-name="TableCaption">Here’s the caption. It may span
-multiple lines.</text:p>
 <text:p text:style-name="First_20_paragraph">Multiline table without
 caption:</text:p>
 <table:table table:name="Table5" table:style-name="Table5">


### PR DESCRIPTION
Fixes #5681

Now table caption is placed before the table.

Example Markdown table
```markdown
Text before table.

Table: A simple table in Markdown.

| Column 1 | Column 2 | Column 3 | Column 4 |
| -------- | -------- | -------- | -------- |
| 11       | 12       | 13       | 14       |
| 21       | 22       | 23       | 24       |
| 31       | 32       | 33       | 34       |
```
gets converted to
<img width="944" alt="conversion result" src="https://user-images.githubusercontent.com/947471/68086234-7f6ef280-fe5a-11e9-9576-b9bbd48bcce6.png">
