### PR TITLE
Minimal support for SIRange in LaTeX reader

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -258,6 +258,29 @@ dosiunitx = do
                       emptyOr160 unit,
                       unit]
 
+-- converts e.g. \SIRange{100}{200}{\ms} to "100 ms to 200 ms"
+doSIRange :: PandocMonad m => LP m Inlines
+doSIRange = do
+  skipopts
+  startvalue <- tok
+  startvalueprefix <- option "" $ bracketed tok
+  stopvalue <- tok
+  stopvalueprefix <- option "" $ bracketed tok
+  unit <- grouped (mconcat <$> many1 siUnit) <|> siUnit <|> tok
+  let emptyOr160 "" = ""
+      emptyOr160 _  = "\160"
+  return . mconcat $ [startvalueprefix,
+                      emptyOr160 startvalueprefix,
+                      startvalue,
+                      emptyOr160 unit,
+                      unit,
+                      " to ",
+                      stopvalueprefix,
+                      emptyOr160 stopvalueprefix,
+                      stopvalue,
+                      emptyOr160 unit,
+                      unit]
+
 siUnit :: PandocMonad m => LP m Inlines
 siUnit = do
   Tok _ (CtrlSeq name) _ <- anyControlSeq
@@ -1140,6 +1163,7 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList
   , ("acsp", doAcronymPlural "abbrv")
   -- siuntix
   , ("SI", dosiunitx)
+  , ("SIRange", doSIRange)
   -- hyphenat
   , ("bshyp", lit "\\\173")
   , ("fshyp", lit "/\173")

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -274,7 +274,7 @@ doSIRange = do
                       startvalue,
                       emptyOr160 unit,
                       unit,
-                      " to ",
+                      " \8211 ", -- An en-dash
                       stopvalueprefix,
                       emptyOr160 stopvalueprefix,
                       stopvalue,

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -269,12 +269,18 @@ doSIRange = do
   unit <- grouped (mconcat <$> many1 siUnit) <|> siUnit <|> tok
   let emptyOr160 "" = ""
       emptyOr160 _  = "\160"
