### PR TITLE
[Latex Reader] Fixing issues with \multirow and \multicolumn table cells

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -2387,9 +2387,11 @@ parseTableRow envname prefsufs = do
 
 parseTableCell :: PandocMonad m => LP m Cell
 parseTableCell = do
+  spaces
   updateState $ \st -> st{ sInTableCell = True }
   cell' <- parseMultiCell <|> parseSimpleCell
   updateState $ \st -> st{ sInTableCell = False }
+  spaces
   return cell'
 
 cellAlignment :: PandocMonad m => LP m Alignment

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -2391,10 +2391,10 @@ parseTableCell :: PandocMonad m => LP m Cell
 parseTableCell = do
   spaces
   updateState $ \st -> st{ sInTableCell = True }
-  cell' <- (    multicolumnCell 
-            <|> multirowCell 
-            <|> parseSimpleCell 
-            <|> parseEmptyCell
+  cell' <- ( multicolumnCell 
+         <|> multirowCell 
+         <|> parseSimpleCell 
+         <|> parseEmptyCell
            )
   updateState $ \st -> st{ sInTableCell = False }
   spaces

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -2389,7 +2389,7 @@ parseTableCell :: PandocMonad m => LP m Cell
 parseTableCell = do
   spaces
   updateState $ \st -> st{ sInTableCell = True }
-  cell' <- parseMultiCell <|> parseSimpleCell
+  cell' <- multicolumnCell <|> multirowCell <|> parseSimpleCell
   updateState $ \st -> st{ sInTableCell = False }
   spaces
   return cell'
@@ -2411,32 +2411,35 @@ plainify bs = case toList bs of
                 [Para ils] -> plain (fromList ils)
                 _          -> bs
 
