### PR TITLE
Implement data-external attribute support for HTML <img> element

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -5864,6 +5864,12 @@ with the `src` attribute.  For example:
       </source>
     </audio>
 
+When using HTML as the input format (as opposed to the raw HTML
+extension), then the `data-external="1"` attribute also works the same
+as described above, but only for the `<img>` element.  The other
+elements have no representation in pandoc's AST and any attributes
+will hence be ignored.
+
 # Jupyter notebooks
 
 When creating a [Jupyter notebook], pandoc will try to infer the

--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -790,7 +790,7 @@ pImage = do
   let getAtt k = case fromAttrib k tag of
                    "" -> []
                    v  -> [(k, v)]
-  let kvs = concatMap getAtt ["width", "height", "sizes", "srcset"]
+  let kvs = concatMap getAtt ["data-external", "width", "height", "sizes", "srcset"]
   return $ B.imageWith (uid, cls, kvs) (escapeURI url) title (B.text alt)
 
 pCodeWithClass :: PandocMonad m => [(T.Text,Text)] -> TagParser m Inlines

--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -1060,7 +1060,8 @@ transformInline  :: PandocMonad m
                  => WriterOptions
                  -> Inline
                  -> E m Inline
-transformInline _opts (Image attr lab (src,tit)) = do
+transformInline _opts (Image attr@(_,_,kvs) lab (src,tit))
+  | isNothing (lookup "data-external" kvs) = do
     newsrc <- modifyMediaRef $ TS.unpack src
     return $ Image attr lab ("../" <> newsrc, tit)
 transformInline opts x@(Math t m)

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -84,6 +84,10 @@ tests = [ testGroup "base tag"
           [ test html "anchor without href" $ "<a name=\"anchor\"/>" =?>
             plain (spanWith ("anchor",[],[]) mempty)
           ]
+        , testGroup "img"
+          [ test html "data-external attribute" $ "<img data-external=\"1\" src=\"http://example.com/stickman.gif\">" =?>
+            plain (imageWith ("", [], [("data-external", "1")]) "http://example.com/stickman.gif" "" "")
+          ]
         , testGroup "lang"
           [ test html "lang on <html>" $ "<html lang=\"es\">hola" =?>
             setMeta "lang" (text "es") (doc (plain (text "hola")))


### PR DESCRIPTION
This makes it possible to use the `data-external` attribute with `<img>` elements when converting HTML input to EPUB, just like it is done for raw HTML.

Using bash:
```
$ pandoc -f html -t epub -o test.epub <<< '<html><head><title>placeholder</title></head><body><img data-external="1" src="https://static.fimfiction.net/images/logo-2x.png"></body></html>'
$ unzip -l test.epub
Archive:  test.epub
  Length      Date    Time    Name
---------  ---------- -----   ----
       20  2020-10-18 14:56   mimetype
      251  2020-10-18 14:56   META-INF/container.xml
      160  2020-10-18 14:56   META-INF/com.apple.ibooks.display-options.xml
     1326  2020-10-18 14:56   EPUB/content.opf
      767  2020-10-18 14:56   EPUB/toc.ncx
      541  2020-10-18 14:56   EPUB/nav.xhtml
      496  2020-10-18 14:56   EPUB/text/title_page.xhtml
     1119  2020-10-18 14:56   EPUB/styles/stylesheet1.css
      582  2020-10-18 14:56   EPUB/text/ch001.xhtml
---------                     -------
     5262                     9 files
$ unzip -l test.epub | grep png
$ unzip -p test.epub EPUB/text/ch001.xhtml | grep img
<img src="https://static.fimfiction.net/images/logo-2x.png" data-external="1" />
```

Fixes #6543