### PR TITLE
add logo options in Pandoc's LaTeX template

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -396,7 +396,7 @@ $if(titlegraphic)$
 \titlegraphic{\includegraphics{$titlegraphic$}}
 $endif$
 $if(logo)$
-\logo{\includegraphics{$logo$}}
+\logo{\includegraphics[$for(logooptions)$$logooptions$$sep$,$endfor$]{$logo$}}
 $endif$
 $endif$
 


### PR DESCRIPTION
add logo options in Pandoc's LaTeX template, so that we can set logo image's width and height directly instead of edit it in Inkscape or something else.