+  localTo <- translateTerm Translations.To
+  let separator = (if localTo /= ""
+                     then text $ T.toLower localTo 
+                     else "\8211")
   return . mconcat $ [startvalueprefix,
                       emptyOr160 startvalueprefix,
                       startvalue,
                       emptyOr160 unit,
                       unit,
-                      " \8211 ", -- An en-dash
+                      text " ",
+                      separator,
+                      text " ",
                       stopvalueprefix,
                       emptyOr160 stopvalueprefix,
                       stopvalue,

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -269,18 +269,12 @@ doSIRange = do
   unit <- grouped (mconcat <$> many1 siUnit) <|> siUnit <|> tok
   let emptyOr160 "" = ""
       emptyOr160 _  = "\160"
-  localTo <- translateTerm Translations.To
-  let separator = (if localTo /= ""
-                     then text $ T.toLower localTo 
-                     else "\8211")
   return . mconcat $ [startvalueprefix,
                       emptyOr160 startvalueprefix,
                       startvalue,
                       emptyOr160 unit,
                       unit,
-                      text " ",
-                      separator,
-                      text " ",
+                      " \8211 ", -- An en-dash
                       stopvalueprefix,
                       emptyOr160 stopvalueprefix,
                       stopvalue,

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -258,7 +258,7 @@ dosiunitx = do
                       emptyOr160 unit,
                       unit]
 
--- converts e.g. \SIRange{100}{200}{\ms} to "100 ms to 200 ms"
+-- converts e.g. \SIRange{100}{200}{\ms} to "100 ms--200 ms"
 doSIRange :: PandocMonad m => LP m Inlines
 doSIRange = do
   skipopts
@@ -274,7 +274,7 @@ doSIRange = do
                       startvalue,
                       emptyOr160 unit,
                       unit,
-                      " \8211 ", -- An en-dash
+                      "\8211", -- An en-dash
                       stopvalueprefix,
                       emptyOr160 stopvalueprefix,
                       stopvalue,

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -55,3 +55,53 @@
 [Para [Str "18.2\160\176C"]]
 ```
 
+# SIRange tests
+
+## Integer range with simple common units
+
+```
+% pandoc -f latex -t native
+\SIRange{10}{20}{\gram}
+^D
+[Para [Str "10\160g",Space,Str "to",Space,Str "20\160g"]]
+```
+```
+% pandoc -f latex -t native
+\SIRange{35}{9}{\milli\meter}
+^D
+[Para [Str "35\160mm",Space,Str "to",Space,Str "9\160mm"]]
+```
+```
+% pandoc -f latex -t native
+\SIRange{4}{97367265}{\celsius}
+^D
+[Para [Str "4\160\176C",Space,Str "to",Space,Str "97367265\160\176C"]]
+```
+
+## Decimal range with simple units
+
+```
+% pandoc -f latex -t native
+\SIRange{4.5}{97367265.5}{\celsius}
+^D
+[Para [Str "4.5\160\176C",Space,Str "to",Space,Str "97367265.5\160\176C"]]
+```
+
+## Squared units
+
+```
+% pandoc -f latex -t native
+\SIRange{10}{20}{\square\meter}
+^D
+[Para [Str "10\160m\178",Space,Str "to",Space,Str "20\160m\178"]]
+```
+
+ ## Test round precision option
+
+```
+% pandoc -f latex -t native
+\SIRange[round-precision=2]{10}{20}{\gram}
+^D
+[Para [Str "10\160g",Space,Str "to",Space,Str "20\160g"]]
+```
+

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -63,19 +63,19 @@
 % pandoc -f latex -t native
 \SIRange{10}{20}{\gram}
 ^D
-[Para [Str "10\160g",Space,Str "\8211",Space,Str "20\160g"]]
+[Para [Str "10\160g",Space,Str "to",Space,Str "20\160g"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange{35}{9}{\milli\meter}
 ^D
-[Para [Str "35\160mm",Space,Str "\8211",Space,Str "9\160mm"]]
+[Para [Str "35\160mm",Space,Str "to",Space,Str "9\160mm"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange{4}{97367265}{\celsius}
 ^D
-[Para [Str "4\160\176C",Space,Str "\8211",Space,Str "97367265\160\176C"]]
+[Para [Str "4\160\176C",Space,Str "to",Space,Str "97367265\160\176C"]]
 ```
 
 ## Decimal range with simple units
@@ -84,7 +84,7 @@
 % pandoc -f latex -t native
 \SIRange{4.5}{97367265.5}{\celsius}
 ^D
-[Para [Str "4.5\160\176C",Space,Str "\8211",Space,Str "97367265.5\160\176C"]]
+[Para [Str "4.5\160\176C",Space,Str "to",Space,Str "97367265.5\160\176C"]]
 ```
 
 ## Squared units
@@ -93,7 +93,7 @@
 % pandoc -f latex -t native
 \SIRange{10}{20}{\square\meter}
 ^D
-[Para [Str "10\160m\178",Space,Str "\8211",Space,Str "20\160m\178"]]
+[Para [Str "10\160m\178",Space,Str "to",Space,Str "20\160m\178"]]
 ```
 
 ## Ignore round precision
@@ -105,12 +105,12 @@
 % pandoc -f latex -t native
 \SIRange[round-precision=2]{10}{20}{\gram}
 ^D
-[Para [Str "10\160g",Space,Str "\8211",Space,Str "20\160g"]]
+[Para [Str "10\160g",Space,Str "to",Space,Str "20\160g"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange[round-precision=2]{10.0}{20.25}{\gram}
 ^D
-[Para [Str "10.0\160g",Space,Str "\8211",Space,Str "20.25\160g"]]
+[Para [Str "10.0\160g",Space,Str "to",Space,Str "20.25\160g"]]
 ```
 

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -63,19 +63,19 @@
 % pandoc -f latex -t native
 \SIRange{10}{20}{\gram}
 ^D
-[Para [Str "10\160g",Space,Str "\8211",Space,Str "20\160g"]]
+[Para [Str "10\160g\8211\&20\160g"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange{35}{9}{\milli\meter}
 ^D
-[Para [Str "35\160mm",Space,Str "\8211",Space,Str "9\160mm"]]
+[Para [Str "35\160mm\8211\&9\160mm"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange{4}{97367265}{\celsius}
 ^D
-[Para [Str "4\160\176C",Space,Str "\8211",Space,Str "97367265\160\176C"]]
+[Para [Str "4\160\176C\8211\&97367265\160\176C"]]
 ```
 
 ## Decimal range with simple units
@@ -84,7 +84,7 @@
 % pandoc -f latex -t native
 \SIRange{4.5}{97367265.5}{\celsius}
 ^D
-[Para [Str "4.5\160\176C",Space,Str "\8211",Space,Str "97367265.5\160\176C"]]
+[Para [Str "4.5\160\176C\8211\&97367265.5\160\176C"]]
 ```
 
 ## Squared units
@@ -93,7 +93,7 @@
 % pandoc -f latex -t native
 \SIRange{10}{20}{\square\meter}
 ^D
-[Para [Str "10\160m\178",Space,Str "\8211",Space,Str "20\160m\178"]]
+[Para [Str "10\160m\178\8211\&20\160m\178"]]
 ```
 
 ## Ignore round precision
@@ -105,12 +105,12 @@
 % pandoc -f latex -t native
 \SIRange[round-precision=2]{10}{20}{\gram}
 ^D
-[Para [Str "10\160g",Space,Str "\8211",Space,Str "20\160g"]]
+[Para [Str "10\160g\8211\&20\160g"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange[round-precision=2]{10.0}{20.25}{\gram}
 ^D
-[Para [Str "10.0\160g",Space,Str "\8211",Space,Str "20.25\160g"]]
+[Para [Str "10.0\160g\8211\&20.25\160g"]]
 ```
 

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -63,19 +63,19 @@
 % pandoc -f latex -t native
 \SIRange{10}{20}{\gram}
 ^D
-[Para [Str "10\160g",Space,Str "to",Space,Str "20\160g"]]
+[Para [Str "10\160g",Space,Str "\8211",Space,Str "20\160g"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange{35}{9}{\milli\meter}
 ^D
-[Para [Str "35\160mm",Space,Str "to",Space,Str "9\160mm"]]
+[Para [Str "35\160mm",Space,Str "\8211",Space,Str "9\160mm"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange{4}{97367265}{\celsius}
 ^D
-[Para [Str "4\160\176C",Space,Str "to",Space,Str "97367265\160\176C"]]
+[Para [Str "4\160\176C",Space,Str "\8211",Space,Str "97367265\160\176C"]]
 ```
 
 ## Decimal range with simple units
@@ -84,7 +84,7 @@
 % pandoc -f latex -t native
 \SIRange{4.5}{97367265.5}{\celsius}
 ^D
-[Para [Str "4.5\160\176C",Space,Str "to",Space,Str "97367265.5\160\176C"]]
+[Para [Str "4.5\160\176C",Space,Str "\8211",Space,Str "97367265.5\160\176C"]]
 ```
 
 ## Squared units
@@ -93,7 +93,7 @@
 % pandoc -f latex -t native
 \SIRange{10}{20}{\square\meter}
 ^D
-[Para [Str "10\160m\178",Space,Str "to",Space,Str "20\160m\178"]]
+[Para [Str "10\160m\178",Space,Str "\8211",Space,Str "20\160m\178"]]
 ```
 
 ## Ignore round precision
@@ -105,12 +105,12 @@
 % pandoc -f latex -t native
 \SIRange[round-precision=2]{10}{20}{\gram}
 ^D
-[Para [Str "10\160g",Space,Str "to",Space,Str "20\160g"]]
+[Para [Str "10\160g",Space,Str "\8211",Space,Str "20\160g"]]
 ```
 ```
 % pandoc -f latex -t native
 \SIRange[round-precision=2]{10.0}{20.25}{\gram}
 ^D
-[Para [Str "10.0\160g",Space,Str "to",Space,Str "20.25\160g"]]
+[Para [Str "10.0\160g",Space,Str "\8211",Space,Str "20.25\160g"]]
 ```
 

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -96,12 +96,21 @@
 [Para [Str "10\160m\178",Space,Str "to",Space,Str "20\160m\178"]]
 ```
 
- ## Test round precision option
+## Ignore round precision
+
+`round-precision` option appears to be ignored by `\SI` as of 7c6dbd37e, so
+`\SIRange` will ignore it as well.
 
 ```
 % pandoc -f latex -t native
 \SIRange[round-precision=2]{10}{20}{\gram}
 ^D
 [Para [Str "10\160g",Space,Str "to",Space,Str "20\160g"]]
+```
+```
+% pandoc -f latex -t native
+\SIRange[round-precision=2]{10.0}{20.25}{\gram}
+^D
+[Para [Str "10.0\160g",Space,Str "to",Space,Str "20.25\160g"]]
 ```
 


### PR DESCRIPTION
This patch adds minimal support for `\SIRange{firstnumber}{secondnumber}{unit}` (provided by siunitx) consistent with existing support for `\SI{value}{unit}`. Implementation is an extension of the existing `dosiunitx` function in the LaTeX reader. Added unit tests for SIRange in `test/command/3587.md`. 

Code passes all new and existing unit tests and compiles without warnings*.

This PR implements a fix for issue https://github.com/jgm/pandoc/issues/6417.

# Example

LaTeX input
```latex
Something important happens \SIRange{100}{200}{\ms} after the event.
```

Markdown output
```markdown
Something important happens 100 ms to 200 ms after the event.
```

----------

*As far as I can tell... I don't see any warning messages when I compile normally. I'm completely new to haskell and `cabal build -Wall` and `cabal test -Wall` both raise errors about unrecognized options, so it's possible there's something I've missed. If there's something different I should be doing please let me know.