### PR TITLE
Added a sentence about `pagetitle` for HTML in the man page

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2111,7 +2111,8 @@ Currently the following pipes are predefined:
     including a title block in the document itself, you can
     set the `title-meta`, `author-meta`, and `date-meta`
     variables.  (By default these are set automatically, based
-    on `title`, `author`, and `date`.)
+    on `title`, `author`, and `date`.) The page title in HTML
+    is set by `pagetitle`, which is equal to `title` by default.
 
 `subtitle`
 :   document subtitle, included in HTML, EPUB, LaTeX, ConTeXt, and docx


### PR DESCRIPTION
Let's inform users about the `pagetitle` variable, which is handy for HTML.

I am not sure which branch this patch should go to, `master` is set by default.  And I assumed `man/pandoc.1` is generated from this text file. Correct me if it's wrong.

	changed:      MANUAL.txt