### PR TITLE
added support for writing nested tables to asciidoc

### DIFF
--- a/src/Text/Pandoc/Logging.hs
+++ b/src/Text/Pandoc/Logging.hs
@@ -91,6 +91,9 @@ data LogMessage =
   | MissingCharacter Text
   | Deprecated Text Text
   | NoTranslation Text
+  | UnsupportedByTarget Text -- ^ causing element
+                        Text -- ^ reason
+                        Text -- ^ action taken
   | CouldNotLoadTranslations Text Text
   | UnusualConversion Text
   | UnexpectedXmlElement Text Text
@@ -206,6 +209,10 @@ instance ToJSON LogMessage where
             "message" .= msg]
       NoTranslation term ->
            ["term" .= term]
+      UnsupportedByTarget element reason courseOfAction ->
+           ["element" .= element
+           ,"reason" .= reason
+           ,"action" .= courseOfAction]
       CouldNotLoadTranslations lang msg ->
            ["lang" .= lang,
             "message" .= msg]
@@ -321,6 +328,9 @@ showLogMessage msg =
             else ". " <> m
        NoTranslation t ->
          "The term " <> t <> " has no translation defined."
+       UnsupportedByTarget cause reason courseOfAction ->
+         "Target format does not support " <> cause <> " from the input "
+         <> "because " <> reason <> ". " <> courseOfAction
        CouldNotLoadTranslations lang m ->
          "Could not load translations for " <> lang <>
            if Text.null m then "" else "\n" <> m
@@ -382,6 +392,7 @@ messageVerbosity msg =
        MissingCharacter{}            -> WARNING
        Deprecated{}                  -> WARNING
        NoTranslation{}               -> WARNING
+       UnsupportedByTarget{}         -> WARNING
        CouldNotLoadTranslations{}    -> WARNING
        UnusualConversion {}          -> WARNING
        UnexpectedXmlElement {}       -> WARNING

--- a/src/Text/Pandoc/Logging.hs
+++ b/src/Text/Pandoc/Logging.hs
@@ -91,9 +91,6 @@ data LogMessage =
   | MissingCharacter Text
   | Deprecated Text Text
   | NoTranslation Text
-  | UnsupportedByTarget Text -- ^ causing element
-                        Text -- ^ reason
-                        Text -- ^ action taken
   | CouldNotLoadTranslations Text Text
   | UnusualConversion Text
   | UnexpectedXmlElement Text Text
@@ -209,10 +206,6 @@ instance ToJSON LogMessage where
             "message" .= msg]
       NoTranslation term ->
            ["term" .= term]
-      UnsupportedByTarget element reason courseOfAction ->
-           ["element" .= element
-           ,"reason" .= reason
-           ,"action" .= courseOfAction]
       CouldNotLoadTranslations lang msg ->
            ["lang" .= lang,
             "message" .= msg]
@@ -328,9 +321,6 @@ showLogMessage msg =
             else ". " <> m
        NoTranslation t ->
          "The term " <> t <> " has no translation defined."
-       UnsupportedByTarget cause reason courseOfAction ->
-         "Target format does not support " <> cause <> " from the input "
-         <> "because " <> reason <> ". " <> courseOfAction
        CouldNotLoadTranslations lang m ->
          "Could not load translations for " <> lang <>
            if Text.null m then "" else "\n" <> m
@@ -392,7 +382,6 @@ messageVerbosity msg =
        MissingCharacter{}            -> WARNING
        Deprecated{}                  -> WARNING
        NoTranslation{}               -> WARNING
-       UnsupportedByTarget{}         -> WARNING
        CouldNotLoadTranslations{}    -> WARNING
        UnusualConversion {}          -> WARNING
        UnexpectedXmlElement {}       -> WARNING

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -36,7 +36,6 @@ import Text.DocLayout
 import Text.Pandoc.Shared
 import Text.Pandoc.Templates (renderTemplate)
 import Text.Pandoc.Writers.Shared
