### PR TITLE
Docbook: map <simplesect> to unnumbered section

### DIFF
--- a/test/docbook-reader.docbook
+++ b/test/docbook-reader.docbook
@@ -47,6 +47,12 @@
       <para>
         with no blank line
       </para>
+      <simplesect>
+        <title>Level 4</title>
+        <para>
+        An unnumbered section.
+        </para>
+      </simplesect>
     </sect3>
   </sect2>
   <sect2 id="level-2">

--- a/test/docbook-reader.native
+++ b/test/docbook-reader.native
@@ -10,6 +10,8 @@ Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Sof
 ,Header 2 ("level-2-with-emphasis",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Emph [Str "emphasis"]]
 ,Header 3 ("level-3",[],[]) [Str "Level",Space,Str "3"]
 ,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
+,Header 4 ("",["unnumbered"],[]) [Str "Level",Space,Str "4"]
+,Para [Str "An",Space,Str "unnumbered",Space,Str "section."]
 ,Header 2 ("level-2",[],[]) [Str "Level",Space,Str "2"]
 ,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
 ,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]


### PR DESCRIPTION
A <simplesect> is a section like any other, except that it never
contains an subsection, and is typically rendered unnumbered.

Fixes #6434