### PR TITLE
Allow framebreaks for beamer's TOC

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -423,7 +423,7 @@ $if(toc-title)$
 \renewcommand*\contentsname{$toc-title$}
 $endif$
 $if(beamer)$
-\begin{frame}
+\begin{frame}[allowframebreaks]
 $if(toc-title)$
   \frametitle{$toc-title$}
 $endif$


### PR DESCRIPTION
Hi, I believe, it is quite easy to overrun theTOC's frame, so I'd suggest automatic frame breaks for the toc frame.

I didn't see any other way to pass this "allowframebreaks" option to the TOC frame.

Thank you for pulling.