### PR TITLE
Add support for $toc-title$ to HTML (4 and 5)

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2559,7 +2559,7 @@ on the output format, and include the following:
 
 `toc-title`
 :   title of table of contents (works only with EPUB,
-    opendocument, odt, docx, pptx, beamer, LaTeX)
+    HTML, opendocument, odt, docx, pptx, beamer, LaTeX)
 
 [pandoc-templates]: https://github.com/jgm/pandoc-templates
 

--- a/data/templates/default.html4
+++ b/data/templates/default.html4
@@ -47,6 +47,9 @@ $endif$
 $endif$
 $if(toc)$
 <div id="$idprefix$TOC">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
 $table-of-contents$
 </div>
 $endif$

--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -50,6 +50,9 @@ $endif$
 $endif$
 $if(toc)$
 <nav id="$idprefix$TOC" role="doc-toc">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
 $table-of-contents$
 </nav>
 $endif$


### PR DESCRIPTION
Inspired by [this trick](https://github.com/jgm/pandoc/wiki/How-to-add-a-%22Table-of-Contents%22-title-in-the-HTML-template). I didn’t see a valid reason for this to remain a trick and not be included by default and that also makes it more consistent with other output formats.