### PR TITLE
Docbook writer: Interpret links without contents as cross-references

### DIFF
--- a/src/Text/Pandoc/Writers/Docbook.hs
+++ b/src/Text/Pandoc/Writers/Docbook.hs
@@ -429,7 +429,9 @@ inlineToDocbook opts (Link attr txt (src, _))
   | otherwise = do
       version <- ask
       (if "#" `T.isPrefixOf` src
-            then inTags False "link" $ ("linkend", writerIdentifierPrefix opts <> T.drop 1 src) : idAndRole attr
+            then let tag = if null txt then "xref" else "link"
+                 in  inTags False tag $
+                     ("linkend", writerIdentifierPrefix opts <> T.drop 1 src) : idAndRole attr
             else if version == DocBook5
                     then inTags False "link" $ ("xlink:href", src) : idAndRole attr
                     else inTags False "ulink" $ ("url", src) : idAndRole attr )

--- a/test/Tests/Writers/Docbook.hs
+++ b/test/Tests/Writers/Docbook.hs
@@ -32,9 +32,11 @@ which is in turn shorthand for
 -}
 
 infix 4 =:
-(=:) :: (ToString a, ToPandoc a)
-     => String -> (a, String) -> TestTree
+(=:), testDb4, testDb5 :: (ToString a, ToPandoc a)
+                       => String -> (a, String) -> TestTree
 (=:) = test docbook
+testDb4 = test docbook
+testDb5 = test docbook5
 
 lineblock :: Blocks
 lineblock = para ("some text" <> linebreak <>
@@ -47,7 +49,19 @@ lineblock_out = [ "<literallayout>some text"
                 ]
 
 tests :: [TestTree]
-tests = [ testGroup "line blocks"
+tests = [ testGroup "inline elements"
+          [ testGroup "links"
+            [ testDb4 "db4 external link" $ link "https://example.com" "" "Hello"
+                                            =?> "<ulink url=\"https://example.com\">Hello</ulink>"
+            , testDb5 "db5 external link" $ link "https://example.com" "" "Hello"
+                                            =?> "<link xlink:href=\"https://example.com\">Hello</link>"
+            , testDb5 "anchor"            $ link "#foo" "" "Hello"
+                                            =?> "<link linkend=\"foo\">Hello</link>"
+            , testDb5 "automatic anchor"  $ link "#foo" "" ""
+                                            =?> "<xref linkend=\"foo\"></xref>"
+            ]
+          ]
+        , testGroup "line blocks"
           [ "none"       =: para "This is a test"
                               =?> unlines
                                     [ "<para>"


### PR DESCRIPTION
This is what MyST does:

https://myst-parser.readthedocs.io/en/latest/using/syntax.html#targets-and-cross-referencing
