### PR TITLE
Load package `microtype` after `xeCJK` to avoid conflict

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -176,12 +176,6 @@ $if(outertheme)$
 \useoutertheme{$outertheme$}
 $endif$
 $endif$
-% Use upquote if available, for straight quotes in verbatim environments
-\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
-\IfFileExists{microtype.sty}{% use microtype if available
-  \usepackage[$for(microtypeoptions)$$microtypeoptions$$sep$,$endfor$]{microtype}
-  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
-}{}
 $if(indent)$
 $else$
 \makeatletter
@@ -324,6 +318,12 @@ $endif$
 $for(header-includes)$
 $header-includes$
 $endfor$
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[$for(microtypeoptions)$$microtypeoptions$$sep$,$endfor$]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
 $if(lang)$
 \ifxetex
   % Load polyglossia as late as possible: uses bidi with RTL langages (e.g. Hebrew, Arabic)


### PR DESCRIPTION
1. This version works:

```
\documentclass{article}
\usepackage{xeCJK}
\usepackage{microtype}
\begin{document}
Hello World
\end{document}
```

2. This version does not work:

```
\documentclass{article}
\usepackage{microtype}
\usepackage{xeCJK}
\begin{document}
Hello World
\end{document}
```