### PR TITLE
Adjust `fenced_divs` syntax to resemble Markdown directive syntax

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -2063,7 +2063,11 @@ divFenced = do
     string ":::"
     skipMany (char ':')
     skipMany spaceChar
-    attribs <- attributes <|> ((\x -> ("",[x],[])) <$> many1Char nonspaceChar)
+    attribs <- attributes <|> do
+      name <- pure <$> many1Char nonspaceChar
+      skipMany spaceChar
+      (ident, classes, keyval) <- option nullAttr attributes
+      return (ident, name ++ classes, keyval)
     skipMany spaceChar
     skipMany (char ':')
     blankline

--- a/test/command/7480.md
+++ b/test/command/7480.md
@@ -1,0 +1,10 @@
+```
+% pandoc
+:::: container {.theorem #id key=value} ::::::
+content
+::::
+^D
+<div id="id" class="container theorem" data-key="value">
+<p>content</p>
+</div>
+```


### PR DESCRIPTION
Resolves #7480.  Adds support for blocks of the form

```
:::: container {.theorem #id key=value} ::::::
This is a theorem.
::::
```
```html
<div id="id" class="container theorem" data-key="value">
<p>This is a theorem.</p>
</div>
```

Previously, you could specify only the attributes list XOR the name, but now you can do one, the other, or both.   As discussed in the issue, this change was made to more closely resemble Markdown's [de-facto standard for directive syntax](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444).  While this change does not fully support directive syntax, it makes documents which use directive syntax more compatible with pandoc.

Note that Markdown directives also allow `[inline content]` like below, but this is currently unsupported:

```
(unsupported)
::: name [inline-content] {key=val}
contents, which are sometimes further block elements
:::
```

For now, I see two options:

* **Option 1:**  Don't support `[inline content]`.  I think this omission would be fine, since pandoc always creates divs from fenced sections, so it's not clear where the text should go anyway.
* **Option 2:**  Parse `[inline content]` but throw it away.  This would ensure that pandoc is compatible with documents that use block directive syntax.

If we go with Option 1, this PR is ready to merge.  If we go with Option 2, I would just need to make a small change.  

Full support for directive syntax will, I think, require an AST change, which would be a much larger project.  I think this PR is a good compromise until then!
