### PR TITLE
[Latex Reader] Table cell parser not consuming spaces correctly

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -2387,9 +2387,11 @@ parseTableRow envname prefsufs = do
 
 parseTableCell :: PandocMonad m => LP m Cell
 parseTableCell = do
+  spaces
   updateState $ \st -> st{ sInTableCell = True }
   cell' <- parseMultiCell <|> parseSimpleCell
   updateState $ \st -> st{ sInTableCell = False }
+  spaces
   return cell'
 
 cellAlignment :: PandocMonad m => LP m Alignment

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -148,6 +148,13 @@ tests = [ testGroup "tokenization"
                                   , simpleCell (plain "Two")
                                   ]
                    ]
+          , "table with multicolumn item (#6596)" =:
+            "\\begin{tabular}{l c r}One & \\multicolumn{2}{c}{Two} & \\\\ \\end{tabular}" =?>
+            table' [AlignLeft, AlignCenter, AlignRight]
+                   [ Row nullAttr [ simpleCell (plain "One")
+                                  , cell AlignCenter (RowSpan 1) (ColSpan 2) (plain "Two")
+                                  ]
+                   ]
           , "Table with multirow item" =:
             T.unlines ["\\begin{tabular}{c}"
                       ,"\\multirow{2}{c}{One}\\\\Two\\\\"


### PR DESCRIPTION
This PR fixes #6596 . It also adds a test so this problem does not come up again.