### PR TITLE
Fix MIME type for TrueType fonts in EPUBs

### DIFF
--- a/src/Text/Pandoc/MIME.hs
+++ b/src/Text/Pandoc/MIME.hs
@@ -461,7 +461,7 @@ mimeTypesList =
            ,("ts","text/texmacs")
            ,("tsp","application/dsptype")
            ,("tsv","text/tab-separated-values")
-           ,("ttf","application/x-font-truetype")
+           ,("ttf","application/font-sfnt")
            ,("txt","text/plain")
            ,("udeb","application/x-debian-package")
            ,("uls","text/iuls")


### PR DESCRIPTION
Heyo. [Per the EPUB 3.2 spec][1], `application/x-font-truetype` is no longer a valid identifier for TrueType fonts. This fixes warnings when validating pandoc-generated EPUBs using [epubcheck][2].

References plfa/plfa.github.io#479.
References #1761.

[1]: https://www.w3.org/publishing/epub3/epub-spec.html#sec-core-media-types
[2]: https://github.com/w3c/epubcheck