### PR TITLE
Support toc-depth option for ODT writer (#6696)

### DIFF
--- a/data/templates/default.opendocument
+++ b/data/templates/default.opendocument
@@ -31,7 +31,7 @@ $include-before$
 $endfor$
 $if(toc)$
 <text:table-of-content>
-  <text:table-of-content-source text:outline-level="10">
+  <text:table-of-content-source text:outline-level="$toc-depth$">
     <text:index-title-template text:style-name="Contents_20_Heading">$toc-title$</text:index-title-template>
     <text:table-of-content-entry-template text:outline-level="1"
     text:style-name="Contents_20_1">

--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -247,6 +247,7 @@ writeOpenDocument opts (Pandoc meta blocks) = do
   let automaticStyles = vcat $ reverse $ styles ++ listStyles
   let context = defField "body" body
               . defField "toc" (writerTableOfContents opts)
+              . defField "toc-depth" (tshow $ writerTOCDepth opts)
               . defField "automatic-styles" automaticStyles
               $ metadata
   return $ render colwidth $


### PR DESCRIPTION
To support `--toc-depth` option for ODT, writer and template are
updated.