### PR TITLE
Do not leak working directory in TikZ filter

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -695,12 +695,12 @@ end
 function RawBlock(el)
   if starts_with('\\begin{tikzpicture}', el.text) then
     local filetype = extension_for[FORMAT] or 'svg'
-    local fname = system.get_working_directory() .. '/' ..
-        pandoc.sha1(el.text) .. '.' .. filetype
+    local fbasename = pandoc.sha1(el.text) .. '.' .. filetype
+    local fname = system.get_working_directory() .. '/' .. fbasename
     if not file_exists(fname) then
       tikz2image(el.text, filetype, fname)
     end
-    return pandoc.Para({pandoc.Image({}, fname)})
+    return pandoc.Para({pandoc.Image({}, fbasename)})
   else
    return el
   end


### PR DESCRIPTION
The TikZ filter in `lua-filters.md` leaks the working directory into its output. I noticed this when inspecting Jupyter Notebooks generated via Pandoc. This pull request attempts to address this by leaving out the working directory in the target file name. 

