### PR TITLE
Fix apparent typos in sample.lua

### DIFF
--- a/data/sample.lua
+++ b/data/sample.lua
@@ -21,7 +21,7 @@ local stringify = (require "pandoc.utils").stringify
 -- configure the writer.
 local meta = PANDOC_DOCUMENT.meta
 
--- Chose the image format based on the value of the
+-- Choose the image format based on the value of the
 -- `image_format` meta value.
 local image_format = meta.image_format
   and stringify(meta.image_format)
@@ -45,9 +45,9 @@ local function escape(s, in_attribute)
         return '&gt;'
       elseif x == '&' then
         return '&amp;'
-      elseif x == '"' then
+      elseif in_attribute and x == '"' then
         return '&quot;'
-      elseif x == "'" then
+      elseif in_attribute and x == "'" then
         return '&#39;'
       else
         return x
@@ -141,8 +141,8 @@ function Strikeout(s)
   return '<del>' .. s .. '</del>'
 end
 
-function Link(s, src, tit, attr)
-  return "<a href='" .. escape(src,true) .. "' title='" ..
+function Link(s, tgt, tit, attr)
+  return "<a href='" .. escape(tgt,true) .. "' title='" ..
          escape(tit,true) .. "'>" .. s .. "</a>"
 end
 
@@ -271,7 +271,7 @@ end
 
 -- Convert pandoc alignment to something HTML can use.
 -- align is AlignLeft, AlignRight, AlignCenter, or AlignDefault.
-function html_align(align)
+local function html_align(align)
   if align == 'AlignLeft' then
     return 'left'
   elseif align == 'AlignRight' then
@@ -286,7 +286,7 @@ end
 function CaptionedImage(src, tit, caption, attr)
    return '<div class="figure">\n<img src="' .. escape(src,true) ..
       '" title="' .. escape(tit,true) .. '"/>\n' ..
-      '<p class="caption">' .. caption .. '</p>\n</div>'
+      '<p class="caption">' .. escape(caption) .. '</p>\n</div>'
 end
 
 -- Caption is a string, aligns is an array of strings,
@@ -357,4 +357,3 @@ meta.__index =
     return function() return "" end
   end
 setmetatable(_G, meta)
-


### PR DESCRIPTION
% pandoc --version // pandoc 2.9.2.1 (but not really relevant)

This PR fixes a few obvious (I hope) typos.

Notes on the changes:
* The escape() function's in_attribute argument wasn't used. I assume it was intended to enable escaping of quote characters
* The html_align() function was global but I think it's a local helper. Maybe it should be moved to the top of the file, along with the other helpers?

There are a few other things that I could fix here (or elsewhere), but I wanted to check first:
* I think that sample.lua should aim to generate the same (or very similar) output to that generated by the built-in HTML writer (although obviously it might lag a bit). Is this agreed?
* I think it would be useful to mention all the available global variables. Only PANDOC_DOCUMENT is mentioned, but I think that these are also available: PANDOC_API_VERSION, PANDOC_SCRIPT_FILE, PANDOC_STATE, PANDOC_VERSION
* I had to change the CaptionedImage() function. The sample.lua one generates a div with a p for the caption, whereas the HTML writer generates a figure and figurecaption so I changed it to do this. I also changed it to generate a bare img if the caption is empty
* The Image() function doesn't include the supplied attributes in the HTML
* The Table() function defines a global 'head' variable that isn't used and might be a hangover?
* The generated HTML uses a mixture of quote types; mostly double but some single, e.g., Link() and Image() use single quotes. I think it would be better to use only one type of quote in the generated HTML (I'd choose double quotes)
* The attributes() function uses pairs() to iterate through the attributes, which means that they're in an undefined order. I think it would be better if the order was predictable, e.g., 'id' first followed by the rest in alphabetical order? I wrote an spairs() (sorted pairs) function that has the same interface as pairs() and ipairs(), and could contribute that if it would be useful