### PR TITLE
Fixed typo #7159

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -109,7 +109,7 @@ element filtering function. In other words, filter entries will
 be called for each corresponding element in the document,
 getting the respective element as input.
 
-The return of a filter function must one of the following:
+The return of a filter function must be one of the following:
 
 -   nil: this means that the object should remain unchanged.
 -   a pandoc object: this must be of the same type as the input


### PR DESCRIPTION
This commit fixes the typo in the Lua filters documentation, see #7159

The Lua filters documentation (file https://github.com/jgm/pandoc/blob/master/doc/lua-filters.md) had a grammatical error, it said "The return of a filter function must one of the following:", which lacks the verb "be", so the correct phrase is "The return of a filter function must be one of the following:".
