### PR TITLE
Lua: do not silently load files from user-defined userdir

### DIFF
--- a/src/Text/Pandoc/Lua/Packages.hs
+++ b/src/Text/Pandoc/Lua/Packages.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {- |
    Module      : Text.Pandoc.Lua.Packages
    Copyright   : Copyright © 2017-2021 Albert Krewinkel
@@ -15,12 +12,10 @@ module Text.Pandoc.Lua.Packages
   ( installPandocPackageSearcher
   ) where
 
-import Control.Monad.Catch (try)
 import Control.Monad (forM_)
 import Data.ByteString (ByteString)
 import Foreign.Lua (Lua, NumResults)
-import Text.Pandoc.Error (PandocError)
-import Text.Pandoc.Class.PandocMonad (readDataFile)
+import Text.Pandoc.Class.PandocMonad (readDefaultDataFile)
 import Text.Pandoc.Lua.PandocLua (PandocLua, liftPandocLua)
 
 import qualified Foreign.Lua as Lua
@@ -54,18 +49,19 @@ pandocPackageSearcher pkgName =
     "pandoc.types"    -> pushWrappedHsFun Types.pushModule
     "pandoc.utils"    -> pushWrappedHsFun Utils.pushModule
     "text"            -> pushWrappedHsFun Text.pushModule
-    _                 -> searchPureLuaLoader
+    "pandoc.List"     -> loadPureLuaPackage
+    _                 -> reportPandocSearcherFailure
  where
   pushWrappedHsFun f = liftPandocLua $ do
     Lua.pushHaskellFunction f
     return 1
-  searchPureLuaLoader = do
-    let filename = pkgName ++ ".lua"
-    try (readDataFile filename) >>= \case
-      Right script -> pushWrappedHsFun (loadStringAsPackage pkgName script)
-      Left (_ :: PandocError) -> liftPandocLua $ do
-        Lua.push ("\n\tno file '" ++ filename ++ "' in pandoc's datadir")
-        return (1 :: NumResults)
+  loadPureLuaPackage = do
+    let filename = pkgName <> ".lua"
+    readDefaultDataFile filename >>=
+      pushWrappedHsFun . loadStringAsPackage pkgName
+  reportPandocSearcherFailure = liftPandocLua $ do
+    Lua.push ("\n\t" <> pkgName <> "is not one of pandoc's default packages")
+    return (1 :: NumResults)
 
 loadStringAsPackage :: String -> ByteString -> Lua NumResults
 loadStringAsPackage pkgName script = do

--- a/src/Text/Pandoc/Lua/PandocLua.hs
+++ b/src/Text/Pandoc/Lua/PandocLua.hs
@@ -23,16 +23,14 @@ module Text.Pandoc.Lua.PandocLua
   , runPandocLua
   , liftPandocLua
   , addFunction
-  , loadScriptFromDataDir
   ) where
 
-import Control.Monad (when)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Except (MonadError (catchError, throwError))
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Foreign.Lua (Lua (..), NumResults, Pushable, ToHaskellFunction)
 import Text.Pandoc.Class.PandocIO (PandocIO)
-import Text.Pandoc.Class.PandocMonad (PandocMonad (..), readDataFile)
+import Text.Pandoc.Class.PandocMonad (PandocMonad (..))
 import Text.Pandoc.Error (PandocError)
 import Text.Pandoc.Lua.Global (Global (..), setGlobals)
 import Text.Pandoc.Lua.ErrorConversion (errorConversion)
@@ -40,7 +38,6 @@ import Text.Pandoc.Lua.ErrorConversion (errorConversion)
 import qualified Control.Monad.Catch as Catch
 import qualified Foreign.Lua as Lua
 import qualified Text.Pandoc.Class.IO as IO
-import qualified Text.Pandoc.Lua.Util as LuaUtil
 
 -- | Type providing access to both, pandoc and Lua operations.
 newtype PandocLua a = PandocLua { unPandocLua :: Lua a }
@@ -85,15 +82,6 @@ addFunction name fn = liftPandocLua $ do
   Lua.push name
   Lua.pushHaskellFunction fn
   Lua.rawset (-3)
-
--- | Load a file from pandoc's data directory.
-loadScriptFromDataDir :: FilePath -> PandocLua ()
-loadScriptFromDataDir scriptFile = do
-  script <- readDataFile scriptFile
-  status <- liftPandocLua $ Lua.dostring script
-  when (status /= Lua.OK) . liftPandocLua $
-    LuaUtil.throwTopMessageAsError'
-      (("Couldn't load '" ++ scriptFile ++ "'.\n") ++)
 
 -- | Global variables which should always be set.
 defaultGlobals :: PandocIO [Global]


### PR DESCRIPTION
A custom initialization file `init.lua` must be placed in the user's
default data directory, or the system-wide default directory. Built-in
Lua packages are only loaded from the system's default data directory.
Loading from a different directory by overriding the default path, e.g.
via `--data-dir`, is no longer supported for these scripts.