### PR TITLE
More flexible citation key syntax #6026

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4825,7 +4825,7 @@ Each citation must have a key, composed of '@' + the citation
 identifier from the database, and may optionally have a prefix,
 a locator, and a suffix.  The citation key must begin with a letter, digit,
 or `_`, and may contain alphanumerics, `_`, and internal punctuation
-characters (`:.#$%&-+?<>~/`).  If you want to use a citation key that do not
+characters (`:.#$%&-+?<>~/`).  If you want to use a citation key that does not
 conform to these constraints, enclose the key in curly braces (`{` and `}`).
 Inside the curly braces, the characters `}` and `\\` must be backslash-escaped.
 Here are some examples:

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4825,13 +4825,20 @@ Each citation must have a key, composed of '@' + the citation
 identifier from the database, and may optionally have a prefix,
 a locator, and a suffix.  The citation key must begin with a letter, digit,
 or `_`, and may contain alphanumerics, `_`, and internal punctuation
-characters (`:.#$%&-+?<>~/`).  Here are some examples:
+characters (`:.#$%&-+?<>~/`).  Alternatively arbitrary citation keys
+can be given inbetween `{` and `}`. Inside them `}` and `\` can be escaped
+using `\`. Here are some examples:
 
     Blah blah [see @doe99, pp. 33-35; also @smith04, chap. 1].
 
     Blah blah [@doe99, pp. 33-35, 38-39 and *passim*].
 
     Blah blah [@smith04; @doe99].
+
+You can also use citation keys directly without brackets:
+
+    Blah blah @smith04.
+    @{A more complex cite key}
 
 `pandoc-citeproc` detects locator terms in the [CSL locale files].
 Either abbreviated or unabbreviated forms are accepted. In the `en-US`

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4825,9 +4825,10 @@ Each citation must have a key, composed of '@' + the citation
 identifier from the database, and may optionally have a prefix,
 a locator, and a suffix.  The citation key must begin with a letter, digit,
 or `_`, and may contain alphanumerics, `_`, and internal punctuation
-characters (`:.#$%&-+?<>~/`).  Alternatively arbitrary citation keys
-can be given inbetween `{` and `}`. Inside them `}` and `\` can be escaped
-using `\`. Here are some examples:
+characters (`:.#$%&-+?<>~/`).  If you want to use a citation key that do not
+conform to these constraints, enclose the key in curly braces (`{` and `}`).
+Inside the curly braces, the characters `}` and `\\` must be backslash-escaped.
+Here are some examples:
 
     Blah blah [see @doe99, pp. 33-35; also @smith04, chap. 1].
 
@@ -4835,10 +4836,7 @@ using `\`. Here are some examples:
 
     Blah blah [@smith04; @doe99].
 
-You can also use citation keys directly without brackets:
-
-    Blah blah @smith04.
-    @{A more complex cite key}
+    Blah blah [@{more complex citekey}]
 
 `pandoc-citeproc` detects locator terms in the [CSL locale files].
 Either abbreviated or unabbreviated forms are accepted. In the `en-US`

--- a/doc/org.md
+++ b/doc/org.md
@@ -127,9 +127,10 @@ the citation identifier from the database, and may optionally
 have a prefix, a locator, and a suffix. The citation key must
 begin with a letter, digit, or `_`, and may contain
 alphanumerics, `_`, and internal punctuation characters
-(`:.#$%&-+?<>~/`). Alternatively arbitrary citation keys can be
-given inbetween `{` and `}`. Inside them `}` and `\` can be
-escaped using `\`.
+(`:.#$%&-+?<>~/`). If you want to use a citation key that do not
+conform to these constraints, enclose the key in curly braces
+(`{` and `}`). Inside the curly braces, the characters `}` and
+`\\` must be backslash-escaped.
 
 ### Simple citation
 
@@ -139,11 +140,10 @@ ID prefixed by '@'.
 
 Example:
 
