### PR TITLE
Add title-background-image to revealjs template

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2104,6 +2104,9 @@ These affect HTML output when [producing slide shows with pandoc].
 All [reveal.js configuration options] are available as variables.
 To turn off boolean flags that default to true in reveal.js, use `0`.
 
+`background-image`
+:   background image for all slides
+
 `revealjs-url`
 :   base URL for reveal.js documents (defaults to `reveal.js`)
 
@@ -2117,6 +2120,9 @@ To turn off boolean flags that default to true in reveal.js, use `0`.
 `slideous-url`
 :   base URL for Slideous documents (defaults to `slideous`)
 
+`title-background-image`
+:   background image for the title slide
+
 [reveal.js configuration options]: https://github.com/hakimel/reveal.js#configuration
 
 ### Variables for Beamer slides
@@ -2127,6 +2133,9 @@ These variables change the appearance of PDF slides using [`beamer`].
 :   slide aspect ratio (`43` for 4:3 [default], `169` for 16:9,
     `1610` for 16:10, `149` for 14:9, `141` for 1.41:1, `54` for 5:4,
     `32` for 3:2)
+
+`background-image`
+:   background image for all slides
 
 `beamerarticle`
 :   produce an article from Beamer slides

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -5349,6 +5349,9 @@ To set an image for a particular reveal.js slide, add
 `{data-background-image="/path/to/image"}`
 to the first slide-level heading on the slide (which may even be empty).
 
+To set an image for the title slide generated from the metadata,
+use the configuration variable `title-background-image`.
+
 In reveal.js's overview mode, the parallaxBackgroundImage will show up
 only on the first slide.
 

--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -55,7 +55,7 @@ $endfor$
     <div class="slides">
 
 $if(title)$
-<section id="$idprefix$title-slide">
+<section id="$idprefix$title-slide"$if(title-background-image)$ data-background-image="$title-background-image$"$endif$>
   <h1 class="title">$title$</h1>
 $if(subtitle)$
   <p class="subtitle">$subtitle$</p>


### PR DESCRIPTION
This pull request adds a new variable `title-background-image` to the default reveal.js template. When set, it adds a `data-background-image` attribute to the title slide which is generated from the metadata.

Closes #4498 