### PR TITLE
Wrap HTML5 body in <main> tag

### DIFF
--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -59,7 +59,9 @@ $endif$
 $table-of-contents$
 </nav>
 $endif$
+<main>
 $body$
+</main>
 $for(include-after)$
 $include-after$
 $endfor$


### PR DESCRIPTION
Wrapping the actual content of a HTML document in a [main](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) tag, makes it easier for tools like [web readers](https://blog.mozilla.org/firefox/reader-view/) to identify what is actual part of the document, and what is a header.

This patch just wraps the `$body$` in such a tag, improving how documents generated by pandoc can be parsed. From my testing, it doesn't break anything.