### PR TITLE
Update current-date.lua filter

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -390,7 +390,7 @@ current date, if a date isn't already set:
 ``` lua
 function Meta(m)
   if m.date == nil then
-    m.date = os.date("%B %e, %Y")
+    m.date = os.date("%B %d, %Y")
     return m
   end
 end


### PR DESCRIPTION
The correct placeholder for day is `%d`, not `%e`, see [Lua docs](https://www.lua.org/pil/22.1.html)