### PR TITLE
update MANUAL.txt - Multi-line block quote

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3096,8 +3096,9 @@ it should not be indented more than three spaces.)
 A "lazy" form, which requires the `>` character only on the first
 line of each block, is also allowed:
 
-    > This is a block quote. This
-    paragraph has two lines.
+    > This is a block quote. This\
+    paragraph has three lines.\
+    The back backslash escape is required.
 
     > 1. This is a list inside a block quote.
     2. Second item.


### PR DESCRIPTION
Multi-line block quotes with pandoc markdown requires escaping with backslashes at end of lines to produced the expected/documented behavior.

This does not work per the current documentation:

```markdown
> This is a block quote. This
paragraph has two lines.
```

Results in: [^1]

```This is a block quote. This paragraph has two lines.```

[^1]: Refers to *pandoc markdown* and not *gfm* which behaves as described.

This will/does work as expected for *pandoc markdown*:

```markdown
> This is a block quote. This\
paragraph has three lines.\
The back backslash escapes are required.
```

Results in: [^2]

```
This is a block quote. This
paragraph has three lines.
The backslash escape is required.
```

[^2]: Refers to *pandoc markdown*.