### PR TITLE
ConTeXt template: Adjustments to title formatting

### DIFF
--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -135,14 +135,14 @@ $endfor$
 \starttext
 $if(title)$
 \startalignment[middle]
-  {\tfd $title$}
+  {\tfd\setupinterlinespace $title$}
 $if(subtitle)$
   \smallskip
-  {\tfa $subtitle$}
+  {\tfa\setupinterlinespace $subtitle$}
 $endif$
 $if(author)$
   \smallskip
-  {\tfa $for(author)$$author$$sep$\crlf $endfor$}
+  {\tfa\setupinterlinespace $for(author)$$author$$sep$\crlf $endfor$}
 $endif$
 $if(date)$
   \smallskip

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -146,7 +146,7 @@ $if(author)$
 $endif$
 $if(date)$
   \smallskip
-  {\tfa $date$}
+  {\tfa\setupinterlinespace $date$}
 $endif$
   \bigskip
 \stopalignment

--- a/test/writer.context
+++ b/test/writer.context
@@ -61,11 +61,11 @@
 
 \starttext
 \startalignment[middle]
-  {\tfd Pandoc Test Suite}
+  {\tfd\setupinterlinespace Pandoc Test Suite}
   \smallskip
-  {\tfa John MacFarlane\crlf Anonymous}
+  {\tfa\setupinterlinespace John MacFarlane\crlf Anonymous}
   \smallskip
-  {\tfa July 17, 2006}
+  {\tfa\setupinterlinespace July 17, 2006}
   \bigskip
 \stopalignment
 


### PR DESCRIPTION
Added `\setupinterlinespace` to `title`, `subtitle` and `author` elements => otherwise longer titles that run over multiple lines will look squashed as `\tfd` etc. won't adapt the line spacing to the font size.