### PR TITLE
Clean up after "hlint --refactor"

### DIFF
--- a/src/Text/Pandoc/Readers/Docx/Fields.hs
+++ b/src/Text/Pandoc/Readers/Docx/Fields.hs
@@ -17,7 +17,7 @@ module Text.Pandoc.Readers.Docx.Fields ( FieldInfo(..)
                                        ) where
 
 import Prelude
-import Data.Functor (($>))
+import Data.Functor (($>), void)
 import qualified Data.Text as T
 import Text.Parsec
 import Text.Parsec.Text (Parser)
@@ -50,7 +50,7 @@ quotedString = do
   T.concat <$> manyTill inQuotes (try (char '"'))
 
 unquotedString :: Parser T.Text
-unquotedString = T.pack <$> manyTill anyChar (try $ lookAhead space Data.Functor.$> () <|> eof)
+unquotedString = T.pack <$> manyTill anyChar (try $ void (lookAhead space) <|> eof)
 
 fieldArgument :: Parser T.Text
 fieldArgument = quotedString <|> unquotedString

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -263,7 +263,7 @@ blockToAsciiDoc opts (OrderedList (start, sty, _delim) items) = do
                        Decimal      -> ["arabic"]
                        Example      -> []
                        _            -> [T.toLower (tshow sty)]
-  let listStart = ["start=" <> tshow start | not (start == 1)]
+  let listStart = ["start=" <> tshow start | start /= 1]
   let listoptions = case T.intercalate ", " (listStyle ++ listStart) of
                           "" -> empty
                           x  -> brackets (literal x)

--- a/src/Text/Pandoc/Writers/MediaWiki.hs
+++ b/src/Text/Pandoc/Writers/MediaWiki.hs
@@ -16,7 +16,6 @@ MediaWiki:  <http://www.mediawiki.org/wiki/MediaWiki>
 -}
 module Text.Pandoc.Writers.MediaWiki ( writeMediaWiki, highlightingLangs ) where
 import Prelude
-import Control.Applicative
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Data.Maybe (fromMaybe)
@@ -168,7 +167,7 @@ blockToMediaWiki (Table capt aligns widths headers rows') = do
 
 blockToMediaWiki x@(BulletList items) = do
   tags <-
-    (|| not (isSimpleList x)) Control.Applicative.<$> asks useTags
+    (|| not (isSimpleList x)) <$> asks useTags
   if tags
      then do
         contents <- local (\ s -> s { useTags = True }) $ mapM listItemToMediaWiki items
@@ -180,7 +179,7 @@ blockToMediaWiki x@(BulletList items) = do
 
 blockToMediaWiki x@(OrderedList attribs items) = do
   tags <-
-    (|| not (isSimpleList x)) Control.Applicative.<$> asks useTags
+    (|| not (isSimpleList x)) <$> asks useTags
   if tags
      then do
         contents <- local (\s -> s { useTags = True }) $ mapM listItemToMediaWiki items
@@ -192,7 +191,7 @@ blockToMediaWiki x@(OrderedList attribs items) = do
 
 blockToMediaWiki x@(DefinitionList items) = do
   tags <-
-    (|| not (isSimpleList x)) Control.Applicative.<$> asks useTags
+    (|| not (isSimpleList x)) <$> asks useTags
   if tags
      then do
         contents <- local (\s -> s { useTags = True }) $ mapM definitionListItemToMediaWiki items
@@ -346,7 +345,7 @@ blockListToMediaWiki :: PandocMonad m
                      => [Block]       -- ^ List of block elements
                      -> MediaWikiWriter m Text
 blockListToMediaWiki blocks =
-  vcat Control.Applicative.<$> mapM blockToMediaWiki blocks
+  vcat <$> mapM blockToMediaWiki blocks
 
 -- | Convert list of Pandoc inline elements to MediaWiki.
 inlineListToMediaWiki :: PandocMonad m => [Inline] -> MediaWikiWriter m Text


### PR DESCRIPTION
HLint's automatic refactoring isn't quite perfect, so some of its
changes were overcomplicated, wrong, or created new findings.
Clean these up.