### PR TITLE
Sort languages in `--list-highlight-languages` output

### DIFF
--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -840,7 +840,7 @@ options =
                                  , sShortname s `notElem`
                                     [T.pack "Alert", T.pack "Alert_indent"]
                                  ]
-                     mapM_ (UTF8.hPutStrLn stdout) langs
+                     mapM_ (UTF8.hPutStrLn stdout) (sort langs)
                      exitSuccess ))
                  ""
 


### PR DESCRIPTION
Languages appear to be sorted by their long name, which leads to
unexpected results: e.g., the long name of *m4* is *GNU m4*, so it is
listed between *gnuassembler* and *go*.