### PR TITLE
Update default ODT style

### DIFF
--- a/data/odt/styles.xml
+++ b/data/odt/styles.xml
@@ -350,7 +350,7 @@ xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2">
     </style:style>
     <style:style style:name="First_20_paragraph"
     style:display-name="First paragraph" style:family="paragraph"
-    style:parent-style-name="Standard"
+    style:parent-style-name="Text_20_body"
     style:next-style-name="Text_20_body" style:class="text" />
     <style:style style:name="Numbering_20_Symbols"
     style:display-name="Numbering Symbols" style:family="text" />


### PR DESCRIPTION
As of now, the default style for ODT documents has a "First paragraph" style that inherits from "Standard" style and has no top or bottom margin. All subsequent paragraphs have "Text_20_body" style that inherits from "Standard" and add "0.0598in" margins on top and bottom. This makes the final document a bit ugly since the first paragraph has a small gap ("0.0598in") towards the second one, and all subsequent have double that.

The proposed fix makes "First paragraph" inherit from "Text_20_body" instead so that it also has a consistent margin.

Another approach would be to inherit "Text_20_body" and add a 0 margin on top.