### PR TITLE
Bump cabal-version to 2.2

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -1,6 +1,6 @@
+cabal-version:   2.2
 name:            pandoc
 version:         2.9.2.1
-cabal-version:   2.0
 build-type:      Simple
 license:         GPL-2.0-or-later
 license-file:    COPYING.md


### PR DESCRIPTION
In b3cfdc2c7 the license was changed to GPL-2.0-or-later which is an SPDX expression, however cabal only interprets the license field as an SPDX expression if cabal-version is 2.2 or later.

Starting with 2.2 cabal-version also has to be the first statement in the .cabal file.

> Starting with cabal-version: 2.2 the license field takes a (case-sensitive) SPDX expression [...]

https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-license

I noticed this because `cabal2nix` was acting up that the license was invalid.