### PR TITLE
Vimwiki reader: Add nested syntax highlighting

### DIFF
--- a/src/Text/Pandoc/Readers/Vimwiki.hs
+++ b/src/Text/Pandoc/Readers/Vimwiki.hs
@@ -236,7 +236,11 @@ preformatted = try $ do
 makeAttr :: Text -> Attr
 makeAttr s =
   let xs = splitTextBy (`elem` (" \t" :: String)) s in
-    ("", [], mapMaybe nameValue xs)
+    ("", syntax xs, mapMaybe nameValue xs)
+
+syntax :: [Text] -> [Text]
+syntax (s:_) | not $ T.isInfixOf "=" s = [s]
+syntax _ = []
 
 nameValue :: Text -> Maybe (Text, Text)
 nameValue s =

--- a/test/vimwiki-reader.native
+++ b/test/vimwiki-reader.native
@@ -49,6 +49,8 @@ Pandoc (Meta {unMeta = fromList [("date",MetaInlines [Str "2017-05-01"]),("title
 ,CodeBlock ("",[],[]) "  Tyger! Tyger! burning bright\n   In the forests of the night,\n    What immortal hand or eye\n     Could frame thy fearful symmetry?\n  In what distant deeps or skies\n   Burnt the fire of thine eyes?\n    On what wings dare he aspire?\n     What the hand dare sieze the fire?"
 ,Header 3 ("preformatted text with attributes",[],[]) [Str "preformatted",Space,Str "text",Space,Str "with",Space,Str "attributes"]
 ,CodeBlock ("",[],[("class","python"),("style","color:blue")]) " for i in range(1, 5):\n     print(i)"
+,Header 3 ("preformatted text with nested syntax",[],[]) [Str "preformatted",Space,Str "text",Space,Str "with",Space,Str "nested",Space,Str "syntax"]
+,CodeBlock ("",["sql"],[]) "SELECT * FROM table"
 ,Header 3 ("empty preformatted text",[],[]) [Str "empty",Space,Str "preformatted",Space,Str "text"]
 ,CodeBlock ("",[],[]) ""
 ,Header 2 ("block quotes",[],[]) [Str "block",Space,Str "quotes"]

--- a/test/vimwiki-reader.wiki
+++ b/test/vimwiki-reader.wiki
@@ -117,6 +117,12 @@ Just two backticks: ``
      print(i)
  }}}
 
+=== preformatted text with nested syntax ===
+
+{{{sql
+SELECT * FROM table
+}}}
+
 === empty preformatted text ===
 
 {{{


### PR DESCRIPTION
Nested syntaxes are specified like this:
{{{sql
SELECT * FROM table
}}}

The preformatted code block parser has been extended to check if the
first attribute of the block is not a `key=value` pair, and in that case
it will be considered as a class.

Closes #6256.