### PR TITLE
Make the setting-the-date example conditional

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -362,12 +362,14 @@ end
 ## Setting the date in the metadata
 
 This filter sets the date in the document's metadata to the
-current date:
+current date, if a date isn't already set:
 
 ``` lua
 function Meta(m)
-  m.date = os.date("%B %e, %Y")
-  return m
+  if m.date == nil then
+    m.date = os.date("%B %e, %Y")
+    return m
+  end
 end
 ```
 


### PR DESCRIPTION
This makes the example a bit more realistic/valuable by checking if the metadata value "date" is already present, before changing the value.