### PR TITLE
Document use of the 'underline' class

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4396,6 +4396,18 @@ Attributes can be attached to verbatim text, just as with
 
     `<$>`{.haskell}
 
+### Underline ###
+
+To underline text, use the `underline` (or `ul`) class:
+
+    [Underline]{.underline}
+
+Or, without the `bracketed_spans` extension (but with `native_spans`):
+
+    <span class="underline">Underline</span>
+
+This will work in all output formats that support underline.
+
 ### Small caps ###
 
 To write small caps, use the `smallcaps` class:


### PR DESCRIPTION
Addresses a comment in #7484.

I wasn't sure whether to include a remark about CSS and compatibility with other markdown flavors (so I didn't). Also, I mentioned `<u>` because that's what the HTML writer generates.