### PR TITLE
Use <kbd> tag

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -5359,7 +5359,7 @@ output. You can add notes to your Markdown document thus:
 
     :::
 
-To show the notes window in reveal.js, press `s` while viewing the
+To show the notes window in reveal.js, press [s]{.kbd} while viewing the
 presentation. Speaker notes in PowerPoint will be available, as usual,
 in handouts and presenter view.
 


### PR DESCRIPTION
Native support for `<kbd>` was added in [Pandoc 2.8](https://github.com/jgm/pandoc/releases/tag/2.8).