### PR TITLE
Syntax highlight for CodeBlock of OpenDocument

### DIFF
--- a/test/writer.opendocument
+++ b/test/writer.opendocument
@@ -1025,149 +1025,99 @@
     <style:style style:name="P2" style:family="paragraph" style:parent-style-name="Quotations">
       <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
     </style:style>
-    <style:style style:name="P3" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-      <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
-    </style:style>
-    <style:style style:name="P4" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-      <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
-    </style:style>
-    <style:style style:name="P5" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-      <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
-    </style:style>
-    <style:style style:name="P6" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L1">
+    <style:style style:name="P3" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L1">
       <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P7" style:family="paragraph" style:parent-style-name="Quotations">
+    <style:style style:name="P4" style:family="paragraph" style:parent-style-name="Quotations">
       <style:paragraph-properties fo:margin-left="1.0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
     </style:style>
-    <style:style style:name="P8" style:family="paragraph" style:parent-style-name="Quotations">
+    <style:style style:name="P5" style:family="paragraph" style:parent-style-name="Quotations">
       <style:paragraph-properties fo:margin-left="1.0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
     </style:style>
-    <style:style style:name="P9" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P10" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P11" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P12" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P13" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P14" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P15" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P16" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P17" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P18" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P19" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L2">
+    <style:style style:name="P6" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L2">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P20" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L3">
+    <style:style style:name="P7" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L3">
     </style:style>
-    <style:style style:name="P21" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L4">
+    <style:style style:name="P8" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L4">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P22" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L5">
+    <style:style style:name="P9" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L5">
     </style:style>
-    <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L6">
+    <style:style style:name="P10" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L6">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L7">
+    <style:style style:name="P11" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L7">
     </style:style>
-    <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L8">
+    <style:style style:name="P12" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L8">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9">
+    <style:style style:name="P13" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L10">
+    <style:style style:name="P14" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L10">
     </style:style>
-    <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L11">
+    <style:style style:name="P15" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L11">
     </style:style>
-    <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L12">
+    <style:style style:name="P16" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L12">
     </style:style>
-    <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L13">
+    <style:style style:name="P17" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L13">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L14">
+    <style:style style:name="P18" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L14">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L15">
+    <style:style style:name="P19" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L15">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L16">
+    <style:style style:name="P20" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L16">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L17">
+    <style:style style:name="P21" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L17">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L18">
+    <style:style style:name="P22" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L18">
     </style:style>
-    <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L19">
+    <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L19">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L20">
+    <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L20">
     </style:style>
-    <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L21">
+    <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L21">
     </style:style>
-    <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L22">
+    <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L22">
     </style:style>
-    <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L23">
+    <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L23">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L24">
+    <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L24">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
+    <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Quotations">
       <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
     </style:style>
-    <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Quotations">
-      <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
-    </style:style>
-    <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L25">
+    <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L25">
       <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L26">
+    <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L26">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L27">
+    <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L27">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L28">
+    <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L28">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L29">
+    <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L29">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
-    <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Quotations">
+    <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Quotations">
       <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
     </style:style>
-    <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Preformatted_20_Text">
-    </style:style>
-    <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Quotations">
+    <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Quotations">
       <style:paragraph-properties fo:margin-left="0.5in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" />
     </style:style>
-    <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L30">
+    <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L30">
       <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" />
     </style:style>
   </office:automatic-styles>
@@ -1221,21 +1171,19 @@ Quotes<text:bookmark-end text:name="block-quotes" /></text:h>
 <text:p text:style-name="P1">This is a block quote. It is pretty
 short.</text:p>
 <text:p text:style-name="P2">Code in a block quote:</text:p>
-<text:p text:style-name="P3">sub status {</text:p>
-<text:p text:style-name="P4"><text:s text:c="4" />print &quot;working&quot;;</text:p>
-<text:p text:style-name="P5">}</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">sub status {</text:span><text:line-break /><text:span text:style-name="Source_Text"><text:s text:c="4" />print &quot;working&quot;;</text:span><text:line-break /><text:span text:style-name="Source_Text">}</text:span></text:p>
 <text:p text:style-name="P2">A list:</text:p>
 <text:list text:style-name="L1">
   <text:list-item>
