### PR TITLE
HTML writer: improve alt-text/caption handling for HTML5

### DIFF
--- a/test/command/3577.md
+++ b/test/command/3577.md
@@ -16,10 +16,10 @@
 \end{figure}
 ^D
 <figure>
-<img src="img1.jpg" alt="" /><figcaption>Caption 1</figcaption>
+<img src="img1.jpg" alt="Caption 1" /><figcaption aria-hidden="true">Caption 1</figcaption>
 </figure>
 <figure>
-<img src="img2.jpg" alt="" /><figcaption>Caption 2</figcaption>
+<img src="img2.jpg" alt="Caption 2" /><figcaption aria-hidden="true">Caption 2</figcaption>
 </figure>
 ```
 ```
@@ -30,6 +30,6 @@
 \end{figure}
 ^D
 <figure>
-<img src="img1.jpg" alt="" /><figcaption>Caption 3</figcaption>
+<img src="img1.jpg" alt="Caption 3" /><figcaption aria-hidden="true">Caption 3</figcaption>
 </figure>
 ```

--- a/test/command/4677.md
+++ b/test/command/4677.md
@@ -3,6 +3,6 @@
 ![Caption](img.png){#img:1}
 ^D
 <figure>
-<img src="img.png" id="img:1" alt="" /><figcaption>Caption</figcaption>
+<img src="img.png" id="img:1" alt="Caption" /><figcaption aria-hidden="true">Caption</figcaption>
 </figure>
 ```

--- a/test/command/5121.md
+++ b/test/command/5121.md
@@ -5,7 +5,7 @@
 ## Header 2
 ^D
 <figure>
-<img src="./my-figure.jpg" width="500" alt="" /><figcaption>My caption</figcaption>
+<img src="./my-figure.jpg" width="500" alt="My caption" /><figcaption aria-hidden="true">My caption</figcaption>
 </figure>
 
 Header 2

--- a/test/command/5642.md
+++ b/test/command/5642.md
@@ -3,6 +3,6 @@
 ![test](foo){aria-describedby="barbaz"}
 ^D
 <figure>
-<img src="foo" aria-describedby="barbaz" alt="" /><figcaption>test</figcaption>
+<img src="foo" aria-describedby="barbaz" alt="test" /><figcaption aria-hidden="true">test</figcaption>
 </figure>
 ```

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -523,7 +523,7 @@ Blah
 <h1 id="images">Images</h1>
 <p>From “Voyage dans la Lune” by Georges Melies (1902):</p>
 <figure>
-<img src="lalune.jpg" title="Voyage dans la Lune" alt="" /><figcaption>lalune</figcaption>
+<img src="lalune.jpg" title="Voyage dans la Lune" alt="lalune" /><figcaption aria-hidden="true">lalune</figcaption>
 </figure>
 <p>Here is a movie <img src="movie.jpg" alt="movie" /> icon.</p>
 <hr />


### PR DESCRIPTION
Screen readers read an image's `alt` attribute and the figure caption,
both of which come from the same source in pandoc. The figure caption is
hidden from screen readers with the `aria-hidden` attribute. This
improves accessibility.

For HTML4, where `aria-hidden` is not allowed, pandoc still uses an
empty `alt` attribute to avoid duplicate contents.

Closes: #6491