### PR TITLE
Stop using the HTTP package.

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -598,7 +598,6 @@ library
                    Text.Pandoc.UTF8,
                    Text.Pandoc.Templates,
                    Text.Pandoc.XML,
-                   Text.Pandoc.Network.HTTP,
                    Text.Pandoc.SelfContained,
                    Text.Pandoc.Highlighting,
                    Text.Pandoc.Logging,

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -709,6 +709,7 @@ library
                    Text.Pandoc.XML.Light.Types,
                    Text.Pandoc.XML.Light.Proc,
                    Text.Pandoc.XML.Light.Output,
+                   Text.Pandoc.Network.HTTP,
                    Text.Pandoc.CSS,
                    Text.Pandoc.CSV,
                    Text.Pandoc.RoffChar,

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -437,7 +437,6 @@ common common-executable
 library
   import:        common-options
   build-depends: Glob                  >= 0.7      && < 0.11,
-                 HTTP                  >= 4000.0.5 && < 4000.4,
                  HsYAML                >= 0.2      && < 0.3,
                  JuicyPixels           >= 3.1.6.1  && < 3.4,
                  SHA                   >= 1.6      && < 1.7,
@@ -599,6 +598,7 @@ library
                    Text.Pandoc.UTF8,
                    Text.Pandoc.Templates,
                    Text.Pandoc.XML,
+                   Text.Pandoc.Network.HTTP,
                    Text.Pandoc.SelfContained,
                    Text.Pandoc.Highlighting,
                    Text.Pandoc.Logging,

--- a/src/Text/Pandoc/Network/HTTP.hs
+++ b/src/Text/Pandoc/Network/HTTP.hs
@@ -1,0 +1,18 @@
+{- |
+   Module      : Text.Pandoc.Writers.Markdown.Inline
+   Copyright   : Copyright (C) 2006-2021 John MacFarlane
+   License     : GNU GPL, version 2 or above
+
+   Maintainer  : John MacFarlane <jgm@berkeley.edu>
+   Stability   : alpha
+   Portability : portable
+-}
+module Text.Pandoc.Network.HTTP (
+  urlEncode
+  ) where
+import qualified Network.HTTP.Types as HTTP
+import qualified Text.Pandoc.UTF8 as UTF8
+import qualified Data.Text as T
+
+urlEncode :: T.Text -> T.Text
+urlEncode = UTF8.toText . HTTP.urlEncode True . UTF8.fromText

--- a/src/Text/Pandoc/Readers/Org/Meta.hs
+++ b/src/Text/Pandoc/Readers/Org/Meta.hs
@@ -27,13 +27,13 @@ import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Class.PandocMonad (PandocMonad)
 import Text.Pandoc.Definition
 import Text.Pandoc.Shared (blocksToInlines, safeRead)
+import Text.Pandoc.Network.HTTP (urlEncode)
 
 import Control.Monad (mzero, void)
 import Data.List (intercalate, intersperse)
 import Data.Map (Map)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Network.HTTP (urlEncode)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -188,7 +188,7 @@ parseFormat = try $ replacePlain <|> replaceUrl <|> justAppend
    -- inefficient
    replacePlain = try $ (\x -> T.concat . flip intersperse x)
                      <$> sequence [tillSpecifier 's', rest]
-   replaceUrl   = try $ (\x -> T.concat . flip intersperse x . T.pack . urlEncode . T.unpack)
+   replaceUrl   = try $ (\x -> T.concat . flip intersperse x . urlEncode)
                      <$> sequence [tillSpecifier 'h', rest]
    justAppend   = try $ (<>) <$> rest
 

--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -32,7 +32,6 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
-import Network.HTTP (urlEncode)
 import System.FilePath (takeExtension, takeFileName, makeRelative)
 import Text.HTML.TagSoup (Tag (TagOpen), fromAttrib, parseTags)
 import Text.Pandoc.Builder (fromList, setMeta)
@@ -45,6 +44,7 @@ import Text.Pandoc.Error
 import Text.Pandoc.ImageSize
 import Text.Pandoc.Logging
 import Text.Pandoc.MIME (MimeType, extensionFromMimeType, getMimeType)
+import Text.Pandoc.Network.HTTP (urlEncode)
 import Text.Pandoc.Options (EPUBVersion (..), HTMLMathMethod (..),
                             ObfuscationMethod (NoObfuscation), WrapOption (..),
                             WriterOptions (..))
@@ -1137,7 +1137,7 @@ transformInline _opts (Image attr@(_,_,kvs) lab (src,tit))
     return $ Image attr lab ("../" <> newsrc, tit)
 transformInline opts x@(Math t m)
   | WebTeX url <- writerHTMLMathMethod opts = do
-    newsrc <- modifyMediaRef (T.unpack url <> urlEncode (T.unpack m))
+    newsrc <- modifyMediaRef (T.unpack (url <> urlEncode m))
     let mathclass = if t == DisplayMath then "display" else "inline"
     return $ Span ("",["math",mathclass],[])
                 [Image nullAttr [x] ("../" <> newsrc, "")]

