### PR TITLE
Update JATS dtd

### DIFF
--- a/data/templates/default.jats
+++ b/data/templates/default.jats
@@ -2,7 +2,7 @@
 $if(xml-stylesheet)$
 <?xml-stylesheet type="text/xsl" href="$xml-stylesheet$"?>
 $endif$
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN"
                   "JATS-archivearticle1.dtd">
 $if(article.type)$
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="$article.type$">

--- a/data/templates/default.jats
+++ b/data/templates/default.jats
@@ -5,9 +5,9 @@ $endif$
 <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
                   "JATS-archivearticle1.dtd">
 $if(article.type)$
-<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1" article-type="$article.type$">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="$article.type$">
 $else$
-<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1" article-type="other">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="other">
 $endif$
 <front>
 <journal-meta>

--- a/data/templates/default.jats
+++ b/data/templates/default.jats
@@ -2,8 +2,8 @@
 $if(xml-stylesheet)$
 <?xml-stylesheet type="text/xsl" href="$xml-stylesheet$"?>
 $endif$
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN"
-                  "JATS-journalpublishing1.dtd">
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
+                  "JATS-archivearticle1.dtd">
 $if(article.type)$
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1" article-type="$article.type$">
 $else$

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN"
                   "JATS-archivearticle1.dtd">
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="other">
 <front>

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
                   "JATS-archivearticle1.dtd">
-<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.0" article-type="other">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="other">
 <front>
 <journal-meta>
 <journal-title-group>

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN"
-                  "JATS-journalpublishing1.dtd">
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
+                  "JATS-archivearticle1.dtd">
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.0" article-type="other">
 <front>
 <journal-meta>

--- a/test/writer.jats
+++ b/test/writer.jats
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN"
-                  "JATS-journalpublishing1.dtd">
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
+                  "JATS-archivearticle1.dtd">
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1" article-type="other">
 <front>
 <journal-meta>

--- a/test/writer.jats
+++ b/test/writer.jats
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN"
                   "JATS-archivearticle1.dtd">
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="other">
 <front>

--- a/test/writer.jats
+++ b/test/writer.jats
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN"
                   "JATS-archivearticle1.dtd">
-<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.1" article-type="other">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="other">
 <front>
 <journal-meta>
 <journal-title-group>


### PR DESCRIPTION
The current DTD for the [JATS writer template](https://github.com/jgm/pandoc/blob/6c435a17cd48af40dbf87ebbec8baf6ac6aabe27/data/templates/default.jats#L5) is for Journal Publishing (`JATS-journalpublishing1.dtd`), which does not permit `ext-link` as a valid child (https://jats.nlm.nih.gov/publishing/tag-library/1.1/element/publisher-name.html).

This update modifies the default output template to be the less restrictive JATS archiving and interchange DTD which systems like PubMed use internally to represent their articles. The new dtd is as follows:

```
<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2d1 20190208//EN" "JATS-archivearticle1.dtd">
```
As suggested by @jgm - I proposed this change to the Pandoc mailing list [a few weeks ago](https://groups.google.com/forum/#!searchin/pandoc-discuss/jats%7Csort:date/pandoc-discuss/CPqStRl9qdQ/O5GbnbKrAwAJ) and haven't received any feedback on this suggestion.

Running the following command in [jats-example-files.zip](https://github.com/jgm/pandoc/files/4008669/jats-example-files.zip) 

```
pandoc -s --metadata-file metadata.json --bibliography references.bib --filter pandoc-citeproc --to jats example.md -o output.xml
```

Produces the file `output.xml` which is currently invalid. Updating the `default.jats` template as modified in this pull request produces `updated-output.xml` which is valid JATS according to the [Pubmed central validator](https://www.ncbi.nlm.nih.gov/pmc/tools/xmlchecker)

Fixes #5634