### PR TITLE
HTML5 writer, remove aria-hidden when explicit atl text is provided.

### DIFF
--- a/test/command/7416.md
+++ b/test/command/7416.md
@@ -4,7 +4,7 @@
 
 ^D
 <figure>
-<img src="../media/rId25.jpg" title="title" alt="alt" /><figcaption aria-hidden="true">caption</figcaption>
+<img src="../media/rId25.jpg" title="title" alt="alt" /><figcaption>caption</figcaption>
 </figure>
 ```
 


### PR DESCRIPTION
Related to #7416 

This PR removes the `aria-hidden=true` attribute from the HTML5 output when an explicit alt text is provided.

```
% pandoc -f markdown -t html
![caption](../media/rId25.jpg "title"){alt="alt"}

^D
<figure>
<img src="../media/rId25.jpg" title="title" alt="alt" /><figcaption>caption</figcaption>
</figure>
```

Quoting from the [w3 recommendation](https://www.w3.org/TR/wai-aria-1.1/#aria-hidden), emphasis mine:

> aria-hidden (state)
>
> Indicates whether the element is exposed to an accessibility API. See related aria-disabled.
>
> User agents determine an element's hidden status based on whether it is rendered, and the rendering is usually controlled by CSS. For example, an element whose display property is set to none is not rendered. An element is considered hidden if it, or any of its ancestors are not rendered or have their aria-hidden attribute value set to true.
>
> Authors MAY, with caution, **use aria-hidden** to hide visibly rendered content from assistive technologies only if the act of hiding this content is intended to improve the experience for users of assistive technologies **by removing redundant or extraneous content**. Authors using aria-hidden to hide visible content from screen readers MUST ensure that identical or equivalent meaning and functionality is exposed to assistive technologies.

It made sense to use it when the content was "redundant", but when an explicit alt text is provided, this is no longer the case.

**Further discussion**

[Discussion](https://github.com/tarleb/pandoc/discussions/12#discussioncomment-943251)