### PR TITLE
Add missing type for Image title

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -1216,7 +1216,7 @@ Fields:
 :   path to the image file (string)
 
 `title`
-:   brief image description
+:   brief image description (string)
 
 `identifier`
 :   alias for `attr.identifier` (string)


### PR DESCRIPTION
Corresponds to the Lua parameter documentation:
https://github.com/jgm/pandoc/blob/60974538b25657c9aa37e72cc66ca3957912ddec/data/pandoc.lua#L629