### PR TITLE
Support colspans and rowspans in HTML tables

### DIFF
--- a/test/Tests/Old.hs
+++ b/test/Tests/Old.hs
@@ -67,8 +67,11 @@ tests pandocPath =
       ]
     ]
   , testGroup "html"
-    [ testGroup "writer" (writerTests' "html4" ++ writerTests' "html5" ++
-        lhsWriterTests' "html")
+    [ testGroup "writer" $ mconcat
+      [ extWriterTests' "html4"
+      , extWriterTests' "html5"
+      , lhsWriterTests' "html"
+      ]
     , test' "reader" ["-r", "html", "-w", "native", "-s"]
       "html-reader.html" "html-reader.native"
     ]
@@ -225,6 +228,7 @@ tests pandocPath =
     fb2WriterTest'  = fb2WriterTest pandocPath
     lhsWriterTests' = lhsWriterTests pandocPath
     lhsReaderTest'  = lhsReaderTest pandocPath
+    extWriterTests' = extendedWriterTests pandocPath
 
 -- makes sure file is fully closed after reading
 readFile' :: FilePath -> IO String
@@ -255,6 +259,19 @@ writerTests pandocPath format
         "basic"  (opts ++ ["-s"]) "testsuite.native" ("writer" <.> format)
     , test pandocPath
        "tables" opts             "tables.native"    ("tables" <.> format)
+    ]
+  where
+    opts = ["-r", "native", "-w", format, "--columns=78",
+            "--variable", "pandoc-version="]
+
+extendedWriterTests :: FilePath -> String -> [TestTree]
+extendedWriterTests pandocPath format
+  = writerTests pandocPath format ++
+    [ test pandocPath
+           "tables"
+           opts
+           ("tables" </> "planets.native")
+           ("tables" </> "planets" <.> format)
     ]
   where
     opts = ["-r", "native", "-w", format, "--columns=78",

--- a/test/tables/planets.html4
+++ b/test/tables/planets.html4
@@ -1,0 +1,133 @@
+<table>
+<caption><p>Data about the planets of our solar system.</p></caption>
+<thead>
+<tr class="header">
+<th align="center" colspan="2"></th>
+<th>Name</th>
+<th align="right">Mass (10^24kg)</th>
+<th align="right">Diameter (km)</th>
+<th align="right">Density (kg/m^3)</th>
+<th align="right">Gravity (m/s^2)</th>
+<th align="right">Length of day (hours)</th>
+<th align="right">Distance from Sun (10^6km)</th>
+<th align="right">Mean temperature (C)</th>
+<th align="right">Number of moons</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<th align="center" colspan="2" rowspan="4">Terrestial planets</th>
+<th>Mercury</th>
+<td align="right">0.330</td>
+<td align="right">4,879</td>
+<td align="right">5427</td>
+<td align="right">3.7</td>
+<td align="right">4222.6</td>
+<td align="right">57.9</td>
+<td align="right">167</td>
+<td align="right">0</td>
+<td>Closest to the Sun</td>
+</tr>
+<tr class="even">
+<th>Venus</th>
+<td align="right">4.87</td>
+<td align="right">12,104</td>
+<td align="right">5243</td>
+<td align="right">8.9</td>
+<td align="right">2802.0</td>
+<td align="right">108.2</td>
+<td align="right">464</td>
+<td align="right">0</td>
+<td></td>
+</tr>
+<tr class="odd">
+<th>Earth</th>
+<td align="right">5.97</td>
+<td align="right">12,756</td>
+<td align="right">5514</td>
+<td align="right">9.8</td>
+<td align="right">24.0</td>
+<td align="right">149.6</td>
+<td align="right">15</td>
+<td align="right">1</td>
+<td>Our world</td>
+</tr>
+<tr class="even">
+<th>Mars</th>
+<td align="right">0.642</td>
+<td align="right">6,792</td>
+<td align="right">3933</td>
+<td align="right">3.7</td>
+<td align="right">24.7</td>
+<td align="right">227.9</td>
+<td align="right">-65</td>
+<td align="right">2</td>
+<td>The red planet</td>
+</tr>
+<tr class="odd">
+<th align="center" rowspan="4">Jovian planets</th>
+<th align="center" rowspan="2">Gas giants</th>
+<th>Jupiter</th>
+<td align="right">1898</td>
+<td align="right">142,984</td>
+<td align="right">1326</td>
+<td align="right">23.1</td>
+<td align="right">9.9</td>
+<td align="right">778.6</td>
+<td align="right">-110</td>
+<td align="right">67</td>
+<td>The largest planet</td>
+</tr>
+<tr class="even">
+<th>Saturn</th>
+<td align="right">568</td>
+<td align="right">120,536</td>
+<td align="right">687</td>
+<td align="right">9.0</td>
+<td align="right">10.7</td>
+<td align="right">1433.5</td>
+<td align="right">-140</td>
+<td align="right">62</td>
+<td></td>
+</tr>
+<tr class="odd">
+<th align="center" rowspan="2">Ice giants</th>
+<th>Uranus</th>
+<td align="right">86.8</td>
+<td align="right">51,118</td>
+<td align="right">1271</td>
+<td align="right">8.7</td>
+<td align="right">17.2</td>
+<td align="right">2872.5</td>
+<td align="right">-195</td>
+<td align="right">27</td>
+<td></td>
+</tr>
+<tr class="even">
+<th>Neptune</th>
+<td align="right">102</td>
+<td align="right">49,528</td>
+<td align="right">1638</td>
+<td align="right">11.0</td>
+<td align="right">16.1</td>
+<td align="right">4495.1</td>
+<td align="right">-200</td>
+<td align="right">14</td>
+<td></td>
+</tr>
+<tr class="odd">
+<th align="center" colspan="2">Dwarf planets</th>
+<th>Pluto</th>
+<td align="right">0.0146</td>
+<td align="right">2,370</td>
+<td align="right">2095</td>
+<td align="right">0.7</td>
+<td align="right">153.3</td>
+<td align="right">5906.4</td>
+<td align="right">-225</td>
+<td align="right">5</td>
+<td>Declassified as a planet in 2006.</td>
+</tr>
+</tbody>
+</table>

--- a/test/tables/planets.html5
+++ b/test/tables/planets.html5
@@ -1,0 +1,133 @@
+<table>
+<caption><p>Data about the planets of our solar system.</p></caption>
+<thead>
+<tr class="header">
+<th style="text-align: center;" colspan="2"></th>
+<th>Name</th>
+<th style="text-align: right;">Mass (10^24kg)</th>
+<th style="text-align: right;">Diameter (km)</th>
+<th style="text-align: right;">Density (kg/m^3)</th>
+<th style="text-align: right;">Gravity (m/s^2)</th>
+<th style="text-align: right;">Length of day (hours)</th>
+<th style="text-align: right;">Distance from Sun (10^6km)</th>
+<th style="text-align: right;">Mean temperature (C)</th>
+<th style="text-align: right;">Number of moons</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<th style="text-align: center;" colspan="2" rowspan="4">Terrestial planets</th>
+<th>Mercury</th>
+<td style="text-align: right;">0.330</td>
+<td style="text-align: right;">4,879</td>
+<td style="text-align: right;">5427</td>
+<td style="text-align: right;">3.7</td>
+<td style="text-align: right;">4222.6</td>
+<td style="text-align: right;">57.9</td>
+<td style="text-align: right;">167</td>
+<td style="text-align: right;">0</td>
+<td>Closest to the Sun</td>
+</tr>
+<tr class="even">
+<th>Venus</th>
+<td style="text-align: right;">4.87</td>
+<td style="text-align: right;">12,104</td>
+<td style="text-align: right;">5243</td>
+<td style="text-align: right;">8.9</td>
+<td style="text-align: right;">2802.0</td>
+<td style="text-align: right;">108.2</td>
+<td style="text-align: right;">464</td>
+<td style="text-align: right;">0</td>
+<td></td>
+</tr>
+<tr class="odd">
+<th>Earth</th>
+<td style="text-align: right;">5.97</td>
+<td style="text-align: right;">12,756</td>
+<td style="text-align: right;">5514</td>
+<td style="text-align: right;">9.8</td>
+<td style="text-align: right;">24.0</td>
+<td style="text-align: right;">149.6</td>
+<td style="text-align: right;">15</td>
+<td style="text-align: right;">1</td>
+<td>Our world</td>
+</tr>
+<tr class="even">
+<th>Mars</th>
+<td style="text-align: right;">0.642</td>
+<td style="text-align: right;">6,792</td>
+<td style="text-align: right;">3933</td>
+<td style="text-align: right;">3.7</td>
+<td style="text-align: right;">24.7</td>
+<td style="text-align: right;">227.9</td>
+<td style="text-align: right;">-65</td>
+<td style="text-align: right;">2</td>
+<td>The red planet</td>
+</tr>
+<tr class="odd">
+<th style="text-align: center;" rowspan="4">Jovian planets</th>
+<th style="text-align: center;" rowspan="2">Gas giants</th>
+<th>Jupiter</th>
+<td style="text-align: right;">1898</td>
+<td style="text-align: right;">142,984</td>
+<td style="text-align: right;">1326</td>
+<td style="text-align: right;">23.1</td>
+<td style="text-align: right;">9.9</td>
+<td style="text-align: right;">778.6</td>
+<td style="text-align: right;">-110</td>
+<td style="text-align: right;">67</td>
+<td>The largest planet</td>
+</tr>
+<tr class="even">
+<th>Saturn</th>
+<td style="text-align: right;">568</td>
+<td style="text-align: right;">120,536</td>
+<td style="text-align: right;">687</td>
+<td style="text-align: right;">9.0</td>
+<td style="text-align: right;">10.7</td>
+<td style="text-align: right;">1433.5</td>
+<td style="text-align: right;">-140</td>
+<td style="text-align: right;">62</td>
+<td></td>
+</tr>
+<tr class="odd">
+<th style="text-align: center;" rowspan="2">Ice giants</th>
+<th>Uranus</th>
+<td style="text-align: right;">86.8</td>
+<td style="text-align: right;">51,118</td>
+<td style="text-align: right;">1271</td>
+<td style="text-align: right;">8.7</td>
+<td style="text-align: right;">17.2</td>
+<td style="text-align: right;">2872.5</td>
+<td style="text-align: right;">-195</td>
+<td style="text-align: right;">27</td>
+<td></td>
+</tr>
+<tr class="even">
+<th>Neptune</th>
+<td style="text-align: right;">102</td>
+<td style="text-align: right;">49,528</td>
+<td style="text-align: right;">1638</td>
+<td style="text-align: right;">11.0</td>
+<td style="text-align: right;">16.1</td>
+<td style="text-align: right;">4495.1</td>
+<td style="text-align: right;">-200</td>
+<td style="text-align: right;">14</td>
+<td></td>
+</tr>
+<tr class="odd">
+<th style="text-align: center;" colspan="2">Dwarf planets</th>
+<th>Pluto</th>
+<td style="text-align: right;">0.0146</td>
+<td style="text-align: right;">2,370</td>
+<td style="text-align: right;">2095</td>
+<td style="text-align: right;">0.7</td>
+<td style="text-align: right;">153.3</td>
+<td style="text-align: right;">5906.4</td>
+<td style="text-align: right;">-225</td>
+<td style="text-align: right;">5</td>
+<td>Declassified as a planet in 2006.</td>
+</tr>
+</tbody>
+</table>

--- a/test/tables/planets.native
+++ b/test/tables/planets.native
@@ -1,0 +1,138 @@
+[Table ("",[],[]) (Caption Nothing
+ [Para [Str "Data about the planets of our solar system."]])
+ [(AlignCenter,ColWidthDefault)
+ ,(AlignCenter,ColWidthDefault)
+ ,(AlignDefault,ColWidthDefault)
+ ,(AlignRight,ColWidthDefault)
+ ,(AlignRight,ColWidthDefault)
+ ,(AlignRight,ColWidthDefault)
+ ,(AlignRight,ColWidthDefault)
+ ,(AlignRight,ColWidthDefault)
+ ,(AlignRight,ColWidthDefault)
+ ,(AlignRight,ColWidthDefault)
+ ,(AlignRight,ColWidthDefault)
+ ,(AlignDefault,ColWidthDefault)]
+ (TableHead ("",[],[])
+  [Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 2) [Plain [Str ""]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Name"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Mass (10^24kg)"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Diameter (km)"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Density (kg/m^3)"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Gravity (m/s^2)"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Length of day (hours)"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Distance from Sun (10^6km)"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Mean temperature (C)"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Number of moons"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Notes"]]]]
+ )
+ [(TableBody ("",[],[]) (RowHeadColumns 3)
+  []
+  [Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 4) (ColSpan 2) [Plain [Str "Terrestial planets"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Mercury"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "0.330"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "4,879"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "5427"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "3.7"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "4222.6"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "57.9"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "167"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "0"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Closest to the Sun"]]]
+  ,Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Venus"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "4.87"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "12,104"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "5243"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "8.9"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "2802.0"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "108.2"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "464"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "0"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str ""]]]
+  ,Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Earth"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "5.97"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "12,756"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "5514"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "9.8"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "24.0"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "149.6"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "15"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "1"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Our world"]]]
+  ,Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Mars"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "0.642"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "6,792"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "3933"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "3.7"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "24.7"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "227.9"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "-65"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "2"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "The red planet"]]]
+  ,Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 4) (ColSpan 1) [Plain [Str "Jovian planets"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 2) (ColSpan 1) [Plain [Str "Gas giants"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Jupiter"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "1898"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "142,984"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "1326"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "23.1"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "9.9"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "778.6"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "-110"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "67"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "The largest planet"]]]
+  ,Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Saturn"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "568"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "120,536"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "687"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "9.0"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "10.7"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "1433.5"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "-140"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "62"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str ""]]]
+  ,Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 2) (ColSpan 1) [Plain [Str "Ice giants"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Uranus"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "86.8"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "51,118"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "1271"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "8.7"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "17.2"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "2872.5"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "-195"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "27"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str ""]]]
+  ,Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Neptune"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "102"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "49,528"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "1638"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "11.0"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "16.1"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "4495.1"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "-200"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "14"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str ""]]]
+  ,Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 2) [Plain [Str "Dwarf planets"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Pluto"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "0.0146"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "2,370"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "2095"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "0.7"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "153.3"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "5906.4"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "-225"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "5"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "Declassified as a planet in 2006."]]]])]
+ (TableFoot ("",[],[])
+ []
+ )
+]


### PR DESCRIPTION
Add support for cells spanning multiple columns or rows.

See: #6314 