### PR TITLE
DocBook reader: Table width support

### DIFF
--- a/test/command/6791.md
+++ b/test/command/6791.md
@@ -1,0 +1,32 @@
+```
+% pandoc -f docbook -t native --quiet
+<informaltable frame="all" rowsep="1" colsep="1">
+<?dbfo table-width="50%"?>
+<tgroup cols="2">
+<colspec colname="col_1" colwidth="6.25*"/>
+<colspec colname="col_2" colwidth="6.25*"/>
+<tbody>
+<row>
+<entry align="center" valign="top"><simpara>2</simpara></entry>
+<entry align="center" valign="top"><simpara>1</simpara></entry>
+</row>
+</tbody>
+</tgroup>
+</informaltable>
+^D
+[Table ("",[],[]) (Caption Nothing
+ [])
+ [(AlignDefault,ColWidth 0.25)
+ ,(AlignDefault,ColWidth 0.25)]
+ (TableHead ("",[],[])
+ [])
+ [(TableBody ("",[],[]) (RowHeadColumns 0)
+  []
+  [Row ("",[],[])
+   [Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
+    [Para [Str "2"]]
+   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
+    [Para [Str "1"]]]])]
+ (TableFoot ("",[],[])
+ [])]
+```


### PR DESCRIPTION
Table width is not natively supported by docbook but is by
the docbook fo stylesheets through an XML processing instruction,
<?dbfo table-width="50%"?> . Implement support for this instruction
in the DocBook reader.