### PR TITLE
DocBook: correct list of admonitions

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -134,6 +134,7 @@ List of all DocBook tags, with [x] indicating implemented,
 [ ] corpcredit - A corporation or organization credited in a document
 [ ] corpname - The name of a corporation
 [ ] country - The name of a country
+[x] danger - An admonition set off from the text indicating hazardous situation
 [ ] database - The name of a database, or part of a database
 [x] date - The date of publication or revision of a document
 [ ] dedication - A wrapper for the dedication section of a book
@@ -718,7 +719,7 @@ blockTags =
   ] ++ admonitionTags
 
 admonitionTags :: [Text]
-admonitionTags = ["important","caution","note","tip","warning"]
+admonitionTags = ["caution","danger","important","note","tip","warning"]
 
 -- Trim leading and trailing newline characters
 trimNl :: Text -> Text

--- a/src/Text/Pandoc/Writers/Docbook.hs
+++ b/src/Text/Pandoc/Writers/Docbook.hs
@@ -198,8 +198,7 @@ blockToDocbook opts (Div (id',"section":_,_) (Header lvl (_,_,attrs) ils : xs)) 
 blockToDocbook opts (Div (ident,classes,_) bs) = do
   version <- ask
   let identAttribs = [(idName version, ident) | not (T.null ident)]
-      admonitions = ["attention","caution","danger","error","hint",
-                     "important","note","tip","warning"]
+      admonitions = ["caution","danger","important","note","tip","warning"]
   case classes of
     (l:_) | l `elem` admonitions -> do
         let (mTitleBs, bodyBs) =

--- a/test/Tests/Writers/Docbook.hs
+++ b/test/Tests/Writers/Docbook.hs
@@ -83,32 +83,32 @@ tests = [ testGroup "line blocks"
                                     , "</warning>"
                                     ]
           , "admonition-with-title" =:
-                            divWith ("foo", ["attention"], []) (
+                            divWith ("foo", ["note"], []) (
                               divWith ("foo", ["title"], [])
                                 (plain (text "This is title")) <>
                               para "This is a test"
                             )
                               =?> unlines
-                                    [ "<attention id=\"foo\">"
+                                    [ "<note id=\"foo\">"
                                     , "  <title>This is title</title>"
                                     , "  <para>"
                                     , "    This is a test"
                                     , "  </para>"
-                                    , "</attention>"
+                                    , "</note>"
                                     ]
           , "admonition-with-title-in-para" =:
-                            divWith ("foo", ["attention"], []) (
+                            divWith ("foo", ["note"], []) (
                               divWith ("foo", ["title"], [])
                                 (para "This is title") <>
                               para "This is a test"
                             )
                               =?> unlines
-                                    [ "<attention id=\"foo\">"
+                                    [ "<note id=\"foo\">"
                                     , "  <title>This is title</title>"
                                     , "  <para>"
                                     , "    This is a test"
                                     , "  </para>"
-                                    , "</attention>"
+                                    , "</note>"
                                     ]
           , "single-child" =:
                             divWith ("foo", [], []) (para "This is a test")


### PR DESCRIPTION
In https://github.com/jgm/pandoc/pull/6922, I accidentally added non-existent admonitions to the DocBook writer (taken from rST). Let’s remove them. Though `danger` is actually supported since DocBook 5.2 so let’s add it to the DocBook reader.
