### PR TITLE
Custom writer: support pretty-printing with DocLayout

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -6940,10 +6940,14 @@ If you want your custom reader to have access to reader options
 (e.g. the tab stop setting), you give your Reader function a
 second `options` parameter.
 
-A custom writer is a Lua script that defines a function
-that specifies how to render each element in a Pandoc AST.
-To see a documented example which you can modify according
-to your needs:
+A custom writer is a Lua script that defines a function that
+specifies how to render each element in a Pandoc AST.  Each
+of these functions must return either a string, or a `Doc`
+element created through the `pandoc.doclayout` Lua module.
+Whether pandoc passes strings or `Doc` values to the
+functions can be controlled through the
+`PANDOC_USE_DOCLAYOUT` variable.  To get a documented example
+which you can modify according to your needs, do
 
     pandoc --print-default-data-file sample.lua
 

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3742,6 +3742,335 @@ Usage:
       print('type of metavalue `author`:', pandoc.utils.type(meta.author))
     end
 
+# Module pandoc.doclayout
+
+`doclayout` is a prettyprinting library for laying out text
+documents. It is useful to create prettified raw text output.
+
+## Rendering
+
+### render {#pandoc.doclayout.render}
+
+`render (doc[, colwidth])`
+
+Render the `Doc` using the given column width.
+
+Parameters:
+
+`doc`
+:   Doc to render
+
+`colwidth`
+:   Maximum number of characters per line
+
+## Doc construction and combination
+
+All functions return a fresh `Doc` element.
+
+### after_break {#pandoc.doclayout.after_break}
+
+`after_break (doc)`
+
+Creates a `Doc` which is conditionally included only if it comes
+at the beginning of a line.
+
+### before_non_blank {#pandoc.doclayout.before_non_blank}
+
+`before_non_blank (doc)`
+
+Conditionally includes the given `Doc` unless it is followed by a
+blank space.
+
+### blankline {#pandoc.doclayout.blankline}
+
+`blankline`
+
+Inserts a blank line unless one exists already.
+
+### blanklines {#pandoc.doclayout.blanklines}
+
+`blanklines (n)`
+
+Insert blank lines unless they exist already.
+
+Parameters:
+
+`n`
+:   Number of blank lines to insert.
+
+### braces {#pandoc.doclayout.braces}
+
+`braces (doc)`
+
+Puts a `Doc` in curly braces.
+
+### brackets {#pandoc.doclayout.brackets}
+
+`brackets (doc)`
+
+Puts a `Doc` in square brackets.
+
+### cblock {#pandoc.doclayout.cblock}
+
+`cblock (width, doc)`
+
+Like `lblock` but aligned centered.
+
+Parameters:
+
+`width`
+:   Width of the created block, in characters
+
+`doc`
+:   Contents of the block ([Doc])
+
+### chomp {#pandoc.doclayout.chomp}
+
+`chomp (doc)`
+
+Chomps trailing blank space off of a `Doc`.
+
+### concat {#pandoc.doclayout.concat}
+
+`concat (docs[, sep])`
+
+Concatenate the given `Doc`s, interspersing `sep` if specified.
+
+Parameters:
+
+`docs`
+:   List of `Doc`s
+
+`sep`
+:   Separator `Doc`
+
+### cr {#pandoc.doclayout.cr}
+
+`cr`
+
+A carriage return. Does nothing if we're at the beginning of a
+line; otherwise inserts a newline.
+
+### double_quotes {#pandoc.doclayout.double_quotes}
+
+`double_quotes (doc)`
+
+Wraps a `Doc` in double quotes
+
+### empty {#pandoc.doclayout.empty}
+
+`empty`
+
+The empty document.
+
+### flush {#pandoc.doclayout.flush}
+
+`flush (doc)`
+
+Makes a `Doc` flush against the left margin.
+
+### hang {#pandoc.doclayout.hang}
+
+`hang (indent, start, doc)`
+
+Creates a hanging indent.
+
+Parameters:
+
+`indent`
+:   Indentation width in characters
+
+`start`
+:   Start, printed unindented
+
+`doc`
+:   Doc which is indented by `indent` spaces on every line.
+
+### inside {#pandoc.doclayout.inside}
+
+`inside (start, end, contents)`
+
+Encloses a `Doc` inside a start and end `Doc`.
+
+Parameters:
+
+`start`
+:   Doc before contents
+
+`end`
+:   Doc after contents
+
+`contents`
+:   Contents Doc
+
+### lblock {#pandoc.doclayout.lblock}
+
+`lblock (width, doc)`
+
+Creates a block with the given width and content, aligned to the
+left.
+
+Parameters:
+
+`width`
+:   Width of the created block, in characters
+
+`doc`
+:   Contents of the block ([Doc])
+
+
+### literal {#pandoc.doclayout.literal}
+
+`literal (string)`
+
+Creates a `Doc` from a string.
+
+### nest {#pandoc.doclayout.nest}
+
+`nest (indent)`
+
+Indents a `Doc` by the specified number of spaces.
+
+Parameters:
+
+`indent`
+:   Indentation width.
+
+### nestle {#pandoc.doclayout.nestle}
+
+`nestle (doc)`
+
+Removes leading blank lines from a `Doc`.
+
+### nowrap {#pandoc.doclayout.nowrap}
+
+`nowrap (doc)`
+
+Makes a `Doc` non-reflowable.
+
+### parens {#pandoc.doclayout.parens}
+
+`parens (doc)`
+
+Puts a `Doc` in parentheses.
+
+### prefixed {#pandoc.doclayout.prefixed}
+
+`prefixed (prefix, doc)`
+
+Uses the specified string as a prefix for every line of the
+inside document (except the first, if not at the beginning of the
+line).
+
+Parameters:
+
+`prefix`
+:   Prefix to prepend to each line
+
+`doc`
+:   Inside Doc.
+
+### quotes {#pandoc.doclayout.quotes}
+
+`quotes (doc)`
+
+Wraps a `Doc` in single quotes.
+
+### rblock {#pandoc.doclayout.rblock}
+
+`rblock (indent, doc)`
+
+Like `lblock` but aligned to the right.
+
+Parameters:
+
+`width`
+:   Width of the created block, in characters
+
+`doc`
+:   Contents of the block ([Doc])
+
+### space {#pandoc.doclayout.space}
+
+`space`
+
+A breaking (reflowable) space.
+
+### vfill {#pandoc.doclayout.vfill}
+
+`vfill`
+
+Creates an expandable border that, when placed next to a box,
+expands to the height of the box.
+
+Parameters:
+
+`text`
+:   Border text
+
+## Operators
+
+### `..` {#pandoc.doclayout.__concat}
+
+Concatenate two `Doc` elements.
+
+### `+` {#pandoc.doclayout.__add}
+
+Concatenate two `Doc`s, inserting a reflowable space between them.
+
+### `/` {#pandoc.doclayout.__div}
+
+If `a` and `b` are `Doc` elements, then `a / b` puts `a` above `b`.
+
+### `//` {#pandoc.doclayout.__idiv}
+
+If `a` and `b` are `Doc` elements, then `a // b` puts `a` above
+`b`, inserting a blank line between them.
+
+## Document Querying
+
+### is_empty {#pandoc.doclayout.is_empty}
+
+`is_empty (doc)`
+
+Returns `true` iff `doc` is the empty document, `false`
+otherwise.
+
+### min_offset {#pandoc.doclayout.min_offset}
+
+`min_offset (doc)`
+
+Returns the minimal width of a @'Doc'@ when reflowed at breakable
+spaces.
+
+### update_column {#pandoc.doclayout.update_column}
+
+`update_column (doc, i)`
+
+Returns the column that would be occupied by the last laid out
+character.
+
+### height {#pandoc.doclayout.height}
+
+`height (doc)`
+
+Returns the height of a block or other Doc.
+
+### real_length {#pandoc.doclayout.real_length}
+
+`real_length (str)`
+
+Returns the real length of a string in a monospace font: 0 for a
+combining character, 1, for a regular character, 2 for an East
+Asian wide character.
+
+### offset {#pandoc.doclayout.offset}
+
+`offset (doc)`
+
+Returns the width of a `Doc` (as number of characters).
+
+
 # Module pandoc.mediabag
 
 The `pandoc.mediabag` module allows accessing pandoc's media

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -359,6 +359,7 @@ extra-source-files:
                  test/writer.xwiki
                  test/writer.muse
                  test/writer.custom
