### PR TITLE
Add haskell-language-server to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -41,6 +41,7 @@ let
     file-embed
     filepath
     haddock-library
+    haskell-language-server
     hsc2hs
     hslua
     hslua-module-system


### PR DESCRIPTION
I find it useful to have this installed via the nix shell when working
on pandoc, so I think others may also find it useful.