### PR TITLE
Options.hs: defaultMathJaxURL: use tex-chtml-full instead of tex-mml-…

### DIFF
--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -308,7 +308,7 @@ isEnabled :: HasSyntaxExtensions a => Extension -> a -> Bool
 isEnabled ext opts = ext `extensionEnabled` getExtensions opts
 
 defaultMathJaxURL :: Text
-defaultMathJaxURL = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+defaultMathJaxURL = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"
 
 defaultKaTeXURL :: Text
 defaultKaTeXURL = "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/"


### PR DESCRIPTION
…chtml

closes #6599

c.f. https://docs.mathjax.org/en/latest/web/components/combined.html

Note that while this use the full variant of the js, this drops the mml support. AFAIK, pandoc don't depends on MathJax to process MML, right?

Edit: by using the full it improves latency at the expense of size (but is compensated by dropping MML support from MathJax.)