### PR TITLE
Parses multiple BibLaTex \textcite references as many Cite Inlines

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -284,7 +284,7 @@ lit = pure . str
 blockquote :: PandocMonad m => Bool -> Maybe Text -> LP m Blocks
 blockquote cvariant mblang = do
   citepar <- if cvariant
-                then (\xs -> para (cite xs mempty))
+                then (\xs -> para (cite (map fst xs) mempty))
                        <$> cites inline NormalCitation False
                 else option mempty $ para <$> bracketed inline
   let lang = mblang >>= babelLangToBCP47

--- a/src/Text/Pandoc/Readers/LaTeX/Citation.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Citation.hs
@@ -86,35 +86,36 @@ citationCommands inline =
 
 -- citations
 
-addPrefix :: [Inline] -> [Citation] -> [Citation]
-addPrefix p (k:ks) = k {citationPrefix = p ++ citationPrefix k} : ks
+addPrefix :: (Text, [Inline]) -> [(Citation, Text)] -> [(Citation, Text)]
+addPrefix (_, p) ((k, raw):ks) = (k {citationPrefix = p ++ citationPrefix k}, raw) : ks
 addPrefix _ _      = []
 
-addSuffix :: [Inline] -> [Citation] -> [Citation]
-addSuffix s ks@(_:_) =
-  let k = last ks
-  in  init ks ++ [k {citationSuffix = citationSuffix k ++ s}]
+addSuffix :: (Text, [Inline]) -> [(Citation, Text)] -> [(Citation, Text)]
+addSuffix (foo, s) ks@(_:_) =
+  let (k, raw) = last ks
+      stuff = if foo == "" then "" else "[" <> foo <> "]"
+  in  init ks ++ [(k {citationSuffix = citationSuffix k ++ s}, stuff <> raw)]
 addSuffix _ _ = []
 
-simpleCiteArgs :: forall m . PandocMonad m => LP m Inlines -> LP m [Citation]
+simpleCiteArgs :: forall m . PandocMonad m => LP m Inlines -> LP m [(Citation, Text)]
 simpleCiteArgs inline = try $ do
-  first  <- optionMaybe $ toList <$> opt
-  second <- optionMaybe $ toList <$> opt
+  first  <- optionMaybe $ fmap toList <$> opt
+  second <- optionMaybe $ fmap toList <$> opt
   keys <- try $ bgroup *> manyTill citationLabel egroup
   let (pre, suf) = case (first  , second ) of
         (Just s , Nothing) -> (mempty, s )
         (Just s , Just t ) -> (s , t )
         _                  -> (mempty, mempty)
-      conv k = Citation { citationId      = k
+      conv k = (Citation { citationId      = k
                         , citationPrefix  = []
                         , citationSuffix  = []
                         , citationMode    = NormalCitation
                         , citationHash    = 0
                         , citationNoteNum = 0
-                        }
+                        }, "{" <> k <> "}")
   return $ addPrefix pre $ addSuffix suf $ map conv keys
  where
-  opt :: PandocMonad m => LP m Inlines
+  opt :: PandocMonad m => LP m (Text, Inlines)
   opt = do
     toks <- try (sp *> bracketedToks <* sp)
     -- now parse the toks as inlines
@@ -122,7 +123,7 @@ simpleCiteArgs inline = try $ do
     parsed <- lift $
       runParserT (mconcat <$> many inline) st "bracketed option" toks
     case parsed of
-      Right result -> return result
+      Right result -> return (untokenize toks, result)
       Left e       -> throwError $ PandocParsecError (toSources toks) e
 
 
@@ -138,7 +139,7 @@ citationLabel  = do
   where bibtexKeyChar = ".:;?!`'()/*@_+=-&[]" :: [Char]
 
 cites :: PandocMonad m
-      => LP m Inlines -> CitationMode -> Bool -> LP m [Citation]
+      => LP m Inlines -> CitationMode -> Bool -> LP m [(Citation, Text)]
 cites inline mode multi = try $ do
   let paropt = parenWrapped inline
   cits <- if multi
@@ -161,35 +162,35 @@ cites inline mode multi = try $ do
   let cs = concat cits
   return $ case mode of
         AuthorInText -> case cs of
-                             (c:rest) -> c {citationMode = mode} : rest
+                             ((c, raw):rest) -> (c {citationMode = mode}, raw) : rest
                              []       -> []
-        _            -> map (\a -> a {citationMode = mode}) cs
+        _            -> map (\(a, raw) -> (a {citationMode = mode}, raw)) cs
   where mprenote (k:ks) = (k:ks) ++ [Space]
         mprenote _ = mempty
         mpostnote (k:ks) = [Str ",", Space] ++ (k:ks)
         mpostnote _ = mempty
         addMprenote mpn (k:ks) =
-          let mpnfinal = case citationPrefix k of
+          let mpnfinal = case citationPrefix (fst k) of
                            (_:_) -> mprenote mpn
                            _ -> mpn
-          in addPrefix mpnfinal (k:ks)
+          in addPrefix (mempty, mpnfinal) (k:ks)
         addMprenote _ _ = []
-        addMpostnote = addSuffix . mpostnote
+        addMpostnote = addSuffix . (\t -> (mempty, mpostnote t))
 
 citationWith :: PandocMonad m
              => LP m Inlines -> Text -> CitationMode -> Bool -> LP m Inlines
 citationWith inline name mode multi = do
-  (c,raw) <- withRaw $ cites inline mode multi
-  return $ cite c (rawLatex name raw)
+  (c, raw) <- withRaw $ cites inline mode multi
+  return $ cite (map fst c) (rawLatex name raw)
 
 multiCites :: PandocMonad m
            => LP m Inlines -> Text -> CitationMode -> Bool -> LP m Inlines
 multiCites inline name mode multi = do
