### PR TITLE
Use `endterm` attribute when present

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -1091,8 +1091,7 @@ parseInline (Elem e) =
             let title = case attrValue "endterm" e of
                             ""      -> maybe "???" xrefTitleByElem
                                          (findElementById linkend content)
-                            endterm -> maybe "???" (T.pack . strContent)
-                                         (findElementById endterm content)
+                            endterm -> endterm
             return $ link ("#" <> linkend) "" (text title)
         "email" -> return $ link ("mailto:" <> T.pack (strContent e)) ""
                           $ str $ T.pack $ strContent e

--- a/test/docbook-xref.native
+++ b/test/docbook-xref.native
@@ -4,7 +4,7 @@ Pandoc (Meta {unMeta = fromList [("title",MetaInlines [Str "An",Space,Str "Examp
 ,BulletList
  [[Para [Str "A",Space,Str "straight",Space,Str "link",Space,Str "generates",Space,Str "the",SoftBreak,Str "cross-reference",Space,Str "text:",Space,Link ("",[],[]) [Str "The",Space,Str "Second",Space,Str "Chapter"] ("#ch02",""),Str "."]]
  ,[Para [Str "A",Space,Str "link",Space,Str "to",Space,Str "an",Space,Str "element",Space,Str "with",Space,Str "an",SoftBreak,Str "XRefLabel:",SoftBreak,Link ("",[],[]) [Str "Chapter",Space,Str "the",Space,Str "Third"] ("#ch03",""),Str "."]]
- ,[Para [Str "A",Space,Str "link",Space,Str "with",Space,Str "an",SoftBreak,Str "EndTerm:",SoftBreak,Link ("",[],[]) [Str "Chapter",Space,Str "4"] ("#ch04",""),Str "."]]
+ ,[Para [Str "A",Space,Str "link",Space,Str "with",Space,Str "an",SoftBreak,Str "EndTerm:",SoftBreak,Link ("",[],[]) [Str "ch04short"] ("#ch04",""),Str "."]]
  ,[Para [Str "A",Space,Str "link",Space,Str "to",Space,Str "an",SoftBreak,Str "cmdsynopsis",Space,Str "element:",Space,Link ("",[],[]) [Str "chgrp"] ("#cmd01",""),Str "."]]
  ,[Para [Str "A",Space,Str "link",Space,Str "to",Space,Str "an",SoftBreak,Str "funcsynopsis",Space,Str "element:",Space,Link ("",[],[]) [Str "max"] ("#func01",""),Str "."]]]
 ,Header 1 ("ch02",[],[]) [Str "The",Space,Str "Second",Space,Str "Chapter"]


### PR DESCRIPTION
Fixes #6619

I should have also updated the tests at:
```
test/docbook-xref.docbook
test/docbook-xref.native
```

But, how do I run "just" those tests?
What should be the output in pandoc's representation?


