### PR TITLE
LaTeX reader: parse \micro siunitx unit command

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -404,6 +404,7 @@ siUnitMap = M.fromList
   , ("mega", str "M")
   , ("meter", str "m")
   , ("metre", str "m")
+  , ("micro", str "μ")
   , ("milli", str "m")
   , ("minute", str "min")
   , ("mmHg", str "mmHg")


### PR DESCRIPTION
This was somehow missed in 884aef31c55e375cd62fcb55a71829d005087cae.