### PR TITLE
Use HTTPS in copyright message

### DIFF
--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -933,7 +933,7 @@ usageMessage programName = usageInfo (programName ++ " [OPTIONS] [FILES]")
 copyrightMessage :: String
 copyrightMessage = intercalate "\n" [
   "Copyright (C) 2006-2019 John MacFarlane",
-  "Web:  http://pandoc.org",
+  "Web:  https://pandoc.org",
   "This is free software; see the source for copying conditions.",
   "There is no warranty, not even for merchantability or fitness",
   "for a particular purpose." ]


### PR DESCRIPTION
Since the website now redirect to https automatically, it would be nice to just use https in the help text.