### PR TITLE
Make MANUAL more explicit about NBSP handling by all_symbols_escapable

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4019,9 +4019,12 @@ which allows only the following characters to be backslash-escaped:
 (However, if the `markdown_strict` format is used, the standard Markdown rule
 will be used.)
 
-A backslash-escaped space is parsed as a nonbreaking space.  It will
-appear in TeX output as `~` and in HTML and XML as `\&#160;` or
-`\&nbsp;`.
+A backslash-escaped space is parsed as a nonbreaking space. In TeX output,
+it will appear as `~`. In HTML and XML output, it will appear as a
+literal unicode nonbreaking space character (note that it will thus
+actually look "invisible" in the generated HTML source; you can still
+use the `--ascii` command-line option to make it appear as an explicit
+entity).
 
 A backslash-escaped newline (i.e. a backslash occurring at the end of
 a line) is parsed as a hard line break.  It will appear in TeX output as


### PR DESCRIPTION
Fixes #6154.

I’m not sure if I should update [man/pandoc.1](https://github.com/jgm/pandoc/blob/master/man/pandoc.1) too? The syntax is quite cryptic, and it looks like it’s actually auto-generated (with Pandoc itself maybe?). If that’s the case, I could auto-generate it (and include the result in this PR), but I’m not sure what command with what set of options I should run to achieve that :man_shrugging:.