### PR TITLE
Fix typos in pandoc.path docs

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3442,7 +3442,7 @@ filepath
 
 Returns:
 
--   `true` iff `filepath` is an absolute path, `false` otherwise.
+-   `true` if `filepath` is an absolute path, `false` otherwise.
     (boolean)
 
 ### is_relative (filepath) {#pandoc.path.is_relative}
@@ -3456,7 +3456,7 @@ filepath
 
 Returns:
 
--   `true` iff `filepath` is a relative path, `false` otherwise.
+-   `true` if `filepath` is a relative path, `false` otherwise.
     (boolean)
 
 ### join (filepaths) {#pandoc.path.join}


### PR DESCRIPTION
`iff` -> `if`, two occurrences.