### PR TITLE
Add --ipynb-output options html, latex

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1282,14 +1282,18 @@ header when requesting a document from a URL:
     the EPUB-specific contents.  The default is `EPUB`.  To put
     the EPUB contents in the top level, use an empty string.
 
-`--ipynb-output=all|none|best`
+`--ipynb-output=all|none|best|html|latex`
 
 :   Determines how ipynb output cells are treated. `all` means
     that all of the data formats included in the original are
     preserved.  `none` means that the contents of data cells
     are omitted.  `best` causes pandoc to try to pick the
     richest data block in each output cell that is compatible
-    with the output format.  The default is `best`.
+    with the output format. `html|latex` is similar to `best`,
+    but manually choose the one best for `html|latex` respectively,
+    which can be useful when multiple pipes are used so that the
+    output format is not immediately known to pandoc.
+    The default is `best`.
 
 `--pdf-engine=`*PROGRAM*
 

--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -237,6 +237,10 @@ convertWithOpts opts = do
                        _ | readerNameBase /= "ipynb" -> id
                        IpynbOutputAll  -> id
                        IpynbOutputNone -> (filterIpynbOutput Nothing :)
+                       IpynbOutputHTML -> (filterIpynbOutput (Just $
+                                     Format "html") :)
+                       IpynbOutputLaTeX -> (filterIpynbOutput (Just $
+                                     Format "latex") :)
                        IpynbOutputBest -> (filterIpynbOutput (Just $
                                      if htmlFormat format
                                         then Format "html"

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -686,6 +686,8 @@ options =
                       "all" -> return opt{ optIpynbOutput = IpynbOutputAll }
                       "best" -> return opt{ optIpynbOutput = IpynbOutputBest }
                       "none" -> return opt{ optIpynbOutput = IpynbOutputNone }
+                      "html" -> return opt{ optIpynbOutput = IpynbOutputHTML }
+                      "latex" -> return opt{ optIpynbOutput = IpynbOutputLaTeX }
                       _ -> E.throwIO $ PandocOptionError
                              "ipynb-output must be all, none, or best")
                  "all|none|best")

--- a/src/Text/Pandoc/App/Opt.hs
+++ b/src/Text/Pandoc/App/Opt.hs
@@ -75,6 +75,8 @@ data IpynbOutput =
     IpynbOutputAll
   | IpynbOutputNone
   | IpynbOutputBest
+  | IpynbOutputHTML
+  | IpynbOutputLaTeX
   deriving (Show, Generic)
 
 instance FromYAML IpynbOutput where
@@ -83,6 +85,8 @@ instance FromYAML IpynbOutput where
       "none"  -> return IpynbOutputNone
       "all"   -> return IpynbOutputAll
       "best"  -> return IpynbOutputBest
+      "html"  -> return IpynbOutputHTML
+      "latex"  -> return IpynbOutputLaTeX
       _       -> fail $ "Unknown ipynb output type " ++ show t
 
 -- | Data structure for command line options.


### PR DESCRIPTION
The effect is basically similar to `best`, but specifying the format would be html/latex manually.

This is useful for example when pandoc is called in multiple pipes, say from markdown to json, then some filtering, then from json to html.