### PR TITLE
Swap suboptimal uses of maybe and fromMaybe

### DIFF
--- a/src/Text/Pandoc/Readers/EPUB.hs
+++ b/src/Text/Pandoc/Readers/EPUB.hs
@@ -67,7 +67,7 @@ archiveToEPUB os archive = do
   (coverId, meta) <- parseMeta content
   (cover, items)  <- parseManifest content coverId
   -- No need to collapse here as the image path is from the manifest file
-  let coverDoc = fromMaybe mempty (imageToPandoc <$> cover)
+  let coverDoc = maybe mempty imageToPandoc cover
   spine <- parseSpine items content
   let escapedSpine = map (escapeURI . T.pack . takeFileName . fst) spine
   Pandoc _ bs <-

--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -812,8 +812,8 @@ pSpan = try $ do
   let isSmallCaps = fontVariant == "small-caps" || "smallcaps" `elem` classes
                     where styleAttr   = fromMaybe "" $ lookup "style" attr
                           fontVariant = fromMaybe "" $ pickStyleAttrProps ["font-variant"] styleAttr
-                          classes     = fromMaybe [] $
-                                          T.words <$> lookup "class" attr
+                          classes     = maybe []
+                                          T.words $ lookup "class" attr
   let tag = if isSmallCaps then B.smallcaps else B.spanWith (mkAttr attr)
   return $ tag contents
 

--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -356,7 +356,7 @@ metadataFromMeta opts meta = EPUBMetadata{
                               (writerVariables opts))
             `mplus` (metaValueToString <$> lookupMeta "cover-image" meta)
         mCss = lookupMeta "css" meta <|> lookupMeta "stylesheet" meta
-        stylesheets = fromMaybe [] (metaValueToPaths <$> mCss) ++
+        stylesheets = maybe [] metaValueToPaths mCss ++
                       case lookupContext "css" (writerVariables opts) of
                          Just xs -> map TS.unpack xs
                          Nothing ->
@@ -659,8 +659,8 @@ pandocToEPUB version opts doc = do
                             ("media-type", maybe "" TS.unpack $
                                   getMimeType $ eRelativePath ent)] $ ()
 
-  let tocTitle = fromMaybe plainTitle $
-                   metaValueToString <$> lookupMeta "toc-title" meta
+  let tocTitle = maybe plainTitle
+                   metaValueToString $ lookupMeta "toc-title" meta
   uuid <- case epubIdentifier metadata of
             (x:_) -> return $ identifierText x  -- use first identifier as UUID
             []    -> throwError $ PandocShouldNeverHappenError "epubIdentifier is null"  -- shouldn't happen
@@ -1400,7 +1400,7 @@ relatorMap =
            ]
 
 docTitle' :: Meta -> [Inline]
-docTitle' meta = fromMaybe [] $ go <$> lookupMeta "title" meta
+docTitle' meta = maybe [] go $ lookupMeta "title" meta
   where go (MetaString s) = [Str s]
         go (MetaInlines xs) = xs
         go (MetaBlocks [Para xs]) = xs

--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -194,9 +194,9 @@ pandocToMarkdown opts (Pandoc meta blocks) = do
                (blockListToMarkdown opts)
                (inlineListToMarkdown opts)
                meta
-  let title' = maybe empty id $ getField "title" metadata
-  let authors' = maybe [] id $ getField "author" metadata
-  let date' = maybe empty id $ getField "date" metadata
+  let title' = fromMaybe empty $ getField "title" metadata
+  let authors' = fromMaybe [] $ getField "author" metadata
+  let date' = fromMaybe empty $ getField "date" metadata
   let titleblock = case writerTemplate opts of
                         Just _ | isPlain ->
                                  plainTitleBlock title' authors' date'

--- a/src/Text/Pandoc/Writers/Ms.hs
+++ b/src/Text/Pandoc/Writers/Ms.hs
@@ -26,7 +26,7 @@ import Control.Monad.State.Strict
 import Data.Char (isLower, isUpper, ord)
 import Data.List (intercalate, intersperse)
 import qualified Data.Map as Map
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Network.URI (escapeURIString, isAllowedInURI)
@@ -507,8 +507,8 @@ toMacro sty toktype =
         tokSty = Map.lookup toktype (tokenStyles sty)
         tokCol = (tokSty >>= tokenColor) `mplus` defaultColor sty
         -- tokBg  = (tokSty >>= tokenBackground) `mplus` backgroundColor sty
-        tokBold = fromMaybe False (tokenBold <$> tokSty)
-        tokItalic = fromMaybe False (tokenItalic <$> tokSty)
+        tokBold = maybe False tokenBold tokSty
+        tokItalic = maybe False tokenItalic tokSty
         -- tokUnderline = fromMaybe False (tokSty >>= tokUnderline)
         -- lnColor = lineNumberColor sty
         -- lnBkgColor = lineNumberBackgroundColor sty


### PR DESCRIPTION
Anywhere `maybe` is used with `id` as its second argument, using `fromMaybe` instead will simplify the code. Conversely, anywhere `fromMaybe` is used with the result of `fmap` or `<$>` as its second argument, using `maybe` instead will simplify the code.