-  (c, raw) <- withRaw $ cites inline mode multi
-  return . mconcat . commaSeparated $ toCite raw <$> c
+  (cites, _) <- withRaw $ cites inline mode multi
+  return . mconcat . commaSeparated $ toCite <$> cites
   where
-    toCite raw citation =
-      cite [citation {citationMode = AuthorInText}] (rawLatex name raw)
+    toCite (citation, raw) =
+      cite [citation {citationMode = AuthorInText}] (rawInline "latex" $ "\\" <> name <> raw)
     commaSeparated =
       L.intersperse (str "," <> space)
 
@@ -197,13 +198,13 @@ rawLatex :: Text -> [Tok] -> Inlines
 rawLatex name raw =
   (rawInline "latex" $ "\\" <> name <> untokenize raw)
 
-handleCitationPart :: Inlines -> [Citation]
+handleCitationPart :: Inlines -> [(Citation, Text)]
 handleCitationPart ils =
   let isCite Cite{} = True
       isCite _      = False
       (pref, rest) = break isCite (toList ils)
   in case rest of
-          (Cite cs _:suff) -> addPrefix pref $ addSuffix suff cs
+          (Cite cs _:suff) -> addPrefix (mempty, pref) $ addSuffix (mempty, suff) (map (\x -> (x, mempty)) cs)
           _                -> []
 
 complexNatbibCitation :: PandocMonad m
@@ -219,7 +220,7 @@ complexNatbibCitation inline mode = try $ do
       return $ map handleCitationPart items
   case cs of
        []       -> mzero
-       (c:cits) -> return $ cite (c{ citationMode = mode }:cits)
+       ((c, r):cits) -> return $ cite (c{ citationMode = mode }:(map fst cits))
                       (rawLatex "citetext" raw)
 
 inNote :: Inlines -> Inlines

--- a/src/Text/Pandoc/Readers/LaTeX/Citation.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Citation.hs
@@ -45,7 +45,7 @@ citationCommands inline =
   , ("autocite*", citation "autocite*" SuppressAuthor False)
   , ("cite*", citation "cite*" SuppressAuthor False)
   , ("parencite*", citation "parencite*" SuppressAuthor False)
-  , ("textcite", multipleCites "textcite" AuthorInText False)
+  , ("textcite", multipleCites "textcite" AuthorInText True)
   , ("citet", citation "citet" AuthorInText False)
   , ("citet*", citation "citet*" AuthorInText False)
   , ("citealt", citation "citealt" AuthorInText False)

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -166,7 +166,7 @@ tests = [ testGroup "basic"
                                   , simpleCell (plain "Two")
                                   ]
                    , Row nullAttr [ simpleCell (plain "Three") ]
-                   , Row nullAttr [ simpleCell (plain "Four") 
+                   , Row nullAttr [ simpleCell (plain "Four")
                                   , simpleCell (plain "Five")
                                   , simpleCell (plain "Six")
                                   , simpleCell (plain "Seven")
@@ -174,8 +174,8 @@ tests = [ testGroup "basic"
                    ]
           , "Table with multicolumn header" =:
             T.unlines [ "\\begin{tabular}{ |l|l| }"
-                      , "\\hline\\multicolumn{2}{|c|}{Header}\\\\" 
-                      , "\\hline key & val\\\\" 
+                      , "\\hline\\multicolumn{2}{|c|}{Header}\\\\"
+                      , "\\hline key & val\\\\"
                       , "\\hline\\end{tabular}"
                       ] =?>
             table emptyCaption
@@ -384,10 +384,16 @@ biblatexCitations = testGroup "biblatex"
   [ "textcite" =: "\\textcite{item1}"
     =?> para (cite [baseCitation] (rt "\\textcite{item1}"))
   , "textcite with multiple citations" =: "\\textcite{item1,item2}"
-    =?> para (cite [baseCitation] (rt "\\textcite{item1,item2}") <>
+    =?> para (cite [baseCitation] (rt "\\textcite{item1}") <>
               str "," <>
               space <>
-              cite [baseCitation {citationId = "item2"}] (rt "\\textcite{item1,item2}")
+              cite [baseCitation {citationId = "item2"}] (rt "\\textcite{item2}")
+             )
+  , "textcite with multiple citations and suffix" =: "\\textcite[suffix]{item1,item2}"
+    =?> para (cite [baseCitation] (rt "\\textcite{item1}") <>
+              str "," <>
+              space <>
+              cite [baseCitation {citationId = "item2", citationSuffix = toList $ text "suffix"}] (rt "\\textcite[suffix]{item2}")
              )
   , "suffix" =: "\\textcite[p.~30]{item1}"
     =?> para

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -383,6 +383,12 @@ biblatexCitations :: TestTree
 biblatexCitations = testGroup "biblatex"
   [ "textcite" =: "\\textcite{item1}"
     =?> para (cite [baseCitation] (rt "\\textcite{item1}"))
+  , "textcite with multiple citations" =: "\\textcite{item1,item2}"
+    =?> para (cite [baseCitation] (rt "\\textcite{item1,item2}") <>
+              str "," <>
+              space <>
+              cite [baseCitation {citationId = "item2"}] (rt "\\textcite{item1,item2}")
+             )
   , "suffix" =: "\\textcite[p.~30]{item1}"
     =?> para
         (cite [baseCitation{ citationSuffix = toList $ text "p.\160\&30" }] (rt "\\textcite[p.~30]{item1}"))


### PR DESCRIPTION
Updates the LaTex Reader to parse \textcite citations having more than
one reference (e.g. \textcite{ref1,ref2}) as multiple `Cite`s (one per
reference) rather than one `Cite` with many `[Citation]`.

Closes: #6042