### PR TITLE
LaTeX reader: fix improper empty cell filtering

### DIFF
--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -174,20 +174,21 @@ tests = [ testGroup "tokenization"
                   , Row nullAttr [ simpleCell (plain "Two") ]
                   ]
           , "Table with nested multirow/multicolumn item" =:
-            T.unlines [ "\\begin{tabular}{c c c}"
-                      , "\\multicolumn{2}{c}{\\multirow{2}{5em}{One}}&Two\\\\"
-                      , "& & Three\\\\"
-                      , "Four&Five&Six\\\\"
+            T.unlines [ "\\begin{tabular}{c c c c}"
+                      , "\\multicolumn{3}{c}{\\multirow{2}{5em}{One}}&Two\\\\"
+                      , "\\multicolumn{2}{c}{} & & Three\\\\"
+                      , "Four&Five&Six&Seven\\\\"
                       , "\\end{tabular}"
                       ] =?>
-            table' [AlignCenter, AlignCenter, AlignCenter]
-                   [ Row nullAttr [ cell AlignCenter (RowSpan 2) (ColSpan 2) (plain "One")
+            table' [AlignCenter, AlignCenter, AlignCenter, AlignCenter]
+                   [ Row nullAttr [ cell AlignCenter (RowSpan 2) (ColSpan 3) (plain "One")
                                   , simpleCell (plain "Two")
                                   ]
                    , Row nullAttr [ simpleCell (plain "Three") ]
                    , Row nullAttr [ simpleCell (plain "Four") 
                                   , simpleCell (plain "Five")
                                   , simpleCell (plain "Six")
+                                  , simpleCell (plain "Seven")
                                   ]
                    ]
           , "Table with multicolumn header" =:
@@ -204,6 +205,25 @@ tests = [ testGroup "tokenization"
                                                          ]
                                            ]
                   ]
+                  (TableFoot nullAttr [])
+          , "Table with normal empty cells" =:
+            T.unlines [ "\\begin{tabular}{|r|r|r|}"
+                      , "A &   & B \\\\"
+                      , "  & C &"
+                      , "\\end{tabular}"
+                      ] =?>
+            table emptyCaption
+                  (replicate 3 (AlignRight, ColWidthDefault))
+                  (TableHead nullAttr [])
+                  [TableBody nullAttr 0 []
+                    [Row nullAttr [ simpleCell (plain "A")
+                                  , emptyCell
+                                  , simpleCell (plain "B")
+                                  ]
+                    ,Row nullAttr [ emptyCell
+                                  , simpleCell (plain "C")
+                                  , emptyCell
+                                  ]]]
                   (TableFoot nullAttr [])
           ]
 


### PR DESCRIPTION
Resolves #6681.

My understanding of LaTeX tables is that a cell that spans `n` rows will overwrite all the grid positions in columns that it spans for the next `n-1` rows. This is where the empty cell padding that needs to be removed comes from. If that is correct, the reader should now properly remove just these empty cells, and hopefully leave malformed tables relatively unmangled before they reach the `table` builder.