-import Prelude hiding (log)
 
 
 data WriterState = WriterState { defListMarker       :: Text
@@ -63,7 +62,6 @@ defaultWriterState = WriterState { defListMarker      = "::"
                                  , inList             = False
                                  , hasMath            = False
                                  , tableNestingLevel  = 0
-                                 , log = []
                                  }
 
 -- | Convert Pandoc to AsciiDoc.

--- a/src/Text/Pandoc/Writers/AsciiDoc.hs
+++ b/src/Text/Pandoc/Writers/AsciiDoc.hs
@@ -51,7 +51,6 @@ data WriterState = WriterState { defListMarker       :: Text
                                -- 1 is top level table
                                -- 2 is a table in a table
                                , tableNestingLevel   :: Int
-                               , log :: [LogMessage]
                                }
 
 defaultWriterState :: WriterState

--- a/test/command/nested-table-to-asciidoc-6942.md
+++ b/test/command/nested-table-to-asciidoc-6942.md
@@ -1,0 +1,86 @@
+A table within a table should be convertet into a table within table
+
+```
+% pandoc -f html -t asciidoc
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title> NestedTables </title>
+</head>
+<body>
+<table>
+ <tr>
+  <td >
+   <table>  <tr> <td> a1 </td> <td> a2 </td> </tr>  </table>
+  </td>
+  <td>b</td>
+ </tr>
+ <tr>
+   <td>c</td> <td>d </td>
+ </tr>
+</table>
+</body>
+</html>
+^D
+[width="100%",cols="50%,50%",]
+|===
+a|
+[cols=",",]
+!===
+!a1 !a2
+!===
+
+|b
+|c |d
+|===
+```
+
+A table within a table within a table cannot be converted because asciidoc only supports two levels of tables.
+The table on level 3 is thus converted to level 2 and a warning is produced
+```
+% pandoc -f html -t asciidoc
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title> NestedTables </title>
+</head>
+<body>
+<table>
+ <tr>
+  <td>
+    <table>  <tr>
+	<td> a1 </td>
+	<td>
+	  <table>  <tr> <td> 1 </td> <td> 2 </td> </tr>  </table>
+	</td>
+    </tr>  </table>
+  </td>
+  <td>b</td>
+ </tr>
+ <tr>
+   <td>c</td> <td>d </td>
+ </tr>
+</table>
+</body>
+</html>
+^D
+[WARNING] Target format does not support a nested table from the input because Asciidoc only supports nesting tables up to one level. However, the table in question is nested at level 3. It will be printed at level 1 so no content is lost but will probably need a manual fix by the user.
+[width="100%",cols="50%,50%",]
+|===
+a|
+[width="100%",cols="50%,50%",]
+!===
+!a1 a!
+[cols=",",]
+!===
+!1 !2
+!===
+
+!===
+
+|b
+|c |d
+|===
+```

--- a/test/command/nested-table-to-asciidoc-6942.md
+++ b/test/command/nested-table-to-asciidoc-6942.md
@@ -39,7 +39,7 @@ a|
 A table within a table within a table cannot be converted because asciidoc only supports two levels of tables.
 The table on level 3 is thus converted to level 2 and a warning is produced
 ```
-% pandoc -f html -t asciidoc
+% pandoc -f html -t asciidoc --verbose
 <!doctype html>
 <html>
 <head>
@@ -66,18 +66,13 @@ The table on level 3 is thus converted to level 2 and a warning is produced
 </body>
 </html>
 ^D
-[WARNING] Target format does not support a nested table from the input because Asciidoc only supports nesting tables up to one level. However, the table in question is nested at level 3. It will be printed at level 1 so no content is lost but will probably need a manual fix by the user.
+[INFO] Not rendering Table ("",[],[]) (Caption Nothing []) [(AlignDefault,ColWidth 0.5),(AlignDefault,ColWidth 0.5)] (TableHead ("",[],[]) []) [TableBody ("",[],[]) (RowHeadColumns 0) [] [Row ("",[],[]) [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "a1"]],Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Table ("",[],[]) (Caption Nothing []) [(AlignDefault,ColWidthDefault),(AlignDefault,ColWidthDefault)] (TableHead ("",[],[]) []) [TableBody ("",[],[]) (RowHeadColumns 0) [] [Row ("",[],[]) [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "1"]],Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1) [Plain [Str "2"]]]]] (TableFoot ("",[],[]) [])]]]] (TableFoot ("",[],[]) [])
 [width="100%",cols="50%,50%",]
 |===
 a|
 [width="100%",cols="50%,50%",]
 !===
-!a1 a!
-[cols=",",]
-!===
-!1 !2
-!===
-
+!a1 !
 !===
 
 |b

--- a/test/command/nested-table-to-asciidoc-6942.md
+++ b/test/command/nested-table-to-asciidoc-6942.md
@@ -36,7 +36,8 @@ a|
 |===
 ```
 
-A table within a table within a table cannot be converted because asciidoc only supports two levels of tables.
+A table within a table within a table cannot be converted because asciidoc only
+supports two levels of tables.
 The table on level 3 is thus converted to level 2 and a warning is produced
 ```
 % pandoc -f html -t asciidoc --verbose


### PR DESCRIPTION
This PR fixes #6942.

A new field is introduced in the WriterState to track the recursion level when writing nested tables.
Tables within tables ("level 1") are written correctly and deeper nested tables are written as level 1 and enclosed by a comment explaining that the nesting depth is not supported by asciidoc.

I did not write any new tests because I don't know how. 
I found `pandoc/test/tables.asciidoc` and that it is used but I don't know which direction the conversion goes and how to extend the source table without affecting other writers' tests.
A test would verify that for:
[table.asciidoc.txt](https://github.com/jgm/pandoc/files/5725516/table.asciidoc.txt)
[table.html.txt](https://github.com/jgm/pandoc/files/5725518/table.html.txt)
[tableThriceNested.asciidoc.txt](https://github.com/jgm/pandoc/files/5725519/tableThriceNested.asciidoc.txt)
[tableThriceNested.html.txt](https://github.com/jgm/pandoc/files/5725520/tableThriceNested.html.txt)

```
stack exec pandoc -- -f html -t asciidoc tableThriceNested.html -o tableThriceNested.asciidoc
stack exec pandoc -- -f html -t asciidoc table.html -o table.asciidoc
```
