### PR TITLE
Lua: disable implicit execution of user-provided init file

### DIFF
--- a/data/init.lua
+++ b/data/init.lua
@@ -1,3 +1,0 @@
--- This Lua script is run every time the Lua interpreter is started when running
--- a Lua filter. It can be customized to load additional modules or to alter the
--- default modules.

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -284,27 +284,6 @@ Some pandoc functions have been made available in Lua:
 -   the [`pandoc.utils`](#module-pandoc.utils) module contains
     various utility functions.
 
-# Lua interpreter initialization
-
-Initialization of pandoc's Lua interpreter can be controlled by
-placing a file `init.lua` in pandoc's data directory. A common
-use-case would be to load additional modules, or even to alter
-default modules.
-
-The following snippet is an example of code that might be useful
-when added to `init.lua`. The snippet adds all Unicode-aware
-functions defined in the [`text` module](#module-text) to the
-default `string` module, prefixed with the string `uc_`.
-
-``` lua
-for name, fn in pairs(require 'text') do
-  string['uc_' .. name] = fn
-end
-```
-
-This makes it possible to apply these functions on strings using
-colon syntax (`mystring:uc_upper()`).
-
 # Debugging Lua filters
 
 It is possible to use a debugging interface to halt execution and

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -172,8 +172,6 @@ data-files:
                  data/abbreviations
                  -- sample lua custom writer
                  data/sample.lua
-                 -- lua init script
-                 data/init.lua
                  -- pandoc lua module
                  data/pandoc.lua
                  -- lua List module


### PR DESCRIPTION
Pandoc used to load the file `init.lua` from a user data directory
during Lua initialization. This feature has been removed, as it was in
conflict with pandoc's philosophy of only loading files that have been
passed explicitly. This also solves a slight security issue, as write
permissions to a user's data directory automatically resulted in the
power to run arbitrary Lua commands.