### PR TITLE
Fixed "The this" typo in lua-filters.md

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3205,7 +3205,7 @@ Usage:
 
 # Module pandoc.List
 
-The this module defines pandoc's list type. It comes with useful
+This module defines pandoc's list type. It comes with useful
 methods and convenience functions.
 
 ## Constructor


### PR DESCRIPTION
The documentation for Lua filters said "The this module defines..."

This has been fixed to say "This module defines..."