### PR TITLE
[Docx Reader] Only use bCs/iCs on runs with rtl or cs property

### DIFF
--- a/src/Text/Pandoc/Readers/Docx/Parse.hs
+++ b/src/Text/Pandoc/Readers/Docx/Parse.hs
@@ -259,10 +259,13 @@ newtype Cell = Cell [BodyPart]
 leftBiasedMergeRunStyle :: RunStyle -> RunStyle -> RunStyle
 leftBiasedMergeRunStyle a b = RunStyle
     { isBold = isBold a <|> isBold b
+    , isBoldCTL = isBoldCTL a <|> isBoldCTL b
     , isItalic = isItalic a <|> isItalic b
+    , isItalicCTL = isItalicCTL a <|> isItalicCTL b
     , isSmallCaps = isSmallCaps a <|> isSmallCaps b
     , isStrike = isStrike a <|> isStrike b
     , isRTL = isRTL a <|> isRTL b
+    , isForceCTL = isForceCTL a <|> isForceCTL b
     , rVertAlign = rVertAlign a <|> rVertAlign b
     , rUnderline = rUnderline a <|> rUnderline b
     , rParentStyle = rParentStyle a


### PR DESCRIPTION
As discussed in #6514.

Apparently, Word will apply `bCs`/`iCs` to a run iff the run has `cs` or `rtl` property set to `true`. This is confirmed by spec. Experiments show that both `cs` and `rtl` can be inherited from styles.

Fixes #6514

**NOTE:** Without #6504 this will likely have some confusing quirks, since I reckon `cs` and `rtl` are likely to be set on paragraph styles, actually.