### PR TITLE
Markdown reader: support GitHub wiki's internal links (#2923)

### DIFF
--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -118,6 +118,7 @@ data Extension =
     | Ext_literate_haskell    -- ^ Enable literate Haskell conventions
     | Ext_markdown_attribute      -- ^ Interpret text inside HTML as markdown iff
                                   --   container has attribute 'markdown'
+    | Ext_wikilinks -- ^ Interpret a markdown wiki link
     | Ext_markdown_in_html_blocks -- ^ Interpret as markdown inside HTML blocks
     | Ext_mmd_header_identifiers -- ^ Multimarkdown style header identifiers [myid]
     | Ext_mmd_link_attributes     -- ^ MMD style reference link attributes
@@ -258,6 +259,7 @@ githubMarkdownExtensions = extensionsFromList
   , Ext_emoji
   , Ext_fenced_code_blocks
   , Ext_backtick_code_blocks
+  , Ext_wikilinks
   ]
 
 -- | Extensions to be used with multimarkdown.
@@ -444,6 +446,7 @@ getAllExtensions f = universalExtensions <> getAll f
        , Ext_tex_math_single_backslash
        , Ext_tex_math_double_backslash
        , Ext_markdown_attribute
+       , Ext_wikilinks
        , Ext_mmd_title_block
        , Ext_abbreviations
        , Ext_autolink_bare_uris

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1485,6 +1485,7 @@ inline = choice [ whitespace
                 , note
                 , cite
                 , bracketedSpan
+                , githubWikiLink
                 , link
                 , image
                 , math
@@ -1779,6 +1780,42 @@ source = do
 
 linkTitle :: PandocMonad m => MarkdownParser m Text
 linkTitle = quotedTitle '"' <|> quotedTitle '\''
+
+-- Github wiki style link, with optional title
+-- syntax documented under https://help.github.com/en/github/building-a-strong-community/editing-wiki-content
+githubWikiLink :: PandocMonad m => MarkdownParser m (F Inlines)
+githubWikiLink = try $ do
+  guardEnabled Ext_wikilinks
+  string "[["
+  inlinedContents <- option (return $ B.fromList [])
+                      $ lookAhead $ try $ mconcat <$> manyTill inline (try $ string "]]")
+  rawContents <- manyTillChar anyChar (try $ string "]]")
+  let allowedInline x = case x of
+                          B.Str _   -> True
+                          B.Space   -> True
+                          B.Link {} -> True
+                          _         -> False
+  let hasNotInlines = all allowedInline . B.toList
+  let ilcs = runF inlinedContents defaultParserState
+  let valid = hasNotInlines ilcs
+  let formatUri l = if isURI l
+                      then l
+                      else T.replace " " "-" l
+  let (label, url) = case T.splitOn "|" rawContents of
+                       (l:u:_) -> (l, u)
+                       [l]     -> (l, l)
+                       []      -> error "T.splitOn changed behavior"
+  let dropLastLink' is = case is of
+                           []                           -> []
+                           -- Merge strings, special case
+                           [B.Str p, B.Link _ _ (l, _)] -> [B.Str $ p <> l]
+                           [B.Link _ _ (l, _)]          -> [B.Str l]
+                           [x]                          -> [x]
+                           (x:xs)                       -> x:dropLastLink' xs
+  let dropLastLink is = B.text "[[" <> B.fromList (dropLastLink' $ B.toList is) <> B.text "]]"
+  return $ if valid
+             then B.link (formatUri url)  "wikilink"  (B.text label) <$ inlinedContents
+             else dropLastLink <$> inlinedContents
 
 link :: PandocMonad m => MarkdownParser m (F Inlines)
 link = try $ do

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -21,6 +21,7 @@ module Text.Pandoc.Readers.Markdown (
 import Control.Monad
 import Control.Monad.Except (throwError)
 import Data.Char (isAlphaNum, isPunctuation, isSpace)
+import Data.Functor (($>))
 import Data.List (transpose, elemIndex, sortOn)
 import qualified Data.Map as M
 import Data.Maybe
@@ -1790,10 +1791,10 @@ githubWikiLink = try $ guardEnabled Ext_wikilinks >> wikilink
       string "[["
       firstPart <- fmap mconcat . sequence <$> wikiText
       (char '|' *> complexWikilink firstPart)
-        <|> (string "]]" *> return (B.link
-                                      <$> (stringify <$> firstPart)
-                                      <*> return "wikilink"
-                                      <*> firstPart))
+        <|> (string "]]" $> (B.link
+                               <$> (stringify <$> firstPart)
+                               <*> return "wikilink"
+                               <*> firstPart))
 
     complexWikilink firstPart = do
       url <- fmap stringify . sequence <$> wikiText

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1787,7 +1787,7 @@ githubWikiLink :: PandocMonad m => MarkdownParser m (F Inlines)
 githubWikiLink = try $ do
   guardEnabled Ext_wikilinks
   string "[["
-  inlinedContents <- option (return $ B.fromList [])
+  inlinedContents <- option (return mempty)
                       $ lookAhead $ try $ mconcat <$> manyTill inline (try $ string "]]")
   rawContents <- manyTillChar anyChar (try $ string "]]")
   let allowedInline x = case x of

--- a/test/Tests/Readers/Markdown.hs
+++ b/test/Tests/Readers/Markdown.hs
@@ -307,6 +307,36 @@ tests = [ testGroup "inline code"
             "[https://example.org(](url)" =?>
             para (link "url" "" (text "https://example.org("))
           ]
+        , testGroup "Github wiki links"
+          [ test markdownGH "autolink" $
+            "[[https://example.org]]" =?>
+            para (link "https://example.org" "wikilink" (text "https://example.org"))
+          , test markdownGH "link with title" $
+            "[[title|https://example.org]]" =?>
+            para (link "https://example.org" "wikilink" (text "title"))
+          , test markdownGH "bad link with title" $
+            "[[title|random string]]" =?>
+            para (link "random-string" "wikilink" (text "title"))
+          , test markdownGH "autolink not being a link" $
+            "[[Name of page]]" =?>
+            para (link "Name-of-page" "wikilink" (text "Name of page"))
+          , test markdownGH "autolink not being a link with a square bracket" $
+            "[[Name of ]page]]" =?>
+            para (link "Name-of-]page" "wikilink" (text "Name of ]page"))
+          , test markdownGH "formatting (strong and emphasis) should not be interpreted" $
+             "[[***a**b **c**d*|https://example.org]]" =?>
+             para (text "[[" <> emph (strong (str "a") <> str "b" <> space
+                   <> strong (str "c") <> str "d") <> text "|https://example.org]]")
+          , test markdownGH "inlined code should not make a link" $
+            "[[ti`|`le|https://example.org]]" =?>
+            para (text "[[ti" <> code "|" <> text "le|https://example.org]]")
+          , test markdownGH "link with title and a cut should take the middle part as link" $
+            "[[tit|le|https://example.org]]" =?>
+            para (link "le" "wikilink" (text "tit"))
+          , test markdownGH "link with inline start should be a link" $
+            "[[t`i*t_le|https://example.org]]" =?>
+            para (link "https://example.org" "wikilink" (text "t`i*t_le"))
+          ]
         , testGroup "Headers"
           [ "blank line before header" =:
             "\n# Header\n"


### PR DESCRIPTION
closes https://github.com/jgm/pandoc/issues/2923

Changes overview:

 * Add a `Ext_markdown_github_wikilink` extension
   * Added in the `githubMarkdownExtensions` list
   * Added in the `getAllExtensions` list
 * Add the parser `githubWikiLink` in `Text.Pandoc.Readers.Markdown`
   * Added it high in the `inline` parsers list
 * Add two tests, one for each form

Notes:

 * It has been done as part as ZuriHac 2020
 * It is my first contribution
 * I am available to pair on Discord if needed

Thanks by advance for your feedback.