### PR TITLE
Remove redundant `otherwise` guard in inlineToAsciiDoc

### DIFF
--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -492,7 +492,6 @@ inlineToAsciiDoc _ il@(RawInline f s)
   | otherwise         = do
       report $ InlineNotRendered il
       return empty
-  | otherwise       = return empty
 inlineToAsciiDoc _ LineBreak = return $ " +" <> cr
 inlineToAsciiDoc _ Space = return space
 inlineToAsciiDoc opts SoftBreak =


### PR DESCRIPTION
The `RawInline` case in `inlineToAsciiDoc` currenty looks like this:

https://github.com/jgm/pandoc/blob/0808c2a03f0dec1cd442e5e3cddfb70419724874/src/Text/Pandoc/Writers/AsciiDoc.hs#L490-L495

Notice how there are there are two overlapping `otherwise` guards. The second `otherwise` guard is completely unreachable, so this patch removes it.