### PR TITLE
Clarify that each YAML block is a separate YAML document

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4179,6 +4179,10 @@ A document may contain multiple metadata blocks.  If two
 metadata blocks attempt to set the same field, the value from
 the second block will be taken.
 
+Each metadata block is handled internally as an independent YAML document.
+This means, for example, that any YAML anchors defined in a block cannot be
+referenced in another block.
+
 When pandoc is used with `-t markdown` to create a Markdown document,
 a YAML metadata block will be produced only if the `-s/--standalone`
 option is used.  All of the metadata will appear in a single block


### PR DESCRIPTION
See the ["Each YAML block is a YAML document?" pandoc-discuss thread](https://groups.google.com/g/pandoc-discuss/c/icIxqbKptDc/m/q2dTCNpAAQAJ) for background.

I am proposing just adding a new paragraph. I did wonder whether "YAML object" could also be changed to "YAML document" (I think it occurs twice) but decided not to propose this in the PR.