### PR TITLE
Lua filters typos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 test/fb2/reader/* -text
+
+# Enforce .editorconfig EOL nomralization rules for Windows OS:
+*.* text eol=lf

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -138,7 +138,7 @@ elements.
 
 ## Filters on element sequences
 
-For some filtering tasks, the it is necessary to know the order
+For some filtering tasks, it is necessary to know the order
 in which elements occur in the document. It is not enough then to
 inspect a single element at a time.
 
@@ -1127,7 +1127,7 @@ A [table cell]{#type-table-cell} is a list of blocks.
 
 *[Alignment]{#type-alignment}* is a string value indicating the
 horizontal alignment of a table column. `AlignLeft`,
-`AlignRight`, and `AlignCenter` leads cell content tob be
+`AlignRight`, and `AlignCenter` leads cell content to be
 left-aligned, right-aligned, and centered, respectively. The
 default alignment is `AlignDefault` (often equivalent to
 centered).
@@ -3035,7 +3035,7 @@ methods and convenience functions.
 [`pandoc.List:insert ([pos], value)`]{#pandoc.list:insert}
 
 :   Inserts element `value` at position `pos` in list, shifting
-    elements to the next-greater indix if necessary.
+    elements to the next-greater index if necessary.
 
     This function is identical to
     [`table.insert`](https://www.lua.org/manual/5.3/manual.html#6.6).
@@ -3082,7 +3082,7 @@ methods and convenience functions.
     Parameters:
 
     `pos`:
-    :   position of the list value that will be remove; defaults
+    :   position of the list value that will be removed; defaults
         to the index of the last element
 
     Returns: the removed element


### PR DESCRIPTION
This PR fixes some minor typos in the Lua Filters document.

It also contains an additional commit that fixes the `.gitattributes` file by setting `*.* text eol=lf` to allow Windows users working with an EditorConfig-compatible editor to commit to the repository.

The current `.editorconfig` settings are enforicing `LF` EOLs on all files, which conflicts with Git defaults (`core.eol = native`) which normalizes all text files to the native EOL, which under Windows means that all text files should be checked out using `CRLF`. If end users have Git configured to `core.autocrlf = true` (reccomended) they won't be able to commit edited files, due to EditorConfig settings enforcing `LF` at savetime.

This was just a quick fix to allow me (and possibly others) to contribute to text documents, but the repository settings for EditorConfig and Git attributes should be revisited to ensure an optimal cross-platform collaboration — i.e. by improving either the `.editorconfig` file or the `.gitattributes` settings (possibly both).

I use EditorConfig settings in most of my repositories to enfoce code-consistency validation of every commit and PR (via Travis CI); and I can see that the current `.editorconfig`/`.gitattributes` settings are far from ideal and need some extra attention.


