### PR TITLE
Update default.context

### DIFF
--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -105,6 +105,24 @@ $endif$
 \setupxtable[body][]
 \setupxtable[foot][bottomframe=on]
 
+% Wrap CSL references in start-stop-environment
+$if(csl-refs)$
+\newdimen\cslhangindent
+\cslhangindent=1.5em
+\definestartstop [cslreferences] [
+	$if(csl-hanging-indent)$
+	before={%
+		\setupnarrower[left=\cslhangindent]
+    	\startnarrower[left]%
+    	\setupindenting[-\leftskip,yes,first]%
+    	%\setuphead[chapter,section][indentnext=yes]%
+		\indentation%
+  	},
+  	after=\stopnarrower,
+	$endif$
+]
+$endif$
+
 $if(includesource)$
 $for(sourcefile)$
 \attachment[file=$curdir$/$sourcefile$,method=hidden]

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -121,7 +121,6 @@ $if(csl-refs)$
 	$endif$
 ]
 $endif$
-
 $if(includesource)$
 $for(sourcefile)$
 \attachment[file=$curdir$/$sourcefile$,method=hidden]

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -105,7 +105,6 @@ $endif$
 \setupxtable[body][]
 \setupxtable[foot][bottomframe=on]
 
-% Wrap CSL references in start-stop-environment
 $if(csl-refs)$
 \newdimen\cslhangindent
 \cslhangindent=1.5em


### PR DESCRIPTION
Define an start-stop-pair `cslreferences` to allow for hanging indents in the bibliography. Analogous to the cslreferences-environment in the default latex template. See here: https://github.com/jgm/pandoc-citeproc/issues/410
For this to work the context writer must be adapted.