### PR TITLE
Improve order of Image fields

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -1206,9 +1206,6 @@ Values of this type can be created with the
 
 Fields:
 
-`attr`
-:   attributes ([Attr])
-
 `caption`
 :   text used to describe the image ([List] of [Inlines])
 
@@ -1217,6 +1214,9 @@ Fields:
 
 `title`
 :   brief image description
+
+`attr`
+:   attributes ([Attr])
 
 `identifier`
 :   alias for `attr.identifier` (string)


### PR DESCRIPTION
Since `identifier`, `classes` and `attributes` are aliases for `attr`, they should follow directly after the `attr` field to avoid confusion. This is the case for all types documented above `Image`.