### PR TITLE
Make it possible to compile using Stack on NixOS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -33,3 +33,5 @@ extra-deps:
 ghc-options:
    "$locals": -fhide-source-paths -Wno-missing-home-modules
 resolver: lts-14.6
+nix:
+  packages: [zlib]


### PR DESCRIPTION
On NixOS, it is necessary to compile with `stack --nix`. It is
furthermore necessary to provide zlib headers when `--nix` is enabled.