### PR TITLE
Org writer: inline latex envs need newlines

### DIFF
--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -407,6 +407,8 @@ inlineToOrg (Math t str) = do
               then "\\(" <> literal str <> "\\)"
               else "\\[" <> literal str <> "\\]"
 inlineToOrg il@(RawInline f str)
+  | elem f ["tex", "latex"] && T.isPrefixOf "\\begin" str =
+    return $ cr <> literal str <> cr
   | isRawFormat f = return $ literal str
   | otherwise     = do
       report $ InlineNotRendered il


### PR DESCRIPTION
Closes #7252 (discssion there).

As specified in https://orgmode.org/manual/LaTeX-fragments.html, an
inline \begin{}...\end{} LaTeX block must start on a new line.