### PR TITLE
Implement defaults file inheritance

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1507,6 +1507,16 @@ input-files:
 - content.md
 # or you may use input-file: with a single value
 
+# Include options from the specified defaults files.
+# The files will be searched for first in the working directory
+# and then in the defaults subdirectory of the user data directory.
+# The files are included in the same order in which they appear in
+# the list. Options specified in this defaults file always have
+# priority over the included ones.
+defaults:
+- defsA
+- defsB
+
 template: letter
 standalone: true
 self-contained: false

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -216,6 +216,13 @@ extra-source-files:
                  test/command/01.csv
                  test/command/defaults1.yaml
                  test/command/defaults2.yaml
+                 test/command/defaults3.yaml
+                 test/command/defaults4.yaml
+                 test/command/defaults5.yaml
+                 test/command/defaults6.yaml
+                 test/command/defaults7.yaml
+                 test/command/defaults8.yaml
+                 test/command/defaults9.yaml
                  test/command/3533-rst-csv-tables.csv
                  test/command/3880.txt
                  test/command/5182.txt

--- a/test/command/defaults-inheritance-1.md
+++ b/test/command/defaults-inheritance-1.md
@@ -1,0 +1,6 @@
+```
+% pandoc -d command/defaults3
+# Header
+^D
+# Header
+```

--- a/test/command/defaults-inheritance-2.md
+++ b/test/command/defaults-inheritance-2.md
@@ -1,0 +1,5 @@
+```
+% pandoc -d command/defaults6
+^D
+Error: Circular defaults file reference in 'command/defaults7.yaml'
+```

--- a/test/command/defaults-inheritance-3.md
+++ b/test/command/defaults-inheritance-3.md
@@ -1,0 +1,6 @@
+```
+% pandoc -d command/defaults8
+<h1>Header</h1>
+^D
+# Header
+```

--- a/test/command/defaults3.yaml
+++ b/test/command/defaults3.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - command/defaults4
+  - command/defaults5
+to: markdown

--- a/test/command/defaults4.yaml
+++ b/test/command/defaults4.yaml
@@ -1,0 +1,3 @@
+from: html
+defaults:
+  - command/defaults5

--- a/test/command/defaults5.yaml
+++ b/test/command/defaults5.yaml
@@ -1,0 +1,2 @@
+from: markdown
+to: html

--- a/test/command/defaults6.yaml
+++ b/test/command/defaults6.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - command/defaults7

--- a/test/command/defaults7.yaml
+++ b/test/command/defaults7.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - command/defaults6

--- a/test/command/defaults8.yaml
+++ b/test/command/defaults8.yaml
@@ -1,0 +1,2 @@
+from: html
+defaults: command/defaults9

--- a/test/command/defaults9.yaml
+++ b/test/command/defaults9.yaml
@@ -1,0 +1,1 @@
+to: markdown


### PR DESCRIPTION
This pull request adds an inheritance system for defaults files as requested in #6827.


## Motivation

Currently, it is not possible to share a set of options between defaults files in a flexible way. The inheritance system implemented in this branch solves that problem by allowing a defaults file to specify other defaults files to inherit from.


## Usage examples

### Simple example
See #6827

### Multiple defaults files
Assume `defsA.yaml` looks like this:
```yaml
defaults:
  - defsB
  - defsC
from: html
```
Then calling `pandoc -d defsA` has the same result as calling `pandoc -d defsB -d defsC -d defsA`. Note that first `defsB.yaml` is "applied", followed by `defsC.yaml` and finally `defsA.yaml`.

### Circular references
Assume:
- `defsA.yaml`:
```yaml
defaults:
  - defsB
```
- `defsB.yaml`:
```yaml
defaults:
  - defsA
```
In this scenario `defsA.yaml` inherits from `defsB.yaml` and vice versa. As there is no sensible way of resolving this circularity, executing `pandoc -d defsA` yields the following error message: "Error: Circular defaults file reference in 'defsB.yaml'.

### User data directories

Assume:
- `defsA.yaml`:
```yaml
defaults:
  - defsB
data-dir: PATH_TO_DATA_DIR_B
template: test
```
- `defsB.yaml`:
```yaml
defaults:
  - defsC
data-dir: PATH_TO_DATA_DIR_C
```
When calling `pandoc -d defsA`, pandoc searches for `defsB.yaml` **and** `test.html` in `PATH_TO_DATA_DIR_B/defaults` and for `defsC.yaml` in `PATH_TO_DATA_DIR_C/defaults`. In other words: specifying a user data directory in `defsB.yaml` does **not** affect `defsA.yaml`.


## Implementation

The feature is implemented by adjusting/extending the `FromYAML (Opt -> Opt)` instance in `Pandoc/App/Opt.hs`. I have tried to change as little as possible, but since parsing a YAML file now potentially requires file-IO and keeping track of a graph-like data structure in order to detect circular inheritance, I had to introduce `MonadIO` and `StateT` to some type signatures.


closes #6827 