--- a/src/Text/Pandoc/Writers/FB2.hs
+++ b/src/Text/Pandoc/Writers/FB2.hs
@@ -29,7 +29,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Encoding as TE
-import Network.HTTP (urlEncode)
+import Text.Pandoc.Network.HTTP (urlEncode)
 import Text.Pandoc.XML.Light as X
 
 import Text.Pandoc.Class.PandocMonad (PandocMonad, report)
@@ -451,7 +451,7 @@ insertMath immode formula = do
   case htmlMath of
     WebTeX url -> do
        let alt = [Code nullAttr formula]
-       let imgurl = url <> T.pack (urlEncode $ T.unpack formula)
+       let imgurl = url <> urlEncode formula
        let img = Image nullAttr alt (imgurl, "")
        insertImage immode img
     _ -> return [el "code" formula]

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -37,7 +37,6 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
-import Network.HTTP (urlEncode)
 import Network.URI (URI (..), parseURIReference)
 import Numeric (showHex)
 import Text.DocLayout (render, literal)
@@ -56,6 +55,7 @@ import Text.Pandoc.Walk
 import Text.Pandoc.Writers.Math
 import Text.Pandoc.Writers.Shared
 import qualified Text.Pandoc.Writers.AnnotatedTable as Ann
+import Text.Pandoc.Network.HTTP (urlEncode)
 import Text.Pandoc.XML (escapeStringForXML, fromEntities, toEntities,
                         html5Attributes, html4Attributes, rdfaAttributes)
 import qualified Text.Blaze.XHtml5 as H5
@@ -1377,7 +1377,7 @@ inlineToHtml opts inline = do
                            InlineMath  -> "\\textstyle "
                            DisplayMath -> "\\displaystyle "
               return $ imtag ! A.style "vertical-align:middle"
-                             ! A.src (toValue $ url <> T.pack (urlEncode (T.unpack $ s <> str)))
+                             ! A.src (toValue . (url <>) . urlEncode $ s <> str)
                              ! A.alt (toValue str)
                              ! A.title (toValue str)
                              ! A.class_ mathClass

--- a/src/Text/Pandoc/Writers/Markdown/Inline.hs
+++ b/src/Text/Pandoc/Writers/Markdown/Inline.hs
@@ -24,7 +24,6 @@ import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Network.HTTP (urlEncode)
 import Text.Pandoc.Class.PandocMonad (PandocMonad, report)
 import Text.Pandoc.Definition
 import Text.Pandoc.Logging
@@ -32,6 +31,7 @@ import Text.Pandoc.Options
 import Text.Pandoc.Parsing hiding (blankline, blanklines, char, space)
 import Text.DocLayout
 import Text.Pandoc.Shared
+import Text.Pandoc.Network.HTTP (urlEncode)
 import Text.Pandoc.Writers.Shared
 import Text.Pandoc.Walk
 import Text.Pandoc.Writers.HTML (writeHtml5String)
@@ -423,7 +423,7 @@ inlineToMarkdown opts (Str str) = do
 inlineToMarkdown opts (Math InlineMath str) =
   case writerHTMLMathMethod opts of
        WebTeX url -> inlineToMarkdown opts
-                       (Image nullAttr [Str str] (url <> T.pack (urlEncode $ T.unpack str), str))
+                       (Image nullAttr [Str str] (url <> urlEncode str, str))
        _ | isEnabled Ext_tex_math_dollars opts ->
              return $ "$" <> literal str <> "$"
          | isEnabled Ext_tex_math_single_backslash opts ->
@@ -439,7 +439,7 @@ inlineToMarkdown opts (Math DisplayMath str) =
   case writerHTMLMathMethod opts of
       WebTeX url -> (\x -> blankline <> x <> blankline) `fmap`
              inlineToMarkdown opts (Image nullAttr [Str str]
-                    (url <> T.pack (urlEncode $ T.unpack str), str))
+                    (url <> urlEncode str, str))
       _ | isEnabled Ext_tex_math_dollars opts ->
             return $ "$$" <> literal str <> "$$"
         | isEnabled Ext_tex_math_single_backslash opts ->


### PR DESCRIPTION
Given https://github.com/osener/markup.rocks/issues/21 and https://github.com/jgm/pandoc/issues/4535, I've recently been working on getting pandoc to build with ghcjs, which I've been able to do here: https://github.com/mt-caret/pandoc-ghcjs. Unfortunately, while the build succeeds there seems to be some problems with the JavaScript emitted so it does not work as-is (I'd love some help understanding what's wrong if anybody is interested). In the meantime, there seem to be relatively trivial changes that I can upstream to make pandoc more ghcjs-friendly.

Pandoc only depends on the urlEncode function in the package, which is also provided by http-types. The HTTP package also depends on the network package, which has difficulty building on ghcjs. I've created some benchmarks and fuzzing tests (https://github.com/mt-caret/bench-url-encode), and based on the results there unfortunately http-type's implementation seems to be 50% slower.