### PR TITLE
Docbook: implement <replaceable>

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -363,7 +363,7 @@ List of all DocBook tags, with [x] indicating implemented,
 [x] releaseinfo - Information about a particular release of a document
 [ ] remark - A remark (or comment) intended for presentation in a draft
     manuscript
-[ ] replaceable - Content that may or must be replaced by the user
+[x] replaceable - Content that may or must be replaced by the user
 [ ] returnvalue - The value returned by a function
 [ ] revdescription - A extended description of a revision to a document
 [ ] revhistory - A history of the revisions to a document
@@ -979,6 +979,8 @@ parseInline (Elem e) =
         "option" -> codeWithLang
         "optional" -> do x <- getInlines e
                          return $ str "[" <> x <> str "]"
+        "replaceable" -> do x <- getInlines e
+                            return $ str "<" <> x <> str ">"
         "markup" -> codeWithLang
         "wordasword" -> emph <$> innerInlines
         "command" -> codeWithLang


### PR DESCRIPTION
A `<replaceable>` is a placeholder that a user is instructed to
replace with a value of their own, like
`<replaceable>prefix</replacable>/bin/foo`. In the standard Docbook
toolchain, this typically appears emphasized, and no other adornement.
But a `<replaceable>` is nearly always in a code element, where
emphasis won't work. So we do the same thing as for `<optional>`:
decorate the content with brackets.