### PR TITLE
DocBook reader: Preserve callouts and xrefs in code

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -1076,7 +1076,10 @@ strContentRecursive = strContent .
   (\e' -> e'{ elContent = map elementToStr $ elContent e' })
 
 elementToStr :: Content -> Content
-elementToStr (Elem e') = Text $ CData CDataText (strContentRecursive e') Nothing
+elementToStr (Elem e') =
+  case qName (elName e') of
+        n | n == "xref" || n == "co" -> Text $ CData CDataText (showElement e') Nothing
+        _ -> Text $ CData CDataText (strContentRecursive e') Nothing
 elementToStr x = x
 
 parseInline :: PandocMonad m => Content -> DB m Inlines


### PR DESCRIPTION
When converting DocBook documents like https://github.com/NixOS/nixpkgs/blob/c06cb69ca0dc02b37e27104ac8415c3cab173328/nixos/modules/programs/plotinus.xml#L27, these need to be dealt with manually.
