### PR TITLE
Remove duplicated alt text in HTML output.

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -1433,7 +1433,7 @@ inlineToHtml opts inline = do
                         return $ if T.null tit
                                     then link'
                                     else link' ! A.title (toValue tit)
-    (Image attr txt (s,tit)) -> do
+    (Image attr@(_, _, attrList) txt (s, tit)) -> do
                         let alternate = stringify txt
                         slideVariant <- gets stSlideVariant
                         let isReveal = slideVariant == RevealJsSlides
@@ -1446,7 +1446,8 @@ inlineToHtml opts inline = do
                               [A.title $ toValue tit | not (T.null tit)] ++
                               attrs
                             imageTag = (if html5 then H5.img else H.img
-                              , [A.alt $ toValue alternate | not (null txt)] )
+                              , [A.alt $ toValue alternate | not (null txt) &&
+                                  isNothing (lookup "alt" attrList)] )
                             mediaTag tg fallbackTxt =
                               let linkTxt = if null txt
                                             then fallbackTxt

--- a/test/command/7416.md
+++ b/test/command/7416.md
@@ -1,0 +1,19 @@
+```
+% pandoc -f markdown -t html
+![caption](../media/rId25.jpg "title"){alt="alt"}
+
+^D
+<figure>
+<img src="../media/rId25.jpg" title="title" alt="alt" /><figcaption aria-hidden="true">caption</figcaption>
+</figure>
+```
+
+```
+% pandoc -f markdown -t html
+![caption](../media/rId25.jpg "title")
+
+^D
+<figure>
+<img src="../media/rId25.jpg" title="title" alt="caption" /><figcaption aria-hidden="true">caption</figcaption>
+</figure>
+```


### PR DESCRIPTION
Addresses  #7416

It prefers the explicitly provided alt attribute.

```
$ pandoc -f markdown -t html
![caption](../media/rId25.jpg "title"){alt="alt"}

<figure>
<img src="../media/rId25.jpg" title="title" alt="alt" /><figcaption aria-hidden="true">caption</figcaption>
</figure>
```

It keeps the old behavior otherwise.

```
% pandoc -f markdown -t html
![caption](../media/rId25.jpg "title")

^D
<figure>
<img src="../media/rId25.jpg" title="title" alt="caption" /><figcaption aria-hidden="true">caption</figcaption>
</figure>
```