### PR TITLE
Clarify 'attributes' extension support

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -5124,7 +5124,8 @@ or image itself, if these differ.
 #### Extension: `attributes` ####
 
 Allows attributes to be attached to any inline or block-level
-element.  The syntax for the attributes is the same as that
+element when parsing `commonmark`.
+The syntax for the attributes is the same as that
 used in [`header_attributes`][Extension: `header_attributes`].
 
 - Attributes that occur immediately after an inline


### PR DESCRIPTION
[This pandoc-discuss message](https://groups.google.com/g/pandoc-discuss/c/sVLyLWoQXTg/m/btSMRifEAwAJ) notes that the `attributes` extension is only supported for `commonmark` and variants. This PR clarifies this.

Note that I only referred to commonmark (and didn't attempt to list variants) because that seemed to be the existing approach.