### PR TITLE
Man page: remove org from list of input formats supporting raw_tex

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2861,7 +2861,7 @@ their respective sections of [Pandoc's Markdown]:
   for the following formats (in addition to `markdown`):
 
   input formats
-  :  `latex`, `org`, `textile`, `html` (environments, `\ref`, and
+  :  `latex`, `textile`, `html` (environments, `\ref`, and
      `\eqref` only), `ipynb`
 
   output formats

--- a/man/pandoc.1
+++ b/man/pandoc.1
@@ -3218,7 +3218,7 @@ addition to \f[C]markdown\f[R]):
 .RS 2
 .TP
 input formats
-\f[C]latex\f[R], \f[C]org\f[R], \f[C]textile\f[R], \f[C]html\f[R]
+\f[C]latex\f[R], \f[C]textile\f[R], \f[C]html\f[R]
 (environments, \f[C]\[rs]ref\f[R], and \f[C]\[rs]eqref\f[R] only),
 \f[C]ipynb\f[R]
 .TP


### PR DESCRIPTION
Update pandoc's man page to reflect the fact that org is no longer a supported input format for the raw_tex extension