### PR TITLE
Fixed Katex standalone script for handling macros

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -281,12 +281,14 @@ pandocToHtml opts (Pandoc meta blocks) = do
           H.script $ text $ T.unlines [
               "document.addEventListener(\"DOMContentLoaded\", function () {"
             , " var mathElements = document.getElementsByClassName(\"math\");"
+            , " var macros = [];"
             , " for (var i = 0; i < mathElements.length; i++) {"
             , "  var texText = mathElements[i].firstChild;"
             , "  if (mathElements[i].tagName == \"SPAN\") {"
             , "   katex.render(texText.data, mathElements[i], {"
             , "    displayMode: mathElements[i].classList.contains('display'),"
             , "    throwOnError: false,"
+            , "    macros: macros,"
             , "    fleqn: " <> katexFlushLeft
             , "   });"
             , "}}});"


### PR DESCRIPTION
This PR fixes an issue that I have not seen reported yet but that I experienced directly.
Katex supports definition of [**global macros** that are persistent across math blocks](https://katex.org/docs/supported.html#macros).
However for this to work, you need to pass the same array as an option each time you render a block.

Taking as an example the following document `test.rst` compiled with command `pandoc --katex -s -f rst -t html -o test.html test.rst`:

```rst
Testing Katex
=============

.. math::
   \gdef\foo{x^2 + y^2}

.. math::
   \foo
```
Before this fix, macro `\foo` was not defined in the second math block. Now everything works as expected.
This should not break existing documents because if you want local macros you're supposed to use `\def` rather than `\gdef`.
