### PR TITLE
LaTeX reader SIrange fix

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -259,9 +259,9 @@ dosiunitx = do
                       emptyOr160 unit,
                       unit]
 
--- converts e.g. \SIRange{100}{200}{\ms} to "100 ms--200 ms"
-doSIRange :: PandocMonad m => LP m Inlines
-doSIRange = do
+-- converts e.g. \SIrange{100}{200}{\ms} to "100 ms--200 ms"
+doSIrange :: PandocMonad m => LP m Inlines
+doSIrange = do
   skipopts
   startvalue <- tok
   startvalueprefix <- option "" $ bracketed tok
@@ -1098,7 +1098,7 @@ inlineCommands = M.union inlineLanguageCommands $ M.fromList
   , ("acsp", doAcronymPlural "abbrv")
   -- siuntix
   , ("SI", dosiunitx)
-  , ("SIRange", doSIRange)
+  , ("SIrange", doSIrange)
   -- hyphenat
   , ("bshyp", lit "\\\173")
   , ("fshyp", lit "/\173")

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -55,25 +55,25 @@
 [Para [Str "18.2\160\176C"]]
 ```
 
-# SIRange tests
+# SIrange tests
 
 ## Integer range with simple common units
 
 ```
 % pandoc -f latex -t native
-\SIRange{10}{20}{\gram}
+\SIrange{10}{20}{\gram}
 ^D
 [Para [Str "10\160g\8211\&20\160g"]]
 ```
 ```
 % pandoc -f latex -t native
-\SIRange{35}{9}{\milli\meter}
+\SIrange{35}{9}{\milli\meter}
 ^D
 [Para [Str "35\160mm\8211\&9\160mm"]]
 ```
 ```
 % pandoc -f latex -t native
-\SIRange{4}{97367265}{\celsius}
+\SIrange{4}{97367265}{\celsius}
 ^D
 [Para [Str "4\160\176C\8211\&97367265\160\176C"]]
 ```
@@ -82,7 +82,7 @@
 
 ```
 % pandoc -f latex -t native
-\SIRange{4.5}{97367265.5}{\celsius}
+\SIrange{4.5}{97367265.5}{\celsius}
 ^D
 [Para [Str "4.5\160\176C\8211\&97367265.5\160\176C"]]
 ```
@@ -91,7 +91,7 @@
 
 ```
 % pandoc -f latex -t native
-\SIRange{10}{20}{\square\meter}
+\SIrange{10}{20}{\square\meter}
 ^D
 [Para [Str "10\160m\178\8211\&20\160m\178"]]
 ```
@@ -99,17 +99,17 @@
 ## Ignore round precision
 
 `round-precision` option appears to be ignored by `\SI` as of 7c6dbd37e, so
-`\SIRange` will ignore it as well.
+`\SIrange` will ignore it as well.
 
 ```
 % pandoc -f latex -t native
-\SIRange[round-precision=2]{10}{20}{\gram}
+\SIrange[round-precision=2]{10}{20}{\gram}
 ^D
 [Para [Str "10\160g\8211\&20\160g"]]
 ```
 ```
 % pandoc -f latex -t native
-\SIRange[round-precision=2]{10.0}{20.25}{\gram}
+\SIrange[round-precision=2]{10.0}{20.25}{\gram}
 ^D
 [Para [Str "10.0\160g\8211\&20.25\160g"]]
 ```


### PR DESCRIPTION
My previous PR implemented pandoc conversion of LaTeX `\SIRange` commands (https://github.com/jgm/pandoc/pull/6418), but the correct syntax is `\SIrange` (as noted by @pauliacomi [here](https://github.com/jgm/pandoc/pull/6418#issuecomment-674017020); see also this [SO question](https://tex.stackexchange.com/questions/133704/sirange-typeset-different-in-text-and-math-mode/133707) for an example of the correct syntax). That's what I get for implementing that feature on a machine without my usual LaTeX setup... Sorry about that.

This PR introduces a trivial fix by changing all references to `SIRange` to `SIrange` in the current master. Unit tests pass, and I double checked the output of pandoc against pdflatex just to be sure.