### PR TITLE
Add option to not surrounding display math in <br>

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1558,6 +1558,7 @@ reference-doc: myref.docx
 html-math-method:
   method: mathjax
   url: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+html-math-surround-br: true
 # none, references, or javascript
 email-obfuscation: javascript
 

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -720,6 +720,12 @@ options =
                       return opt { optHTMLMathMethod = GladTeX }))
                  "" -- "Use gladtex for HTML math"
 
+    , Option "" ["no-html-math-surround-br"]
+                 (NoArg
+                  (\opt ->
+                      return opt { optHTMLMathSurroundBr = False }))
+                 "" -- "Don't surround display math with br in html output."
+
     , Option "" ["trace"]
                  (NoArg
                   (\opt -> return opt { optTrace = True }))

--- a/src/Text/Pandoc/App/Opt.hs
+++ b/src/Text/Pandoc/App/Opt.hs
@@ -96,6 +96,7 @@ data Opt = Opt
     , optSyntaxDefinitions     :: [FilePath]  -- ^ xml syntax defs to load
     , optTopLevelDivision      :: TopLevelDivision -- ^ Type of the top-level divisions
     , optHTMLMathMethod        :: HTMLMathMethod -- ^ Method to print HTML math
+    , optHTMLMathSurroundBr    :: Bool -- ^ Whether to put <br> around display math elements
     , optAbbreviations         :: Maybe FilePath -- ^ Path to abbrevs file
     , optReferenceDoc          :: Maybe FilePath -- ^ Path of reference doc
     , optEpubSubdirectory      :: String -- ^ EPUB subdir in OCF container
@@ -245,6 +246,8 @@ doOpt (k',v) = do
       parseYAML v >>= \x -> return (\o -> o{ optTopLevelDivision = x })
     "html-math-method" ->
       parseYAML v >>= \x -> return (\o -> o{ optHTMLMathMethod = x })
+    "html-math-surround-br" ->
+      parseYAML v >>= \x -> return (\o -> o{ optHTMLMathSurroundBr = x })
     "abbreviations" ->
       parseYAML v >>= \x ->
              return (\o -> o{ optAbbreviations = unpack <$> x })
@@ -426,6 +429,7 @@ defaultOpts = Opt
     , optSyntaxDefinitions     = []
     , optTopLevelDivision      = TopLevelDefault
     , optHTMLMathMethod        = PlainMath
+    , optHTMLMathSurroundBr    = True
     , optAbbreviations         = Nothing
     , optReferenceDoc          = Nothing
     , optEpubSubdirectory      = "EPUB"

--- a/src/Text/Pandoc/App/OutputSettings.hs
+++ b/src/Text/Pandoc/App/OutputSettings.hs
@@ -184,6 +184,7 @@ optToOutputSettings opts = do
         , writerTabStop          = optTabStop opts
         , writerTableOfContents  = optTableOfContents opts
         , writerHTMLMathMethod   = optHTMLMathMethod opts
+        , writerHTMLMathSurroundBr = optHTMLMathSurroundBr opts
         , writerIncremental      = optIncremental opts
         , writerCiteMethod       = optCiteMethod opts
         , writerNumberSections   = optNumberSections opts

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -235,6 +235,7 @@ data WriterOptions = WriterOptions
   , writerTableOfContents   :: Bool   -- ^ Include table of contents
   , writerIncremental       :: Bool   -- ^ True if lists should be incremental
   , writerHTMLMathMethod    :: HTMLMathMethod  -- ^ How to print math in HTML
+  , writerHTMLMathSurroundBr:: Bool   -- ^ Whether to put <br> around display math in HTML
   , writerNumberSections    :: Bool   -- ^ Number sections in LaTeX
   , writerNumberOffset      :: [Int]  -- ^ Starting number for section, subsection, ...
   , writerSectionDivs       :: Bool   -- ^ Put sections in div tags in HTML
@@ -272,6 +273,7 @@ instance Default WriterOptions where
                       , writerTableOfContents  = False
                       , writerIncremental      = False
                       , writerHTMLMathMethod   = PlainMath
+                      , writerHTMLMathSurroundBr = True
                       , writerNumberSections   = False
                       , writerNumberOffset     = [0,0,0,0,0,0]
                       , writerSectionDivs      = False

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -1114,8 +1114,9 @@ inlineToHtml opts inline = do
                             ! A.title (toValue str)
               let brtag = if html5 then H5.br else H.br
               return $ case t of
-                        InlineMath  -> m
-                        DisplayMath -> brtag >> m >> brtag
+                        DisplayMath | writerHTMLMathSurroundBr opts
+                          -> brtag >> m >> brtag
+                        _  -> m
            GladTeX ->
               return $
                 customParent (textTag "eq") !
@@ -1145,8 +1146,9 @@ inlineToHtml opts inline = do
               let m = H.span ! A.class_ mathClass $ x
               let brtag = if html5 then H5.br else H.br
               return  $ case t of
-                         InlineMath  -> m
-                         DisplayMath -> brtag >> m >> brtag
+                         DisplayMath | writerHTMLMathSurroundBr opts
+                           -> brtag >> m >> brtag
+                         _ -> m
     (RawInline f str) -> do
       ishtml <- isRawHtml f
       if ishtml


### PR DESCRIPTION
Motivation is that I would rather handle the spacing with CSS. Also when using pandoc-crossref with the tableEqns options it formats equations with references inside a table and the <br>s mess up spacing.