### PR TITLE
Keep the \author{} command even if author is not specified

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -383,9 +383,7 @@ $else$
 $endif$
 \subtitle{$subtitle$}
 $endif$
-$if(author)$
 \author{$for(author)$$author$$sep$ \and $endfor$}
-$endif$
 \date{$date$}
 $if(beamer)$
 $if(institute)$

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -82,6 +82,7 @@
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 
+\author{}
 \date{}
 
 \begin{document}

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -49,6 +49,7 @@
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 
+\author{}
 \date{}
 
 \begin{document}

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -78,6 +78,7 @@
   \newenvironment{LTR}{\beginL}{\endL}
 \fi
 
+\author{}
 \date{}
 
 \begin{document}


### PR DESCRIPTION
otherwise there will be a LaTeX warning "No \author given" when the .tex file is compiled.