### PR TITLE
docs: adds a new Pandoc filtering framework

### DIFF
--- a/doc/filters.md
+++ b/doc/filters.md
@@ -255,7 +255,7 @@ For a more Pythonic alternative to pandocfilters, see
 the [panflute](https://pypi.org/project/panflute) library.
 Don't like Python? There are also ports of pandocfilters in
 
-- [PHP](https://github.com/vinai/pandocfilters-php)
+- [PHP](https://github.com/vinai/pandocfilters-php),
 - [perl](https://metacpan.org/pod/Pandoc::Filter),
 - TypeScript/JavaScript via Node.js
   - [pandoc-filter](https://github.com/mvhenderson/pandoc-filter-node),

--- a/doc/filters.md
+++ b/doc/filters.md
@@ -253,12 +253,15 @@ repository](https://github.com/jgm/pandocfilters).
 
 For a more Pythonic alternative to pandocfilters, see
 the [panflute](https://pypi.org/project/panflute) library.
-Don't like Python?   There are also ports of pandocfilters in
-[PHP](https://github.com/vinai/pandocfilters-php),
-[perl](https://metacpan.org/pod/Pandoc::Filter),
-[TypeScript/JavaScript](https://github.com/mu-io/node-pandoc-filter),
-[Groovy](https://github.com/dfrommi/groovy-pandoc), and
-[Ruby](https://heerdebeer.org/Software/markdown/paru/).
+Don't like Python? There are also ports of pandocfilters in
+
+- [PHP](https://github.com/vinai/pandocfilters-php)
+- [perl](https://metacpan.org/pod/Pandoc::Filter),
+- TypeScript/JavaScript via Node.js
+  - [pandoc-filter](https://github.com/mvhenderson/pandoc-filter-node),
+  - [node-pandoc-filter](https://github.com/mu-io/node-pandoc-filter),
+- [Groovy](https://github.com/dfrommi/groovy-pandoc), and
+- [Ruby](https://heerdebeer.org/Software/markdown/paru/).
 
 Starting with pandoc 2.0, pandoc includes built-in support for
 writing filters in lua.  The lua interpreter is built in to

--- a/doc/filters.md
+++ b/doc/filters.md
@@ -256,7 +256,7 @@ the [panflute](https://pypi.org/project/panflute) library.
 Don't like Python?   There are also ports of pandocfilters in
 [PHP](https://github.com/vinai/pandocfilters-php),
 [perl](https://metacpan.org/pod/Pandoc::Filter),
-[javascript/node.js](https://github.com/mvhenderson/pandoc-filter-node),
+[TypeScript/JavaScript](https://github.com/mu-io/node-pandoc-filter),
 [Groovy](https://github.com/dfrommi/groovy-pandoc), and
 [Ruby](https://heerdebeer.org/Software/markdown/paru/).
 


### PR DESCRIPTION
The new package linked for NodeJS supersedes the previous one. It contains significantly better typing, better documentation, better CI, and more.