### PR TITLE
LaTeX-parser: restrict \endinput to current file

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -242,6 +242,7 @@ extra-source-files:
                  test/command/sub-file-chapter-1.tex
                  test/command/sub-file-chapter-2.tex
                  test/command/bar.tex
+                 test/command/bar-endinput.tex
                  test/command/yaml-metadata.yaml
                  test/command/3510-subdoc.org
                  test/command/3510-export.latex

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -890,7 +890,7 @@ blockCommands = M.fromList
          addMeta "bibliography" . splitBibs . untokenize))
    , ("addbibresource", mempty <$ (skipopts *> braced >>=
          addMeta "bibliography" . splitBibs . untokenize))
-   , ("endinput", mempty <$ skipMany anyTok)
+   , ("endinput", mempty <$ skipSameFileToks)
    -- includes
    , ("lstinputlisting", inputListing)
    , ("inputminted", inputMinted)
@@ -921,6 +921,10 @@ blockCommands = M.fromList
    , ("epigraph", epigraph)
    ]
 
+skipSameFileToks :: PandocMonad m => LP m ()
+skipSameFileToks = do
+    pos <- getPosition
+    skipMany $ infile (sourceName pos)
 
 environments :: PandocMonad m => M.Map Text (LP m Blocks)
 environments = M.union (tableEnvironments blocks inline) $

--- a/src/Text/Pandoc/Readers/LaTeX/Parsing.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Parsing.hs
@@ -45,6 +45,7 @@ module Text.Pandoc.Readers.LaTeX.Parsing
   , isNewlineTok
   , isWordTok
   , isArgTok
+  , infile
   , spaces
   , spaces1
   , tokTypeIn
@@ -645,6 +646,9 @@ isWordTok _              = False
 isArgTok :: Tok -> Bool
 isArgTok (Tok _ (Arg _) _) = True
 isArgTok _                 = False
+
+infile :: PandocMonad m => SourceName -> LP m Tok
+infile reference = satisfyTok (\(Tok source _ _) -> (sourceName source) == reference)
 
 spaces :: PandocMonad m => LP m ()
 spaces = skipMany (satisfyTok (tokTypeIn [Comment, Spaces, Newline]))

--- a/test/command/bar-endinput.tex
+++ b/test/command/bar-endinput.tex
@@ -1,0 +1,3 @@
+\emph{hi there}
+\endinput
+\emph{invisible}

--- a/test/command/input-with-endinput.md
+++ b/test/command/input-with-endinput.md
@@ -1,0 +1,14 @@
+```
+% pandoc --from=latex -t native
+\begin{document}
+Visible
+
+\include{command/bar-endinput}
+
+Visible
+\end{document}
+^D
+[Para [Str "Visible"]
+,Para [Emph [Str "hi",Space,Str "there"]]
+,Para [Str "Visible"]]
+```


### PR DESCRIPTION
In LaTex, `\endinput` only concerns the handling of the file containing the directive.
So if an `\endinput` is encountered within an included file, the remaining content in the parent file is still relevant and valid.
Unfortunatly, pandoc does not respect this scoping of `\endinput`.
This patch attempts to implement the correct behaviour.