### PR TITLE
OpenDocument Writer: Implement span with ident support

### DIFF
--- a/test/command/6755.md
+++ b/test/command/6755.md
@@ -1,0 +1,11 @@
+```
+%pandoc -f native -t opendocument
+[Div ("divId",[],[])
+ [Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "div."]],
+Para [Span ("spanId",[],[]) [Str "And",Space,Str "here",Space,Str "is",Space,Str "a",Space,Str "span."]]]
+^D
+<text:section text:name="divId"><text:p text:style-name="Text_20_body">Here
+is a div.</text:p></text:section>
+<text:p text:style-name="Text_20_body"><text:bookmark-start text:name="spanId" />And
+here is a span.<text:bookmark-end text:name="spanId" /></text:p>
+```


### PR DESCRIPTION
Spans containing an ident in the Attr will become bookmarks
in OpenDocument format.