### PR TITLE
Wrap url colours in braces in the default LaTeX template

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -219,10 +219,10 @@ $if(keywords)$
 $endif$
 $if(colorlinks)$
   colorlinks=true,
-  linkcolor=$if(linkcolor)$$linkcolor$$else$Maroon$endif$,
-  filecolor=$if(filecolor)$$filecolor$$else$Maroon$endif$,
-  citecolor=$if(citecolor)$$citecolor$$else$Blue$endif$,
-  urlcolor=$if(urlcolor)$$urlcolor$$else$Blue$endif$,
+  linkcolor={$if(linkcolor)$$linkcolor$$else$Maroon$endif$},
+  filecolor={$if(filecolor)$$filecolor$$else$Maroon$endif$},
+  citecolor={$if(citecolor)$$citecolor$$else$Blue$endif$},
+  urlcolor={$if(urlcolor)$$urlcolor$$else$Blue$endif$},
 $else$
   hidelinks,
 $endif$


### PR DESCRIPTION
The current default LaTeX template writes the url colours without braces in the hypersetup block. This makes it impossible to use colour that contain commas (as in `linkcolor: "rgb:red,34;green,136;blue,51"` using xcolor extended colour expressions) because the comma clashes with the key=value parsing.

This PR fix this by simply adding braces around the colour names.