### PR TITLE
Require text for trypandoc

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -729,7 +729,7 @@ executable trypandoc
   main-is:         trypandoc.hs
   hs-source-dirs:  trypandoc
   if flag(trypandoc)
-    build-depends: aeson, http-types, wai >= 0.3, wai-extra >= 3.0.24
+    build-depends: aeson, http-types, text, wai >= 0.3, wai-extra >= 3.0.24
     buildable:     True
   else
     buildable:     False


### PR DESCRIPTION
```
Building executable 'trypandoc' for pandoc-2.13..
[1 of 1] Compiling Main

trypandoc/trypandoc.hs:25:1: error:
    Could not load module ‘Data.Text’
    It is a member of the hidden package ‘text-1.2.4.1’.
    Perhaps you need to add ‘text’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
25 | import qualified Data.Text as T
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

trypandoc/trypandoc.hs:26:1: error:
    Could not load module ‘Data.Text’
    It is a member of the hidden package ‘text-1.2.4.1’.
    Perhaps you need to add ‘text’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
   |
26 | import Data.Text (Text)
   | ^^^^^^^^^^^^^^^^^^^^^^^
```