-    <text:p text:style-name="P6">item one</text:p>
+    <text:p text:style-name="P3">item one</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P6">item two</text:p>
+    <text:p text:style-name="P3">item two</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="P2">Nested block quotes:</text:p>
-<text:p text:style-name="P7">nested</text:p>
-<text:p text:style-name="P8">nested</text:p>
+<text:p text:style-name="P4">nested</text:p>
+<text:p text:style-name="P5">nested</text:p>
 <text:p text:style-name="First_20_paragraph">This should not be a block quote:
 2 &gt; 1.</text:p>
 <text:p text:style-name="Text_20_body">And a following paragraph.</text:p>
@@ -1243,163 +1191,155 @@ short.</text:p>
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="code-blocks" />Code
 Blocks<text:bookmark-end text:name="code-blocks" /></text:h>
 <text:p text:style-name="First_20_paragraph">Code:</text:p>
-<text:p text:style-name="P9">---- (should be four hyphens)</text:p>
-<text:p text:style-name="P10"></text:p>
-<text:p text:style-name="P11">sub status {</text:p>
-<text:p text:style-name="P12"><text:s text:c="4" />print &quot;working&quot;;</text:p>
-<text:p text:style-name="P13">}</text:p>
-<text:p text:style-name="P14"></text:p>
-<text:p text:style-name="P15">this code block is indented by one tab</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">---- (should be four hyphens)</text:span><text:line-break /><text:span text:style-name="Source_Text"></text:span><text:line-break /><text:span text:style-name="Source_Text">sub status {</text:span><text:line-break /><text:span text:style-name="Source_Text"><text:s text:c="4" />print &quot;working&quot;;</text:span><text:line-break /><text:span text:style-name="Source_Text">}</text:span><text:line-break /><text:span text:style-name="Source_Text"></text:span><text:line-break /><text:span text:style-name="Source_Text">this code block is indented by one tab</text:span></text:p>
 <text:p text:style-name="First_20_paragraph">And:</text:p>
