### PR TITLE
[CI] Use setup-haskell action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,16 +61,10 @@ jobs:
     # need to install older cabal/ghc versions from ppa repository
 
     - name: Install recent cabal/ghc
-      run: |
-         if [[ ! -d /opt/ghc/${{ matrix.versions.ghc }} ]]
-         then
-           sudo add-apt-repository ppa:hvr/ghc
-           sudo apt-get update
-           sudo apt-get install ghc-${{ matrix.versions.ghc }} cabal-install-${{ matrix.versions.cabal }}
-         fi
-         # Use a GitHub workflow command to add folders to PATH.
-         echo "::add-path::/opt/ghc/${{ matrix.versions.ghc }}/bin"
-         echo "::add-path::/opt/cabal/${{ matrix.versions.cabal }}/bin"
+      uses: actions/setup-haskell@v1.1
+      with:
+        ghc-version: ${{ matrix.versions.ghc }}
+        cabal-version: ${{ matrix.versions.cabal }}
 
     # declare/restore cached things
     # caching doesn't work for scheduled runs yet


### PR DESCRIPTION
This replaces Haskell setup on Linux by a GitHub-provided action https://github.com/actions/setup-haskell. At the moment, it is a bit more robust. On Linux, this action will try hvr-ghc PPA, and if that fails, install via ghcup. Windows and macOS are also supported. Certain GHC/Cabal versions are preinstalled on GitHub Action runners, the action won't reinstall those.

A transient failure on CI prompted this.

~~Actually, I think I will also fix caching while at it. Converting to draft in the meantime.~~ nevermind, it seems mostly fine as is. I could swear I've noticed something weird going on, but apparently not.