### PR TITLE
Update bounds for random

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -476,7 +476,7 @@ library
                  pandoc-types          >= 1.22     && < 1.23,
                  parsec                >= 3.1      && < 3.2,
                  process               >= 1.2.3    && < 1.7,
-                 random                >= 1        && < 1.2,
+                 random                >= 1        && < 1.3,
                  safe                  >= 0.3      && < 0.4,
                  scientific            >= 0.3      && < 0.4,
                  skylighting           >= 0.10.4.1 && < 0.11,


### PR DESCRIPTION
This PR updates bounds for random-1.2 which was released about a year ago.

If possible a new revision on hackage would be awesome, since it is blocking commercialhaskell/stackage#5474