-<text:p text:style-name="P16"><text:s text:c="4" />this code block is indented by two tabs</text:p>
-<text:p text:style-name="P17"></text:p>
-<text:p text:style-name="P18">These should not be escaped: <text:s text:c="1" />\$ \\ \&gt; \[ \{</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text"><text:s text:c="4" />this code block is indented by two tabs</text:span><text:line-break /><text:span text:style-name="Source_Text"></text:span><text:line-break /><text:span text:style-name="Source_Text">These should not be escaped: <text:s text:c="1" />\$ \\ \&gt; \[ \{</text:span></text:p>
 <text:p text:style-name="Horizontal_20_Line" />
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="lists" />Lists<text:bookmark-end text:name="lists" /></text:h>
 <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="unordered" />Unordered<text:bookmark-end text:name="unordered" /></text:h>
 <text:p text:style-name="First_20_paragraph">Asterisks tight:</text:p>
 <text:list text:style-name="L2">
   <text:list-item>
-    <text:p text:style-name="P19">asterisk 1</text:p>
+    <text:p text:style-name="P6">asterisk 1</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P19">asterisk 2</text:p>
+    <text:p text:style-name="P6">asterisk 2</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P19">asterisk 3</text:p>
+    <text:p text:style-name="P6">asterisk 3</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">Asterisks loose:</text:p>
 <text:list text:style-name="L3">
   <text:list-item>
-    <text:p text:style-name="P20">asterisk 1</text:p>
+    <text:p text:style-name="P7">asterisk 1</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P20">asterisk 2</text:p>
+    <text:p text:style-name="P7">asterisk 2</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P20">asterisk 3</text:p>
+    <text:p text:style-name="P7">asterisk 3</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">Pluses tight:</text:p>
 <text:list text:style-name="L4">
   <text:list-item>
-    <text:p text:style-name="P21">Plus 1</text:p>
+    <text:p text:style-name="P8">Plus 1</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P21">Plus 2</text:p>
+    <text:p text:style-name="P8">Plus 2</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P21">Plus 3</text:p>
+    <text:p text:style-name="P8">Plus 3</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">Pluses loose:</text:p>
 <text:list text:style-name="L5">
   <text:list-item>
-    <text:p text:style-name="P22">Plus 1</text:p>
+    <text:p text:style-name="P9">Plus 1</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P22">Plus 2</text:p>
+    <text:p text:style-name="P9">Plus 2</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P22">Plus 3</text:p>
+    <text:p text:style-name="P9">Plus 3</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">Minuses tight:</text:p>
 <text:list text:style-name="L6">
   <text:list-item>
-    <text:p text:style-name="P23">Minus 1</text:p>
+    <text:p text:style-name="P10">Minus 1</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P23">Minus 2</text:p>
+    <text:p text:style-name="P10">Minus 2</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P23">Minus 3</text:p>
+    <text:p text:style-name="P10">Minus 3</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">Minuses loose:</text:p>
 <text:list text:style-name="L7">
   <text:list-item>
-    <text:p text:style-name="P24">Minus 1</text:p>
+    <text:p text:style-name="P11">Minus 1</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P24">Minus 2</text:p>
+    <text:p text:style-name="P11">Minus 2</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P24">Minus 3</text:p>
+    <text:p text:style-name="P11">Minus 3</text:p>
   </text:list-item>
 </text:list>
 <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="ordered" />Ordered<text:bookmark-end text:name="ordered" /></text:h>
 <text:p text:style-name="First_20_paragraph">Tight:</text:p>
 <text:list text:style-name="L8">
   <text:list-item>
-    <text:p text:style-name="P25">First</text:p>
+    <text:p text:style-name="P12">First</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P25">Second</text:p>
+    <text:p text:style-name="P12">Second</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P25">Third</text:p>
+    <text:p text:style-name="P12">Third</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">and:</text:p>
 <text:list text:style-name="L9">
   <text:list-item>
-    <text:p text:style-name="P26">One</text:p>
+    <text:p text:style-name="P13">One</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P26">Two</text:p>
+    <text:p text:style-name="P13">Two</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P26">Three</text:p>
+    <text:p text:style-name="P13">Three</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">Loose using tabs:</text:p>
 <text:list text:style-name="L10">
   <text:list-item>
-    <text:p text:style-name="P27">First</text:p>
+    <text:p text:style-name="P14">First</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P27">Second</text:p>
+    <text:p text:style-name="P14">Second</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P27">Third</text:p>
+    <text:p text:style-name="P14">Third</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">and using spaces:</text:p>
 <text:list text:style-name="L11">
   <text:list-item>
-    <text:p text:style-name="P28">One</text:p>
+    <text:p text:style-name="P15">One</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P28">Two</text:p>
+    <text:p text:style-name="P15">Two</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P28">Three</text:p>
+    <text:p text:style-name="P15">Three</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">Multiple paragraphs:</text:p>
 <text:list text:style-name="L12">
   <text:list-item>
-    <text:p text:style-name="P29">Item 1, graf one.</text:p>
-    <text:p text:style-name="P29">Item 1. graf two. The quick brown fox jumped
+    <text:p text:style-name="P16">Item 1, graf one.</text:p>
+    <text:p text:style-name="P16">Item 1. graf two. The quick brown fox jumped
     over the lazy dog’s back.</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P29">Item 2.</text:p>
+    <text:p text:style-name="P16">Item 2.</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P29">Item 3.</text:p>
+    <text:p text:style-name="P16">Item 3.</text:p>
   </text:list-item>
 </text:list>
 <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="nested" />Nested<text:bookmark-end text:name="nested" /></text:h>
 <text:list text:style-name="L13">
   <text:list-item>
-    <text:p text:style-name="P30">Tab</text:p><text:list text:style-name="L14">
+    <text:p text:style-name="P17">Tab</text:p><text:list text:style-name="L14">
       <text:list-item>
-        <text:p text:style-name="P31">Tab</text:p><text:list text:style-name="L15">
+        <text:p text:style-name="P18">Tab</text:p><text:list text:style-name="L15">
           <text:list-item>
-            <text:p text:style-name="P32">Tab</text:p>
+            <text:p text:style-name="P19">Tab</text:p>
           </text:list-item>
         </text:list>
       </text:list-item>
@@ -1409,66 +1349,66 @@ Blocks<text:bookmark-end text:name="code-blocks" /></text:h>
 <text:p text:style-name="First_20_paragraph">Here’s another:</text:p>
 <text:list text:style-name="L16">
   <text:list-item>
-    <text:p text:style-name="P33">First</text:p>
+    <text:p text:style-name="P20">First</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P33">Second:</text:p>
+    <text:p text:style-name="P20">Second:</text:p>
     <text:list text:style-name="L17">
       <text:list-item>
-        <text:p text:style-name="P34">Fee</text:p>
+        <text:p text:style-name="P21">Fee</text:p>
       </text:list-item>
       <text:list-item>
-        <text:p text:style-name="P34">Fie</text:p>
+        <text:p text:style-name="P21">Fie</text:p>
       </text:list-item>
       <text:list-item>
-        <text:p text:style-name="P34">Foe</text:p>
+        <text:p text:style-name="P21">Foe</text:p>
       </text:list-item>
     </text:list>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P33">Third</text:p>
+    <text:p text:style-name="P20">Third</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">Same thing but with
 paragraphs:</text:p>
 <text:list text:style-name="L18">
   <text:list-item>
-    <text:p text:style-name="P35">First</text:p>
+    <text:p text:style-name="P22">First</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P35">Second:</text:p>
+    <text:p text:style-name="P22">Second:</text:p>
     <text:list text:style-name="L19">
       <text:list-item>
-        <text:p text:style-name="P36">Fee</text:p>
+        <text:p text:style-name="P23">Fee</text:p>
       </text:list-item>
       <text:list-item>
-        <text:p text:style-name="P36">Fie</text:p>
+        <text:p text:style-name="P23">Fie</text:p>
       </text:list-item>
       <text:list-item>
-        <text:p text:style-name="P36">Foe</text:p>
+        <text:p text:style-name="P23">Foe</text:p>
       </text:list-item>
     </text:list>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P35">Third</text:p>
+    <text:p text:style-name="P22">Third</text:p>
   </text:list-item>
 </text:list>
 <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="tabs-and-spaces" />Tabs
 and spaces<text:bookmark-end text:name="tabs-and-spaces" /></text:h>
 <text:list text:style-name="L20">
   <text:list-item>
-    <text:p text:style-name="P37">this is a list item indented with
+    <text:p text:style-name="P24">this is a list item indented with
     tabs</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P37">this is a list item indented with
+    <text:p text:style-name="P24">this is a list item indented with
     spaces</text:p><text:list text:style-name="L21">
       <text:list-item>
-        <text:p text:style-name="P38">this is an example list item indented
+        <text:p text:style-name="P25">this is an example list item indented
         with tabs</text:p>
       </text:list-item>
       <text:list-item>
-        <text:p text:style-name="P38">this is an example list item indented
+        <text:p text:style-name="P25">this is an example list item indented
         with spaces</text:p>
       </text:list-item>
     </text:list>
@@ -1478,24 +1418,24 @@ and spaces<text:bookmark-end text:name="tabs-and-spaces" /></text:h>
 list markers<text:bookmark-end text:name="fancy-list-markers" /></text:h>
 <text:list text:style-name="L22">
   <text:list-item>
-    <text:p text:style-name="P39">begins with 2</text:p>
+    <text:p text:style-name="P26">begins with 2</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P39">and now 3</text:p>
-    <text:p text:style-name="P39">with a continuation</text:p>
+    <text:p text:style-name="P26">and now 3</text:p>
+    <text:p text:style-name="P26">with a continuation</text:p>
     <text:list>
       <text:list-item>
-        <text:p text:style-name="P39">sublist with roman numerals, starting
+        <text:p text:style-name="P26">sublist with roman numerals, starting
         with 4</text:p>
       </text:list-item>
       <text:list-item>
-        <text:p text:style-name="P39">more items</text:p>
+        <text:p text:style-name="P26">more items</text:p>
         <text:list>
           <text:list-item>
-            <text:p text:style-name="P39">a subsublist</text:p>
+            <text:p text:style-name="P26">a subsublist</text:p>
           </text:list-item>
           <text:list-item>
-            <text:p text:style-name="P39">a subsublist</text:p>
+            <text:p text:style-name="P26">a subsublist</text:p>
           </text:list-item>
         </text:list>
       </text:list-item>
@@ -1505,16 +1445,16 @@ list markers<text:bookmark-end text:name="fancy-list-markers" /></text:h>
 <text:p text:style-name="First_20_paragraph">Nesting:</text:p>
 <text:list text:style-name="L23">
   <text:list-item>
-    <text:p text:style-name="P40">Upper Alpha</text:p>
+    <text:p text:style-name="P27">Upper Alpha</text:p>
     <text:list>
       <text:list-item>
-        <text:p text:style-name="P40">Upper Roman.</text:p>
+        <text:p text:style-name="P27">Upper Roman.</text:p>
         <text:list>
           <text:list-item>
-            <text:p text:style-name="P40">Decimal start with 6</text:p>
+            <text:p text:style-name="P27">Decimal start with 6</text:p>
             <text:list>
               <text:list-item>
-                <text:p text:style-name="P40">Lower alpha with paren</text:p>
+                <text:p text:style-name="P27">Lower alpha with paren</text:p>
               </text:list-item>
             </text:list>
           </text:list-item>
@@ -1526,13 +1466,13 @@ list markers<text:bookmark-end text:name="fancy-list-markers" /></text:h>
 <text:p text:style-name="First_20_paragraph">Autonumbering:</text:p>
 <text:list text:style-name="L24">
   <text:list-item>
-    <text:p text:style-name="P41">Autonumber.</text:p>
+    <text:p text:style-name="P28">Autonumber.</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P41">More.</text:p>
+    <text:p text:style-name="P28">More.</text:p>
     <text:list>
       <text:list-item>
-        <text:p text:style-name="P41">Nested.</text:p>
+        <text:p text:style-name="P28">Nested.</text:p>
       </text:list-item>
     </text:list>
   </text:list-item>
@@ -1577,7 +1517,7 @@ fruit</text:p><text:p text:style-name="Definition_20_Definition">contains
 seeds, crisp, pleasant to taste</text:p>
 <text:p text:style-name="Definition_20_Term"><text:span text:style-name="T1">orange</text:span></text:p>
 <text:p text:style-name="Definition_20_Definition">orange
-fruit</text:p><text:p text:style-name="P42">{ orange code block }</text:p><text:p text:style-name="P43">orange
+fruit</text:p><text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">{ orange code block }</text:span></text:p><text:p text:style-name="P29">orange
 block quote</text:p>
 <text:p text:style-name="First_20_paragraph">Multiple definitions,
 tight:</text:p>
@@ -1605,10 +1545,10 @@ marker, alternate markers:</text:p>
 <text:p text:style-name="Definition_20_Definition">orange
 fruit</text:p><text:list text:style-name="L25">
   <text:list-item>
-    <text:p text:style-name="P44">sublist</text:p>
+    <text:p text:style-name="P30">sublist</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P44">sublist</text:p>
+    <text:p text:style-name="P30">sublist</text:p>
   </text:list-item>
 </text:list>
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="html-blocks" />HTML
@@ -1630,22 +1570,20 @@ table:</text:p>
 <text:p text:style-name="Text_20_body">foo</text:p>
 <text:p text:style-name="Text_20_body">This should be a code block,
 though:</text:p>
-<text:p text:style-name="P45">&lt;div&gt;</text:p>
-<text:p text:style-name="P46"><text:s text:c="4" />foo</text:p>
-<text:p text:style-name="P47">&lt;/div&gt;</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">&lt;div&gt;</text:span><text:line-break /><text:span text:style-name="Source_Text"><text:s text:c="4" />foo</text:span><text:line-break /><text:span text:style-name="Source_Text">&lt;/div&gt;</text:span></text:p>
 <text:p text:style-name="First_20_paragraph">As should this:</text:p>
-<text:p text:style-name="P48">&lt;div&gt;foo&lt;/div&gt;</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">&lt;div&gt;foo&lt;/div&gt;</text:span></text:p>
 <text:p text:style-name="First_20_paragraph">Now, nested:</text:p>
 <text:p text:style-name="Text_20_body">foo</text:p>
 <text:p text:style-name="Text_20_body">This should just be an HTML
 comment:</text:p>
 <text:p text:style-name="Text_20_body">Multiline:</text:p>
 <text:p text:style-name="Text_20_body">Code block:</text:p>
-<text:p text:style-name="P49">&lt;!-- Comment --&gt;</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">&lt;!-- Comment --&gt;</text:span></text:p>
 <text:p text:style-name="First_20_paragraph">Just plain comment, with trailing
 spaces on the line:</text:p>
 <text:p text:style-name="Text_20_body">Code:</text:p>
-<text:p text:style-name="P50">&lt;hr /&gt;</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">&lt;hr /&gt;</text:span></text:p>
 <text:p text:style-name="First_20_paragraph">Hr’s:</text:p>
 <text:p text:style-name="Horizontal_20_Line" />
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="inline-markup" />Inline
@@ -1709,48 +1647,48 @@ five.</text:p>
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="latex" />LaTeX<text:bookmark-end text:name="latex" /></text:h>
 <text:list text:style-name="L26">
   <text:list-item>
-    <text:p text:style-name="P51"></text:p>
+    <text:p text:style-name="P31"></text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P51">2 + 2 = 4</text:p>
+    <text:p text:style-name="P31">2 + 2 = 4</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P51"><text:span text:style-name="T1">x</text:span> ∈ <text:span text:style-name="T1">y</text:span></text:p>
+    <text:p text:style-name="P31"><text:span text:style-name="T1">x</text:span> ∈ <text:span text:style-name="T1">y</text:span></text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P51"><text:span text:style-name="T1">α</text:span> ∧ <text:span text:style-name="T1">ω</text:span></text:p>
+    <text:p text:style-name="P31"><text:span text:style-name="T1">α</text:span> ∧ <text:span text:style-name="T1">ω</text:span></text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P51">223</text:p>
+    <text:p text:style-name="P31">223</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P51"><text:span text:style-name="T1">p</text:span>-Tree</text:p>
+    <text:p text:style-name="P31"><text:span text:style-name="T1">p</text:span>-Tree</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P51">Here’s some display math:
+    <text:p text:style-name="P31">Here’s some display math:
     $$\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}$$</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P51">Here’s one that has a line break in it:
+    <text:p text:style-name="P31">Here’s one that has a line break in it:
     <text:span text:style-name="T1">α</text:span> + <text:span text:style-name="T1">ω</text:span> × <text:span text:style-name="T1">x</text:span><text:span text:style-name="T6">2</text:span>.</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">These shouldn’t be math:</text:p>
 <text:list text:style-name="L27">
   <text:list-item>
-    <text:p text:style-name="P52">To get the famous equation, write
+    <text:p text:style-name="P32">To get the famous equation, write
     <text:span text:style-name="Source_Text">$e = mc^2$</text:span>.</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P52">$22,000 is a
+    <text:p text:style-name="P32">$22,000 is a
     <text:span text:style-name="T1">lot</text:span> of money. So is $34,000.
     (It worked if “lot” is emphasized.)</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P52">Shoes ($20) and socks ($5).</text:p>
+    <text:p text:style-name="P32">Shoes ($20) and socks ($5).</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P52">Escaped
+    <text:p text:style-name="P32">Escaped
     <text:span text:style-name="Source_Text">$</text:span>: $73
     <text:span text:style-name="T1">this should be emphasized</text:span>
     23$.</text:p>
@@ -1763,19 +1701,19 @@ Characters<text:bookmark-end text:name="special-characters" /></text:h>
 <text:p text:style-name="First_20_paragraph">Here is some unicode:</text:p>
 <text:list text:style-name="L28">
   <text:list-item>
-    <text:p text:style-name="P53">I hat: Î</text:p>
+    <text:p text:style-name="P33">I hat: Î</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P53">o umlaut: ö</text:p>
+    <text:p text:style-name="P33">o umlaut: ö</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P53">section: §</text:p>
+    <text:p text:style-name="P33">section: §</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P53">set membership: ∈</text:p>
+    <text:p text:style-name="P33">set membership: ∈</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P53">copyright: ©</text:p>
+    <text:p text:style-name="P33">copyright: ©</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">AT&amp;T has an ampersand in
@@ -1835,7 +1773,7 @@ by itself should be a link.</text:p>
 <text:p text:style-name="Text_20_body">Indented
 <text:a xlink:type="simple" xlink:href="/url" office:name=""><text:span text:style-name="Definition">thrice</text:span></text:a>.</text:p>
 <text:p text:style-name="Text_20_body">This should [not][] be a link.</text:p>
-<text:p text:style-name="P54">[not]: /url</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">[not]: /url</text:span></text:p>
 <text:p text:style-name="First_20_paragraph">Foo
 <text:a xlink:type="simple" xlink:href="/url/" office:name="Title with &quot;quotes&quot; inside"><text:span text:style-name="Definition">bar</text:span></text:a>.</text:p>
 <text:p text:style-name="Text_20_body">Foo
@@ -1859,22 +1797,22 @@ link in pointy braces</text:span></text:a>.</text:p>
 <text:a xlink:type="simple" xlink:href="http://example.com/?foo=1&amp;bar=2" office:name=""><text:span text:style-name="Definition">http://example.com/?foo=1&amp;bar=2</text:span></text:a></text:p>
 <text:list text:style-name="L29">
   <text:list-item>
-    <text:p text:style-name="P55">In a list?</text:p>
+    <text:p text:style-name="P34">In a list?</text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P55"><text:a xlink:type="simple" xlink:href="http://example.com/" office:name=""><text:span text:style-name="Definition">http://example.com/</text:span></text:a></text:p>
+    <text:p text:style-name="P34"><text:a xlink:type="simple" xlink:href="http://example.com/" office:name=""><text:span text:style-name="Definition">http://example.com/</text:span></text:a></text:p>
   </text:list-item>
   <text:list-item>
-    <text:p text:style-name="P55">It should.</text:p>
+    <text:p text:style-name="P34">It should.</text:p>
   </text:list-item>
 </text:list>
 <text:p text:style-name="First_20_paragraph">An e-mail address:
 <text:a xlink:type="simple" xlink:href="mailto:nobody@nowhere.net" office:name=""><text:span text:style-name="Definition">nobody@nowhere.net</text:span></text:a></text:p>
-<text:p text:style-name="P56">Blockquoted:
+<text:p text:style-name="P35">Blockquoted:
 <text:a xlink:type="simple" xlink:href="http://example.com/" office:name=""><text:span text:style-name="Definition">http://example.com/</text:span></text:a></text:p>
 <text:p text:style-name="First_20_paragraph">Auto-links should not occur here:
 <text:span text:style-name="Source_Text">&lt;http://example.com/&gt;</text:span></text:p>
-<text:p text:style-name="P57">or here: &lt;http://example.com/&gt;</text:p>
+<text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text">or here: &lt;http://example.com/&gt;</text:span></text:p>
 <text:p text:style-name="Horizontal_20_Line" />
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="images" />Images<text:bookmark-end text:name="images" /></text:h>
 <text:p text:style-name="First_20_paragraph">From “Voyage dans la Lune” by
@@ -1895,7 +1833,7 @@ another.<text:note text:id="ftn1" text:note-class="footnote"><text:note-citation
 the long note. This one contains multiple
 blocks.</text:p><text:p text:style-name="Footnote">Subsequent blocks are
 indented to show that they belong to the footnote (as with list
-items).</text:p><text:p text:style-name="P58"><text:s text:c="2" />{ &lt;code&gt; }</text:p><text:p text:style-name="Footnote">If
+items).</text:p><text:p text:style-name="Source_20_Code"><text:span text:style-name="Source_Text"><text:s text:c="2" />{ &lt;code&gt; }</text:span></text:p><text:p text:style-name="Footnote">If
 you want, you can indent every line, but you can also be lazy and just indent
 the first line of each block.</text:p></text:note-body></text:note> This
 should <text:span text:style-name="T1">not</text:span> be a footnote