+                 test/writer.custom-doclayout
                  test/writers-lang-and-dir.latex
                  test/writers-lang-and-dir.context
                  test/dokuwiki_inline_formatting.dokuwiki
@@ -408,6 +409,7 @@ extra-source-files:
                  test/lua/module/*.lua
                  test/lua/module/partial.test
                  test/lua/module/tiny.epub
+                 test/lua/writers/*.lua
 source-repository head
   type:          git
   location:      git://github.com/jgm/pandoc.git
@@ -483,6 +485,7 @@ library
                  hslua                 >= 2.1      && < 2.2,
                  hslua-aeson           >= 2.1      && < 2.2,
                  hslua-marshalling     >= 2.1      && < 2.2,
+                 hslua-module-doclayout >= 1.0.1   && < 1.1,
                  hslua-module-path     >= 1.0      && < 1.1,
                  hslua-module-system   >= 1.0      && < 1.1,
                  hslua-module-text     >= 1.0      && < 1.1,

--- a/src/Text/Pandoc/Lua/Packages.hs
+++ b/src/Text/Pandoc/Lua/Packages.hs
@@ -21,6 +21,7 @@ import Text.Pandoc.Lua.Marshal.List (pushListModule)
 import Text.Pandoc.Lua.PandocLua (PandocLua, liftPandocLua)
 
 import qualified HsLua as Lua
+import qualified HsLua.Module.DocLayout as DocLayout
 import qualified HsLua.Module.Path as Path
 import qualified HsLua.Module.Text as Text
 import qualified Text.Pandoc.Lua.Module.Pandoc as Pandoc
@@ -48,6 +49,7 @@ pandocPackageSearcher :: String -> PandocLua Lua.NumResults
 pandocPackageSearcher pkgName =
   case pkgName of
     "pandoc"          -> pushModuleLoader Pandoc.documentedModule
+    "pandoc.doclayout"-> pushModuleLoader DocLayout.documentedModule
     "pandoc.mediabag" -> pushModuleLoader MediaBag.documentedModule
     "pandoc.path"     -> pushModuleLoader Path.documentedModule
     "pandoc.system"   -> pushModuleLoader System.documentedModule

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,6 +18,7 @@ extra-deps:
 - hslua-classes-2.1.0
 - hslua-core-2.1.0
 - hslua-marshalling-2.1.0
+- hslua-module-doclayout-1.0.0
 - hslua-module-path-1.0.1
 - hslua-module-system-1.0.1
 - hslua-module-text-1.0.1

--- a/test/Tests/Old.hs
+++ b/test/Tests/Old.hs
@@ -199,6 +199,9 @@ tests pandocPath =
       "testsuite.native" "writer.custom"
     , test' "tables" ["-f", "native", "-t", "../data/sample.lua"]
       "tables.native" "tables.custom"
+    , test' "doclayout" [ "-f", "native", "-t", "lua/writers/md-doclayout.lua"
+                        , "--columns", "78"]
+      "testsuite.native" "writer.custom-doclayout"
     ]
   , testGroup "man"
     [ test' "reader" ["-r", "man", "-w", "native", "-s"]

--- a/test/lua/writers/md-doclayout.lua
+++ b/test/lua/writers/md-doclayout.lua
@@ -1,0 +1,209 @@
+-- This is a sample custom writer for pandoc, using DocLayout to
+-- produce nicely wrapped output.
+
+PANDOC_USE_DOCLAYOUT = true
+
+doclayout = require 'pandoc.doclayout'
+text = require 'text'
+
+-- Table to store footnotes, so they can be included at the end.
+local notes = pandoc.List()
+
+-- Blocksep is used to separate block elements.
+function Blocksep()
+  return doclayout.blankline
+end
+
+-- This function is called once for the whole document. Parameters:
+-- body is a Doc, metadata is a table, variables is a table.
+-- This gives you a fragment.  You could use the metadata table to
+-- fill variables in a custom lua template.  Or, pass `--template=...`
+-- to pandoc, and pandoc will do the template processing as usual.
+function Doc(body, metadata, variables)
+  local buffer = pandoc.List()
+  buffer:insert(body)
+  for i, note in ipairs(notes) do
+    buffer:insert(
+      doclayout.blankline ..
+      doclayout.hang(5, '[^' .. tostring(i) .. ']: ', note)
+    )
+  end
+  return doclayout.concat(buffer, doclayout.cr) .. doclayout.cr
+end
+
+function Str(s)
+  return s:gsub('[%[%]%#%`%\\]', '\\%0')
+end
+
+function Space()
+  return doclayout.space
+end
+
+function SoftBreak()
+  return doclayout.space
+end
+
+function LineBreak()
+  return doclayout.cr
+end
+
+function Emph(s)
+  return "_" .. s .. "_"
+end
+
+function Strong(s)
+  return "**" .. s .. "**"
+end
+
+function Subscript(s)
+  return "~" .. s .. "~"
+end
+
+function Superscript(s)
+  return "^" .. s .. "^"
+end
+
+function SmallCaps(s)
+  return text.upper(s)
+end
+
+function Strikeout(s)
+  return '<del>' .. s .. '</del>'
+end
+
+function Link(s, src, tit, attr)
+  local title = tit == ''
+    and ''
+    or ' ' .. tit:gsub('"', '\\"')
+  return doclayout.inside('[', ']', s) ..
+    doclayout.inside('(', ')', src .. title)
+end
+
+function Image(s, src, tit, attr)
+  return '!' .. Link(s, src, tit, attr)
+end
+
+function Code(s, attr)
+  return doclayout.inside('`', '`', s)
+end
+
+function InlineMath(s)
+  return doclayout.inside('$', '$', s)
+end
+
+function DisplayMath(s)
+  return doclayout.inside('$$', '$$', s)
+end
+
+function SingleQuoted(s)
+  return "'" .. s .. "'"
+end
+
+function DoubleQuoted(s)
+  return '"' .. s .. '"'
+end
+
+function Note(s)
+  notes:insert(s)
+  return '[^' .. tostring(#notes) .. ']'
+end
+
+function Span(s, attr)
+  return s
+end
+
+function RawInline(format, str)
+  return format == "markdown" and str or ''
+end
+
+function Cite(s, cs)
+  return s
+end
+
+function Plain(s)
+  return s
+end
+
+function Para(s)
+  return s
+end
+
+-- lev is an integer, the header level.
+function Header(lev, s, attr)
+  return doclayout.nowrap(string.rep('#', lev) + s)
+end
+
+function BlockQuote(s)
+  return doclayout.prefixed('> ', s)
+end
+
+function HorizontalRule()
+  return string.rep('- ', 8):sub(1, -2)
+end
+
+function LineBlock(ls)
+  return '<div style="white-space: pre-line;">' .. table.concat(ls, '\n') ..
+         '</div>'
+end
+
+function CodeBlock(s, attr)
+  return doclayout.literal '```' / s / '```'
+end
+
+function BulletList(items)
+  local result = pandoc.List()
+  for _, item in ipairs(items) do
+    result:insert(doclayout.hang(2, '- ', item))
+  end
+  return doclayout.concat(result, doclayout.blankline)
+end
+
+function OrderedList(items)
+  local result = pandoc.List()
+  for i, item in ipairs(items) do
+    result:insert(doclayout.hang(3, tostring(i) .. '. ', item))
+  end
+  return doclayout.concat(result, doclayout.blankline)
+end
+
+function DefinitionList(items)
+  local result = pandoc.List()
+  for i, item in ipairs(items) do
+    local key, value = next(item)
+    result:insert(
+      doclayout.hang(2,
+        key .. doclayout.cr,
+        doclayout.concat(value, doclayout.blankline)
+      )
+    )
+  end
+  return doclayout.concat(result, doclayout.blankline)
+end
+
+function CaptionedImage(src, tit, caption, attr)
+  return Image(caption, src, tit, attr)
+end
+
+function Table(caption, aligns, widths, headers, rows)
+  return ''
+end
+
+function RawBlock(format, str)
+  return format == 'markdown' and str or ''
+end
+
+function Div(s, attr)
+  return s
+end
+
+-- The following code will produce runtime warnings when you
+-- haven't defined all of the functions you need for the custom
+-- writer, so it's useful to include when you're working on a
+-- writer.
+local meta = {}
+meta.__index =
+  function(_, key)
+    io.stderr:write(string.format("WARNING: Undefined function '%s'\n",key))
+    return function() return "" end
+  end
+setmetatable(_G, meta)

--- a/test/writer.custom-doclayout
+++ b/test/writer.custom-doclayout
@@ -1,0 +1,700 @@
+This is a set of tests for pandoc. Most of them are adapted from John Gruber’s
+markdown test suite.
+
+- - - - - - - -
+
+# Headers
+
+## Level 2 with an [embedded link](/url)
+
+### Level 3 with _emphasis_
+
+#### Level 4
+
+##### Level 5
+
+# Level 1
+
+## Level 2 with _emphasis_
+
+### Level 3
+
+with no blank line
+
+## Level 2
+
+with no blank line
+
+- - - - - - - -
+
+# Paragraphs
+
+Here’s a regular paragraph.
+
+In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item.
+Because a hard-wrapped line in the middle of a paragraph looked like a list
+item.
+
+Here’s one with a bullet. * criminey.
+
+There should be a hard line break
+here.
+
+- - - - - - - -
+
+# Block Quotes
+
+E-mail style:
+
+> This is a block quote. It is pretty short.
+
+> Code in a block quote:
+>
+> ```
+> sub status {
+>     print "working";
+> }
+> ```
+>
+> A list:
+>
+> 1. item one
+>
+> 2. item two
+>
+> Nested block quotes:
+>
+> > nested
+>
+> > nested
+
+This should not be a block quote: 2 > 1.
+
+And a following paragraph.
+
+- - - - - - - -
+
+# Code Blocks
+
+Code:
+
+```
+---- (should be four hyphens)
+
+sub status {
+    print "working";
+}
+
+this code block is indented by one tab
+```
+
+And:
+
+```
+    this code block is indented by two tabs
+
+These should not be escaped:  \$ \\ \> \[ \{
+```
+
+- - - - - - - -
+
+# Lists
+
+## Unordered
+
+Asterisks tight:
+
+- asterisk 1
+
+- asterisk 2
+
+- asterisk 3
+
+Asterisks loose:
+
+- asterisk 1
+
+- asterisk 2
+
+- asterisk 3
+
+Pluses tight:
+
+- Plus 1
+
+- Plus 2
+
+- Plus 3
+
+Pluses loose:
+
+- Plus 1
+
+- Plus 2
+
+- Plus 3
+
+Minuses tight:
+
+- Minus 1
+
+- Minus 2
+
+- Minus 3
+
+Minuses loose:
+
+- Minus 1
+
+- Minus 2
+
+- Minus 3
+
+## Ordered
+
+Tight:
+
+1. First
+
+2. Second
+
+3. Third
+
+and:
+
+1. One
+
+2. Two
+
+3. Three
+
+Loose using tabs:
+
+1. First
+
+2. Second
+
+3. Third
+
+and using spaces:
+
+1. One
+
+2. Two
+
+3. Three
+
+Multiple paragraphs:
+
+1. Item 1, graf one.
+
+   Item 1. graf two. The quick brown fox jumped over the lazy dog’s back.
+
+2. Item 2.
+
+3. Item 3.
+
+## Nested
+
+- Tab
+
+  - Tab
+
+    - Tab
+
+Here’s another:
+
+1. First
+
+2. Second:
+
+   - Fee
+
+   - Fie
+
+   - Foe
+
+3. Third
+
+Same thing but with paragraphs:
+
+1. First
+
+2. Second:
+
+   - Fee
+
+   - Fie
+
+   - Foe
+
+3. Third
+
+## Tabs and spaces
+
+- this is a list item indented with tabs
+
+- this is a list item indented with spaces
+
+  - this is an example list item indented with tabs
+
+  - this is an example list item indented with spaces
+
+## Fancy list markers
+
+1. begins with 2
+
+2. and now 3
+
+   with a continuation
+
+   1. sublist with roman numerals, starting with 4
+
+   2. more items
+
+      1. a subsublist
+
+      2. a subsublist
+
+Nesting:
+
+1. Upper Alpha
+
+   1. Upper Roman.
+
+      1. Decimal start with 6
+
+         1. Lower alpha with paren
+
+Autonumbering:
+
+1. Autonumber.
+
+2. More.
+
+   1. Nested.
+
+Should not be a list item:
+
+M.A. 2007
+
+B. Williams
+
+- - - - - - - -
+
+# Definition Lists
+
+Tight using spaces:
+
+apple
+  red fruit
+
+orange
+  orange fruit
+
+banana
+  yellow fruit
+
+Tight using tabs:
+
+apple
+  red fruit
+
+orange
+  orange fruit
+
+banana
+  yellow fruit
+
+Loose:
+
+apple
+  red fruit
+
+orange
+  orange fruit
+
+banana
+  yellow fruit
+
+Multiple blocks with italics:
+
+_apple_
+  red fruit
+
+  contains seeds, crisp, pleasant to taste
+
+_orange_
+  orange fruit
+
+  ```
+  { orange code block }
+  ```
+
+  > orange block quote
+
+Multiple definitions, tight:
+
+apple
+  red fruit
+
+  computer
+
+orange
+  orange fruit
+
+  bank
+
+Multiple definitions, loose:
+
+apple
+  red fruit
+
+  computer
+
+orange
+  orange fruit
+
+  bank
+
+Blank line after term, indented marker, alternate markers:
+
+apple
+  red fruit
+
+  computer
+
+orange
+  orange fruit
+
+  1. sublist
+
+  2. sublist
+
+# HTML Blocks
+
+Simple block on one line:
+
+foo
+
+And nested without indentation:
+
+foo
+
+bar
+
+Interpreted markdown in a table:
+
+This is _emphasized_
+
+And this is **strong**
+
+Here’s a simple block:
+
+foo
+
+This should be a code block, though:
+
+```
+<div>
+    foo
+</div>
+```
+
+As should this:
+
+```
+<div>foo</div>
+```
+
+Now, nested:
+
+foo
+
+This should just be an HTML comment:
+
+Multiline:
+
+Code block:
+
+```
+<!-- Comment -->
+```
+
+Just plain comment, with trailing spaces on the line:
+
+Code:
+
+```
+<hr />
+```
+
+Hr’s:
+
+- - - - - - - -
+
+# Inline Markup
+
+This is _emphasized_, and so _is this_.
+
+This is **strong**, and so **is this**.
+
+An _[emphasized link](/url)_.
+
+**_This is strong and em._**
+
+So is **_this_** word.
+
+**_This is strong and em._**
+
+So is **_this_** word.
+
+This is code: `>`, `$`, `\`, `\$`, `<html>`.
+
+<del>This is _strikeout_.</del>
+
+Superscripts: a^bc^d a^_hello_^ a^hello there^.
+
+Subscripts: H~2~O, H~23~O, H~many of them~O.
+
+These should not be superscripts or subscripts, because of the unescaped
+spaces: a^b c^d, a~b c~d.
+
+- - - - - - - -
+
+# Smart quotes, ellipses, dashes
+
+"Hello," said the spider. "'Shelob' is my name."
+
+'A', 'B', and 'C' are letters.
+
+'Oak,' 'elm,' and 'beech' are names of trees. So is 'pine.'
+
+'He said, "I want to go."' Were you alive in the 70’s?
+
+Here is some quoted '`code`' and a "[quoted
+link](http://example.com/?foo=1&bar=2)".
+
+Some dashes: one—two — three—four — five.
+
+Dashes between numbers: 5–7, 255–66, 1987–1999.
+
+Ellipses…and…and….
+
+- - - - - - - -
+
+# LaTeX
+
+- 
+
+- $2+2=4$
+
+- $x \in y$
+
+- $\alpha \wedge \omega$
+
+- $223$
+
+- $p$-Tree
+
+- Here’s some display math:
+  $$\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}$$
+
+- Here’s one that has a line break in it: $\alpha + \omega \times x^2$.
+
+These shouldn’t be math:
+
+- To get the famous equation, write `$e = mc^2$`.
+
+- $22,000 is a _lot_ of money. So is $34,000. (It worked if "lot" is
+  emphasized.)
+
+- Shoes ($20) and socks ($5).
+
+- Escaped `$`: $73 _this should be emphasized_ 23$.
+
+Here’s a LaTeX table:
+
+- - - - - - - -
+
+# Special Characters
+
+Here is some unicode:
+
+- I hat: Î
+
+- o umlaut: ö
+
+- section: §
+
+- set membership: ∈
+
+- copyright: ©
+
+AT&T has an ampersand in their name.
+
+AT&T is another way to write it.
+
+This & that.
+
+4 < 5.
+
+6 > 5.
+
+Backslash: \\
+
+Backtick: \`
+
+Asterisk: *
+
+Underscore: _
+
+Left brace: {
+
+Right brace: }
+
+Left bracket: \[
+
+Right bracket: \]
+
+Left paren: (
+
+Right paren: )
+
+Greater-than: >
+
+Hash: \#
+
+Period: .
+
+Bang: !
+
+Plus: +
+
+Minus: -
+
+- - - - - - - -
+
+# Links
+
+## Explicit
+
+Just a [URL](/url/).
+
+[URL and title](/url/ title).
+
+[URL and title](/url/ title preceded by two spaces).
+
+[URL and title](/url/ title preceded by a tab).
+
+[URL and title](/url/ title with \"quotes\" in it)
+
+[URL and title](/url/ title with single quotes)
+
+[with_underscore](/url/with_underscore)
+
+[Email link](mailto:nobody@nowhere.net)
+
+[Empty]().
+
+## Reference
+
+Foo [bar](/url/).
+
+With [embedded \[brackets\]](/url/).
+
+[b](/url/) by itself should be a link.
+
+Indented [once](/url).
+
+Indented [twice](/url).
+
+Indented [thrice](/url).
+
+This should \[not\]\[\] be a link.
+
+```
+[not]: /url
+```
+
+Foo [bar](/url/ Title with \"quotes\" inside).
+
+Foo [biz](/url/ Title with \"quote\" inside).
+
+## With ampersands
+
+Here’s a [link with an ampersand in the URL](http://example.com/?foo=1&bar=2).
+
+Here’s a link with an amersand in the link text: [AT&T](http://att.com/ AT&T).
+
+Here’s an [inline link](/script?foo=1&bar=2).
+
+Here’s an [inline link in pointy braces](/script?foo=1&bar=2).
+
+## Autolinks
+
+With an ampersand:
+[http://example.com/?foo=1&bar=2](http://example.com/?foo=1&bar=2)
+
+- In a list?
+
+- [http://example.com/](http://example.com/)
+
+- It should.
+
+An e-mail address: [nobody@nowhere.net](mailto:nobody@nowhere.net)
+
+> Blockquoted: [http://example.com/](http://example.com/)
+
+Auto-links should not occur here: `<http://example.com/>`
+
+```
+or here: <http://example.com/>
+```
+
+- - - - - - - -
+
+# Images
+
+From "Voyage dans la Lune" by Georges Melies (1902):
+
+![lalune](lalune.jpg fig:Voyage dans la Lune)
+
+Here is a movie ![movie](movie.jpg) icon.
+
+- - - - - - - -
+
+# Footnotes
+
+Here is a footnote reference,[^1] and another.[^2] This should _not_ be a
+footnote reference, because it contains a space.\[^my note\] Here is an inline
+note.[^3]
+
+> Notes can go in quotes.[^4]
+
+1. And in list items.[^5]
+
+This paragraph should not be part of the note, as it is not indented.
+
+[^1]: Here is the footnote. It can go anywhere after the footnote reference.
+     It need not be placed at the end of the document.
+
+[^2]: Here’s the long note. This one contains multiple blocks.
+
+     Subsequent blocks are indented to show that they belong to the footnote
+     (as with list items).
+
+     ```
+       { <code> }
+     ```
+
+     If you want, you can indent every line, but you can also be lazy and just
+     indent the first line of each block.
+
+[^3]: This is _easier_ to type. Inline notes may contain
+     [links](http://google.com) and `]` verbatim characters, as well as
+     \[bracketed text\].
+
+[^4]: In quote.
+
+[^5]: In list.


### PR DESCRIPTION
This would allow users to use the full power the DocLayout library in their custom writers.

Unfortunately, this is not fully backwards compatible. We could probably hide it behind some kind of toggle.