### PR TITLE
Remove unused dependency `vector`

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -410,7 +410,6 @@ library
                  temporary >= 1.1 && < 1.4,
                  blaze-html >= 0.9 && < 0.10,
                  blaze-markup >= 0.8 && < 0.9,
-                 vector >= 0.10 && < 0.13,
                  jira-wiki-markup >= 1.3.1 && < 1.4,
                  hslua >= 1.1 && < 1.2,
                  hslua-module-system >= 0.2 && < 0.3,


### PR DESCRIPTION
Hello,

I noticed that the `vector` package is actually never used explicitly in Pandoc. This PR removes the dependency. Most importantly, there won't be a need to track the version upper bound anymore (e.g. dce6a7388a5f546ebbfd192febcb1753b743b377 and c56669ec39b741f8b14f16603294e27415576510). 