### PR TITLE
Failing attempt at applying simpleCell at "entry" level

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -900,7 +900,7 @@ parseBlock (Elem e) =
                                                 Just ws' -> let tot = sum ws'
                                                             in  ColWidth . (/ tot) <$> ws'
                                                 Nothing  -> replicate numrows ColWidthDefault
-                      let toRow = Row nullAttr . map simpleCell
+                      let toRow = Row nullAttr
                           toHeaderRow l = if null l then [] else [toRow l]
                       return $ table (simpleCaption $ plain capt)
                                      (zip aligns widths)
@@ -908,7 +908,8 @@ parseBlock (Elem e) =
                                      [TableBody nullAttr 0 [] $ map toRow bodyrows]
                                      (TableFoot nullAttr [])
          isEntry x  = named "entry" x || named "td" x || named "th" x
-         parseRow = mapM (parseMixed plain . elContent) . filterChildren isEntry
+         parseEntry = simpleCell . (parseMixed plain) . elContent
+         parseRow = mapM parseEntry . filterChildren isEntry
          sect n = sectWith (attrValue "id" e,[],[]) n
          sectWith attr n = do
            isbook <- gets dbBook


### PR DESCRIPTION
Hi,

I've started working on adding parsing of column spans to the DocBook reader - however - my haskell knowledge is lacking and I am a bit lost and would be happy for some help if someone has time.

I need to replace the simpleCell with (cell AlignDefault 1 1 ) and then substitute in the correct variables. Before I can do this however I need to first move the cell creation to the point where we actually parse the cell i.e. the "entry" in DocBook. However, doing this breaks compilation with a horrible monadic error:

src/Text/Pandoc/Readers/DocBook.hs:911:36-65: error:
    • Couldn't match type ‘StateT DBState m0 Blocks’ with ‘Many Block’
      Expected type: Element -> Blocks
        Actual type: Element -> StateT DBState m0 Blocks
    • In the second argument of ‘(.)’, namely
        ‘(parseMixed plain) . elContent’
      In the expression: simpleCell . (parseMixed plain) . elContent
      In an equation for ‘parseEntry’:
          parseEntry = simpleCell . (parseMixed plain) . elContent
    |
911 |          parseEntry = simpleCell . (parseMixed plain) . elContent
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Text/Pandoc/Readers/DocBook.hs:912:26-35: error:
    • Couldn't match type ‘Cell’ with ‘m1 b’
      Expected type: Element -> m1 b
        Actual type: Element -> Cell
    • In the first argument of ‘mapM’, namely ‘parseEntry’
      In the first argument of ‘(.)’, namely ‘mapM parseEntry’
      In the expression: mapM parseEntry . filterChildren isEntry
    • Relevant bindings include
        parseRow :: Element -> m1 [b]
          (bound at src/Text/Pandoc/Readers/DocBook.hs:912:10)
    |
912 |          parseRow = mapM parseEntry . filterChildren isEntry
    |                          ^^^^^^^^^^
cabal: Failed to build pandoc-2.10 (which is required by test:test-pandoc from


If someone could help me understand what I'm doing wrong I would be very grateful!