### PR TITLE
Ipynb reader: improve Ipynb.Raw handling

### DIFF
--- a/src/Text/Pandoc/Readers/Ipynb.hs
+++ b/src/Text/Pandoc/Readers/Ipynb.hs
@@ -101,7 +101,7 @@ cellToBlocks opts lang c = do
               "text/latex"      -> "latex"
               "application/pdf" -> "latex"
               "text/markdown"   -> "markdown"
-              "text/x-rsrt"     -> "rst"
+              "text/x-rst"      -> "rst"
               _                 -> format
       return $ B.divWith ("",["cell","raw"],kvs) $ B.rawBlock format' source
     Ipynb.Code{ codeOutputs = outputs, codeExecutionCount = ec } -> do

--- a/src/Text/Pandoc/Readers/Ipynb.hs
+++ b/src/Text/Pandoc/Readers/Ipynb.hs
@@ -97,12 +97,16 @@ cellToBlocks opts lang c = do
       let format = fromMaybe "ipynb" $ lookup "format" kvs
       let format' =
             case format of
-              "text/html"       -> "html"
-              "text/latex"      -> "latex"
-              "application/pdf" -> "latex"
-              "text/markdown"   -> "markdown"
-              "text/x-rst"      -> "rst"
-              _                 -> format
+              "text/html"             -> "html"
+              "slides"                -> "html"
+              "text/latex"            -> "latex"
+              "application/pdf"       -> "latex"
+              "pdf"                   -> "latex"
+              "text/markdown"         -> "markdown"
+              "text/x-rst"            -> "rst"
+              "text/restructuredtext" -> "rst"
+              "text/asciidoc"         -> "asciidoc"
+              _                       -> format
       return $ B.divWith ("",["cell","raw"],kvs) $ B.rawBlock format' source
     Ipynb.Code{ codeOutputs = outputs, codeExecutionCount = ec } -> do
       outputBlocks <- mconcat <$> mapM outputToBlock outputs

--- a/src/Text/Pandoc/Readers/Ipynb.hs
+++ b/src/Text/Pandoc/Readers/Ipynb.hs
@@ -19,6 +19,7 @@ import Data.Char (isDigit)
 import Data.Maybe (fromMaybe)
 import Data.Digest.Pure.SHA (sha1, showDigest)
 import Text.Pandoc.Options
+import Control.Applicative ((<|>))
 import qualified Data.Scientific as Scientific
 import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Logging
@@ -94,7 +95,7 @@ cellToBlocks opts lang c = do
              $ B.fromList bs
     Ipynb.Raw -> do
       -- we use ipynb to indicate no format given (a wildcard in nbformat)
-      let format = fromMaybe "ipynb" $ lookup "format" kvs
+      let format = fromMaybe "ipynb" $ lookup "raw_mimetype" kvs <|> lookup "format" kvs
       let format' =
             case format of
               "text/html"             -> "html"

--- a/src/Text/Pandoc/Writers/Ipynb.hs
+++ b/src/Text/Pandoc/Writers/Ipynb.hs
@@ -138,10 +138,17 @@ extractCells opts (Div (_id,classes,kvs) xs : bs)
           let format' =
                 case T.toLower f of
                   "html"     -> "text/html"
+                  "html4"    -> "text/html"
+                  "html5"    -> "text/html"
+                  "s5"       -> "text/html"
+                  "slidy"    -> "text/html"
+                  "slideous" -> "text/html"
+                  "dzslides" -> "text/html"
                   "revealjs" -> "text/html"
                   "latex"    -> "text/latex"
                   "markdown" -> "text/markdown"
                   "rst"      -> "text/x-rst"
+                  "asciidoc" -> "text/asciidoc"
                   _          -> f
           (Ipynb.Cell{
               cellType = Raw

--- a/src/Text/Pandoc/Writers/Ipynb.hs
+++ b/src/Text/Pandoc/Writers/Ipynb.hs
@@ -147,7 +147,7 @@ extractCells opts (Div (_id,classes,kvs) xs : bs)
                   "revealjs" -> "text/html"
                   "latex"    -> "text/latex"
                   "markdown" -> "text/markdown"
-                  "rst"      -> "text/x-rst"
+                  "rst"      -> "text/restructuredtext"
                   "asciidoc" -> "text/asciidoc"
                   _          -> f
           (Ipynb.Cell{
@@ -155,7 +155,7 @@ extractCells opts (Div (_id,classes,kvs) xs : bs)
             , cellSource = Source $ breakLines raw
             , cellMetadata = if format' == "ipynb" -- means no format given
                                 then mempty
-                                else M.insert "format"
+                                else M.insert "raw_mimetype"
                                        (Aeson.String format') mempty
             , cellAttachments = Nothing } :) <$> extractCells opts bs
         _ -> extractCells opts bs


### PR DESCRIPTION
This issue centers around Ipynb.Raw.

- fixes a typo in the [mime type of rst](https://docutils.sourceforge.io/FAQ.html#what-s-the-official-mime-type-for-restructuredtext-data)
- add most (i.e. those relevant to pandoc) selectable formats in jupyterlab's "Raw NBConvert Format", which includes a different mime-type for rst.
- format -> raw_mimetype. See jupyter/nbformat#229. Essentially while in the nbformat spec, format should be used, in the actual implementation of nbconvert, lab and notebook (i.e. the official ecosystem around ipynb) uses raw_mimetype instead. So for practicality for now we should use `raw_mimetype` as it is the only implemented key in the wild. We'll see how nbformat is resolving that issue.

Edit: also matches the above behavior in the ipynb writer too. Especially there's a backward incompatible changes documented in commit 346df3b.