### PR TITLE
LaTeX template: Fix bad vertical spacing after the bibliography

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -384,7 +384,10 @@ $if(csl-refs)$
  {% don't indent paragraphs
   \setlength{\parindent}{0pt}
   % turn on hanging indent if param 1 is 1
-  \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+  \ifodd #1
+  \let\oldpar\par
+  \def\par{\hangindent=\cslhangindent\oldpar}
+  \fi
   % set entry spacing
   \ifnum #2 > 0
   \setlength{\parskip}{#2\baselineskip}


### PR DESCRIPTION
With the attached file test-biblio-header-spacing.md and the default LaTeX template, I observed that the space between the bibliography and the subsequent heading is too short in the PDF output (see bad.pdf). This comes from the implementation of the hanging indentation in the CSLReferences environment. This fix redefines `\par` instead of tweaking `\everypar`.

[test-biblio-header-spacing.md](https://github.com/jgm/pandoc/files/6341980/test-biblio-header-spacing.md)
[bad.pdf](https://github.com/jgm/pandoc/files/6341981/bad.pdf)
[good.pdf](https://github.com/jgm/pandoc/files/6341983/good.pdf)


.