### PR TITLE
Update default.context

### DIFF
--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -108,18 +108,16 @@ $endif$
 \setupxtable[foot][bottomframe=on]
 
 $if(csl-refs)$
-\newdimen\cslhangindent
-\cslhangindent=1.5em
+\definemeasure[cslhangindent][1.5em]
+\definenarrower[hangingreferences][left=\measure{cslhangindent}]
 \definestartstop [cslreferences] [
 	$if(csl-hanging-indent)$
 	before={%
-		\setupnarrower[left=\cslhangindent]
-    	\startnarrower[left]%
-    	\setupindenting[-\leftskip,yes,first]%
-    	%\setuphead[chapter,section][indentnext=yes]%
-		\indentation%
+	  \starthangingreferences[left]
+      \setupindenting[-\leftskip,yes,first]
+      \doindentation
   	},
-  	after=\stopnarrower,
+  	after=\stophangingreferences,
 	$endif$
 ]
 $endif$


### PR DESCRIPTION
Fix `\startcslreferences`:
- The old version had a too large skip at the beginning of the reference list => fixed that.
- Change syntax to ConTeXt conventions