### PR TITLE
rST writer: add option for list tables, closes #4564

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -952,6 +952,10 @@ header when requesting a document from a URL:
     placement of link references is affected by the
     `--reference-location` option.
 
+`--list-tables`
+
+:   In writing reStructuredText, render tables using the [list table syntax].
+
 `--reference-location=block`|`section`|`document`
 
 :   Specify whether footnotes (and references, if `reference-links` is
@@ -1292,6 +1296,7 @@ header when requesting a document from a URL:
     auxiliary files, use `--pdf-engine-opt=-outdir=foo`.
     Note that no check for duplicate options is done.
 
+[list table syntax]: https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table
 [Dublin Core elements]: https://www.dublincore.org/specifications/dublin-core/dces/
 [ISO 8601 format]: https://www.w3.org/TR/NOTE-datetime
 [Encoding issue with the listings package]:

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -520,6 +520,11 @@ options =
                   (\opt -> return opt { optReferenceLinks = True } ))
                  "" -- "Use reference links in parsing HTML"
 
+    , Option "" ["list-tables"]
+                 (NoArg
+                  (\opt -> return opt { optListTables = True } ))
+                 "" -- "Use list tables in rendering rST"
+
     , Option "" ["reference-location"]
                  (ReqArg
                   (\arg opt -> do

--- a/src/Text/Pandoc/App/Opt.hs
+++ b/src/Text/Pandoc/App/Opt.hs
@@ -124,6 +124,7 @@ data Opt = Opt
     , optLogFile               :: Maybe FilePath -- ^ File to write JSON log output
     , optFailIfWarnings        :: Bool    -- ^ Fail on warnings
     , optReferenceLinks        :: Bool    -- ^ Use reference links in writing markdown, rst
+    , optListTables            :: Bool -- ^ Use list tables in writing rst
     , optReferenceLocation     :: ReferenceLocation -- ^ location for footnotes and link references in markdown output
     , optDpi                   :: Int     -- ^ Dpi
     , optWrap                  :: WrapOption  -- ^ Options for wrapping text
@@ -354,6 +355,8 @@ doOpt (k',v) = do
       parseYAML v >>= \x -> return (\o -> o{ optFailIfWarnings = x })
     "reference-links" ->
       parseYAML v >>= \x -> return (\o -> o{ optReferenceLinks = x })
+    "list-tables" ->
+      parseYAML v >>= \x -> return (\o -> o{ optListTables = x })
     "reference-location" ->
       parseYAML v >>= \x -> return (\o -> o{ optReferenceLocation = x })
     "dpi" ->
@@ -530,6 +533,7 @@ defaultOpts = Opt
     , optLogFile               = Nothing
     , optFailIfWarnings        = False
     , optReferenceLinks        = False
+    , optListTables            = False
     , optReferenceLocation     = EndOfDocument
     , optDpi                   = 96
     , optWrap                  = WrapAuto

--- a/src/Text/Pandoc/App/OutputSettings.hs
+++ b/src/Text/Pandoc/App/OutputSettings.hs
@@ -191,6 +191,7 @@ optToOutputSettings opts = do
         , writerSectionDivs      = optSectionDivs opts
         , writerExtensions       = writerExts
         , writerReferenceLinks   = optReferenceLinks opts
+        , writerListTables       = optListTables opts
         , writerReferenceLocation = optReferenceLocation opts
         , writerDpi              = optDpi opts
         , writerWrapText         = optWrap opts

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -242,6 +242,7 @@ data WriterOptions = WriterOptions
   , writerSectionDivs       :: Bool   -- ^ Put sections in div tags in HTML
   , writerExtensions        :: Extensions -- ^ Markdown extensions that can be used
   , writerReferenceLinks    :: Bool   -- ^ Use reference links in writing markdown, rst
+  , writerListTables        :: Bool   -- ^ Use list tables in writing rST
   , writerDpi               :: Int    -- ^ Dpi for pixel to\/from inch\/cm conversions
   , writerWrapText          :: WrapOption  -- ^ Option for wrapping text
   , writerColumns           :: Int    -- ^ Characters in a line (for text wrapping)
@@ -279,6 +280,7 @@ instance Default WriterOptions where
                       , writerSectionDivs      = False
                       , writerExtensions       = emptyExtensions
                       , writerReferenceLinks   = False
+                      , writerListTables       = False
                       , writerDpi              = 96
                       , writerWrapText         = WrapAuto
                       , writerColumns          = 72

--- a/src/Text/Pandoc/Writers/RST.hs
+++ b/src/Text/Pandoc/Writers/RST.hs
@@ -316,9 +316,13 @@ blockToRST (Table _ blkCapt specs thead tbody tfoot) = do
                       (map (const AlignDefault) aligns) widths
                       headers rows
                  else return tbl'
-            else gridTable opts blocksToDoc (all null headers)
-                  (map (const AlignDefault) aligns) widths
-                  headers rows
+              else if writerListTables opts
+                   then tableToRSTList caption
+                        (map (const AlignDefault) aligns) widths
+                        headers rows
+                   else gridTable opts blocksToDoc (all null headers)
+                        (map (const AlignDefault) aligns) widths
+                        headers rows
   return $ blankline $$
            (if null caption
                then tbl
@@ -417,6 +421,79 @@ blockListToRST :: PandocMonad m
                => [Block]       -- ^ List of block elements
                -> RST m (Doc Text)
 blockListToRST = blockListToRST' False
+
+{-
+
+http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#directives
+ 
+According to the terminology used in the spec, a marker includes a
+final whitespace and a block includes the directive arguments. Here
+the variable names have slightly different meanings because we don't
+want to finish the line with a space if there are no arguments, it
+would produce rST that differs from what users expect in a way that's
+not easy to detect
+
+-}
+toRSTDirective :: Doc Text -> Doc Text -> [(Doc Text, Doc Text)] -> Doc Text -> Doc Text
+toRSTDirective typ args options content = marker <> spaceArgs <> cr <> block
+  where marker = ".. " <> typ <> "::"
+        block = nest 3 (fieldList $$
+                        blankline $$
+                        content $$
+                        blankline)
+        spaceArgs = if isEmpty args then "" else " " <> args
+        -- a field list could end up being an empty doc thus being
+        -- omitted by $$
+        fieldList = foldl ($$) "" $ map joinField options
+        -- a field body can contain multiple lines
+        joinField (name, body) = ":" <> name <> ": " <> body
+
+tableToRSTList :: PandocMonad m
+             => [Inline]
+             -> [Alignment]
+             -> [Double]
+             -> [[Block]]
+             -> [[[Block]]]
+             -> RST m (Doc Text)
+tableToRSTList caption _ propWidths headers rows = do
+  captionRST <- inlineListToRST caption
+  opts       <- gets stOptions
+  content    <- listTableContent toWrite
+  pure $ toRSTDirective "list-table" captionRST (directiveOptions opts) content
+  where directiveOptions opts = widths (writerColumns opts) propWidths <>
+                                headerRows
+        toWrite = if noHeaders then rows else headers:rows
+        headerRows = [("header-rows", text $ show (1 :: Int)) | not noHeaders]
+        widths tot pro = [("widths", showWidths tot pro) |
+                          not (null propWidths || all (==0.0) propWidths)]
+        noHeaders = all null headers
+        -- >>> showWidths 70 [0.5, 0.5]
+        -- "35 35"
+        showWidths :: Int -> [Double] -> Doc Text
+        showWidths tot = text . unwords . map (show . toColumns tot)
+        -- toColumns converts a width expressed as a proportion of the
+        -- total into a width expressed as a number of columns
+        toColumns :: Int -> Double -> Int
+        toColumns t p = round (p * fromIntegral t)
+        listTableContent :: PandocMonad m => [[[Block]]] -> RST m (Doc Text)
+        listTableContent = joinTable joinDocsM joinDocsM .
+                           mapTable blockListToRST
+        -- joinDocsM adapts joinDocs in order to work in the `RST m` monad
+        joinDocsM :: PandocMonad m => [RST m (Doc Text)] -> RST m (Doc Text)
+        joinDocsM = fmap joinDocs . sequence
+        -- joinDocs will be used to join cells and to join rows
+        joinDocs :: [Doc Text] -> Doc Text
+        joinDocs items = blankline $$
+                         (chomp . vcat . map formatItem) items $$
+                         blankline
+        formatItem :: Doc Text -> Doc Text
+        formatItem i = hang 3 "- " (i <> cr)
+        -- apply a function to all table cells changing their type
+        mapTable :: (a -> b) -> [[a]] -> [[b]]
+        mapTable = map . map
+        -- function hor to join cells and function ver to join rows
+        joinTable :: ([a] -> a) -> ([a] -> a) -> [[a]] -> a
+        joinTable hor ver = ver . map hor
 
 transformInlines :: [Inline] -> [Inline]
 transformInlines =  insertBS .

--- a/test/command/4564.md
+++ b/test/command/4564.md
@@ -1,0 +1,65 @@
+```
+% pandoc -f native -t rst --list-tables
+[BlockQuote
+ [Table ("",[],[]) (Caption Nothing
+  [])
+  [(AlignDefault,ColWidth 0.1527777777777778)
+  ,(AlignDefault,ColWidth 0.1388888888888889)
+  ,(AlignDefault,ColWidth 0.16666666666666666)
+  ,(AlignDefault,ColWidth 0.375)]
+  (TableHead ("",[],[])
+  [Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+    [Plain [Str "Centered",SoftBreak,Str "Header"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+    [Plain [Str "Left",SoftBreak,Str "Aligned"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+    [Plain [Str "Right",SoftBreak,Str "Aligned"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+    [Plain [Str "Default",Space,Str "aligned"]]]])
+  [(TableBody ("",[],[]) (RowHeadColumns 0)
+   []
+   [Row ("",[],[])
+    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "First"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "row"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "12.0"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",SoftBreak,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
+   ,Row ("",[],[])
+    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "Second"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "row"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "5.0"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",SoftBreak,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",SoftBreak,Str "rows."]]]])]
+  (TableFoot ("",[],[])
+  [])]]
+^D
+   .. list-table::
+      :widths: 11 10 12 27
+      :header-rows: 1
+
+      - 
+
+         - Centered Header
+         - Left Aligned
+         - Right Aligned
+         - Default aligned
+      - 
+
+         - First
+         - row
+         - 12.0
+         - Example of a row that spans multiple lines.
+      - 
+
+         - Second
+         - row
+         - 5.0
+         - Here’s another one. Note the blank line between rows.
+```


### PR DESCRIPTION
this changes the API adding a global `--list-table` option which only
affects the rST writer, and causes all tables to be rendered using the
list table syntax documented here
http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table