### PR TITLE
 Document no template fallback for absolute path

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1897,7 +1897,8 @@ ${ styles.html() }
 ```
 
 (If a partial is not found in the directory of the
-template, it will also be sought in the `templates`
+template and the template path is given as a relative 
+path, it will also be sought in the `templates`
 subdirectory of the user data directory.)
 
 Partials may optionally be applied to variables using


### PR DESCRIPTION
Reopening of https://github.com/jgm/pandoc-website/pull/44, but targeted at the correct website

See jgm/pandoc#7077