### PR TITLE
Markdown reader: allow more attributes in special spans

### DIFF
--- a/test/command/4102.md
+++ b/test/command/4102.md
@@ -1,0 +1,11 @@
+SmallCaps spans can have additional attributes.
+```
+% pandoc -t latex -f markdown
+[Populus]{.smallcaps lang=la}
+
+[Romanus]{.smallcaps}
+^D
+\foreignlanguage{latin}{\textsc{Populus}}
+
+\textsc{Romanus}
+```

--- a/test/command/nested-spanlike.md
+++ b/test/command/nested-spanlike.md
@@ -2,5 +2,5 @@
 % pandoc -f markdown -t html
 [test]{.foo .underline #bar .smallcaps .kbd}
 ^D
-<p><u id="bar"><span class="smallcaps"><kbd>test</kbd></span></u></p>
+<p><kbd id="bar"><u><span class="smallcaps">test</span></u></kbd></p>
 ```


### PR DESCRIPTION
Spans with "smallcaps" as the first class are converted to *SmallCaps*
elements. While previously no other classes or attributes were allowed,
additional classes, attributes, and an identifier are not permitted and
kept in a *SmallCaps* wrapping *Span* element.

The same change is applied to underline spans, where the first class
must be either "ul" or "underline".

Closes: #4102