-    @citekey
-    @{this is a citekey}
     [prefix @citekey suffix]
     [see @doe2000 pp. 23-42]
     [@doe2000 p. 5; to a lesser extend @doe2005]
+    [@{more complex citekey}]
 
 
 LaTeX-Syntax

--- a/doc/org.md
+++ b/doc/org.md
@@ -127,7 +127,9 @@ the citation identifier from the database, and may optionally
 have a prefix, a locator, and a suffix. The citation key must
 begin with a letter, digit, or `_`, and may contain
 alphanumerics, `_`, and internal punctuation characters
-(`:.#$%&-+?<>~/`). Here are some examples:
+(`:.#$%&-+?<>~/`). Alternatively arbitrary citation keys can be
+given inbetween `{` and `}`. Inside them `}` and `\` can be
+escaped using `\`.
 
 ### Simple citation
 
@@ -137,6 +139,8 @@ ID prefixed by '@'.
 
 Example:
 
+    @citekey
+    @{this is a citekey}
     [prefix @citekey suffix]
     [see @doe2000 pp. 23-42]
     [@doe2000 p. 5; to a lesser extend @doe2005]

--- a/doc/org.md
+++ b/doc/org.md
@@ -127,7 +127,7 @@ the citation identifier from the database, and may optionally
 have a prefix, a locator, and a suffix. The citation key must
 begin with a letter, digit, or `_`, and may contain
 alphanumerics, `_`, and internal punctuation characters
-(`:.#$%&-+?<>~/`). If you want to use a citation key that do not
+(`:.#$%&-+?<>~/`). If you want to use a citation key that does not
 conform to these constraints, enclose the key in curly braces
 (`{` and `}`). Inside the curly braces, the characters `}` and
 `\\` must be backslash-escaped.

--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -1468,12 +1468,14 @@ citeKey = try $ do
   guard =<< notAfterString
   suppress_author <- option False (True <$ char '-')
   char '@'
-  firstChar <- alphaNum <|> char '_' <|> char '*' -- @* for wildcard in nocite
-  let regchar = satisfy (\c -> isAlphaNum c || c == '_')
-  let internal p = try $ p <* lookAhead regchar
-  rest <- many $ regchar <|> internal (oneOf ":.#$%&-+?<>~/") <|>
-                 try (oneOf ":/" <* lookAhead (char '/'))
-  let key = firstChar:rest
+  key <-
+    do firstChar <- alphaNum <|> char '_' <|> char '*' -- @* for wildcard in nocite
+       let regchar = satisfy (\c -> isAlphaNum c || c == '_')
+       let internal p = try $ p <* lookAhead regchar
+       rest <- many $ regchar <|> internal (oneOf ":.#$%&-+?<>~/") <|>
+                      try (oneOf ":/" <* lookAhead (char '/'))
+       pure $ firstChar:rest
+    <|> char '{' *> many (noneOf "}\\" <|> char '\\' *> anyChar) <* char '}'
   return (suppress_author, T.pack key)
 
 

--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -1475,7 +1475,13 @@ citeKey = try $ do
        rest <- many $ regchar <|> internal (oneOf ":.#$%&-+?<>~/") <|>
                       try (oneOf ":/" <* lookAhead (char '/'))
        pure $ firstChar:rest
-    <|> char '{' *> many (noneOf "}\\" <|> char '\\' *> anyChar) <* char '}'
+    <|> char '{' *>
+        many `id` choice
+          [ noneOf "}\n\\"
+          , ' ' <$ newline <* skipSpaces <* notFollowedBy newline
+          , char '\\' *> anyChar
+          ]
+        <* char '}'
   return (suppress_author, T.pack key)
 
 


### PR DESCRIPTION
This implements the `{citekey}` syntax and also allows escaping using `\` both `}` and `\` inside `{}` ~~and any illegal character in the existing syntax~~.

This does not address all of #6026. I still want to implement the `[@citekey]: citekey'` syntax.

#### TODO:

- [ ] Update documentation to reflect new behaviour of citekey parser regarding newlines.
- [ ] Add tests?