### PR TITLE
Simplify an overcomplicated filtering function

### DIFF
--- a/src/Text/Pandoc/Readers/Odt/Generic/XMLConverter.hs
+++ b/src/Text/Pandoc/Readers/Odt/Generic/XMLConverter.hs
@@ -389,7 +389,7 @@ filterChildrenName'        :: (NameSpaceID nsID)
 filterChildrenName' nsID f =     getCurrentElement
                              >>> arr XML.elChildren
                              >>> iterateS (keepingTheValue (elemNameMatches nsID f))
-                             >>> arr (catMaybes . fmap (uncurry $ bool Nothing . Just))
+                             >>> arr (map fst . filter snd)
 
 --------------------------------------------------------------------------------
 -- Attributes


### PR DESCRIPTION
There's no need to use `catMaybes`, `uncurry`, `bool`, etc., just to get elements where the second element of a tuple is True.