@@ -1907,12 +1845,12 @@ may contain
 and <text:span text:style-name="Source_Text">]</text:span> verbatim
 characters, as well as [bracketed
 text].</text:p></text:note-body></text:note></text:p>
-<text:p text:style-name="P59">Notes can go in
+<text:p text:style-name="P36">Notes can go in
 quotes.<text:note text:id="ftn3" text:note-class="footnote"><text:note-citation>4</text:note-citation><text:note-body><text:p text:style-name="Footnote">In
 quote.</text:p></text:note-body></text:note></text:p>
 <text:list text:style-name="L30">
   <text:list-item>
-    <text:p text:style-name="P60">And in list
+    <text:p text:style-name="P37">And in list
     items.<text:note text:id="ftn4" text:note-class="footnote"><text:note-citation>5</text:note-citation><text:note-body><text:p text:style-name="Footnote">In
     list.</text:p></text:note-body></text:note></text:p>
   </text:list-item>


### PR DESCRIPTION
By #6711, syntax highlighting for inline Code has been implemented.
Syntax highlighting for CodeBlock is also implemented based on Docx Writer.

* Paragraph style of CodeBlock is changed from "Preformatted_20_Text" to "Source_Code".
* As similar to docx writer, CodeBlock is decomposed to "Code + LineBreak" lines.
* To do this, inlineToOpenDocument Code is updated again to treat multiple lines.
* Styles will be incorporated by Writer/ODT.hs

Further discussion will be added to #6710.