### PR TITLE
Add highlight directive to the rST reader

### DIFF
--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -1138,6 +1138,7 @@ data ParserState = ParserState
       stateExamples          :: M.Map Text Int, -- ^ Map from example labels to numbers
       stateMacros            :: M.Map Text Macro, -- ^ Table of macros defined so far
       stateRstDefaultRole    :: Text,        -- ^ Current rST default interpreted text role
+      stateRstHighlight      :: Maybe Text,  -- ^ Current rST literal block language
       stateRstCustomRoles    :: M.Map Text (Text, Maybe Text, Attr), -- ^ Current rST custom text roles
       -- Triple represents: 1) Base role, 2) Optional format (only for :raw:
       -- roles), 3) Additional classes (rest of Attr is unused)).
@@ -1248,6 +1249,7 @@ defaultParserState =
                   stateExamples        = M.empty,
                   stateMacros          = M.empty,
                   stateRstDefaultRole  = "title-reference",
+                  stateRstHighlight    = Nothing,
                   stateRstCustomRoles  = M.empty,
                   stateCaption         = Nothing,
                   stateInHtmlBlock     = Nothing,

--- a/test/rst-reader.native
+++ b/test/rst-reader.native
@@ -39,6 +39,10 @@ Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Spa
 ,CodeBlock ("",[],[]) "this block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
 ,Para [Str "And:"]
 ,CodeBlock ("",["python"],[]) "def my_function(x):\n    return x + 1"
+,Para [Str "If",Space,Str "we",Space,Str "use",Space,Str "the",Space,Str "highlight",Space,Str "directive,",Space,Str "we",Space,Str "can",Space,Str "specify",Space,Str "a",Space,Str "default",Space,Str "language",SoftBreak,Str "for",Space,Str "literate",Space,Str "blocks."]
+,CodeBlock ("",["haskell"],[]) "-- this code is in haskell\ndata Tree = Leaf | Node Tree Tree"
+,CodeBlock ("",["haskell"],[]) "-- this code is in haskell too\ndata Nat = Zero | Succ Nat"
+,CodeBlock ("",["javascript"],[]) "-- this code is in javascript\nlet f = (x, y) => x + y"
 ,Header 1 ("lists",[],[]) [Str "Lists"]
 ,Header 2 ("unordered",[],[]) [Str "Unordered"]
 ,Para [Str "Asterisks",Space,Str "tight:"]

--- a/test/rst-reader.rst
+++ b/test/rst-reader.rst
@@ -107,6 +107,30 @@ And:
    def my_function(x):
        return x + 1
 
+If we use the highlight directive, we can specify a default language
+for literate blocks.
+
+.. highlight:: haskell
+
+::
+
+  -- this code is in haskell
+  data Tree = Leaf | Node Tree Tree
+
+::
+
+  -- this code is in haskell too
+  data Nat = Zero | Succ Nat
+
+.. highlight:: javascript
+
+::
+
+  -- this code is in javascript
+  let f = (x, y) => x + y
+
+.. highlight::
+
 Lists
 =====
 


### PR DESCRIPTION
This PR adds the [highlight directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-highlight) from Sphinx rST to the pandoc rST reader.
This enables one to declare a default language used for highlighting in literal blocks.

```rst
.. highlight:: haskell

From now on code will be highlighted as Haskell code::

  data Tree = Leaf | Node Tree Tree

Another exemple to show how terse using literal blocks becomes::

  main :: IO ()
  main = putStrLn "Hello World!"

We can change the language at any point in the document.

.. highlight:: python

So this block contains python code::

  def main():
    print("OK")

An we can still disable having a default language:

.. highlight::

::
  This literal block will not be highlighted

```

As explained on [pandoc-discuss], this directive is not in the docutils rST reference, however Sphinx is arguably one of the most popular target for rST, and this directive has proven to be very useful.