### PR TITLE
Fix a tiny Typo in the CSV reader module

### DIFF
--- a/src/Text/Pandoc/Readers/CSV.hs
+++ b/src/Text/Pandoc/Readers/CSV.hs
@@ -2,7 +2,7 @@
 
 {-# LANGUAGE ScopedTypeVariables #-}
 {- |
-   Module      : Text.Pandoc.Readers.RST
+   Module      : Text.Pandoc.Readers.CSV
    Copyright   : Copyright (C) 2006-2020 John MacFarlane
    License     : GNU GPL, version 2 or above
 


### PR DESCRIPTION
Header comment in the CSV reader module says "RST" instead of "CSV".