-parseMultiCell :: PandocMonad m => LP m Cell
-parseMultiCell =   (controlSeq "multirow"    >> parseMultirowCell) 
-               <|> (controlSeq "multicolumn" >> parseMulticolCell)
-  where
-    parseMultirowCell = parseMultiXCell RowSpan (const $ ColSpan 1)
-    parseMulticolCell = parseMultiXCell (const $ RowSpan 1) ColSpan
+multirowCell :: PandocMonad m => LP m Cell
+multirowCell = controlSeq "multirow" >> do
+  span' <- fmap (fromMaybe 1 . safeRead . untokenize) braced     
+  _ <- symbol '{' *> blocks <* symbol '}' -- --TODO: handle column widths
+  content <- symbol '{' *> (plainify <$> blocks) <* symbol '}'
+  return $ cell AlignDefault (RowSpan span') (ColSpan 1) content
 
-    parseMultiXCell rowspanf colspanf = do
-      span' <- fmap (fromMaybe 1 . safeRead . untokenize) braced
-      alignment <- symbol '{' *> cellAlignment <* symbol '}'
+multicolumnCell :: PandocMonad m => LP m Cell
+multicolumnCell = controlSeq "multicolumn" >> do
+  span' <- fmap (fromMaybe 1 . safeRead . untokenize) braced
+  alignment <- symbol '{' *> cellAlignment <* symbol '}'
 
-      -- Two possible contents: either a nested \multirow/\multicol, or content.
-      -- E.g. \multirow{1}{c}{\multicol{1}{c}{content}}
-      let singleCell = do
-            content <- plainify <$> blocks
-            return $ cell alignment (rowspanf span') (colspanf span') content
+  let singleCell = do
+        content <- plainify <$> blocks
+        return $ cell alignment (RowSpan 1) (ColSpan span') content
+  
+  -- Two possible contents: either a \multirow cell, or content.
+  -- E.g. \multicol{1}{c}{\multirow{2}{1em}{content}}
+  -- Note that a \multirow cell can be nested in a \multicolumn,
+  -- but not the other way around. See #6603
+  let nestedCell = do
+        (Cell _ _ (RowSpan rs) _ bs) <- multirowCell
+        return $ cell
+                  alignment
+                  (RowSpan $ rs)
+                  (ColSpan $ span')
+                  (fromList bs)
 
-      let nestedCell = do
-            (Cell _ _ (RowSpan rs) (ColSpan cs) bs) <- parseMultiCell
-            return $ cell
-                      alignment
-                      (RowSpan $ max span' rs)
-                      (ColSpan $ max span' cs)
-                      (fromList bs)
-
-      symbol '{' *> (nestedCell <|> singleCell) <* symbol '}'
+  symbol '{' *> (nestedCell <|> singleCell) <* symbol '}'
 
 -- Parse a simple cell, i.e. not multirow/multicol
 parseSimpleCell :: PandocMonad m => LP m Cell

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -167,7 +167,7 @@ tests = [ testGroup "tokenization"
           , "Table with nested multirow/multicolumn item" =:
             T.unlines [ "\\begin{tabular}{c c c}"
                       , "\\multicolumn{2}{c}{\\multirow{2}{5em}{One}}&Two\\\\"
-                      , "Three\\\\"
+                      , "& & Three\\\\"
                       , "Four&Five&Six\\\\"
                       , "\\end{tabular}"
                       ] =?>

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -148,6 +148,13 @@ tests = [ testGroup "tokenization"
                                   , simpleCell (plain "Two")
                                   ]
                    ]
+          , "table with multicolumn item (#6596)" =:
+            "\\begin{tabular}{l c r}One & \\multicolumn{2}{c}{Two} & \\\\ \\end{tabular}" =?>
+            table' [AlignLeft, AlignCenter, AlignRight]
+                   [ Row nullAttr [ simpleCell (plain "One")
+                                  , cell AlignCenter (RowSpan 1) (ColSpan 2) (plain "Two")
+                                  ]
+                   ]
           , "Table with multirow item" =:
             T.unlines ["\\begin{tabular}{c}"
                       ,"\\multirow{2}{c}{One}\\\\Two\\\\"

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -157,16 +157,16 @@ tests = [ testGroup "tokenization"
                    ]
           , "Table with multirow item" =:
             T.unlines ["\\begin{tabular}{c}"
-                      ,"\\multirow{2}{c}{One}\\\\Two\\\\"
+                      ,"\\multirow{2}{5em}{One}\\\\Two\\\\"
                       ,"\\end{tabular}"
                       ] =?>
             table' [AlignCenter]
-                  [ Row nullAttr [ cell AlignCenter (RowSpan 2) (ColSpan 1) (plain "One") ]
+                  [ Row nullAttr [ cell AlignDefault (RowSpan 2) (ColSpan 1) (plain "One") ]
                   , Row nullAttr [ simpleCell (plain "Two") ]
                   ]
           , "Table with nested multirow/multicolumn item" =:
             T.unlines [ "\\begin{tabular}{c c c}"
-                      , "\\multirow{2}{c}{\\multicolumn{2}{c}{One}}&Two\\\\"
+                      , "\\multicolumn{2}{c}{\\multirow{2}{5em}{One}}&Two\\\\"
                       , "Three\\\\"
                       , "Four&Five&Six\\\\"
                       , "\\end{tabular}"

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -164,6 +164,15 @@ tests = [ testGroup "tokenization"
                   [ Row nullAttr [ cell AlignDefault (RowSpan 2) (ColSpan 1) (plain "One") ]
                   , Row nullAttr [ simpleCell (plain "Two") ]
                   ]
+          , "Table with multirow item using full prototype" =:
+            T.unlines ["\\begin{tabular}{c}"
+                      ,"\\multirow[c]{2}[3]{5em}[1in]{One}\\\\Two\\\\"
+                      ,"\\end{tabular}"
+                      ] =?>
+            table' [AlignCenter]
+                  [ Row nullAttr [ cell AlignDefault (RowSpan 2) (ColSpan 1) (plain "One") ]
+                  , Row nullAttr [ simpleCell (plain "Two") ]
+                  ]
           , "Table with nested multirow/multicolumn item" =:
             T.unlines [ "\\begin{tabular}{c c c}"
                       , "\\multicolumn{2}{c}{\\multirow{2}{5em}{One}}&Two\\\\"


### PR DESCRIPTION
This PR fixes issue #6603

The main issues that need fixing are:
* [x] `\multirow` is not like `\multicolumn`; the second argument in `\multirow` is the text width;
* [x] Empty cells must be parsed, separated by the usual `&`;
* [x] Technically, the nesting of `\multirow` and `\multicolumn` is not interchangeable. `\multicolumn` must be at the top level.