### PR TITLE
Opting out of a Reveal.js theme with no-theme

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -21,10 +21,13 @@ $endif$
   <style>
     $styles.html()$
   </style>
+$if(no-theme)$
+$else$
 $if(theme)$
   <link rel="stylesheet" href="$revealjs-url$/css/theme/$theme$.css" id="theme">
 $else$
   <link rel="stylesheet" href="$revealjs-url$/css/theme/black.css" id="theme">
+$endif$
 $endif$
 $for(css)$
   <link rel="stylesheet" href="$css$"/>


### PR DESCRIPTION
I've written my own Reveal.js theme, and I'm using `revealjs-url=https://revealjs.com`, which means that the only way to include my theme is with Pandoc's existing `css` variable in the `revealjs` template.

The problem is that the `revealjs` template defaults to `black.css` when no `theme` variable is given, which means my custom theme has to go to extra effort to reset the styles introduced by `black.css`. I'd rather have a way to opt out of that.

I think the current default (no `theme` implies `black.css`) is a good default for people, so I've added another variable to opt in to no theme: `no-theme`.


```yaml
---
no-theme: true
---
```