### PR TITLE
Asciidoctor images

### DIFF
--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -66,7 +66,8 @@ writeAsciiDoc opts document =
 -- | Convert Pandoc to AsciiDoctor compatible AsciiDoc.
 writeAsciiDoctor :: PandocMonad m => WriterOptions -> Pandoc -> m Text
 writeAsciiDoctor opts document =
-  evalStateT (pandocToAsciiDoc opts document) defaultWriterState{ asciidoctorVariant = True }
+  evalStateT (pandocToAsciiDoc opts document)
+    defaultWriterState{ asciidoctorVariant = True }
 
 type ADW = StateT WriterState
 
@@ -141,7 +142,8 @@ blockToAsciiDoc opts (Plain inlines) = do
 blockToAsciiDoc opts (Para [Image attr alternate (src,tgt)])
   -- image::images/logo.png[Company logo, title="blah"]
   | Just tit <- T.stripPrefix "fig:" tgt
-  = (\args -> "image::" <> args <> blankline) <$> imageArguments opts attr alternate src tit
+  = (\args -> "image::" <> args <> blankline) <$>
+    imageArguments opts attr alternate src tit
 blockToAsciiDoc opts (Para inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   -- escape if para starts with ordered list marker
@@ -193,7 +195,8 @@ blockToAsciiDoc opts (BlockQuote blocks) = do
   let bar = text "____"
   return $ bar $$ chomp contents' $$ bar <> blankline
 blockToAsciiDoc opts (Table _ blkCapt specs thead tbody tfoot) = do
-  let (caption, aligns, widths, headers, rows) = toLegacyTable blkCapt specs thead tbody tfoot
+  let (caption, aligns, widths, headers, rows) =
+        toLegacyTable blkCapt specs thead tbody tfoot
   caption' <- inlineListToAsciiDoc opts caption
   let caption'' = if null caption
                      then empty
@@ -382,7 +385,10 @@ blockListToAsciiDoc opts blocks =
 data SpacyLocation = End | Start
 
 -- | Convert list of Pandoc inline elements to asciidoc.
-inlineListToAsciiDoc :: PandocMonad m => WriterOptions -> [Inline] -> ADW m (Doc Text)
+inlineListToAsciiDoc :: PandocMonad m =>
+                        WriterOptions ->
+                        [Inline] ->
+                        ADW m (Doc Text)
 inlineListToAsciiDoc opts lst = do
   oldIntraword <- gets intraword
   setIntraword False

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -542,7 +542,7 @@ inlineToAsciiDoc opts (Span (ident,classes,_) ils) = do
 -- | Provides the arguments for both `image:` and `image::`
 -- e.g.: sunset.jpg[Sunset,300,200]
 imageArguments :: PandocMonad m => WriterOptions ->
-  (Text, [Text], [(Text, Text)]) -> [Inline] -> Text -> Text ->
+  Attr -> [Inline] -> Text -> Text ->
   ADW m (Doc Text)
 imageArguments opts attr altText src title = do
   let txt = if null altText || (altText == [Str ""])
@@ -556,7 +556,8 @@ imageArguments opts attr altText src title = do
                       Just (Percent a) ->
                         ["scaledwidth=" <> text (show (Percent a))]
                       Just dim         ->
-                        [text (show dir) <> "=" <> literal (showInPixel opts dim)]
+                        [text (show dir) <> "=" <>
+                          literal (showInPixel opts dim)]
                       Nothing          ->
                         []
       dimList = showDim Width ++ showDim Height

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -138,9 +138,17 @@ blockToAsciiDoc opts (Div (id',"section":_,_)
 blockToAsciiDoc opts (Plain inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   return $ contents <> blankline
-blockToAsciiDoc opts (Para [Image attr alt (src,tgt)])
+
+blockToAsciiDoc opts (Para [Image attr alternate (src,tgt)])
+  -- image::images/logo.png[Company logo, title="blah"]
   | Just tit <- T.stripPrefix "fig:" tgt
-  = blockToAsciiDoc opts (Para [Image attr alt (src,tit)])
+  -- = (fmap (\t -> "image::" <> T.drop (T.length "image:") t)) <$> blockToAsciiDoc opts (Para [Image attr alternate (src,tit)])
+  = func <$> blockToAsciiDoc opts (Para [Image attr alternate (src,tit)])
+  where
+  func :: Doc Text -> Doc Text
+  func (Concat (Concat (Text 6 "image:") bb) b) = Concat (Concat (Text 7 "image::") bb) b
+  func t = t -- If this line is reached it means `blockToAsciiDoc` function for Image has a differet output now
+
 blockToAsciiDoc opts (Para inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   -- escape if para starts with ordered list marker
@@ -518,6 +526,7 @@ inlineToAsciiDoc opts (Link _ txt (src, _tit)) = do
   return $ if useAuto
               then literal srcSuffix
               else prefix <> literal src <> "[" <> linktext <> "]"
+
 inlineToAsciiDoc opts (Image attr alternate (src, tit)) = do
 -- image:images/logo.png[Company logo, title="blah"]
   let txt = if null alternate || (alternate == [Str ""])
@@ -539,6 +548,7 @@ inlineToAsciiDoc opts (Image attr alternate (src, tit)) = do
                 then empty
                 else "," <> mconcat (intersperse "," dimList)
   return $ "image:" <> literal src <> "[" <> linktext <> linktitle <> dims <> "]"
+
 inlineToAsciiDoc opts (Note [Para inlines]) =
   inlineToAsciiDoc opts (Note [Plain inlines])
 inlineToAsciiDoc opts (Note [Plain inlines]) = do

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -141,7 +141,7 @@ blockToAsciiDoc opts (Plain inlines) = do
 blockToAsciiDoc opts (Para [Image attr alternate (src,tgt)])
   -- image::images/logo.png[Company logo, title="blah"]
   | Just tit <- T.stripPrefix "fig:" tgt
-  = ("image::" <>) <$> imageHelper opts attr alternate src tit
+  = (\args -> "image::" <> args <> blankline) <$> imageHelper opts attr alternate src tit
 blockToAsciiDoc opts (Para inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   -- escape if para starts with ordered list marker

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -141,7 +141,7 @@ blockToAsciiDoc opts (Plain inlines) = do
 blockToAsciiDoc opts (Para [Image attr alternate (src,tgt)])
   -- image::images/logo.png[Company logo, title="blah"]
   | Just tit <- T.stripPrefix "fig:" tgt
-  = (\args -> "image::" <> args <> blankline) <$> imageHelper opts attr alternate src tit
+  = (\args -> "image::" <> args <> blankline) <$> imageArguments opts attr alternate src tit
 blockToAsciiDoc opts (Para inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   -- escape if para starts with ordered list marker
@@ -520,7 +520,7 @@ inlineToAsciiDoc opts (Link _ txt (src, _tit)) = do
               then literal srcSuffix
               else prefix <> literal src <> "[" <> linktext <> "]"
 inlineToAsciiDoc opts (Image attr alternate (src, tit)) =
-  ("image:" <>) <$> imageHelper opts attr alternate src tit
+  ("image:" <>) <$> imageArguments opts attr alternate src tit
 inlineToAsciiDoc opts (Note [Para inlines]) =
   inlineToAsciiDoc opts (Note [Plain inlines])
 inlineToAsciiDoc opts (Note [Plain inlines]) = do
@@ -541,10 +541,10 @@ inlineToAsciiDoc opts (Span (ident,classes,_) ils) = do
 
 -- | Provides the arguments for both `image:` and `image::`
 -- e.g.: sunset.jpg[Sunset,300,200]
-imageHelper :: PandocMonad m => WriterOptions ->
+imageArguments :: PandocMonad m => WriterOptions ->
   (Text, [Text], [(Text, Text)]) -> [Inline] -> Text -> Text ->
   ADW m (Doc Text)
-imageHelper opts attr altText src title = do
+imageArguments opts attr altText src title = do
   let txt = if null altText || (altText == [Str ""])
                then [Str "image"]
                else altText

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -138,7 +138,6 @@ blockToAsciiDoc opts (Div (id',"section":_,_)
 blockToAsciiDoc opts (Plain inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   return $ contents <> blankline
-
 blockToAsciiDoc opts (Para [Image attr alternate (src,tgt)])
   -- image::images/logo.png[Company logo, title="blah"]
   | Just tit <- T.stripPrefix "fig:" tgt
@@ -148,7 +147,6 @@ blockToAsciiDoc opts (Para [Image attr alternate (src,tgt)])
   func :: Doc Text -> Doc Text
   func (Concat (Concat (Text 6 "image:") bb) b) = Concat (Concat (Text 7 "image::") bb) b
   func t = t -- If this line is reached it means `blockToAsciiDoc` function for Image has a differet output now
-
 blockToAsciiDoc opts (Para inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   -- escape if para starts with ordered list marker
@@ -526,7 +524,6 @@ inlineToAsciiDoc opts (Link _ txt (src, _tit)) = do
   return $ if useAuto
               then literal srcSuffix
               else prefix <> literal src <> "[" <> linktext <> "]"
-
 inlineToAsciiDoc opts (Image attr alternate (src, tit)) = do
 -- image:images/logo.png[Company logo, title="blah"]
   let txt = if null alternate || (alternate == [Str ""])
@@ -548,7 +545,6 @@ inlineToAsciiDoc opts (Image attr alternate (src, tit)) = do
                 then empty
                 else "," <> mconcat (intersperse "," dimList)
   return $ "image:" <> literal src <> "[" <> linktext <> linktitle <> dims <> "]"
-
 inlineToAsciiDoc opts (Note [Para inlines]) =
   inlineToAsciiDoc opts (Note [Plain inlines])
 inlineToAsciiDoc opts (Note [Plain inlines]) = do

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -141,12 +141,14 @@ blockToAsciiDoc opts (Plain inlines) = do
 blockToAsciiDoc opts (Para [Image attr alternate (src,tgt)])
   -- image::images/logo.png[Company logo, title="blah"]
   | Just tit <- T.stripPrefix "fig:" tgt
-  -- = (fmap (\t -> "image::" <> T.drop (T.length "image:") t)) <$> blockToAsciiDoc opts (Para [Image attr alternate (src,tit)])
-  = func <$> blockToAsciiDoc opts (Para [Image attr alternate (src,tit)])
+  = blockImage <$> blockToAsciiDoc opts (Para [Image attr alternate (src,tit)])
   where
-  func :: Doc Text -> Doc Text
-  func (Concat (Concat (Text 6 "image:") bb) b) = Concat (Concat (Text 7 "image::") bb) b
-  func t = t -- If this line is reached it means `blockToAsciiDoc` function for Image has a differet output now
+  blockImage :: Doc Text -> Doc Text
+  blockImage (Concat (Concat (Text 6 "image:") bb) b) =
+     Concat (Concat (Text 7 "image::") bb) b
+  -- If this line is reached it means `blockToAsciiDoc` function for Image has a
+  -- differet output now
+  blockImage t = t 
 blockToAsciiDoc opts (Para inlines) = do
   contents <- inlineListToAsciiDoc opts inlines
   -- escape if para starts with ordered list marker

--- a/test/writer.asciidoc
+++ b/test/writer.asciidoc
@@ -622,7 +622,7 @@ or here: <http://example.com/>
 
 From ``Voyage dans la Lune'' by Georges Melies (1902):
 
-image:lalune.jpg[lalune,title="Voyage dans la Lune"]
+image::lalune.jpg[lalune,title="Voyage dans la Lune"]
 
 Here is a movie image:movie.jpg[movie] icon.
 

--- a/test/writer.asciidoctor
+++ b/test/writer.asciidoctor
@@ -623,7 +623,7 @@ or here: <http://example.com/>
 
 From "`Voyage dans la Lune`" by Georges Melies (1902):
 
-image:lalune.jpg[lalune,title="Voyage dans la Lune"]
+image::lalune.jpg[lalune,title="Voyage dans la Lune"]
 
 Here is a movie image:movie.jpg[movie] icon.
 


### PR DESCRIPTION
Addresses  #6538 by implementing jgm's [proposed solution](https://github.com/jgm/pandoc/issues/6538#issuecomment-659536590).

I had to change `writer.asciidoctor` to pass the tests.

Concretely:

Given the file: `my-test.markdown`

```{markdown}
Inline-style: ![alt text](media/rId25.jpg)

Block image:


![alt text 2](media/rId26.jpg "image title")

The end.
````

This patch generates, after running:

```
$ stack run pandoc -- -f markdown test/my-test.markdown -t asciidoctor -o -
```

The following file:

```
Inline-style: image:media/rId25.jpg[alt text]

Block image:

image::media/rId26.jpg[alt text 2,title="image title"]

The end.

```
I think the current basic test doesn't distinguish between inline and block figures. Should the distinction be added to the basic test?

As mentioned in  #3177, this fix is brittle for the time being.

I have only just seen kukimik's comment.