### PR TITLE
CONTRIBUTING.md: add notes on getting nightly directly from GitHub Actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,13 @@ Before you submit a bug report, search the [open issues] *and* [closed issues]
 to make sure the issue hasn't come up before. Also, check the [User's Guide] and
 [FAQs] for anything relevant.
 
-Make sure you can reproduce the bug with the [latest released version] of pandoc
-(or, even better, the [development version]).
+Make sure you can reproduce the bug with the [latest released version] of
+pandoc. Optionally, you may check against development version to ensure the bug
+isn't already fixed. You can download them from the
+[official development version] or a [third party development version] as a
+fallback. (To found the file from the [official development version], log-in
+with your GitHub account first. Then from that link click the topmost "Nightly"
+in the table, and then choose your platform under "Artifacts".)
 
 Your report should give detailed, *reproducible* instructions, including
 
@@ -346,7 +351,8 @@ you may want to consider submitting a pull request to the
 [open issues]: https://github.com/jgm/pandoc/issues
 [closed issues]: https://github.com/jgm/pandoc/issues?q=is%3Aissue+is%3Aclosed
 [latest released version]: https://github.com/jgm/pandoc/releases/latest
-[development version]: https://github.com/pandoc-extras/pandoc-nightly/releases/latest
+[official development version]: https://github.com/jgm/pandoc/actions?query=workflow%3ANightly+is%3Asuccess+branch%3Amaster
+[third party development version]: https://github.com/pandoc-extras/pandoc-nightly/releases/latest
 [pandoc-discuss]: http://groups.google.com/group/pandoc-discuss
 [issue tracker]: https://github.com/jgm/pandoc/issues
 [User's Guide]: http://pandoc.org/MANUAL.html


### PR DESCRIPTION
Note: There isn't a direct link to the latest nightly from GitHub Actions, and it requires people to log in with a GitHub account (public access to that link has artifacts greyed out.)