### PR TITLE
Fix duplicate "class" attribute in HTML writer

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -1089,16 +1089,18 @@ tableRowToHtml :: PandocMonad m
                -> TableRow
                -> StateT WriterState m Html
 tableRowToHtml opts (TableRow tblpart attr rownum rowhead rowbody) = do
-  let rowclass = A.class_ $ case rownum of
+  let rowclass = case rownum of
         Ann.RowNumber x | x `rem` 2 == 1   -> "odd"
         _               | tblpart /= Thead -> "even"
         _                                  -> "header"
+  let attr' = case attr of
+                (id', classes, rest) -> (id', rowclass:classes, rest)
   let celltype = case tblpart of
                    Thead -> HeaderCell
                    _     -> BodyCell
   headcells <- mapM (cellToHtml opts HeaderCell) rowhead
   bodycells <- mapM (cellToHtml opts celltype) rowbody
-  rowHtml <- addAttrs opts attr $ H.tr ! rowclass $ do
+  rowHtml <- addAttrs opts attr' $ H.tr $ do
     nl opts
     mconcat headcells
     mconcat bodycells

--- a/test/tables/nordics.html4
+++ b/test/tables/nordics.html4
@@ -17,38 +17,38 @@
 </tr>
 </thead>
 <tbody class="souvereign-states">
-<tr class="odd" class="country">
+<tr class="odd country">
 <th align="center">Denmark</th>
 <td align="left">Copenhagen</td>
 <td align="left">5,809,502</td>
 <td align="left">43,094</td>
 </tr>
-<tr class="even" class="country">
+<tr class="even country">
 <th align="center">Finland</th>
 <td align="left">Helsinki</td>
 <td align="left">5,537,364</td>
 <td align="left">338,145</td>
 </tr>
-<tr class="odd" class="country">
+<tr class="odd country">
 <th align="center">Iceland</th>
 <td align="left">Reykjavik</td>
 <td align="left">343,518</td>
 <td align="left">103,000</td>
 </tr>
-<tr class="even" class="country">
+<tr class="even country">
 <th align="center">Norway</th>
 <td align="left">Oslo</td>
 <td align="left">5,372,191</td>
 <td align="left">323,802</td>
 </tr>
-<tr class="odd" class="country">
+<tr class="odd country">
 <th align="center">Sweden</th>
 <td align="left">Stockholm</td>
 <td align="left">10,313,447</td>
 <td align="left">450,295</td>
 </tr>
 </tbody><tfoot>
-<tr class="even" id="summary">
+<tr id="summary" class="even">
 <td align="center">Total</td>
 <td align="left"></td>
 <td align="left" id="total-population">27,376,022</td>

--- a/test/tables/nordics.html5
+++ b/test/tables/nordics.html5
@@ -17,38 +17,38 @@
 </tr>
 </thead>
 <tbody class="souvereign-states">
-<tr class="odd" class="country">
+<tr class="odd country">
 <th style="text-align: center;">Denmark</th>
 <td style="text-align: left;">Copenhagen</td>
 <td style="text-align: left;">5,809,502</td>
 <td style="text-align: left;">43,094</td>
 </tr>
-<tr class="even" class="country">
+<tr class="even country">
 <th style="text-align: center;">Finland</th>
 <td style="text-align: left;">Helsinki</td>
 <td style="text-align: left;">5,537,364</td>
 <td style="text-align: left;">338,145</td>
 </tr>
-<tr class="odd" class="country">
+<tr class="odd country">
 <th style="text-align: center;">Iceland</th>
 <td style="text-align: left;">Reykjavik</td>
 <td style="text-align: left;">343,518</td>
 <td style="text-align: left;">103,000</td>
 </tr>
-<tr class="even" class="country">
+<tr class="even country">
 <th style="text-align: center;">Norway</th>
 <td style="text-align: left;">Oslo</td>
 <td style="text-align: left;">5,372,191</td>
 <td style="text-align: left;">323,802</td>
 </tr>
-<tr class="odd" class="country">
+<tr class="odd country">
 <th style="text-align: center;">Sweden</th>
 <td style="text-align: left;">Stockholm</td>
 <td style="text-align: left;">10,313,447</td>
 <td style="text-align: left;">450,295</td>
 </tr>
 </tbody><tfoot>
-<tr class="even" id="summary">
+<tr id="summary" class="even">
 <td style="text-align: center;">Total</td>
 <td style="text-align: left;"></td>
 <td style="text-align: left;" id="total-population">27,376,022</td>


### PR DESCRIPTION
The html writer adds a class "odd" or "even" to each row in tables. If a row has any user-specified classes (e.g. from a filter), then this results in the tag in the output having two `class` attributes, the second one being ignored by browsers.

So this PR changes the table row code slightly so that the `even`/`odd` classes are just added to the existing `Attr` instead.