### PR TITLE
Correct license listed in cabal

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -2,7 +2,7 @@ name:            pandoc
 version:         2.9.2.1
 cabal-version:   2.0
 build-type:      Simple
-license:         GPL-2
+license:         GPL-2.0-or-later
 license-file:    COPYING.md
 copyright:       (c) 2006-2020 John MacFarlane
 author:          John MacFarlane <jgm@berkeley.edu>


### PR DESCRIPTION
`GPL-2` is interpreted as `GPL-2.0-only` only and is displayed as such on Hackage, however according to all the headers in the actual Haskell files the license is GPLv2 or later, i.e. `GPL-2.0-or-later` (https://spdx.org/licenses/).