### PR TITLE
Update Tests for ConTeXt writer

### DIFF
--- a/test/writer.context
+++ b/test/writer.context
@@ -61,11 +61,11 @@
 
 \starttext
 \startalignment[middle]
-  {\tfd Pandoc Test Suite}
+  {\tfd\setupinterlinespace Pandoc Test Suite}
   \smallskip
-  {\tfa John MacFarlane\crlf Anonymous}
+  {\tfa\setupinterlinespace John MacFarlane\crlf Anonymous}
   \smallskip
-  {\tfa July 17, 2006}
+  {\tfa\setupinterlinespace July 17, 2006}
   \bigskip
 \stopalignment
 


### PR DESCRIPTION
Added `\setupinterlinespace` to `title`, `subtitle` and `author` elements => otherwise longer titles that run over multiple lines will look squashed as `\tfd` etc. won't adapt the line spacing to the font size.