### PR TITLE
Org writer: Use LaTeX style maths deliminators

### DIFF
--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -404,8 +404,8 @@ inlineToOrg (Str str) = return . literal $ escapeString str
 inlineToOrg (Math t str) = do
   modify $ \st -> st{ stHasMath = True }
   return $ if t == InlineMath
-              then "$" <> literal str <> "$"
-              else "$$" <> literal str <> "$$"
+              then "\\(" <> literal str <> "\\)"
+              else "\\[" <> literal str <> "\\]"
 inlineToOrg il@(RawInline f str)
   | isRawFormat f = return $ literal str
   | otherwise     = do

--- a/test/writer.org
+++ b/test/writer.org
@@ -600,14 +600,14 @@ Ellipses...and...and....
   :END:
 
 - \cite[22-23]{smith.1899}
-- $2+2=4$
-- $x \in y$
-- $\alpha \wedge \omega$
-- $223$
-- $p$-Tree
+- \(2+2=4\)
+- \(x \in y\)
+- \(\alpha \wedge \omega\)
+- \(223\)
+- \(p\)-Tree
 - Here's some display math:
-  $$\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}$$
-- Here's one that has a line break in it: $\alpha + \omega \times x^2$.
+  \[\frac{d}{dx}f(x)=\lim_{h\to 0}\frac{f(x+h)-f(x)}{h}\]
+- Here's one that has a line break in it: \(\alpha + \omega \times x^2\).
 
 These shouldn't be math:
 


### PR DESCRIPTION
Like Markdown, Org supports LaTeX fragments. However, while many Markdown flavours like the TeX-style `$` / `$$`, as mentioned in the Org manual [1], Org works better with LaTeX-style `\( \)` / `\[ \]` delimiters. It also supports LaTeX environments (`\begin{*} ... \end{*}`) without any form of escaping, but that is best left to another patch.

\[1\]: https://orgmode.org/manual/LaTeX-fragments.html