### PR TITLE
fix docs: pandoc.system functions

### DIFF
--- a/data/sample.lua
+++ b/data/sample.lua
@@ -358,4 +358,3 @@ meta.__index =
     return function() return "" end
   end
 setmetatable(_G, meta)
-

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -2761,9 +2761,9 @@ Returns:
 -   A table mapping environment variables names to their string
     value (table).
 
-### get\_working\_directory {#system-get_working_directory}
+### get\_current\_directory {#system-get_current_directory}
 
-`get_working_directory ()`
+`get_current_directory ()`
 
 Obtain the current working directory as an absolute path.
 

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -2795,9 +2795,9 @@ Returns:
 
 -   The result(s) of the call to `callback`
 
-### with\_temporary\_directory {#system-with_temporary_directory}
+### with\_temp\_directory {#system-with_temp_directory}
 
-`with_temporary_directory ([parent_dir,] templ, callback)`
+`with_temp_directory ([parent_dir,] templ, callback)`
 
 Create and use a temporary directory inside the given directory.
 The directory is deleted after the callback returns.


### PR DESCRIPTION
Fixed mismatching of documentation and implementation:
* `pandoc.system.get_working_directory()` -> `pandoc.system.get_current_directory()` 
* `pandoc.system.with_temporary_directory()`  -> `pandoc.system.with_temp_directory()` 
