### PR TITLE
Respect image external attribute in epub writer

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -6177,6 +6177,12 @@ with the `src` attribute.  For example:
       </source>
     </audio>
 
+If the input format already is HTML then `data-external="1"` will work
+as expected for `<img>` elements. Similarly, for Markdown, external
+images can be declared with `![img](url){external=1}`. Note that this
+only works for images; the other media elements have no native
+representation in pandoc's AST and requires the use of raw HTML.
+
 # Jupyter notebooks
 
 When creating a [Jupyter notebook], pandoc will try to infer the

--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -1131,7 +1131,8 @@ transformInline  :: PandocMonad m
                  => WriterOptions
                  -> Inline
                  -> E m Inline
-transformInline _opts (Image attr lab (src,tit)) = do
+transformInline _opts (Image attr@(_,_,kvs) lab (src,tit))
+  | isNothing (lookup "external" kvs) = do
     newsrc <- modifyMediaRef $ T.unpack src
     return $ Image attr lab ("../" <> newsrc, tit)
 transformInline opts x@(Math t m)


### PR DESCRIPTION
Builds upon #7429 and fixes #6543