### PR TITLE
Distinguish between single and double quotes when using enquote package

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -1234,7 +1234,9 @@ inlineToLaTeX (Quoted qt lst) = do
   csquotes <- liftM stCsquotes get
   opts <- gets stOptions
   if csquotes
-     then return $ "\\enquote" <> braces contents
+     then return $ case qt of
+               DoubleQuote -> "\\enquote" <> braces contents
+               SingleQuote -> "\\enquote*" <> braces contents
      else do
        let s1 = if not (null lst) && isQuoted (head lst)
                    then "\\,"


### PR DESCRIPTION
Hi,

its bugging me for quite some time, that wen using the csquotes package its actually not really distinguished between single and double quotes. Therefore this PR.