### PR TITLE
Relaxes haddock-library upper bound

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -461,7 +461,7 @@ library
                  exceptions            >= 0.8      && < 0.11,
                  file-embed            >= 0.0      && < 0.1,
                  filepath              >= 1.1      && < 1.5,
-                 haddock-library       >= 1.8      && < 1.10,
+                 haddock-library       >= 1.8      && < 1.11,
                  hslua                 >= 1.1      && < 1.4,
                  hslua-module-path     >= 0.1.0    && < 0.2.0,
                  hslua-module-system   >= 0.2      && < 0.3,


### PR DESCRIPTION
Relates to https://github.com/commercialhaskell/stackage/issues/5890

I haven't tested this locally, but the `haddock-library-1.10.0` changelog makes me think that this should be fairly safe; I figured letting CI run the compile/test loop would be "good enough" but let me know if you think I should pull the changes down and run a sanity check.