### PR TITLE
Ipynb reader: add text/markdown support in handleData

### DIFF
--- a/src/Text/Pandoc/Readers/Ipynb.hs
+++ b/src/Text/Pandoc/Readers/Ipynb.hs
@@ -192,6 +192,9 @@ handleData metadata (MimeBundle mb) =
     dataBlock ("text/latex", TextualData t)
       = return $ B.rawBlock "latex" t
 
+    dataBlock ("text/markdown", TextualData t)
+      = return $ B.rawBlock "markdown" t
+
     dataBlock ("text/plain", TextualData t) =
       return $ B.codeBlock t
 


### PR DESCRIPTION
As of IPython version


```python
import IPython

print(IPython.__version__)
```

    7.25.0


it supports the following mime-types in output cell:


```python
ip = get_ipython()
for mime in ip.display_formatter.formatters:
    print(mime)
```

    text/plain
    text/html
    text/markdown
    image/svg+xml
    image/png
    application/pdf
    image/jpeg
    text/latex
    application/json
    application/javascript


This PR add support to the only one not already supporting: text/markdown
