### PR TITLE
Use pretty-simple to create native output

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -583,7 +583,8 @@ library
                  xml-conduit           >= 1.9.1.1  && < 1.10,
                  unicode-collation     >= 0.1.1    && < 0.2,
                  zip-archive           >= 0.2.3.4  && < 0.5,
-                 zlib                  >= 0.5      && < 0.7
+                 zlib                  >= 0.5      && < 0.7,
+                 pretty-simple         >= 4.0      && < 4.1
   if os(windows) && arch(i386)
      build-depends: basement >= 0.0.10,
                     foundation >= 0.0.23

--- a/src/Text/Pandoc/Writers/Native.hs
+++ b/src/Text/Pandoc/Writers/Native.hs
@@ -12,82 +12,24 @@ Conversion of a 'Pandoc' document to a string representation.
 -}
 module Text.Pandoc.Writers.Native ( writeNative )
 where
-import Data.List (intersperse)
 import Data.Text (Text)
+import qualified Data.Text.Lazy as TL
 import Text.Pandoc.Class.PandocMonad (PandocMonad)
 import Text.Pandoc.Definition
-import Text.Pandoc.Options (WrapOption (..), WriterOptions (..))
-import Text.DocLayout
-
-prettyList :: [Doc Text] -> Doc Text
-prettyList ds =
-  "[" <>
-  mconcat (intersperse (cr <> ",") $ map (nest 1) ds) <> "]"
-
--- | Prettyprint Pandoc block element.
-prettyBlock :: Block -> Doc Text
-prettyBlock (LineBlock lines') =
-  "LineBlock" $$ prettyList (map (text . show) lines')
-prettyBlock (BlockQuote blocks) =
-  "BlockQuote" $$ prettyList (map prettyBlock blocks)
-prettyBlock (OrderedList attribs blockLists) =
-  "OrderedList" <> space <> text (show attribs) $$
-  prettyList (map (prettyList . map prettyBlock) blockLists)
-prettyBlock (BulletList blockLists) =
-  "BulletList" $$
-  prettyList (map (prettyList . map prettyBlock) blockLists)
-prettyBlock (DefinitionList items) = "DefinitionList" $$
-  prettyList (map deflistitem items)
-    where deflistitem (term, defs) = "(" <> text (show term) <> "," <> cr <>
-           nest 1 (prettyList $ map (prettyList . map prettyBlock) defs) <> ")"
-prettyBlock (Table attr blkCapt specs thead tbody tfoot) =
-  mconcat [ "Table "
-          , text (show attr)
-          , " "
-          , prettyCaption blkCapt ] $$
-  prettyList (map (text . show) specs) $$
-  prettyHead thead $$
-  prettyBodies tbody $$
-  prettyFoot tfoot
-  where prettyRows = prettyList . map prettyRow
-        prettyRow (Row a body) =
-          text ("Row " <> show a) $$ prettyList (map prettyCell body)
-        prettyCell (Cell a ma h w b) =
-          mconcat [ "Cell "
-                  , text (show a)
-                  , " "
-                  , text (show ma)
-                  , " ("
-                  , text (show h)
-                  , ") ("
-                  , text (show w)
-                  , ")" ] $$
-          prettyList (map prettyBlock b)
-        prettyCaption (Caption mshort body) =
-          "(Caption " <> text (showsPrec 11 mshort "") $$ prettyList (map prettyBlock body) <> ")"
-        prettyHead (TableHead thattr body)
-          = "(TableHead " <> text (show thattr) $$ prettyRows body <> ")"
-        prettyBody (TableBody tbattr rhc hd bd)
-          = mconcat [ "(TableBody "
-                    , text (show tbattr)
-                    , " ("
-                    , text (show rhc)
-                    , ")" ] $$ prettyRows hd $$ prettyRows bd <> ")"
-        prettyBodies = prettyList . map prettyBody
-        prettyFoot (TableFoot tfattr body)
-          = "(TableFoot " <> text (show tfattr) $$ prettyRows body <> ")"
-prettyBlock (Div attr blocks) =
-  text ("Div " <> show attr) $$ prettyList (map prettyBlock blocks)
-prettyBlock block = text $ show block
+import Text.Pandoc.Options (WriterOptions (..))
+import Text.Pretty.Simple (pShowOpt, defaultOutputOptionsNoColor,
+                           OutputOptions(..), StringOutputStyle(..))
 
 -- | Prettyprint Pandoc document.
 writeNative :: PandocMonad m => WriterOptions -> Pandoc -> m Text
-writeNative opts (Pandoc meta blocks) = return $
-  let colwidth = if writerWrapText opts == WrapAuto
-                    then Just $ writerColumns opts
-                    else Nothing
-      withHead = case writerTemplate opts of
-                      Just _  -> \bs -> text ("Pandoc (" ++ show meta ++ ")") $$
-                                  bs $$ cr
-                      Nothing -> id
-  in  render colwidth $ withHead $ prettyList $ map prettyBlock blocks
+writeNative opts (Pandoc meta blocks) = do
+  let popts = defaultOutputOptionsNoColor{
+               outputOptionsIndentAmount = 2,
+               outputOptionsPageWidth = writerColumns opts,
+               outputOptionsCompact = True,
+               outputOptionsCompactParens = False,
+               outputOptionsStringStyle = Literal }
+  return $
+    case writerTemplate opts of
+      Just _  -> TL.toStrict $ pShowOpt popts (Pandoc meta blocks) <> "\n"
+      Nothing -> TL.toStrict $ pShowOpt popts blocks

--- a/test/Tests/Old.hs
+++ b/test/Tests/Old.hs
@@ -146,7 +146,7 @@ tests pandocPath =
       "dokuwiki_external_images.native" "dokuwiki_external_images.dokuwiki"
     ]
   , testGroup "opml"
-    [ test' "basic" ["-r", "native", "-w", "opml", "--columns=78", "-s"]
+    [ test' "basic" ["-r", "native", "-w", "opml", "--columns=80", "-s"]
        "testsuite.native" "writer.opml"
     , test' "reader" ["-r", "opml", "-w", "native", "-s"]
       "opml-reader.opml" "opml-reader.native"
@@ -262,7 +262,7 @@ writerTests pandocPath format
        "tables" opts             "tables.native"    ("tables" <.> format)
     ]
   where
-    opts = ["-r", "native", "-w", format, "--columns=78",
+    opts = ["-r", "native", "-w", format, "--columns=80",
             "--variable", "pandoc-version="]
 
 extendedWriterTests :: FilePath -> String -> [TestTree]
@@ -276,7 +276,7 @@ extendedWriterTests pandocPath format
                ("tables" </> name <.> format)
     in map testForTable ["planets", "nordics", "students"]
   where
-    opts = ["-r", "native", "-w", format, "--columns=78",
+    opts = ["-r", "native", "-w", format, "--columns=80",
             "--variable", "pandoc-version="]
 
 s5WriterTest :: FilePath -> String -> [String] -> String -> TestTree

--- a/test/command/1390.md
+++ b/test/command/1390.md
@@ -3,7 +3,9 @@
 \newcommand\foo{+}
 Testing: $\mu\foo\eta$.
 ^D
-[Para [Str "Testing:",Space,Math InlineMath "\\mu+\\eta",Str "."]]
+[ Para
+  [ Str "Testing:", Space, Math InlineMath "\\mu+\\eta", Str "." ]
+]
 ```
 
 <!-- It would be nice to handle this case, but I don't

--- a/test/command/1592.md
+++ b/test/command/1592.md
@@ -2,35 +2,35 @@
 % pandoc -t native
 [hi]{.smallcaps}
 ^D
-[Para [SmallCaps [Str "hi"]]]
+[ Para [ SmallCaps [ Str "hi" ] ] ]
 ```
 
 ```
 % pandoc -t native
 [hi]{style="font-variant: small-caps;"}
 ^D
-[Para [SmallCaps [Str "hi"]]]
+[ Para [ SmallCaps [ Str "hi" ] ] ]
 ```
 
 ```
 % pandoc -t native
 <span class="smallcaps">hi</span>
 ^D
-[Para [SmallCaps [Str "hi"]]]
+[ Para [ SmallCaps [ Str "hi" ] ] ]
 ```
 
 ```
 % pandoc -f html -t native
 <p><span class="smallcaps">hi</span></p>
 ^D
-[Para [SmallCaps [Str "hi"]]]
+[ Para [ SmallCaps [ Str "hi" ] ] ]
 ```
 
 ```
 % pandoc -f html -t native
 <p><span style="font-variant:small-caps">hi</span></p>
 ^D
-[Para [SmallCaps [Str "hi"]]]
+[ Para [ SmallCaps [ Str "hi" ] ] ]
 ```
 
 ```
@@ -51,14 +51,24 @@
 % pandoc -f html -t native
 <bdo dir="ltr">foo</bdo>
 ^D
-[Plain [Span ("",[],[("dir","ltr")]) [Str "foo"]]]
+[ Plain [ Span ( "", [], [ ( "dir", "ltr" ) ] ) [ Str "foo" ] ] ]
 ```
 
 ```
 % pandoc -f html -t native
 <bdo dir="rtl">foo<bdo dir="ltr">bar</bdo>baz</bdo>
 ^D
-[Plain [Span ("",[],[("dir","rtl")]) [Str "foo",Span ("",[],[("dir","ltr")]) [Str "bar"],Str "baz"]]]
+[ Plain
+  [ Span
+    ( "", [], [ ( "dir", "rtl" ) ] )
+    [ Str "foo"
+    , Span
+      ( "", [], [ ( "dir", "ltr" ) ] )
+      [ Str "bar" ]
+    , Str "baz"
+    ]
+  ]
+]
 ```
 
 ```
@@ -66,5 +76,23 @@
 <p><bdo dir="rtl">This text will go right
 to left.</bdo></p>
 ^D
-[Para [Span ("",[],[("dir","rtl")]) [Str "This",Space,Str "text",Space,Str "will",Space,Str "go",Space,Str "right",SoftBreak,Str "to",Space,Str "left."]]]
+[ Para
+  [ Span
+    ( "", [], [ ( "dir", "rtl" ) ] )
+    [ Str "This"
+    , Space
+    , Str "text"
+    , Space
+    , Str "will"
+    , Space
+    , Str "go"
+    , Space
+    , Str "right"
+    , SoftBreak
+    , Str "to"
+    , Space
+    , Str "left."
+    ]
+  ]
+]
 ```

--- a/test/command/1608.md
+++ b/test/command/1608.md
@@ -28,14 +28,183 @@ Triangles with sides of length \(a=p^2-q^2\), \(b=2pq\) and \(c=p^2+q^2\) are ri
 These are all pretty interesting facts.
 \end{remark}
 ^D
-[Div ("def:tri",["definition"],[])
- [Para [Strong [Str "Definition",Space,Str "1"],Space,Str "(right-angled",Space,Str "triangles).",Space,Space,Str "A",Space,Emph [Str "right-angled",Space,Str "triangle"],Space,Str "is",Space,Str "a",Space,Str "triangle",Space,Str "whose",Space,Str "sides",Space,Str "of",Space,Str "length\160",Math InlineMath "a",Str ",",Space,Math InlineMath "b",Space,Str "and\160",Math InlineMath "c",Str ",",Space,Str "in",Space,Str "some",Space,Str "permutation",Space,Str "of",Space,Str "order,",Space,Str "satisfies",Space,Math InlineMath "a^2+b^2=c^2",Str "."]]
-,Div ("",["lemma"],[])
- [Para [Strong [Str "Lemma",Space,Str "2"],Str ".",Space,Space,Emph [Str "The",Space,Str "triangle",Space,Str "with",Space,Str "sides",Space,Str "of",Space,Str "length\160",Math InlineMath "3",Str ",",Space,Math InlineMath "4",Space,Str "and\160",Math InlineMath "5",Space,Str "is",Space,Str "right-angled."]]]
-,Div ("",["proof"],[])
- [Para [Emph [Str "Proof."],Space,Str "This",Space,Str "lemma",Space,Str "follows",Space,Str "from",Space,Link ("",[],[("reference-type","ref"),("reference","def:tri")]) [Str "Definition\160\&1"] ("#def:tri",""),Space,Str "since",Space,Math InlineMath "3^2+4^2=9+16=25=5^2",Str ".",Str "\160\9723"]]
-,Div ("thm:py",["theorem"],[])
- [Para [Strong [Str "Theorem",Space,Str "3"],Space,Str "(Pythagorean",Space,Str "triplets).",Space,Space,Emph [Str "Triangles",Space,Str "with",Space,Str "sides",Space,Str "of",Space,Str "length",Space,Math InlineMath "a=p^2-q^2",Str ",",Space,Math InlineMath "b=2pq",Space,Str "and",Space,Math InlineMath "c=p^2+q^2",Space,Str "are",Space,Str "right-angled",Space,Str "triangles."]]]
-,Div ("",["remark"],[])
- [Para [Emph [Str "Remark",Space,Str "1"],Str ".",Space,Space,Str "These",Space,Str "are",Space,Str "all",Space,Str "pretty",Space,Str "interesting",Space,Str "facts."]]]
+[ Div
+  ( "def:tri", [ "definition" ], [] )
+  [ Para
+    [ Strong
+      [ Str "Definition", Space, Str "1" ]
+    , Space
+    , Str "(right-angled"
+    , Space
+    , Str "triangles)."
+    , Space
+    , Space
+    , Str "A"
+    , Space
+    , Emph
+      [ Str "right-angled", Space, Str "triangle" ]
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "triangle"
+    , Space
+    , Str "whose"
+    , Space
+    , Str "sides"
+    , Space
+    , Str "of"
+    , Space
+    , Str "length\160"
+    , Math InlineMath "a"
+    , Str ","
+    , Space
+    , Math InlineMath "b"
+    , Space
+    , Str "and\160"
+    , Math InlineMath "c"
+    , Str ","
+    , Space
+    , Str "in"
+    , Space
+    , Str "some"
+    , Space
+    , Str "permutation"
+    , Space
+    , Str "of"
+    , Space
+    , Str "order,"
+    , Space
+    , Str "satisfies"
+    , Space
+    , Math InlineMath "a^2+b^2=c^2"
+    , Str "."
+    ]
+  ]
+, Div
+  ( "", [ "lemma" ], [] )
+  [ Para
+    [ Strong
+      [ Str "Lemma", Space, Str "2" ]
+    , Str "."
+    , Space
+    , Space
+    , Emph
+      [ Str "The"
+      , Space
+      , Str "triangle"
+      , Space
+      , Str "with"
+      , Space
+      , Str "sides"
+      , Space
+      , Str "of"
+      , Space
+      , Str "length\160"
+      , Math InlineMath "3"
+      , Str ","
+      , Space
+      , Math InlineMath "4"
+      , Space
+      , Str "and\160"
+      , Math InlineMath "5"
+      , Space
+      , Str "is"
+      , Space
+      , Str "right-angled."
+      ]
+    ]
+  ]
+, Div
+  ( "", [ "proof" ], [] )
+  [ Para
+    [ Emph
+      [ Str "Proof." ]
+    , Space
+    , Str "This"
+    , Space
+    , Str "lemma"
+    , Space
+    , Str "follows"
+    , Space
+    , Str "from"
+    , Space
+    , Link
+      ( ""
+      , []
+      ,
+        [ ( "reference-type", "ref" ), ( "reference", "def:tri" ) ]
+      )
+      [ Str "Definition\160\&1" ]
+      ( "#def:tri", "" )
+    , Space
+    , Str "since"
+    , Space
+    , Math InlineMath "3^2+4^2=9+16=25=5^2"
+    , Str "."
+    , Str "\160\9723"
+    ]
+  ]
+, Div
+  ( "thm:py", [ "theorem" ], [] )
+  [ Para
+    [ Strong
+      [ Str "Theorem", Space, Str "3" ]
+    , Space
+    , Str "(Pythagorean"
+    , Space
+    , Str "triplets)."
+    , Space
+    , Space
+    , Emph
+      [ Str "Triangles"
+      , Space
+      , Str "with"
+      , Space
+      , Str "sides"
+      , Space
+      , Str "of"
+      , Space
+      , Str "length"
+      , Space
+      , Math InlineMath "a=p^2-q^2"
+      , Str ","
+      , Space
+      , Math InlineMath "b=2pq"
+      , Space
+      , Str "and"
+      , Space
+      , Math InlineMath "c=p^2+q^2"
+      , Space
+      , Str "are"
+      , Space
+      , Str "right-angled"
+      , Space
+      , Str "triangles."
+      ]
+    ]
+  ]
+, Div
+  ( "", [ "remark" ], [] )
+  [ Para
+    [ Emph
+      [ Str "Remark", Space, Str "1" ]
+    , Str "."
+    , Space
+    , Space
+    , Str "These"
+    , Space
+    , Str "are"
+    , Space
+    , Str "all"
+    , Space
+    , Str "pretty"
+    , Space
+    , Str "interesting"
+    , Space
+    , Str "facts."
+    ]
+  ]
+]
 ```

--- a/test/command/168.md
+++ b/test/command/168.md
@@ -11,13 +11,25 @@ nested div
 :::
 :::::::::::::::::::::::::::::::
 ^D
-[Div ("",["warning"],[])
- [Para [Str "This",Space,Str "is",Space,Str "the",Space,Str "warning!"]
- ,OrderedList (1,Decimal,Period)
-  [[Plain [Str "list"]]
-  ,[Plain [Str "another"]]]
- ,Div ("myid",["class"],[("key","val")])
-  [Para [Str "nested",Space,Str "div"]]]]
+[ Div
+  ( "", [ "warning" ], [] )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "the"
+    , Space
+    , Str "warning!"
+    ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [ [ Plain [ Str "list" ] ], [ Plain [ Str "another" ] ] ]
+  , Div
+    ( "myid", [ "class" ], [ ( "key", "val" ) ] )
+    [ Para [ Str "nested", Space, Str "div" ] ]
+  ]
+]
 ```
 
 ```
@@ -26,7 +38,7 @@ foo
 :::
 bar
 ^D
-[Para [Str "foo",SoftBreak,Str ":::",SoftBreak,Str "bar"]]
+[ Para [ Str "foo", SoftBreak, Str ":::", SoftBreak, Str "bar" ] ]
 ```
 
 ```
@@ -37,7 +49,19 @@ Here is a paragraph.
 And another.
 :::::
 ^D
-[Div ("",["Warning"],[])
- [Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "paragraph."]
- ,Para [Str "And",Space,Str "another."]]]
+[ Div
+  ( "", [ "Warning" ], [] )
+  [ Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "And", Space, Str "another." ]
+  ]
+]
 ```

--- a/test/command/1718.md
+++ b/test/command/1718.md
@@ -7,5 +7,11 @@ Note[^1].
 [^2]: the second, unused, note.
 ^D
 [WARNING] Note with key '2' defined at line 5 column 1 but not used.
-[Para [Str "Note",Note [Para [Str "the",Space,Str "first",Space,Str "note."]],Str "."]]
+[ Para
+  [ Str "Note"
+  , Note
+    [ Para [ Str "the", Space, Str "first", Space, Str "note." ] ]
+  , Str "."
+  ]
+]
 ```

--- a/test/command/1773.md
+++ b/test/command/1773.md
@@ -2,5 +2,5 @@
 % pandoc -f latex+raw_tex -t native
 \noindent hi
 ^D
-[Para [RawInline (Format "latex") "\\noindent ",Str "hi"]]
+[ Para [ RawInline ( Format "latex" ) "\\noindent ", Str "hi" ] ]
 ```

--- a/test/command/1881.md
+++ b/test/command/1881.md
@@ -20,35 +20,88 @@
 </tbody>
 </table>
 ^D
-[Table ("",[],[]) (Caption Nothing
- [Plain [Str "Demonstration",Space,Str "of",Space,Str "simple",Space,Str "table",Space,Str "syntax."]])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",["header"],[])
-  [Cell ("",[],[]) AlignRight (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignLeft (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",["odd"],[])
-   [Cell ("",[],[]) AlignRight (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignLeft (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing
+    [ Plain
+      [ Str "Demonstration"
+      , Space
+      , Str "of"
+      , Space
+      , Str "simple"
+      , Space
+      , Str "table"
+      , Space
+      , Str "syntax."
+      ]
+    ]
+  )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [ "header" ], [] )
+      [ Cell
+        ( "", [], [] ) AlignRight
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignLeft
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [ "odd" ], [] )
+      [ Cell
+        ( "", [], [] ) AlignRight
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignLeft
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 
 ```
@@ -62,26 +115,48 @@
 </tr>
 </table>
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",["odd"],[])
-   [Cell ("",[],[]) AlignRight (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignLeft (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignRight (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignRight, ColWidthDefault )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [ "odd" ], [] )
+      [ Cell
+        ( "", [], [] ) AlignRight
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignLeft
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignRight
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 

--- a/test/command/2118.md
+++ b/test/command/2118.md
@@ -7,5 +7,11 @@
   \label{fig:setminus}
 \end{figure}
 ^D
-[Para [Image ("fig:setminus",[],[("width","80%")]) [Str "Set",Space,Str "subtraction"] ("setminus.png","fig:")]]
+[ Para
+  [ Image
+    ( "fig:setminus", [], [ ( "width", "80%" ) ] )
+    [ Str "Set", Space, Str "subtraction" ]
+    ( "setminus.png", "fig:" )
+  ]
+]
 ```

--- a/test/command/2549.md
+++ b/test/command/2549.md
@@ -4,7 +4,7 @@
 \section{A section}\label{foo}
 }
 ^D
-[Header 1 ("foo",[],[]) [Str "A",Space,Str "section"]]
+[ Header 1 ( "foo", [], [] ) [ Str "A", Space, Str "section" ] ]
 ```
 
 ```
@@ -13,15 +13,17 @@
 \section{A section}\label{foo}
 }
 ^D
-[Div ("bar",[],[])
- [Header 1 ("foo",[],[]) [Str "A",Space,Str "section"]]]
+[ Div
+  ( "bar", [], [] )
+  [ Header 1 ( "foo", [], [] ) [ Str "A", Space, Str "section" ] ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 Bar \hypertarget{foo}{Foo}
 ^D
-[Para [Str "Bar",Space,Span ("foo",[],[]) [Str "Foo"]]]
+[ Para [ Str "Bar", Space, Span ( "foo", [], [] ) [ Str "Foo" ] ] ]
 ```
 
 ```
@@ -32,7 +34,6 @@ bar
 \end{verbatim}
 }
 ^D
-[Div ("foo",[],[])
- [CodeBlock ("",[],[]) "bar"]]
+[ Div ( "foo", [], [] ) [ CodeBlock ( "", [], [] ) "bar" ] ]
 ```
 

--- a/test/command/256.md
+++ b/test/command/256.md
@@ -2,11 +2,41 @@
 % pandoc --abbreviations=command/abbrevs -t native
 Foo. bar baz h.k. and e.g. and Mr. Brown.
 ^D
-[Para [Str "Foo.\160bar",Space,Str "baz",Space,Str "h.k.\160and",Space,Str "e.g.",Space,Str "and",Space,Str "Mr.",Space,Str "Brown."]]
+[ Para
+  [ Str "Foo.\160bar"
+  , Space
+  , Str "baz"
+  , Space
+  , Str "h.k.\160and"
+  , Space
+  , Str "e.g."
+  , Space
+  , Str "and"
+  , Space
+  , Str "Mr."
+  , Space
+  , Str "Brown."
+  ]
+]
 ```
 ```
 % pandoc -t native
 Foo. bar baz h.k. and e.g. and Mr. Brown.
 ^D
-[Para [Str "Foo.",Space,Str "bar",Space,Str "baz",Space,Str "h.k.",Space,Str "and",Space,Str "e.g.\160and",Space,Str "Mr.\160Brown."]]
+[ Para
+  [ Str "Foo."
+  , Space
+  , Str "bar"
+  , Space
+  , Str "baz"
+  , Space
+  , Str "h.k."
+  , Space
+  , Str "and"
+  , Space
+  , Str "e.g.\160and"
+  , Space
+  , Str "Mr.\160Brown."
+  ]
+]
 ```

--- a/test/command/3113.md
+++ b/test/command/3113.md
@@ -8,6 +8,8 @@ C&=&D,\\
 E&=&F
 \end{eqnarray}
 ^D
-[Para [Math DisplayMath "\\begin{aligned}\nA&=&B,\\\\\nC&=&D,\\\\\n%\\end{eqnarray}\n%\\begin{eqnarray}\nE&=&F\\end{aligned}"]]
+[ Para
+  [ Math DisplayMath "\\begin{aligned}\nA&=&B,\\\\\nC&=&D,\\\\\n%\\end{eqnarray}\n%\\begin{eqnarray}\nE&=&F\\end{aligned}" ]
+]
 ```
 

--- a/test/command/3123.md
+++ b/test/command/3123.md
@@ -2,12 +2,14 @@
 % pandoc -f markdown -t native
 <?php echo "1" ; ?>
 ^D
-[RawBlock (Format "html") "<?php echo \"1\" ; ?>"]
+[ RawBlock ( Format "html" ) "<?php echo \"1\" ; ?>" ]
 ```
 
 ```
 % pandoc -f markdown -t native
 a<?php echo "1" ; ?>
 ^D
-[Para [Str "a",RawInline (Format "html") "<?php echo \"1\" ; ?>"]]
+[ Para
+  [ Str "a", RawInline ( Format "html" ) "<?php echo \"1\" ; ?>" ]
+]
 ```

--- a/test/command/3236.md
+++ b/test/command/3236.md
@@ -5,5 +5,17 @@
 \includegraphics[width=17cm]{\mycolor /header}
 Magnificent \mycolor{} header.
 ^D
-[Para [Image ("",[],[("width","17cm")]) [Str "image"] ("red/header",""),SoftBreak,Str "Magnificent",Space,Str "red",Space,Str "header."]]
+[ Para
+  [ Image
+    ( "", [], [ ( "width", "17cm" ) ] )
+    [ Str "image" ]
+    ( "red/header", "" )
+  , SoftBreak
+  , Str "Magnificent"
+  , Space
+  , Str "red"
+  , Space
+  , Str "header."
+  ]
+]
 ```

--- a/test/command/3257.md
+++ b/test/command/3257.md
@@ -2,12 +2,12 @@
 % pandoc -t native
 (i<j)
 ^D
-[Para [Str "(i<j)"]]
+[ Para [ Str "(i<j)" ] ]
 ```
 
 ```
 % pandoc -t native
 i<j-1, j>k
 ^D
-[Para [Str "i<j-1,",Space,Str "j>k"]]
+[ Para [ Str "i<j-1,", Space, Str "j>k" ] ]
 ```

--- a/test/command/3348.md
+++ b/test/command/3348.md
@@ -7,24 +7,61 @@
         line of text
   ----- ------------------------------------------------
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidth 8.333333333333333e-2)
- ,(AlignLeft,ColWidth 0.6805555555555556)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "foo"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "bar"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "foo"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "this",Space,Str "is",Space,Str "a",Space,Str "long",SoftBreak,Str "line",Space,Str "of",Space,Str "text"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignRight, ColWidth 8.333333333333333 e- 2 )
+  ,
+    ( AlignLeft, ColWidth 0.6805555555555556 )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "foo" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "bar" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "foo" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "this"
+          , Space
+          , Str "is"
+          , Space
+          , Str "a"
+          , Space
+          , Str "long"
+          , SoftBreak
+          , Str "line"
+          , Space
+          , Str "of"
+          , Space
+          , Str "text"
+          ]
+        ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/3401.md
+++ b/test/command/3401.md
@@ -5,7 +5,7 @@ See #3401 and <http://orgmode.org/manual/Macro-replacement.html>
 #+MACRO: HELLO /Hello, $1/
 {{{HELLO(World)}}}
 ^D
-[Para [Emph [Str "Hello,",Space,Str "World"]]]
+[ Para [ Emph [ Str "Hello,", Space, Str "World" ] ] ]
 ```
 
 Inverted argument order
@@ -15,5 +15,5 @@ Inverted argument order
 #+MACRO: A $2,$1
 {{{A(1,2)}}}
 ^D
-[Para [Str "2,1"]]
+[ Para [ Str "2,1" ] ]
 ```

--- a/test/command/3407.md
+++ b/test/command/3407.md
@@ -9,5 +9,7 @@
 % pandoc -f rst -t native
 :foo:`text`
 ^D
-[Para [Code ("",["interpreted-text"],[("role","foo")]) "text"]]
+[ Para
+  [ Code ( "", [ "interpreted-text" ], [ ( "role", "foo" ) ] ) "text" ]
+]
 ```

--- a/test/command/3510.md
+++ b/test/command/3510.md
@@ -10,11 +10,20 @@ Text
 
 More text
 ^D
-[Para [Str "Text"]
-,Header 1 ("subsection",[],[]) [Str "Subsection"]
-,Para [Str "Included",Space,Str "text"]
-,Plain [Str "Lorem",Space,Str "ipsum."]
-,CodeBlock ("",["haskell"],[]) "putStrLn outString\n"
-,RawBlock (Format "latex") "\\emph{Hello}"
-,Para [Str "More",Space,Str "text"]]
+[ Para
+  [ Str "Text" ]
+, Header 1
+  ( "subsection", [], [] )
+  [ Str "Subsection" ]
+, Para
+  [ Str "Included", Space, Str "text" ]
+, Plain
+  [ Str "Lorem", Space, Str "ipsum." ]
+, CodeBlock
+  ( "", [ "haskell" ], [] ) "putStrLn outString\n"
+, RawBlock
+  ( Format "latex" ) "\\emph{Hello}"
+, Para
+  [ Str "More", Space, Str "text" ]
+]
 ```

--- a/test/command/3511.md
+++ b/test/command/3511.md
@@ -10,16 +10,22 @@
 
     not continuation
 ^D
-[BulletList
- [[Plain [Str "a"]
-  ,BulletList
-   [[Plain [Str "b"]
-    ,BulletList
-     [[Plain [Str "c"]]]]]]
- ,[CodeBlock ("",[],[]) "code"]]
-,OrderedList (1000,Decimal,Period)
- [[Plain [Str "one"]]]
-,CodeBlock ("",[],[]) "not continuation"]
+[ BulletList
+  [
+    [ Plain
+      [ Str "a" ]
+    , BulletList
+      [ [ Plain [ Str "b" ], BulletList [ [ Plain [ Str "c" ] ] ] ] ]
+    ]
+  ,
+    [ CodeBlock ( "", [], [] ) "code" ]
+  ]
+, OrderedList
+  ( 1000, Decimal, Period )
+  [ [ Plain [ Str "one" ] ] ]
+, CodeBlock
+  ( "", [], [] ) "not continuation"
+]
 ```
 
 ```
@@ -34,13 +40,16 @@
 
     continuation
 ^D
-[BulletList
- [[Plain [Str "a"]]
- ,[Plain [Str "b"]
-  ,BulletList
-   [[Plain [Str "c"]]]]
- ,[CodeBlock ("",[],[]) "not code"]]
-,OrderedList (1000,Decimal,Period)
- [[Para [Str "one"]
-  ,Para [Str "continuation"]]]]
+[ BulletList
+  [
+    [ Plain [ Str "a" ] ]
+  ,
+    [ Plain [ Str "b" ], BulletList [ [ Plain [ Str "c" ] ] ] ]
+  ,
+    [ CodeBlock ( "", [], [] ) "not code" ]
+  ]
+, OrderedList
+  ( 1000, Decimal, Period )
+  [ [ Para [ Str "one" ], Para [ Str "continuation" ] ] ]
+]
 ```

--- a/test/command/3516.md
+++ b/test/command/3516.md
@@ -24,26 +24,46 @@ on Windows builds.
 |   |   |
 +---+---+
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 5.555555555555555e-2)
- ,(AlignDefault,ColWidth 5.555555555555555e-2)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidth 5.555555555555555 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 5.555555555555555 e- 2 )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "2" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 
 ```

--- a/test/command/3530.md
+++ b/test/command/3530.md
@@ -3,10 +3,53 @@
 \subfile{command/sub-file-chapter-1}
 \subfile{command/sub-file-chapter-2}
 ^D
-[Header 1 ("chapter-1",[],[]) [Str "Chapter",Space,Str "1"]
-,Para [Str "This",Space,Str "is",Space,Str "Chapter",Space,Str "1,",Space,Str "provided",Space,Str "in",Space,Str "a",Space,Str "sub",Space,Str "file."]
-,Header 1 ("chapter-2",[],[]) [Str "Chapter",Space,Str "2"]
-,Para [Str "This",Space,Str "is",Space,Str "Chapter",Space,Str "2,",Space,Str "provided",Space,Str "in",Space,Str "a",Space,Str "second",Space,Str "sub",Space,Str "file."]]
+[ Header 1
+  ( "chapter-1", [], [] )
+  [ Str "Chapter", Space, Str "1" ]
+, Para
+  [ Str "This"
+  , Space
+  , Str "is"
+  , Space
+  , Str "Chapter"
+  , Space
+  , Str "1,"
+  , Space
+  , Str "provided"
+  , Space
+  , Str "in"
+  , Space
+  , Str "a"
+  , Space
+  , Str "sub"
+  , Space
+  , Str "file."
+  ]
+, Header 1
+  ( "chapter-2", [], [] )
+  [ Str "Chapter", Space, Str "2" ]
+, Para
+  [ Str "This"
+  , Space
+  , Str "is"
+  , Space
+  , Str "Chapter"
+  , Space
+  , Str "2,"
+  , Space
+  , Str "provided"
+  , Space
+  , Str "in"
+  , Space
+  , Str "a"
+  , Space
+  , Str "second"
+  , Space
+  , Str "sub"
+  , Space
+  , Str "file."
+  ]
+]
 ```
 
 ```
@@ -14,6 +57,9 @@
 \subfile{command/sub-file-chapter-1}
 \subfile{command/sub-file-chapter-2}
 ^D
-[RawBlock (Format "latex") "\\subfile{command/sub-file-chapter-1}"
-,RawBlock (Format "latex") "\\subfile{command/sub-file-chapter-2}"]
+[ RawBlock
+  ( Format "latex" ) "\\subfile{command/sub-file-chapter-1}"
+, RawBlock
+  ( Format "latex" ) "\\subfile{command/sub-file-chapter-2}"
+]
 ```

--- a/test/command/3533-rst-csv-tables.md
+++ b/test/command/3533-rst-csv-tables.md
@@ -5,37 +5,108 @@
    :header: Flavor,Price,Slogan
    :file: command/3533-rst-csv-tables.csv
 ^D
-[Table ("",[],[]) (Caption Nothing
- [Plain [Str "Test"]])
- [(AlignDefault,ColWidth 0.4)
- ,(AlignDefault,ColWidth 0.2)
- ,(AlignDefault,ColWidth 0.4)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Flavor"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Price"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Slogan"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Albatross"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2.99"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "On",Space,Str "a",Space,Str "stick!"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Crunchy",Space,Str "Frog"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1.49"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "If",Space,Str "we",Space,Str "took",Space,Str "the",Space,Str "bones",Space,Str "out,",Space,Str "it",Space,Str "wouldn't",Space,Str "be",SoftBreak,Str "crunchy,",Space,Str "now",Space,Str "would",Space,Str "it?"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [ Plain [ Str "Test" ] ] )
+  [
+    ( AlignDefault, ColWidth 0.4 )
+  ,
+    ( AlignDefault, ColWidth 0.2 )
+  ,
+    ( AlignDefault, ColWidth 0.4 )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Flavor" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Price" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Slogan" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Albatross" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "2.99" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "On", Space, Str "a", Space, Str "stick!" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Crunchy", Space, Str "Frog" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1.49" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "If"
+          , Space
+          , Str "we"
+          , Space
+          , Str "took"
+          , Space
+          , Str "the"
+          , Space
+          , Str "bones"
+          , Space
+          , Str "out,"
+          , Space
+          , Str "it"
+          , Space
+          , Str "wouldn't"
+          , Space
+          , Str "be"
+          , SoftBreak
+          , Str "crunchy,"
+          , Space
+          , Str "now"
+          , Space
+          , Str "would"
+          , Space
+          , Str "it?"
+          ]
+        ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 
 ```
@@ -49,37 +120,80 @@
    'cat''s' 3 4
    'dog''s' 2 3
 ^D
-[Table ("",[],[]) (Caption Nothing
- [Plain [Str "Test"]])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "a"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "b"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "cat's"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "dog's"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [ Plain [ Str "Test" ] ] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "a" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "b" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "cat's" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "3" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "4" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "dog's" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "3" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 
 ```
@@ -89,20 +203,34 @@
 
    "1","\""
 ^D
-[Table ("",[],[]) (Caption Nothing
- [Plain [Str "Test"]])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "\""]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [ Plain [ Str "Test" ] ] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "\"" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 

--- a/test/command/3534.md
+++ b/test/command/3534.md
@@ -18,7 +18,26 @@ I want to explain the interface of \lstinline{public class MyClass}.
 % pandoc -f latex -t native
 I want to explain the interface of \lstinline[language=Java]{public class MyClass}.
 ^D
-[Para [Str "I",Space,Str "want",Space,Str "to",Space,Str "explain",Space,Str "the",Space,Str "interface",Space,Str "of",Space,Code ("",["java"],[]) "public class MyClass",Str "."]]
+[ Para
+  [ Str "I"
+  , Space
+  , Str "want"
+  , Space
+  , Str "to"
+  , Space
+  , Str "explain"
+  , Space
+  , Str "the"
+  , Space
+  , Str "interface"
+  , Space
+  , Str "of"
+  , Space
+  , Code
+    ( "", [ "java" ], [] ) "public class MyClass"
+  , Str "."
+  ]
+]
 ```
 
 ```
@@ -41,5 +60,24 @@ I want to explain the interface of \mintinline{java}|public class MyClass|.
 % pandoc -f latex -t native
 I want to explain the interface of \mintinline[linenos]{java}{public class MyClass}.
 ^D
-[Para [Str "I",Space,Str "want",Space,Str "to",Space,Str "explain",Space,Str "the",Space,Str "interface",Space,Str "of",Space,Code ("",["java"],[]) "public class MyClass",Str "."]]
+[ Para
+  [ Str "I"
+  , Space
+  , Str "want"
+  , Space
+  , Str "to"
+  , Space
+  , Str "explain"
+  , Space
+  , Str "the"
+  , Space
+  , Str "interface"
+  , Space
+  , Str "of"
+  , Space
+  , Code
+    ( "", [ "java" ], [] ) "public class MyClass"
+  , Str "."
+  ]
+]
 ```

--- a/test/command/3537.md
+++ b/test/command/3537.md
@@ -7,14 +7,14 @@ Generalized raw attributes.
 foo bar
 ```
 ^D
-[RawBlock (Format "ms") ".MACRO\nfoo bar"]
+[ RawBlock ( Format "ms" ) ".MACRO\nfoo bar" ]
 ````
 
 ````
 % pandoc -t native
 Hi `there`{=ms}.
 ^D
-[Para [Str "Hi",Space,RawInline (Format "ms") "there",Str "."]]
+[ Para [ Str "Hi", Space, RawInline ( Format "ms" ) "there", Str "." ] ]
 ````
 
 ````
@@ -24,5 +24,5 @@ Hi `there`{=ms}.
 foo bar
 ~~~
 ^D
-[RawBlock (Format "ms") ".MACRO\nfoo bar"]
+[ RawBlock ( Format "ms" ) ".MACRO\nfoo bar" ]
 ````

--- a/test/command/3539.md
+++ b/test/command/3539.md
@@ -4,35 +4,231 @@
 % pandoc -f latex -t native
 Many programming languages provide \glspl{API}. Each \gls{API} should provide a documentation.
 ^D
-[Para [Str "Many",Space,Str "programming",Space,Str "languages",Space,Str "provide",Space,Span ("",[],[("acronym-label","API"),("acronym-form","plural+short")]) [Str "APIs"],Str ".",Space,Str "Each",Space,Span ("",[],[("acronym-label","API"),("acronym-form","singular+short")]) [Str "API"],Space,Str "should",Space,Str "provide",Space,Str "a",Space,Str "documentation."]]
+[ Para
+  [ Str "Many"
+  , Space
+  , Str "programming"
+  , Space
+  , Str "languages"
+  , Space
+  , Str "provide"
+  , Space
+  , Span
+    ( ""
+    , []
+    ,
+      [ ( "acronym-label", "API" ), ( "acronym-form", "plural+short" ) ]
+    )
+    [ Str "APIs" ]
+  , Str "."
+  , Space
+  , Str "Each"
+  , Space
+  , Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+short" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "should"
+  , Space
+  , Str "provide"
+  , Space
+  , Str "a"
+  , Space
+  , Str "documentation."
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \Glsdesc{API} XYZ ist not as performant as \glsdesc{API} ZXY.
 ^D
-[Para [Span ("",[],[("acronym-label","API"),("acronym-form","singular+long")]) [Str "API"],Space,Str "XYZ",Space,Str "ist",Space,Str "not",Space,Str "as",Space,Str "performant",Space,Str "as",Space,Span ("",[],[("acronym-label","API"),("acronym-form","singular+long")]) [Str "API"],Space,Str "ZXY."]]
+[ Para
+  [ Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+long" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "XYZ"
+  , Space
+  , Str "ist"
+  , Space
+  , Str "not"
+  , Space
+  , Str "as"
+  , Space
+  , Str "performant"
+  , Space
+  , Str "as"
+  , Space
+  , Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+long" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "ZXY."
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \Acrlong{API} XYZ ist not as performant as \acrlong{API} ZXY.
 ^D
-[Para [Span ("",[],[("acronym-label","API"),("acronym-form","singular+long")]) [Str "API"],Space,Str "XYZ",Space,Str "ist",Space,Str "not",Space,Str "as",Space,Str "performant",Space,Str "as",Space,Span ("",[],[("acronym-label","API"),("acronym-form","singular+long")]) [Str "API"],Space,Str "ZXY."]]
+[ Para
+  [ Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+long" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "XYZ"
+  , Space
+  , Str "ist"
+  , Space
+  , Str "not"
+  , Space
+  , Str "as"
+  , Space
+  , Str "performant"
+  , Space
+  , Str "as"
+  , Space
+  , Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+long" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "ZXY."
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \Acrfull{API} XYZ ist not as performant as \acrfull{API} ZXY.
 ^D
-[Para [Span ("",[],[("acronym-label","API"),("acronym-form","singular+full")]) [Str "API"],Space,Str "XYZ",Space,Str "ist",Space,Str "not",Space,Str "as",Space,Str "performant",Space,Str "as",Space,Span ("",[],[("acronym-label","API"),("acronym-form","singular+full")]) [Str "API"],Space,Str "ZXY."]]
+[ Para
+  [ Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+full" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "XYZ"
+  , Space
+  , Str "ist"
+  , Space
+  , Str "not"
+  , Space
+  , Str "as"
+  , Space
+  , Str "performant"
+  , Space
+  , Str "as"
+  , Space
+  , Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+full" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "ZXY."
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \Acrshort{API} XYZ ist not as performant as \acrshort{API} ZXY.
 ^D
-[Para [Span ("",[],[("acronym-label","API"),("acronym-form","singular+abbrv")]) [Str "API"],Space,Str "XYZ",Space,Str "ist",Space,Str "not",Space,Str "as",Space,Str "performant",Space,Str "as",Space,Span ("",[],[("acronym-label","API"),("acronym-form","singular+abbrv")]) [Str "API"],Space,Str "ZXY."]]
+[ Para
+  [ Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+abbrv" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "XYZ"
+  , Space
+  , Str "ist"
+  , Space
+  , Str "not"
+  , Space
+  , Str "as"
+  , Space
+  , Str "performant"
+  , Space
+  , Str "as"
+  , Space
+  , Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+abbrv" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "ZXY."
+  ]
+]
 ```
 
 # Commands of [acronym package](ftp://ftp.mpi-sb.mpg.de/pub/tex/mirror/ftp.dante.de/pub/tex/macros/latex/contrib/acronym/acronym.pdf)
@@ -41,5 +237,45 @@ Many programming languages provide \glspl{API}. Each \gls{API} should provide a 
 % pandoc -f latex -t native
 Many programming languages provide \acp{API}. Each \ac{API} should provide a documentation.
 ^D
-[Para [Str "Many",Space,Str "programming",Space,Str "languages",Space,Str "provide",Space,Span ("",[],[("acronym-label","API"),("acronym-form","plural+short")]) [Str "APIs"],Str ".",Space,Str "Each",Space,Span ("",[],[("acronym-label","API"),("acronym-form","singular+short")]) [Str "API"],Space,Str "should",Space,Str "provide",Space,Str "a",Space,Str "documentation."]]
+[ Para
+  [ Str "Many"
+  , Space
+  , Str "programming"
+  , Space
+  , Str "languages"
+  , Space
+  , Str "provide"
+  , Space
+  , Span
+    ( ""
+    , []
+    ,
+      [ ( "acronym-label", "API" ), ( "acronym-form", "plural+short" ) ]
+    )
+    [ Str "APIs" ]
+  , Str "."
+  , Space
+  , Str "Each"
+  , Space
+  , Span
+    ( ""
+    , []
+    ,
+      [
+        ( "acronym-label", "API" )
+      ,
+        ( "acronym-form", "singular+short" )
+      ]
+    )
+    [ Str "API" ]
+  , Space
+  , Str "should"
+  , Space
+  , Str "provide"
+  , Space
+  , Str "a"
+  , Space
+  , Str "documentation."
+  ]
+]
 ```

--- a/test/command/3558.md
+++ b/test/command/3558.md
@@ -6,7 +6,11 @@ hello
 
 \endmulti
 ^D
-[RawBlock (Format "tex") "\\multi"
-,Para [Str "hello"]
-,RawBlock (Format "tex") "\\endmulti"]
+[ RawBlock
+  ( Format "tex" ) "\\multi"
+, Para
+  [ Str "hello" ]
+, RawBlock
+  ( Format "tex" ) "\\endmulti"
+]
 ```

--- a/test/command/3585.md
+++ b/test/command/3585.md
@@ -4,13 +4,35 @@
 
 Same but bzip2 it and nice it <tt>zfs send tank/storage/data/svn@daily-2014-03-20_00.00.00--2w | nice -15 bzip2 | ssh user@hyper.somewhere.org "> /storage/c-3po/tank-storage-data-svn.dmp.bz2"</tt>
 ^D
-[Para [Quoted DoubleQuote [Str "Hello"]]
-,Para [Str "Same",Space,Str "but",Space,Str "bzip2",Space,Str "it",Space,Str "and",Space,Str "nice",Space,Str "it",Space,Code ("",[],[]) "zfs send tank/storage/data/svn@daily-2014-03-20_00.00.00--2w | nice -15 bzip2 | ssh user@hyper.somewhere.org \"> /storage/c-3po/tank-storage-data-svn.dmp.bz2\""]]
+[ Para
+  [ Quoted DoubleQuote [ Str "Hello" ] ]
+, Para
+  [ Str "Same"
+  , Space
+  , Str "but"
+  , Space
+  , Str "bzip2"
+  , Space
+  , Str "it"
+  , Space
+  , Str "and"
+  , Space
+  , Str "nice"
+  , Space
+  , Str "it"
+  , Space
+  , Code
+    ( ""
+    , []
+    , []
+    ) "zfs send tank/storage/data/svn@daily-2014-03-20_00.00.00--2w | nice -15 bzip2 | ssh user@hyper.somewhere.org \"> /storage/c-3po/tank-storage-data-svn.dmp.bz2\""
+  ]
+]
 ```
 
 ```
 % pandoc -f mediawiki -t native
 "Hello"
 ^D
-[Para [Str "\"Hello\""]]
+[ Para [ Str "\"Hello\"" ] ]
 ```

--- a/test/command/3587.md
+++ b/test/command/3587.md
@@ -2,14 +2,36 @@
 % pandoc -f latex -t native
 \SI[round-precision=2]{1}{m} is equal to \SI{1000}{mm}
 ^D
-[Para [Str "1\160m",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "1000\160mm"]]
+[ Para
+  [ Str "1\160m"
+  , Space
+  , Str "is"
+  , Space
+  , Str "equal"
+  , Space
+  , Str "to"
+  , Space
+  , Str "1000\160mm"
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \SI[round-precision=2]{1}[\$]{} is equal to \SI{0.938094}{\euro}
 ^D
-[Para [Str "$\160\&1",Space,Str "is",Space,Str "equal",Space,Str "to",Space,Str "0.938094\160\8364"]]
+[ Para
+  [ Str "$\160\&1"
+  , Space
+  , Str "is"
+  , Space
+  , Str "equal"
+  , Space
+  , Str "to"
+  , Space
+  , Str "0.938094\160\8364"
+  ]
+]
 ```
 
 
@@ -17,35 +39,35 @@
 % pandoc -f latex -t native
 \SI{30}{\milli\meter}
 ^D
-[Para [Str "30\160mm"]]
+[ Para [ Str "30\160mm" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \SI{6}{\gram}
 ^D
-[Para [Str "6\160g"]]
+[ Para [ Str "6\160g" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \SI{25}{\square\meter}
 ^D
-[Para [Str "25\160m",Superscript [Str "2"]]]
+[ Para [ Str "25\160m", Superscript [ Str "2" ] ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \SI{18.2}{\degreeCelsius}
 ^D
-[Para [Str "18.2\160\176C"]]
+[ Para [ Str "18.2\160\176C" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \SI{18.2}{\celsius}
 ^D
-[Para [Str "18.2\160\176C"]]
+[ Para [ Str "18.2\160\176C" ] ]
 ```
 
 # SIrange tests
@@ -56,19 +78,19 @@
 % pandoc -f latex -t native
 \SIrange{10}{20}{\gram}
 ^D
-[Para [Str "10\160g\8211\&20\160g"]]
+[ Para [ Str "10\160g\8211\&20\160g" ] ]
 ```
 ```
 % pandoc -f latex -t native
 \SIrange{35}{9}{\milli\meter}
 ^D
-[Para [Str "35\160mm\8211\&9\160mm"]]
+[ Para [ Str "35\160mm\8211\&9\160mm" ] ]
 ```
 ```
 % pandoc -f latex -t native
 \SIrange{4}{97367265}{\celsius}
 ^D
-[Para [Str "4\160\176C\8211\&97367265\160\176C"]]
+[ Para [ Str "4\160\176C\8211\&97367265\160\176C" ] ]
 ```
 
 ## Decimal range with simple units
@@ -77,7 +99,7 @@
 % pandoc -f latex -t native
 \SIrange{4.5}{97367265.5}{\celsius}
 ^D
-[Para [Str "4.5\160\176C\8211\&97367265.5\160\176C"]]
+[ Para [ Str "4.5\160\176C\8211\&97367265.5\160\176C" ] ]
 ```
 
 ## Squared, cubed etc. units
@@ -86,21 +108,45 @@
 % pandoc -f latex -t native
 \SIrange{10}{20}{\square\meter}
 ^D
-[Para [Str "10\160m",Superscript [Str "2"],Str "\8211\&20\160m",Superscript [Str "2"]]]
+[ Para
+  [ Str "10\160m"
+  , Superscript
+    [ Str "2" ]
+  , Str "\8211\&20\160m"
+  , Superscript
+    [ Str "2" ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \SIrange{10}{20}{\cubic\meter}
 ^D
-[Para [Str "10\160m",Superscript [Str "3"],Str "\8211\&20\160m",Superscript [Str "3"]]]
+[ Para
+  [ Str "10\160m"
+  , Superscript
+    [ Str "3" ]
+  , Str "\8211\&20\160m"
+  , Superscript
+    [ Str "3" ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \SIrange{10}{20}{\raisetothe{4}\meter}
 ^D
-[Para [Str "10\160m",Superscript [Str "4"],Str "\8211\&20\160m",Superscript [Str "4"]]]
+[ Para
+  [ Str "10\160m"
+  , Superscript
+    [ Str "4" ]
+  , Str "\8211\&20\160m"
+  , Superscript
+    [ Str "4" ]
+  ]
+]
 ```
 
 
@@ -108,21 +154,45 @@
 % pandoc -f latex -t native
 \SIrange{10}{20}{\meter\squared}
 ^D
-[Para [Str "10\160m",Superscript [Str "2"],Str "\8211\&20\160m",Superscript [Str "2"]]]
+[ Para
+  [ Str "10\160m"
+  , Superscript
+    [ Str "2" ]
+  , Str "\8211\&20\160m"
+  , Superscript
+    [ Str "2" ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \SIrange{10}{20}{\meter\cubed}
 ^D
-[Para [Str "10\160m",Superscript [Str "3"],Str "\8211\&20\160m",Superscript [Str "3"]]]
+[ Para
+  [ Str "10\160m"
+  , Superscript
+    [ Str "3" ]
+  , Str "\8211\&20\160m"
+  , Superscript
+    [ Str "3" ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \SIrange{10}{20}{\meter\tothe{4}}
 ^D
-[Para [Str "10\160m",Superscript [Str "4"],Str "\8211\&20\160m",Superscript [Str "4"]]]
+[ Para
+  [ Str "10\160m"
+  , Superscript
+    [ Str "4" ]
+  , Str "\8211\&20\160m"
+  , Superscript
+    [ Str "4" ]
+  ]
+]
 ```
 
 
@@ -136,12 +206,12 @@
 % pandoc -f latex -t native
 \SIrange[round-precision=2]{10}{20}{\gram}
 ^D
-[Para [Str "10\160g\8211\&20\160g"]]
+[ Para [ Str "10\160g\8211\&20\160g" ] ]
 ```
 ```
 % pandoc -f latex -t native
 \SIrange[round-precision=2]{10.0}{20.25}{\gram}
 ^D
-[Para [Str "10.0\160g\8211\&20.25\160g"]]
+[ Para [ Str "10.0\160g\8211\&20.25\160g" ] ]
 ```
 

--- a/test/command/3681.md
+++ b/test/command/3681.md
@@ -4,7 +4,34 @@
 
 Software developers create \cicd pipelines to… Following issue can be resolved by \cicd:
 ^D
-[Para [Str "Software",Space,Str "developers",Space,Str "create",Space,Str "CI/CD",Space,Str "pipelines",Space,Str "to\8230",Space,Str "Following",Space,Str "issue",Space,Str "can",Space,Str "be",Space,Str "resolved",Space,Str "by",Space,Str "CI/CD:"]]
+[ Para
+  [ Str "Software"
+  , Space
+  , Str "developers"
+  , Space
+  , Str "create"
+  , Space
+  , Str "CI/CD"
+  , Space
+  , Str "pipelines"
+  , Space
+  , Str "to\8230"
+  , Space
+  , Str "Following"
+  , Space
+  , Str "issue"
+  , Space
+  , Str "can"
+  , Space
+  , Str "be"
+  , Space
+  , Str "resolved"
+  , Space
+  , Str "by"
+  , Space
+  , Str "CI/CD:"
+  ]
+]
 ```
 
 ```
@@ -13,7 +40,22 @@ Software developers create \cicd pipelines to… Following issue can be resolved
 
 \cicd\footnote{\url{https://en.wikipedia.org/wiki/CI/CD}} is awesome.
 ^D
-[Para [Str "CI/CD",Note [Para [Link ("",[],[]) [Str "https://en.wikipedia.org/wiki/CI/CD"] ("https://en.wikipedia.org/wiki/CI/CD","")]],Space,Str "is",Space,Str "awesome."]]
+[ Para
+  [ Str "CI/CD"
+  , Note
+    [ Para
+      [ Link
+        ( "", [], [] )
+        [ Str "https://en.wikipedia.org/wiki/CI/CD" ]
+        ( "https://en.wikipedia.org/wiki/CI/CD", "" )
+      ]
+    ]
+  , Space
+  , Str "is"
+  , Space
+  , Str "awesome."
+  ]
+]
 ```
 
 ```
@@ -23,5 +65,5 @@ Software developers create \cicd pipelines to… Following issue can be resolved
 
 \cicd\pipeline.
 ^D
-[Para [Str "CI/CD",Space,Str "pipeline."]]
+[ Para [ Str "CI/CD", Space, Str "pipeline." ] ]
 ```

--- a/test/command/3706.md
+++ b/test/command/3706.md
@@ -15,36 +15,80 @@ Results marker can be hidden in block attributes (#3706)
 |  2 | La   |
 |  3 | La   |
 ^D
-[Div ("tab",[],[])
- [Table ("",[],[]) (Caption Nothing
-  [Plain [Str "Lalelu."]])
-  [(AlignDefault,ColWidthDefault)
-  ,(AlignDefault,ColWidthDefault)]
-  (TableHead ("",[],[])
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Id"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Desc"]]]])
-  [(TableBody ("",[],[]) (RowHeadColumns 0)
-   []
-   [Row ("",[],[])
-    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "1"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "La"]]]
-   ,Row ("",[],[])
-    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "2"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "La"]]]
-   ,Row ("",[],[])
-    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "3"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "La"]]]])]
-  (TableFoot ("",[],[])
-  [])]]
+[ Div
+  ( "tab", [], [] )
+  [ Table
+    ( "", [], [] )
+    ( Caption Nothing [ Plain [ Str "Lalelu." ] ] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Id" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Desc" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "La" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "La" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "La" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  ]
+]
 ```
 
 ```

--- a/test/command/3708.md
+++ b/test/command/3708.md
@@ -5,24 +5,42 @@
     C & D
 \end{tabular}
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "A"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "B&1"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "C"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "D"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignCenter, ColWidthDefault ), ( AlignCenter, ColWidthDefault ) ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "A" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "B&1" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "C" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "D" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/3733.md
+++ b/test/command/3733.md
@@ -6,8 +6,9 @@
 some: code
 ```
 ^D
-[BulletList
- [[Plain [Str "Item1"]]
- ,[Plain [Str "Item2"]]]
-,CodeBlock ("",["yaml"],[]) "some: code"]
+[ BulletList
+  [ [ Plain [ Str "Item1" ] ], [ Plain [ Str "Item2" ] ] ]
+, CodeBlock
+  ( "", [ "yaml" ], [] ) "some: code"
+]
 ````

--- a/test/command/3755.md
+++ b/test/command/3755.md
@@ -5,8 +5,19 @@ title: 'Titel'
 date: '22. Juni 2017'
 ---
 ^D
-Pandoc (Meta {unMeta = fromList [("date",MetaInlines [Str "22.",Space,Str "Juni",Space,Str "2017"]),("title",MetaInlines [Str "Titel"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "date"
+        , MetaInlines
+          [ Str "22.", Space, Str "Juni", Space, Str "2017" ]
+        )
+      ,
+        ( "title", MetaInlines [ Str "Titel" ] )
+      ]
+    }
+  ) []
 ```
 
 ```
@@ -17,7 +28,24 @@ date: |
   22. Juni 2017
 ---
 ^D
-Pandoc (Meta {unMeta = fromList [("date",MetaBlocks [OrderedList (22,Decimal,Period) [[Plain [Str "Juni",Space,Str "2017"]]]]),("title",MetaBlocks [Div ("",[],[]) [Plain [Str "foo"]]])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "date"
+        , MetaBlocks
+          [ OrderedList
+            ( 22, Decimal, Period )
+            [ [ Plain [ Str "Juni", Space, Str "2017" ] ] ]
+          ]
+        )
+      ,
+        ( "title"
+        , MetaBlocks
+          [ Div ( "", [], [] ) [ Plain [ Str "foo" ] ] ]
+        )
+      ]
+    }
+  ) []
 ```
 

--- a/test/command/3779.md
+++ b/test/command/3779.md
@@ -20,9 +20,40 @@
     Pandoc is 300\% awesome.
 }
 ^D
-[BulletList
- [[Para [Str "Pandoc",Space,Str "is",Space,Str "100%",Space,Str "awesome."]]]
-,BulletList
- [[Para [Str "Pandoc",Space,Str "is",Space,Str "200%",Space,Str "awesome."]]]
-,Para [Str "Pandoc",Space,Str "is",Space,Str "300%",Space,Str "awesome."]]
+[ BulletList
+  [
+    [ Para
+      [ Str "Pandoc"
+      , Space
+      , Str "is"
+      , Space
+      , Str "100%"
+      , Space
+      , Str "awesome."
+      ]
+    ]
+  ]
+, BulletList
+  [
+    [ Para
+      [ Str "Pandoc"
+      , Space
+      , Str "is"
+      , Space
+      , Str "200%"
+      , Space
+      , Str "awesome."
+      ]
+    ]
+  ]
+, Para
+  [ Str "Pandoc"
+  , Space
+  , Str "is"
+  , Space
+  , Str "300%"
+  , Space
+  , Str "awesome."
+  ]
+]
 ```

--- a/test/command/3794.md
+++ b/test/command/3794.md
@@ -2,6 +2,5 @@
 % pandoc -f html -t native
 <div><p>hello</div>
 ^D
-[Div ("",[],[])
- [Para [Str "hello"]]]
+[ Div ( "", [], [] ) [ Para [ Str "hello" ] ] ]
 ```

--- a/test/command/3804.md
+++ b/test/command/3804.md
@@ -2,5 +2,7 @@
 % pandoc -t native
 \titleformat{\chapter}[display]{\normalfont\large\bfseries}{第\thechapter{}章}{20pt}{\Huge}
 ^D
-[RawBlock (Format "tex") "\\titleformat{\\chapter}[display]{\\normalfont\\large\\bfseries}{\31532\\thechapter{}\31456}{20pt}{\\Huge}"]
+[ RawBlock
+  ( Format "tex" ) "\\titleformat{\\chapter}[display]{\\normalfont\\large\\bfseries}{\31532\\thechapter{}\31456}{20pt}{\\Huge}"
+]
 ```

--- a/test/command/3853.md
+++ b/test/command/3853.md
@@ -20,7 +20,11 @@ more
 
 hello \iftoggle{ebook}{ebook}{noebook}
 ^D
-[Para [Str "ebook",SoftBreak,Str "more"]
-,Para [Str "not",Space,Str "ebook",SoftBreak,Str "more"]
-,Para [Str "hello",Space,Str "noebook"]]
+[ Para
+  [ Str "ebook", SoftBreak, Str "more" ]
+, Para
+  [ Str "not", Space, Str "ebook", SoftBreak, Str "more" ]
+, Para
+  [ Str "hello", Space, Str "noebook" ]
+]
 ```

--- a/test/command/3880.md
+++ b/test/command/3880.md
@@ -2,5 +2,5 @@
 % pandoc -f rst -t native
 .. include:: command/3880.txt
 ^D
-[Para [Str "hi"]]
+[ Para [ Str "hi" ] ]
 ```

--- a/test/command/3916.md
+++ b/test/command/3916.md
@@ -4,8 +4,16 @@
 <pre>blabla</pre>
 # more
 ^D
-[OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "text",Space,Str "text"]
-  ,CodeBlock ("",[],[]) "blabla"]
- ,[Plain [Str "more"]]]]
+[ OrderedList
+  ( 1, DefaultStyle, DefaultDelim )
+  [
+    [ Plain
+      [ Str "text", Space, Str "text" ]
+    , CodeBlock
+      ( "", [], [] ) "blabla"
+    ]
+  ,
+    [ Plain [ Str "more" ] ]
+  ]
+]
 ```

--- a/test/command/3947.md
+++ b/test/command/3947.md
@@ -6,6 +6,9 @@
 
 	Another Code block
 ^D
-[RawBlock (Format "tex") "\\newpage"
-,CodeBlock ("",[],[]) "Code block\n\nAnother Code block"]
+[ RawBlock
+  ( Format "tex" ) "\\newpage"
+, CodeBlock
+  ( "", [], [] ) "Code block\n\nAnother Code block"
+]
 ```

--- a/test/command/3958.md
+++ b/test/command/3958.md
@@ -2,19 +2,19 @@
 % pandoc -f latex -t native
 \texttt{"hi"}
 ^D
-[Para [Code ("",[],[]) "\"hi\""]]
+[ Para [ Code ( "", [], [] ) "\"hi\"" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \texttt{``hi''}
 ^D
-[Para [Code ("",[],[]) "\8220hi\8221"]]
+[ Para [ Code ( "", [], [] ) "\8220hi\8221" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \texttt{`hi'}
 ^D
-[Para [Code ("",[],[]) "\8216hi\8217"]]
+[ Para [ Code ( "", [], [] ) "\8216hi\8217" ] ]
 ```

--- a/test/command/3971.md
+++ b/test/command/3971.md
@@ -5,5 +5,5 @@
 \code{f}
 \end{document}
 ^D
-[Para [Code ("",[],[]) "f"]]
+[ Para [ Code ( "", [], [] ) "f" ] ]
 ```

--- a/test/command/3983.md
+++ b/test/command/3983.md
@@ -5,8 +5,11 @@
 \graphicspath\expandafter{\expandafter{\filename@area}}%
 \makeatother
 ^D
-[RawBlock (Format "latex") "\\makeatletter"
-,RawBlock (Format "latex") "\\makeatother"]
+[ RawBlock
+  ( Format "latex" ) "\\makeatletter"
+, RawBlock
+  ( Format "latex" ) "\\makeatother"
+]
 ```
 
 ```
@@ -16,8 +19,11 @@
   \DeclareRobustCommand{\urlfootnote}{\hyper@normalise\urlfootnote@}
 \makeatother
 ^D
-[RawBlock (Format "latex") "\\makeatletter"
-,RawBlock (Format "latex") "\\makeatother"]
+[ RawBlock
+  ( Format "latex" ) "\\makeatletter"
+, RawBlock
+  ( Format "latex" ) "\\makeatother"
+]
 ```
 
 ```
@@ -25,5 +31,5 @@
 \def\foo{bar}
 \expandafter\bam\foo
 ^D
-[RawBlock (Format "latex") "\\bambar"]
+[ RawBlock ( Format "latex" ) "\\bambar" ]
 ```

--- a/test/command/3989.md
+++ b/test/command/3989.md
@@ -3,5 +3,22 @@
 <span title="1st line of text <br> 2nd line of text">foo</span>
  <span title="1st line of text <br> 2nd line of text">foo</span>
 ^D
-[Para [Span ("",[],[("title","1st line of text <br> 2nd line of text")]) [Str "foo"],SoftBreak,Span ("",[],[("title","1st line of text <br> 2nd line of text")]) [Str "foo"]]]
+[ Para
+  [ Span
+    ( ""
+    , []
+    ,
+      [ ( "title", "1st line of text <br> 2nd line of text" ) ]
+    )
+    [ Str "foo" ]
+  , SoftBreak
+  , Span
+    ( ""
+    , []
+    ,
+      [ ( "title", "1st line of text <br> 2nd line of text" ) ]
+    )
+    [ Str "foo" ]
+  ]
+]
 ```

--- a/test/command/4007.md
+++ b/test/command/4007.md
@@ -3,7 +3,7 @@
 \newcommand\arrow\to
 $a\arrow b$
 ^D
-[Para [Math InlineMath "a\\to b"]]
+[ Para [ Math InlineMath "a\\to b" ] ]
 ```
 
 ```
@@ -11,7 +11,7 @@ $a\arrow b$
 \newcommand\pfeil[1]{\to #1}
 $a\pfeil b$
 ^D
-[Para [Math InlineMath "a\\to b"]]
+[ Para [ Math InlineMath "a\\to b" ] ]
 ```
 
 ```
@@ -19,5 +19,5 @@ $a\pfeil b$
 \newcommand\fleche{\to}
 $a\fleche b$
 ^D
-[Para [Math InlineMath "a\\to b"]]
+[ Para [ Math InlineMath "a\\to b" ] ]
 ```

--- a/test/command/4054.md
+++ b/test/command/4054.md
@@ -2,13 +2,17 @@
 % pandoc -t native -s -M title=New
 % Old
 ^D
-Pandoc (Meta {unMeta = fromList [("title",MetaString "New")]})
-[]
+Pandoc
+  ( Meta { unMeta = fromList [ ( "title", MetaString "New" ) ] } ) []
 ```
 
 ```
 % pandoc -t native -s -M foo=1 -M foo=2
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaList [MetaString "1",MetaString "2"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [ ( "foo", MetaList [ MetaString "1", MetaString "2" ] ) ]
+    }
+  ) []
 ```

--- a/test/command/4056.md
+++ b/test/command/4056.md
@@ -5,7 +5,9 @@
 \end{shaded}
 }
 ^D
-[RawBlock (Format "tex") "\\parbox[t]{0.4\\textwidth}{\n\\begin{shaded}\n\\end{shaded}\n}"]
+[ RawBlock
+  ( Format "tex" ) "\\parbox[t]{0.4\\textwidth}{\n\\begin{shaded}\n\\end{shaded}\n}"
+]
 ```
 
 ```
@@ -14,22 +16,40 @@
 Blah & Foo & Bar \\
 \end{tabular}
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Blah"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Foo"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Bar"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignRight, ColWidthDefault )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Blah" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Foo" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Bar" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/4063.md
+++ b/test/command/4063.md
@@ -11,19 +11,29 @@
 </tr>
 </table>
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.3)
- ,(AlignDefault,ColWidth 0.7)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignDefault, ColWidth 0.3 ), ( AlignDefault, ColWidth 0.7 ) ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "2" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/4068.md
+++ b/test/command/4068.md
@@ -4,6 +4,25 @@
 
 [http://domain.com?a=. open productname bugs]
 ^D
-[Para [Link ("",[],[]) [Str "open",Space,Str "productname",Space,Str "bugs"] ("https://domain.com/script.php?a=1&b=2&c=&d=4","")]
-,Para [Str "[",Link ("",[],[]) [Str "http://domain.com?a="] ("http://domain.com?a=",""),Str ".",Space,Str "open",Space,Str "productname",Space,Str "bugs]"]]
+[ Para
+  [ Link
+    ( "", [], [] )
+    [ Str "open", Space, Str "productname", Space, Str "bugs" ]
+    ( "https://domain.com/script.php?a=1&b=2&c=&d=4", "" )
+  ]
+, Para
+  [ Str "["
+  , Link
+    ( "", [], [] )
+    [ Str "http://domain.com?a=" ]
+    ( "http://domain.com?a=", "" )
+  , Str "."
+  , Space
+  , Str "open"
+  , Space
+  , Str "productname"
+  , Space
+  , Str "bugs]"
+  ]
+]
 ```

--- a/test/command/4119.md
+++ b/test/command/4119.md
@@ -8,25 +8,52 @@
 not a caption!
 ::::::::::::::::
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col2"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]]])]
- (TableFoot ("",[],[])
- [])
-,Div ("",["notes"],[])
- [Para [Str "not",Space,Str "a",Space,Str "caption!"]]]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "col1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "col2" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "2" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Div
+  ( "", [ "notes" ], [] )
+  [ Para [ Str "not", Space, Str "a", Space, Str "caption!" ] ]
+]
 ```

--- a/test/command/4134.md
+++ b/test/command/4134.md
@@ -3,7 +3,7 @@
 Hello.\
 world.
 ^D
-[Para [Str "Hello.\160world."]]
+[ Para [ Str "Hello.\160world." ] ]
 ```
 
 ```
@@ -11,7 +11,7 @@ world.
 Hello.\  
  world.
 ^D
-[Para [Str "Hello.\160world."]]
+[ Para [ Str "Hello.\160world." ] ]
 ```
 
 ```
@@ -20,6 +20,5 @@ Hello.\
 
 World.
 ^D
-[Para [Str "Hello.\160"]
-,Para [Str "World."]]
+[ Para [ Str "Hello.\160" ], Para [ Str "World." ] ]
 ```

--- a/test/command/4159.md
+++ b/test/command/4159.md
@@ -3,6 +3,9 @@
 \newcommand{\gen}{a\ Gen\ b}
 abc
 ^D
-[RawBlock (Format "tex") "\\newcommand{\\gen}{a\\ Gen\\ b}"
-,Para [Str "abc"]]
+[ RawBlock
+  ( Format "tex" ) "\\newcommand{\\gen}{a\\ Gen\\ b}"
+, Para
+  [ Str "abc" ]
+]
 ```

--- a/test/command/4162.md
+++ b/test/command/4162.md
@@ -3,8 +3,5 @@
 <div class="line-block">hi<br /><br>
  there</div>
 ^D
-[LineBlock
- [[Str "hi"]
- ,[]
- ,[Str "\160there"]]]
+[ LineBlock [ [ Str "hi" ], [], [ Str "\160there" ] ] ]
 ```

--- a/test/command/4183.md
+++ b/test/command/4183.md
@@ -4,7 +4,7 @@
   <img src="foo" alt="bar">
 </figure>
 ^D
-[Para [Image ("",[],[]) [] ("foo","fig:")]]
+[ Para [ Image ( "", [], [] ) [] ( "foo", "fig:" ) ] ]
 ```
 
 ```
@@ -18,7 +18,7 @@
   </figcaption>
 </figure>
 ^D
-[Para [Image ("",[],[]) [Str "baz"] ("foo","fig:")]]
+[ Para [ Image ( "", [], [] ) [ Str "baz" ] ( "foo", "fig:" ) ] ]
 ```
 
 ```
@@ -28,5 +28,7 @@
   <figcaption><p><em>baz</em></p></figcaption>
 </figure>
 ^D
-[Para [Image ("",[],[]) [Emph [Str "baz"]] ("foo","fig:")]]
+[ Para
+  [ Image ( "", [], [] ) [ Emph [ Str "baz" ] ] ( "foo", "fig:" ) ]
+]
 ```

--- a/test/command/4186.md
+++ b/test/command/4186.md
@@ -4,7 +4,12 @@
     This should retain the four leading spaces
 #+end_example
 ^D
-[CodeBlock ("",["example"],[]) "    This should retain the four leading spaces\n"]
+[ CodeBlock
+  ( ""
+  , [ "example" ]
+  , []
+  ) "    This should retain the four leading spaces\n"
+]
 ```
 
 ```

--- a/test/command/4193.md
+++ b/test/command/4193.md
@@ -4,7 +4,5 @@
  a
 - b
 ^D
-[BulletList
- [[Plain [Str "a"]]
- ,[Plain [Str "b"]]]]
+[ BulletList [ [ Plain [ Str "a" ] ], [ Plain [ Str "b" ] ] ] ]
 ```

--- a/test/command/4199.md
+++ b/test/command/4199.md
@@ -2,5 +2,5 @@
 % pandoc -f latex -t native
 \foreignlanguage{ngerman}{foo}
 ^D
-[Para [Span ("",[],[("lang","de-DE")]) [Str "foo"]]]
+[ Para [ Span ( "", [], [ ( "lang", "de-DE" ) ] ) [ Str "foo" ] ] ]
 ```

--- a/test/command/4240.md
+++ b/test/command/4240.md
@@ -25,9 +25,27 @@ header3
 header4
 ~~~~~~~
 ^D
-Pandoc (Meta {unMeta = fromList [("subtitle",MetaInlines [Str "Subtitle"]),("title",MetaInlines [Str "Title"])]})
-[Header 1 ("header1",[],[]) [Str "header1"]
-,Header 2 ("header2",[],[]) [Str "header2"]
-,Header 3 ("id",[],[]) [Str "header3"]
-,Header 3 ("id3",[],[]) [Str "header4",Span ("id2",[],[]) []]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "subtitle", MetaInlines [ Str "Subtitle" ] )
+      ,
+        ( "title", MetaInlines [ Str "Title" ] )
+      ]
+    }
+  )
+  [ Header 1
+    ( "header1", [], [] )
+    [ Str "header1" ]
+  , Header 2
+    ( "header2", [], [] )
+    [ Str "header2" ]
+  , Header 3
+    ( "id", [], [] )
+    [ Str "header3" ]
+  , Header 3
+    ( "id3", [], [] )
+    [ Str "header4", Span ( "id2", [], [] ) [] ]
+  ]
 ```

--- a/test/command/4253.md
+++ b/test/command/4253.md
@@ -4,5 +4,5 @@
 \noop{\newcommand{\foo}[1]{#1}}
 \foo{hi}
 ^D
-[Para [Str "hi"]]
+[ Para [ Str "hi" ] ]
 ```

--- a/test/command/4280.md
+++ b/test/command/4280.md
@@ -3,5 +3,5 @@
 Driver 
 ------
 ^D
-[Header 1 ("driver",[],[]) [Str "Driver"]]
+[ Header 1 ( "driver", [], [] ) [ Str "Driver" ] ]
 ```

--- a/test/command/4281.md
+++ b/test/command/4281.md
@@ -9,10 +9,18 @@
   :::
 ::::
 ^D
-[Div ("",["a"],[])
- [BulletList
-  [[Div ("",["b"],[])
-    [Para [Str "text"]]
-   ,Div ("",["c"],[])
-    [Para [Str "text"]]]]]]
+[ Div
+  ( "", [ "a" ], [] )
+  [ BulletList
+    [
+      [ Div
+        ( "", [ "b" ], [] )
+        [ Para [ Str "text" ] ]
+      , Div
+        ( "", [ "c" ], [] )
+        [ Para [ Str "text" ] ]
+      ]
+    ]
+  ]
+]
 ```

--- a/test/command/4284.md
+++ b/test/command/4284.md
@@ -8,7 +8,31 @@
 ** Children of headers with excluded tags should not appear       :xylophone:
 * This should not appear                                                  :%:
 ^D
-[Header 1 ("noexport-should-appear-if-not-specified-in-excludetags",[],[]) [Str "NOEXPORT",Space,Str "should",Space,Str "appear",Space,Str "if",Space,Str "not",Space,Str "specified",Space,Str "in",Space,Str "EXCLUDE",Subscript [Str "TAGS"],Space,Span ("",["tag"],[("tag-name","noexport")]) [SmallCaps [Str "noexport"]]]]
+[ Header 1
+  ( "noexport-should-appear-if-not-specified-in-excludetags", [], [] )
+  [ Str "NOEXPORT"
+  , Space
+  , Str "should"
+  , Space
+  , Str "appear"
+  , Space
+  , Str "if"
+  , Space
+  , Str "not"
+  , Space
+  , Str "specified"
+  , Space
+  , Str "in"
+  , Space
+  , Str "EXCLUDE"
+  , Subscript
+    [ Str "TAGS" ]
+  , Space
+  , Span
+    ( "", [ "tag" ], [ ( "tag-name", "noexport" ) ] )
+    [ SmallCaps [ Str "noexport" ] ]
+  ]
+]
 ```
 
 ```
@@ -17,7 +41,19 @@
 * This should not appear                                           :elephant:
 * This should appear                                                   :fawn:
 ^D
-[Header 1 ("this-should-appear",[],[]) [Str "This",Space,Str "should",Space,Str "appear",Space,Span ("",["tag"],[("tag-name","fawn")]) [SmallCaps [Str "fawn"]]]]
+[ Header 1
+  ( "this-should-appear", [], [] )
+  [ Str "This"
+  , Space
+  , Str "should"
+  , Space
+  , Str "appear"
+  , Space
+  , Span
+    ( "", [ "tag" ], [ ( "tag-name", "fawn" ) ] )
+    [ SmallCaps [ Str "fawn" ] ]
+  ]
+]
 ```
 
 ```
@@ -28,7 +64,19 @@
 * This should not appear                                              :hippo:
 * This should appear                                               :noexport:
 ^D
-[Header 1 ("this-should-appear",[],[]) [Str "This",Space,Str "should",Space,Str "appear",Space,Span ("",["tag"],[("tag-name","noexport")]) [SmallCaps [Str "noexport"]]]]
+[ Header 1
+  ( "this-should-appear", [], [] )
+  [ Str "This"
+  , Space
+  , Str "should"
+  , Space
+  , Str "appear"
+  , Space
+  , Span
+    ( "", [ "tag" ], [ ( "tag-name", "noexport" ) ] )
+    [ SmallCaps [ Str "noexport" ] ]
+  ]
+]
 ```
 
 ```
@@ -36,5 +84,29 @@
 #+EXCLUDE_TAGS:
 * NOEXPORT should appear if not specified in EXCLUDE_TAGS          :noexport:
 ^D
-[Header 1 ("noexport-should-appear-if-not-specified-in-excludetags",[],[]) [Str "NOEXPORT",Space,Str "should",Space,Str "appear",Space,Str "if",Space,Str "not",Space,Str "specified",Space,Str "in",Space,Str "EXCLUDE",Subscript [Str "TAGS"],Space,Span ("",["tag"],[("tag-name","noexport")]) [SmallCaps [Str "noexport"]]]]
+[ Header 1
+  ( "noexport-should-appear-if-not-specified-in-excludetags", [], [] )
+  [ Str "NOEXPORT"
+  , Space
+  , Str "should"
+  , Space
+  , Str "appear"
+  , Space
+  , Str "if"
+  , Space
+  , Str "not"
+  , Space
+  , Str "specified"
+  , Space
+  , Str "in"
+  , Space
+  , Str "EXCLUDE"
+  , Subscript
+    [ Str "TAGS" ]
+  , Space
+  , Span
+    ( "", [ "tag" ], [ ( "tag-name", "noexport" ) ] )
+    [ SmallCaps [ Str "noexport" ] ]
+  ]
+]
 ```

--- a/test/command/4306.md
+++ b/test/command/4306.md
@@ -6,5 +6,18 @@
 The file id is \nolinkurl{ESP_123_5235}.
 \end{document}
 ^D
-[Para [Str "The",Space,Str "file",Space,Str "id",Space,Str "is",Space,Code ("",[],[]) "ESP_123_5235",Str "."]]
+[ Para
+  [ Str "The"
+  , Space
+  , Str "file"
+  , Space
+  , Str "id"
+  , Space
+  , Str "is"
+  , Space
+  , Code
+    ( "", [], [] ) "ESP_123_5235"
+  , Str "."
+  ]
+]
 ```

--- a/test/command/4374.md
+++ b/test/command/4374.md
@@ -3,5 +3,18 @@
 \cite{a%
 }
 ^D
-[Para [Cite [Citation {citationId = "a", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cite{a%\n}"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "a"
+      , citationPrefix = []
+      , citationSuffix = []
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ RawInline ( Format "latex" ) "\\cite{a%\n}" ]
+  ]
+]
 ```

--- a/test/command/4382.md
+++ b/test/command/4382.md
@@ -4,7 +4,5 @@
 
 =====
 ^D
-[BulletList
- [[]]
-,HorizontalRule]
+[ BulletList [ [] ], HorizontalRule ]
 ```

--- a/test/command/4424.md
+++ b/test/command/4424.md
@@ -6,5 +6,5 @@
 Test
 \end{document}
 ^D
-[Para [Str "Test"]]
+[ Para [ Str "Test" ] ]
 ```

--- a/test/command/4454.md
+++ b/test/command/4454.md
@@ -3,7 +3,5 @@
 • a
 • b
 ^D
-[BulletList
- [[Plain [Str "a"]]
- ,[Plain [Str "b"]]]]
+[ BulletList [ [ Plain [ Str "a" ] ], [ Plain [ Str "b" ] ] ] ]
 ```

--- a/test/command/4499.md
+++ b/test/command/4499.md
@@ -9,7 +9,7 @@
 % pandoc -f latex+raw_tex -t native
 \mbox{abc def}
 ^D
-[Para [RawInline (Format "latex") "\\mbox{abc def}"]]
+[ Para [ RawInline ( Format "latex" ) "\\mbox{abc def}" ] ]
 ```
 
 ```
@@ -53,7 +53,7 @@ mno} pqr
 % pandoc -f latex+raw_tex -t native
 \hbox{abc def}
 ^D
-[Para [RawInline (Format "latex") "\\hbox{abc def}"]]
+[ Para [ RawInline ( Format "latex" ) "\\hbox{abc def}" ] ]
 ```
 
 ```

--- a/test/command/4513.md
+++ b/test/command/4513.md
@@ -2,19 +2,32 @@
 % pandoc -f textile -t native
 |_. heading 1 |_. heading 2|
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "heading",Space,Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "heading",Space,Str "2"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "heading", Space, Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "heading", Space, Str "2" ] ]
+      ]
+    ]
+  )
+  [ TableBody ( "", [], [] ) ( RowHeadColumns 0 ) [] [] ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/4528.md
+++ b/test/command/4528.md
@@ -30,6 +30,7 @@ This has <span class="smallcaps">small caps</span> in it.
 This has <s>strikeout</s> in it.
 ^D
 This has strikeout in it.
+```
 
 ```
 % pandoc --wrap=none -f html -t commonmark+raw_html-strikeout

--- a/test/command/4553.md
+++ b/test/command/4553.md
@@ -2,14 +2,13 @@
 % pandoc -f latex -t native
 foo \include{command/bar}
 ^D
-[Para [Str "foo"]
-,Para [Emph [Str "hi",Space,Str "there"]]]
+[ Para [ Str "foo" ], Para [ Emph [ Str "hi", Space, Str "there" ] ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 foo \input{command/bar}
 ^D
-[Para [Str "foo",Space,Emph [Str "hi",Space,Str "there"]]]
+[ Para [ Str "foo", Space, Emph [ Str "hi", Space, Str "there" ] ] ]
 ```
 

--- a/test/command/4576.md
+++ b/test/command/4576.md
@@ -2,5 +2,5 @@
 % pandoc -f latex -t native
 $\rho_\text{D$_2$O}=866$
 ^D
-[Para [Math InlineMath "\\rho_\\text{D$_2$O}=866"]]
+[ Para [ Math InlineMath "\\rho_\\text{D$_2$O}=866" ] ]
 ```

--- a/test/command/4579.md
+++ b/test/command/4579.md
@@ -8,23 +8,49 @@
   * - spam
     - ham
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Foo"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Bar"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "spam"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "ham"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Foo" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Bar" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "spam" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "ham" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/4624.md
+++ b/test/command/4624.md
@@ -22,9 +22,15 @@ code4
 \begin{verbatim}
 code5\end{verbatim}
 ^D
-[CodeBlock ("",[],[("key1","value1")]) "code1\n"
-,CodeBlock ("",[],[("key2","value2")]) "code2\n  "
-,CodeBlock ("",[],[]) "code3"
-,CodeBlock ("",[],[]) "code4"
-,CodeBlock ("",[],[]) "code5"]
+[ CodeBlock
+  ( "", [], [ ( "key1", "value1" ) ] ) "code1\n"
+, CodeBlock
+  ( "", [], [ ( "key2", "value2" ) ] ) "code2\n  "
+, CodeBlock
+  ( "", [], [] ) "code3"
+, CodeBlock
+  ( "", [], [] ) "code4"
+, CodeBlock
+  ( "", [], [] ) "code5"
+]
 ```

--- a/test/command/4635.md
+++ b/test/command/4635.md
@@ -3,7 +3,7 @@
 (cf.
 foo)
 ^D
-[Para [Str "(cf.",SoftBreak,Str "foo)"]]
+[ Para [ Str "(cf.", SoftBreak, Str "foo)" ] ]
 ```
 
 ```
@@ -11,7 +11,7 @@ foo)
 a (cf.
 foo)
 ^D
-[Para [Str "a",Space,Str "(cf.",SoftBreak,Str "foo)"]]
+[ Para [ Str "a", Space, Str "(cf.", SoftBreak, Str "foo)" ] ]
 ```
 
 ```
@@ -19,7 +19,7 @@ foo)
 cf.
 foo
 ^D
-[Para [Str "cf.",SoftBreak,Str "foo"]]
+[ Para [ Str "cf.", SoftBreak, Str "foo" ] ]
 ```
 
 ```
@@ -27,5 +27,5 @@ foo
 a cf.
 foo
 ^D
-[Para [Str "a",Space,Str "cf.",SoftBreak,Str "foo"]]
+[ Para [ Str "a", Space, Str "cf.", SoftBreak, Str "foo" ] ]
 ```

--- a/test/command/4669.md
+++ b/test/command/4669.md
@@ -6,8 +6,11 @@
   while (n > 0) {
 \end{verbatim}
 ^D
-[Para [Span ("",[],[]) [Code ("",[],[]) "<-"]]
-,CodeBlock ("",[],[]) "  while (n > 0) {"]
+[ Para
+  [ Span ( "", [], [] ) [ Code ( "", [], [] ) "<-" ] ]
+, CodeBlock
+  ( "", [], [] ) "  while (n > 0) {"
+]
 ```
 
 ```
@@ -20,10 +23,17 @@
 \item<beamer:2> five
 \end{itemize}
 ^D
-[BulletList
- [[Para [Str "one"]]
- ,[Para [Str "two"]]
- ,[Para [Str "three"]]
- ,[Para [Str "four"]]
- ,[Para [Str "five"]]]]
+[ BulletList
+  [
+    [ Para [ Str "one" ] ]
+  ,
+    [ Para [ Str "two" ] ]
+  ,
+    [ Para [ Str "three" ] ]
+  ,
+    [ Para [ Str "four" ] ]
+  ,
+    [ Para [ Str "five" ] ]
+  ]
+]
 ```

--- a/test/command/4715.md
+++ b/test/command/4715.md
@@ -11,6 +11,26 @@
    acquisizione-software.rst
    riuso-software.rst
 ^D
-[Div ("tree1",["toctree","foo","bar"],[("caption","Indice dei contenuti"),("numbered",""),("maxdepth","3")])
- [Para [Str "premessa.rst",SoftBreak,Str "acquisizione-software.rst",SoftBreak,Str "riuso-software.rst"]]]
+[ Div
+  ( "tree1"
+  ,
+    [ "toctree", "foo", "bar" ]
+  ,
+    [
+      ( "caption", "Indice dei contenuti" )
+    ,
+      ( "numbered", "" )
+    ,
+      ( "maxdepth", "3" )
+    ]
+  )
+  [ Para
+    [ Str "premessa.rst"
+    , SoftBreak
+    , Str "acquisizione-software.rst"
+    , SoftBreak
+    , Str "riuso-software.rst"
+    ]
+  ]
+]
  ```

--- a/test/command/4722.md
+++ b/test/command/4722.md
@@ -6,14 +6,25 @@
 ***Level 3
 *Level 1
 ^D
-[BulletList
- [[Plain [Str "Level",Space,Str "1"]]
- ,[Plain [Str "Level",Space,Str "1"]
-  ,BulletList
-   [[Plain [Str "Level",Space,Str "2"]
-    ,BulletList
-     [[Plain [Str "Level",Space,Str "3"]]]]]]
- ,[Plain [Str "Level",Space,Str "1"]]]]
+[ BulletList
+  [
+    [ Plain [ Str "Level", Space, Str "1" ] ]
+  ,
+    [ Plain
+      [ Str "Level", Space, Str "1" ]
+    , BulletList
+      [
+        [ Plain
+          [ Str "Level", Space, Str "2" ]
+        , BulletList
+          [ [ Plain [ Str "Level", Space, Str "3" ] ] ]
+        ]
+      ]
+    ]
+  ,
+    [ Plain [ Str "Level", Space, Str "1" ] ]
+  ]
+]
 ```
 ```
 % pandoc -f tikiwiki -t native
@@ -23,12 +34,26 @@
 ###Level 3
 #Level 1
 ^D
-[OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Level",Space,Str "1"]]
- ,[Plain [Str "Level",Space,Str "1"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "Level",Space,Str "2"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "Level",Space,Str "3"]]]]]]
- ,[Plain [Str "Level",Space,Str "1"]]]]
+[ OrderedList
+  ( 1, DefaultStyle, DefaultDelim )
+  [
+    [ Plain [ Str "Level", Space, Str "1" ] ]
+  ,
+    [ Plain
+      [ Str "Level", Space, Str "1" ]
+    , OrderedList
+      ( 1, DefaultStyle, DefaultDelim )
+      [
+        [ Plain
+          [ Str "Level", Space, Str "2" ]
+        , OrderedList
+          ( 1, DefaultStyle, DefaultDelim )
+          [ [ Plain [ Str "Level", Space, Str "3" ] ] ]
+        ]
+      ]
+    ]
+  ,
+    [ Plain [ Str "Level", Space, Str "1" ] ]
+  ]
+]
 ```

--- a/test/command/4742.md
+++ b/test/command/4742.md
@@ -5,7 +5,17 @@ extension properly.
 % pandoc -f commonmark+gfm_auto_identifiers+ascii_identifiers -t native
 # non ascii ⚠️ räksmörgås
 ^D
-[Header 1 ("non-ascii--raksmorgas",[],[]) [Str "non",Space,Str "ascii",Space,Str "\9888\65039",Space,Str "r\228ksm\246rg\229s"]]
+[ Header 1
+  ( "non-ascii--raksmorgas", [], [] )
+  [ Str "non"
+  , Space
+  , Str "ascii"
+  , Space
+  , Str "\9888\65039"
+  , Space
+  , Str "r\228ksm\246rg\229s"
+  ]
+]
 ```
 
 Note that the emoji here is actually a composite character,
@@ -16,7 +26,17 @@ so it survives...
 % pandoc -f commonmark+gfm_auto_identifiers-ascii_identifiers -t native
 # non ascii ⚠️ räksmörgås
 ^D
-[Header 1 ("non-ascii-\65039-r\228ksm\246rg\229s",[],[]) [Str "non",Space,Str "ascii",Space,Str "\9888\65039",Space,Str "r\228ksm\246rg\229s"]]
+[ Header 1
+  ( "non-ascii-\65039-r\228ksm\246rg\229s", [], [] )
+  [ Str "non"
+  , Space
+  , Str "ascii"
+  , Space
+  , Str "\9888\65039"
+  , Space
+  , Str "r\228ksm\246rg\229s"
+  ]
+]
 ```
 
 `gfm` should have `ascii_identifiers` disabled by default.
@@ -25,5 +45,15 @@ so it survives...
 % pandoc -f gfm -t native
 # non ascii ⚠️ räksmörgås
 ^D
-[Header 1 ("non-ascii-\65039-r\228ksm\246rg\229s",[],[]) [Str "non",Space,Str "ascii",Space,Str "\9888\65039",Space,Str "r\228ksm\246rg\229s"]]
+[ Header 1
+  ( "non-ascii-\65039-r\228ksm\246rg\229s", [], [] )
+  [ Str "non"
+  , Space
+  , Str "ascii"
+  , Space
+  , Str "\9888\65039"
+  , Space
+  , Str "r\228ksm\246rg\229s"
+  ]
+]
 ```

--- a/test/command/4743.md
+++ b/test/command/4743.md
@@ -4,14 +4,34 @@ Test that emojis are wrapped in Span
 % pandoc -f commonmark+emoji -t native
 My:thumbsup:emoji:heart:
 ^D
-[Para [Str "My",Span ("",["emoji"],[("data-emoji","thumbsup")]) [Str "\128077"],Str "emoji",Span ("",["emoji"],[("data-emoji","heart")]) [Str "\10084\65039"]]]
+[ Para
+  [ Str "My"
+  , Span
+    ( "", [ "emoji" ], [ ( "data-emoji", "thumbsup" ) ] )
+    [ Str "\128077" ]
+  , Str "emoji"
+  , Span
+    ( "", [ "emoji" ], [ ( "data-emoji", "heart" ) ] )
+    [ Str "\10084\65039" ]
+  ]
+]
 ```
 
 ```
 % pandoc -f markdown+emoji -t native
 My:thumbsup:emoji:heart:
 ^D
-[Para [Str "My",Span ("",["emoji"],[("data-emoji","thumbsup")]) [Str "\128077"],Str "emoji",Span ("",["emoji"],[("data-emoji","heart")]) [Str "\10084\65039"]]]
+[ Para
+  [ Str "My"
+  , Span
+    ( "", [ "emoji" ], [ ( "data-emoji", "thumbsup" ) ] )
+    [ Str "\128077" ]
+  , Str "emoji"
+  , Span
+    ( "", [ "emoji" ], [ ( "data-emoji", "heart" ) ] )
+    [ Str "\10084\65039" ]
+  ]
+]
 ```
 
 ```

--- a/test/command/4781.md
+++ b/test/command/4781.md
@@ -6,9 +6,13 @@ Markdown parsed *here*
 
 *But not here*
 ^D
-[Para [Str "Markdown",Space,Str "parsed",Space,Emph [Str "here"]]
-,RawBlock (Format "tex") "\\include{command/bar}"
-,Para [Emph [Str "But",Space,Str "not",Space,Str "here"]]]
+[ Para
+  [ Str "Markdown", Space, Str "parsed", Space, Emph [ Str "here" ] ]
+, RawBlock
+  ( Format "tex" ) "\\include{command/bar}"
+, Para
+  [ Emph [ Str "But", Space, Str "not", Space, Str "here" ] ]
+]
 ```
 
 ```
@@ -17,6 +21,14 @@ Markdown parsed *here*
 
 *But not here*
 ^D
-[Para [Emph [Str "here"],Space,RawInline (Format "tex") "\\input{command/bar}"]
-,Para [Emph [Str "But",Space,Str "not",Space,Str "here"]]]
+[ Para
+  [ Emph
+    [ Str "here" ]
+  , Space
+  , RawInline
+    ( Format "tex" ) "\\input{command/bar}"
+  ]
+, Para
+  [ Emph [ Str "But", Space, Str "not", Space, Str "here" ] ]
+]
 ```

--- a/test/command/4811.md
+++ b/test/command/4811.md
@@ -6,8 +6,7 @@ No blank lines in inline interpreted roles:
 
 blank`:myrole:
 ^D
-[Para [Str "`no"]
-,Para [Str "blank`:myrole:"]]
+[ Para [ Str "`no" ], Para [ Str "blank`:myrole:" ] ]
 ```
 
 Backslash escape behaves properly in interpreted roles:
@@ -18,8 +17,11 @@ Backslash escape behaves properly in interpreted roles:
 
 `hi\ there`:code:
 ^D
-[Para [Superscript [Str "hithere"]]
-,Para [Code ("",[],[]) "hi\\ there"]]
+[ Para
+  [ Superscript [ Str "hithere" ] ]
+, Para
+  [ Code ( "", [], [] ) "hi\\ there" ]
+]
 ```
 
 Backtick followed by alphanumeric doesn't end the span:
@@ -27,7 +29,11 @@ Backtick followed by alphanumeric doesn't end the span:
 % pandoc -f rst -t native
 `hi`there`:myrole:
 ^D
-[Para [Code ("",["interpreted-text"],[("role","myrole")]) "hi`there"]]
+[ Para
+  [ Code
+    ( "", [ "interpreted-text" ], [ ( "role", "myrole" ) ] ) "hi`there"
+  ]
+]
 ```
 
 Newline is okay, as long as not blank:
@@ -36,7 +42,11 @@ Newline is okay, as long as not blank:
 `hi
 there`:myrole:
 ^D
-[Para [Code ("",["interpreted-text"],[("role","myrole")]) "hi\nthere"]]
+[ Para
+  [ Code
+    ( "", [ "interpreted-text" ], [ ( "role", "myrole" ) ] ) "hi\nthere"
+  ]
+]
 ```
 
 Use span for title-reference:
@@ -44,5 +54,5 @@ Use span for title-reference:
 % pandoc -f rst -t native
 `default`
 ^D
-[Para [Span ("",["title-ref"],[]) [Str "default"]]]
+[ Para [ Span ( "", [ "title-ref" ], [] ) [ Str "default" ] ] ]
 ```

--- a/test/command/4817.md
+++ b/test/command/4817.md
@@ -5,6 +5,17 @@ foo:
 - bar: bam
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaList [MetaMap (fromList [("bar",MetaInlines [Str "bam"])])])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "foo"
+        , MetaList
+          [ MetaMap
+            ( fromList [ ( "bar", MetaInlines [ Str "bam" ] ) ] )
+          ]
+        )
+      ]
+    }
+  ) []
 ```

--- a/test/command/4819.md
+++ b/test/command/4819.md
@@ -4,8 +4,10 @@
 foo: 42
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaInlines [Str "42"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList [ ( "foo", MetaInlines [ Str "42" ] ) ] }
+  ) []
 ```
 
 ```
@@ -14,8 +16,8 @@ Pandoc (Meta {unMeta = fromList [("foo",MetaInlines [Str "42"])]})
 foo: true
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaBool True)]})
-[]
+Pandoc
+  ( Meta { unMeta = fromList [ ( "foo", MetaBool True ) ] } ) []
 ```
 
 ```
@@ -24,8 +26,8 @@ Pandoc (Meta {unMeta = fromList [("foo",MetaBool True)]})
 foo: True
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaBool True)]})
-[]
+Pandoc
+  ( Meta { unMeta = fromList [ ( "foo", MetaBool True ) ] } ) []
 ```
 
 ```
@@ -34,8 +36,8 @@ Pandoc (Meta {unMeta = fromList [("foo",MetaBool True)]})
 foo: FALSE
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaBool False)]})
-[]
+Pandoc
+  ( Meta { unMeta = fromList [ ( "foo", MetaBool False ) ] } ) []
 ```
 
 ```
@@ -44,7 +46,9 @@ Pandoc (Meta {unMeta = fromList [("foo",MetaBool False)]})
 foo: no
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaInlines [Str "no"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList [ ( "foo", MetaInlines [ Str "no" ] ) ] }
+  ) []
 ```
 

--- a/test/command/4832.md
+++ b/test/command/4832.md
@@ -2,20 +2,38 @@
 % pandoc -f latex -t native
 \url{http://example.com/foo%20bar.htm}
 ^D
-[Para [Link ("",[],[]) [Str "http://example.com/foo%20bar.htm"] ("http://example.com/foo%20bar.htm","")]]
+[ Para
+  [ Link
+    ( "", [], [] )
+    [ Str "http://example.com/foo%20bar.htm" ]
+    ( "http://example.com/foo%20bar.htm", "" )
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \url{http://example.com/foo{bar}.htm}
 ^D
-[Para [Link ("",[],[]) [Str "http://example.com/foo{bar}.htm"] ("http://example.com/foo{bar}.htm","")]]
+[ Para
+  [ Link
+    ( "", [], [] )
+    [ Str "http://example.com/foo{bar}.htm" ]
+    ( "http://example.com/foo{bar}.htm", "" )
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \href{http://example.com/foo%20bar}{Foobar}
 ^D
-[Para [Link ("",[],[]) [Str "Foobar"] ("http://example.com/foo%20bar","")]]
+[ Para
+  [ Link
+    ( "", [], [] )
+    [ Str "Foobar" ]
+    ( "http://example.com/foo%20bar", "" )
+  ]
+]
 ```
 

--- a/test/command/4842.md
+++ b/test/command/4842.md
@@ -2,5 +2,5 @@
 % pandoc -f latex -t native
 \l
 ^D
-[Para [Str "\322"]]
+[ Para [ Str "\322" ] ]
 ```

--- a/test/command/4845.md
+++ b/test/command/4845.md
@@ -2,5 +2,15 @@
 % pandoc -f html -t native
 x<a href="/foo"> leading trailing space </a>x
 ^D
-[Plain [Str "x",Space,Link ("",[],[]) [Str "leading",Space,Str "trailing",Space,Str "space"] ("/foo",""),Space,Str "x"]]
+[ Plain
+  [ Str "x"
+  , Space
+  , Link
+    ( "", [], [] )
+    [ Str "leading", Space, Str "trailing", Space, Str "space" ]
+    ( "/foo", "" )
+  , Space
+  , Str "x"
+  ]
+]
 ```

--- a/test/command/4848.md
+++ b/test/command/4848.md
@@ -2,21 +2,29 @@
 % pandoc -f latex -t native
 \enquote*{hi}
 ^D
-[Para [Quoted SingleQuote [Str "hi"]]]
+[ Para [ Quoted SingleQuote [ Str "hi" ] ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \foreignquote{italian}{hi}
 ^D
-[Para [Quoted DoubleQuote [Span ("",[],[("lang","it")]) [Str "hi"]]]]
+[ Para
+  [ Quoted DoubleQuote
+    [ Span ( "", [], [ ( "lang", "it" ) ] ) [ Str "hi" ] ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \hyphenquote*{italian}{hi}
 ^D
-[Para [Quoted SingleQuote [Span ("",[],[("lang","it")]) [Str "hi"]]]]
+[ Para
+  [ Quoted SingleQuote
+    [ Span ( "", [], [ ( "lang", "it" ) ] ) [ Str "hi" ] ]
+  ]
+]
 ```
 
 ```
@@ -25,10 +33,13 @@ Lorem ipsum
 \blockquote{dolor sit amet}
 consectetuer.
 ^D
-[Para [Str "Lorem",Space,Str "ipsum"]
-,BlockQuote
- [Para [Str "dolor",Space,Str "sit",Space,Str "amet"]]
-,Para [Str "consectetuer."]]
+[ Para
+  [ Str "Lorem", Space, Str "ipsum" ]
+, BlockQuote
+  [ Para [ Str "dolor", Space, Str "sit", Space, Str "amet" ] ]
+, Para
+  [ Str "consectetuer." ]
+]
 ```
 
 ```
@@ -37,11 +48,28 @@ Lorem ipsum
 \blockcquote[198]{Knu86}{dolor sit amet}
 consectetuer.
 ^D
-[Para [Str "Lorem",Space,Str "ipsum"]
-,BlockQuote
- [Para [Str "dolor",Space,Str "sit",Space,Str "amet"]
- ,Para [Cite [Citation {citationId = "Knu86", citationPrefix = [], citationSuffix = [Str "198"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] []]]
-,Para [Str "consectetuer."]]
+[ Para
+  [ Str "Lorem", Space, Str "ipsum" ]
+, BlockQuote
+  [ Para
+    [ Str "dolor", Space, Str "sit", Space, Str "amet" ]
+  , Para
+    [ Cite
+      [ Citation
+        { citationId = "Knu86"
+        , citationPrefix = []
+        , citationSuffix =
+          [ Str "198" ]
+        , citationMode = NormalCitation
+        , citationNoteNum = 0
+        , citationHash = 0
+        }
+      ] []
+    ]
+  ]
+, Para
+  [ Str "consectetuer." ]
+]
 ```
 
 ```
@@ -50,10 +78,15 @@ Lorem ipsum
 \foreignblockquote{italian}{dolor sit amet}
 consectetuer.
 ^D
-[Para [Str "Lorem",Space,Str "ipsum"]
-,BlockQuote
- [Div ("",[],[("lang","it")])
-  [Para [Str "dolor",Space,Str "sit",Space,Str "amet"]]]
-,Para [Str "consectetuer."]]
+[ Para
+  [ Str "Lorem", Space, Str "ipsum" ]
+, BlockQuote
+  [ Div
+    ( "", [], [ ( "lang", "it" ) ] )
+    [ Para [ Str "dolor", Space, Str "sit", Space, Str "amet" ] ]
+  ]
+, Para
+  [ Str "consectetuer." ]
+]
 ```
 

--- a/test/command/4860.md
+++ b/test/command/4860.md
@@ -5,5 +5,16 @@ This is broken_.
 .. ***** REFERENCES FOLLOW *****
 .. _broken: http://google.com
 ^D
-[Para [Str "This",Space,Str "is",Space,Link ("",[],[]) [Str "broken"] ("http://google.com",""),Str "."]]
+[ Para
+  [ Str "This"
+  , Space
+  , Str "is"
+  , Space
+  , Link
+    ( "", [], [] )
+    [ Str "broken" ]
+    ( "http://google.com", "" )
+  , Str "."
+  ]
+]
 ```

--- a/test/command/4877.md
+++ b/test/command/4877.md
@@ -2,12 +2,12 @@
 % pandoc -f html -t native
 My <script type="math/tex">\mathcal{D}</script>
 ^D
-[Plain [Str "My",Space,Math InlineMath "\\mathcal{D}"]]
+[ Plain [ Str "My", Space, Math InlineMath "\\mathcal{D}" ] ]
 ```
 
 ```
 % pandoc -f html -t native
 <script type="math/tex; mode=display">\mathcal{D}</script>
 ^D
-[Plain [Math DisplayMath "\\mathcal{D}"]]
+[ Plain [ Math DisplayMath "\\mathcal{D}" ] ]
 ```

--- a/test/command/4919.md
+++ b/test/command/4919.md
@@ -7,8 +7,9 @@
 
      V = \frac{K}{r^2}
 ^D
-[Div ("tgtmath",[],[])
- [BlockQuote
-  [Para [Math DisplayMath "V = \\frac{K}{r^2}"]]]]
+[ Div
+  ( "tgtmath", [], [] )
+  [ BlockQuote [ Para [ Math DisplayMath "V = \\frac{K}{r^2}" ] ] ]
+]
 ```
 

--- a/test/command/4928.md
+++ b/test/command/4928.md
@@ -2,47 +2,225 @@
 % pandoc -f latex -t native
 \cites(Multiprenote)(multipostnote)[23][42]{Knu86}[65]{Nie72}
 ^D
-[Para [Cite [Citation {citationId = "Knu86", citationPrefix = [Str "Multiprenote",Space,Str "23"], citationSuffix = [Str "42"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0},Citation {citationId = "Nie72", citationPrefix = [], citationSuffix = [Str "65",Str ",",Space,Str "multipostnote"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cites(Multiprenote)(multipostnote)[23][42]{Knu86}[65]{Nie72}"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "Knu86"
+      , citationPrefix =
+        [ Str "Multiprenote", Space, Str "23" ]
+      , citationSuffix =
+        [ Str "42" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    , Citation
+      { citationId = "Nie72"
+      , citationPrefix = []
+      , citationSuffix =
+        [ Str "65", Str ",", Space, Str "multipostnote" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ RawInline
+      ( Format "latex" ) "\\cites(Multiprenote)(multipostnote)[23][42]{Knu86}[65]{Nie72}"
+    ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \cites(Multiprenote)()[23][42]{Knu86}[65]{Nie72}
 ^D
-[Para [Cite [Citation {citationId = "Knu86", citationPrefix = [Str "Multiprenote",Space,Str "23"], citationSuffix = [Str "42"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0},Citation {citationId = "Nie72", citationPrefix = [], citationSuffix = [Str "65"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cites(Multiprenote)()[23][42]{Knu86}[65]{Nie72}"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "Knu86"
+      , citationPrefix =
+        [ Str "Multiprenote", Space, Str "23" ]
+      , citationSuffix =
+        [ Str "42" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    , Citation
+      { citationId = "Nie72"
+      , citationPrefix = []
+      , citationSuffix =
+        [ Str "65" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ RawInline
+      ( Format "latex" ) "\\cites(Multiprenote)()[23][42]{Knu86}[65]{Nie72}"
+    ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \cites()(multipostnote)[23][42]{Knu86}[65]{Nie72}
 ^D
-[Para [Cite [Citation {citationId = "Knu86", citationPrefix = [Str "23"], citationSuffix = [Str "42"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0},Citation {citationId = "Nie72", citationPrefix = [], citationSuffix = [Str "65",Str ",",Space,Str "multipostnote"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cites()(multipostnote)[23][42]{Knu86}[65]{Nie72}"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "Knu86"
+      , citationPrefix =
+        [ Str "23" ]
+      , citationSuffix =
+        [ Str "42" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    , Citation
+      { citationId = "Nie72"
+      , citationPrefix = []
+      , citationSuffix =
+        [ Str "65", Str ",", Space, Str "multipostnote" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ RawInline
+      ( Format "latex" ) "\\cites()(multipostnote)[23][42]{Knu86}[65]{Nie72}"
+    ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \cites()()[23][42]{Knu86}[65]{Nie72}
 ^D
-[Para [Cite [Citation {citationId = "Knu86", citationPrefix = [Str "23"], citationSuffix = [Str "42"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0},Citation {citationId = "Nie72", citationPrefix = [], citationSuffix = [Str "65"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cites()()[23][42]{Knu86}[65]{Nie72}"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "Knu86"
+      , citationPrefix =
+        [ Str "23" ]
+      , citationSuffix =
+        [ Str "42" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    , Citation
+      { citationId = "Nie72"
+      , citationPrefix = []
+      , citationSuffix =
+        [ Str "65" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ RawInline
+      ( Format "latex" ) "\\cites()()[23][42]{Knu86}[65]{Nie72}"
+    ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \cites(multipostnote)[23][42]{Knu86}[65]{Nie72}
 ^D
-[Para [Cite [Citation {citationId = "Knu86", citationPrefix = [Str "23"], citationSuffix = [Str "42"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0},Citation {citationId = "Nie72", citationPrefix = [], citationSuffix = [Str "65",Str ",",Space,Str "multipostnote"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cites(multipostnote)[23][42]{Knu86}[65]{Nie72}"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "Knu86"
+      , citationPrefix =
+        [ Str "23" ]
+      , citationSuffix =
+        [ Str "42" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    , Citation
+      { citationId = "Nie72"
+      , citationPrefix = []
+      , citationSuffix =
+        [ Str "65", Str ",", Space, Str "multipostnote" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ RawInline
+      ( Format "latex" ) "\\cites(multipostnote)[23][42]{Knu86}[65]{Nie72}"
+    ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \cites(Multiprenote)(multipostnote){Knu86}
 ^D
-[Para [Cite [Citation {citationId = "Knu86", citationPrefix = [Str "Multiprenote"], citationSuffix = [Str ",",Space,Str "multipostnote"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cites(Multiprenote)(multipostnote){Knu86}"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "Knu86"
+      , citationPrefix =
+        [ Str "Multiprenote" ]
+      , citationSuffix =
+        [ Str ",", Space, Str "multipostnote" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ RawInline
+      ( Format "latex" ) "\\cites(Multiprenote)(multipostnote){Knu86}"
+    ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \footcites(Multiprenote)(multipostnote)[23][42]{Knu86}[65]{Nie72}
 ^D
-[Para [Note [Para [Cite [Citation {citationId = "Knu86", citationPrefix = [Str "Multiprenote",Space,Str "23"], citationSuffix = [Str "42"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0},Citation {citationId = "Nie72", citationPrefix = [], citationSuffix = [Str "65",Str ",",Space,Str "multipostnote"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\footcites(Multiprenote)(multipostnote)[23][42]{Knu86}[65]{Nie72}"],Str "."]]]]
+[ Para
+  [ Note
+    [ Para
+      [ Cite
+        [ Citation
+          { citationId = "Knu86"
+          , citationPrefix =
+            [ Str "Multiprenote", Space, Str "23" ]
+          , citationSuffix =
+            [ Str "42" ]
+          , citationMode = NormalCitation
+          , citationNoteNum = 0
+          , citationHash = 0
+          }
+        , Citation
+          { citationId = "Nie72"
+          , citationPrefix = []
+          , citationSuffix =
+            [ Str "65", Str ",", Space, Str "multipostnote" ]
+          , citationMode = NormalCitation
+          , citationNoteNum = 0
+          , citationHash = 0
+          }
+        ]
+        [ RawInline
+          ( Format "latex" ) "\\footcites(Multiprenote)(multipostnote)[23][42]{Knu86}[65]{Nie72}"
+        ]
+      , Str "."
+      ]
+    ]
+  ]
+]
 ```

--- a/test/command/4933.md
+++ b/test/command/4933.md
@@ -2,5 +2,5 @@
 % pandoc -f latex -t native
 \includegraphics{lalune}
 ^D
-[Para [Image ("",[],[]) [Str "image"] ("lalune.jpg","")]]
+[ Para [ Image ( "", [], [] ) [ Str "image" ] ( "lalune.jpg", "" ) ] ]
 ```

--- a/test/command/5014.md
+++ b/test/command/5014.md
@@ -13,18 +13,35 @@
     </tbody>
 </table>
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Name"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Accounts"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignDefault, ColWidthDefault ) ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Name" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Accounts" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/5079.md
+++ b/test/command/5079.md
@@ -10,16 +10,24 @@
 </tbody>
 </table>
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignDefault, ColWidthDefault ) ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/5099.md
+++ b/test/command/5099.md
@@ -2,12 +2,26 @@
 % pandoc -t native
 (@citation
 ^D
-[Para [Str "(",Cite [Citation {citationId = "citation", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 1, citationHash = 0}] [Str "@citation"]]]
+[ Para
+  [ Str "("
+  , Cite
+    [ Citation
+      { citationId = "citation"
+      , citationPrefix = []
+      , citationSuffix = []
+      , citationMode = AuthorInText
+      , citationNoteNum = 1
+      , citationHash = 0
+      }
+    ]
+    [ Str "@citation" ]
+  ]
+]
 ```
 
 ```
 % pandoc -t native
 ('asd')
 ^D
-[Para [Str "(",Quoted SingleQuote [Str "asd"],Str ")"]]
+[ Para [ Str "(", Quoted SingleQuote [ Str "asd" ], Str ")" ] ]
 ```

--- a/test/command/5178.md
+++ b/test/command/5178.md
@@ -22,8 +22,21 @@ unsafePerformIO main
   (+ 2 2)
 #+end_src
 ^D
-[CodeBlock ("",["commonlisp","numberLines"],[("org-language","lisp"),("startFrom","20")]) "(+ 1 1)\n"
-,CodeBlock ("",["commonlisp","numberLines","continuedSourceBlock"],[("org-language","lisp"),("startFrom","10")]) "(+ 2 2)\n"]
+[ CodeBlock
+  ( ""
+  ,
+    [ "commonlisp", "numberLines" ]
+  ,
+    [ ( "org-language", "lisp" ), ( "startFrom", "20" ) ]
+  ) "(+ 1 1)\n"
+, CodeBlock
+  ( ""
+  ,
+    [ "commonlisp", "numberLines", "continuedSourceBlock" ]
+  ,
+    [ ( "org-language", "lisp" ), ( "startFrom", "10" ) ]
+  ) "(+ 2 2)\n"
+]
 ```
 
 ```

--- a/test/command/5182.md
+++ b/test/command/5182.md
@@ -2,5 +2,7 @@
 % pandoc -f rst -t native
 .. include:: command/5182.txt
 ^D
-[CodeBlock ("",["python","numberLines"],[]) "def func(x):\n  return y"]
+[ CodeBlock
+  ( "", [ "python", "numberLines" ], [] ) "def func(x):\n  return y"
+]
 ```

--- a/test/command/5271.md
+++ b/test/command/5271.md
@@ -7,6 +7,35 @@ abstract: |
   It consists of two paragraphs.
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("abstract",MetaBlocks [Para [Str "This",Space,Str "is",Space,Str "the",Space,Str "abstract."],Para [Str "It",Space,Str "consists",Space,Str "of",Space,Str "two",Space,Str "paragraphs."]])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "abstract"
+        , MetaBlocks
+          [ Para
+            [ Str "This"
+            , Space
+            , Str "is"
+            , Space
+            , Str "the"
+            , Space
+            , Str "abstract."
+            ]
+          , Para
+            [ Str "It"
+            , Space
+            , Str "consists"
+            , Space
+            , Str "of"
+            , Space
+            , Str "two"
+            , Space
+            , Str "paragraphs."
+            ]
+          ]
+        )
+      ]
+    }
+  ) []
 ```

--- a/test/command/5285.md
+++ b/test/command/5285.md
@@ -7,11 +7,15 @@
 
 - b
 ^D
-[BulletList
- [[Para [Str "a"]
-  ,Para [Str "b"]]
- ,[Para [Str "a"]]
- ,[Para [Str "b"]]]]
+[ BulletList
+  [
+    [ Para [ Str "a" ], Para [ Str "b" ] ]
+  ,
+    [ Para [ Str "a" ] ]
+  ,
+    [ Para [ Str "b" ] ]
+  ]
+]
 ```
 
 ```
@@ -23,10 +27,11 @@
 
   > foo
 ^D
-[BulletList
- [[Para [Str "foo"]
-  ,Para [Str "foo"]]
- ,[Para [Str "foo"]
-  ,BlockQuote
-   [Para [Str "foo"]]]]]
+[ BulletList
+  [
+    [ Para [ Str "foo" ], Para [ Str "foo" ] ]
+  ,
+    [ Para [ Str "foo" ], BlockQuote [ Para [ Str "foo" ] ] ]
+  ]
+]
 ```

--- a/test/command/5321.md
+++ b/test/command/5321.md
@@ -7,7 +7,9 @@
   <graphic xlink:href="foo.png" xlink:alt-text="baz" />
 </fig>
 ^D
-[Para [Image ("fig-1",[],[]) [Str "bar"] ("foo.png","fig:")]]
+[ Para
+  [ Image ( "fig-1", [], [] ) [ Str "bar" ] ( "foo.png", "fig:" ) ]
+]
 ```
 
 ```
@@ -20,5 +22,11 @@
   <graphic xlink:href="foo.png" xlink:alt-text="baz" />
 </fig>
 ^D
-[Para [Image ("fig-1",[],[]) [Str "foo",LineBreak,Str "bar"] ("foo.png","fig:")]]
+[ Para
+  [ Image
+    ( "fig-1", [], [] )
+    [ Str "foo", LineBreak, Str "bar" ]
+    ( "foo.png", "fig:" )
+  ]
+]
 ```

--- a/test/command/5360.md
+++ b/test/command/5360.md
@@ -8,12 +8,22 @@
 </table>
 :::
 ^D
-[Div ("",["foo"],[])
- [RawBlock (Format "html") "<table>"
- ,RawBlock (Format "html") "<tr>"
- ,RawBlock (Format "html") "<td>"
- ,Plain [Str "hi"]
- ,RawBlock (Format "html") "</td>"
- ,RawBlock (Format "html") "</tr>"
- ,RawBlock (Format "html") "</table>"]]
+[ Div
+  ( "", [ "foo" ], [] )
+  [ RawBlock
+    ( Format "html" ) "<table>"
+  , RawBlock
+    ( Format "html" ) "<tr>"
+  , RawBlock
+    ( Format "html" ) "<td>"
+  , Plain
+    [ Str "hi" ]
+  , RawBlock
+    ( Format "html" ) "</td>"
+  , RawBlock
+    ( Format "html" ) "</tr>"
+  , RawBlock
+    ( Format "html" ) "</table>"
+  ]
+]
 ```

--- a/test/command/5368.md
+++ b/test/command/5368.md
@@ -12,12 +12,28 @@
 
 Quux.
 ^D
-[OrderedList (1,Decimal,Period)
- [[Para [Str "foo"]
-  ,Para [Image ("",[],[]) [Str "bar"] ("bar.png","fig:")]]
- ,[Para [Str "foo2"]
-  ,Para [Image ("",[],[]) [Str "bar2"] ("bar2.png","fig:")]]
- ,[Para [Str "foo3"]
-  ,Para [Image ("",[],[]) [Str "foo3"] ("foo3.png","fig:")]]]
-,Para [Str "Quux."]]
+[ OrderedList
+  ( 1, Decimal, Period )
+  [
+    [ Para
+      [ Str "foo" ]
+    , Para
+      [ Image ( "", [], [] ) [ Str "bar" ] ( "bar.png", "fig:" ) ]
+    ]
+  ,
+    [ Para
+      [ Str "foo2" ]
+    , Para
+      [ Image ( "", [], [] ) [ Str "bar2" ] ( "bar2.png", "fig:" ) ]
+    ]
+  ,
+    [ Para
+      [ Str "foo3" ]
+    , Para
+      [ Image ( "", [], [] ) [ Str "foo3" ] ( "foo3.png", "fig:" ) ]
+    ]
+  ]
+, Para
+  [ Str "Quux." ]
+]
 ```

--- a/test/command/5410.md
+++ b/test/command/5410.md
@@ -3,5 +3,5 @@
 .ie n \{\
 'br\}
 ^D
-[Para [LineBreak]]
+[ Para [ LineBreak ] ]
 ```

--- a/test/command/5416.md
+++ b/test/command/5416.md
@@ -2,12 +2,12 @@
 % pandoc -f dokuwiki -t native
 {
 ^D
-[Para [Str "{"]]
+[ Para [ Str "{" ] ]
 ```
 
 ```
 % pandoc -f dokuwiki -t native
 {{
 ^D
-[Para [Str "{{"]]
+[ Para [ Str "{{" ] ]
 ```

--- a/test/command/5540.md
+++ b/test/command/5540.md
@@ -4,5 +4,11 @@
 Stay pure!
 \end{lstlisting}
 ^D
-[CodeBlock ("",["myfunnylanguage"],[("language","myfunnylanguage")]) "Stay pure!"]
+[ CodeBlock
+  ( ""
+  , [ "myfunnylanguage" ]
+  ,
+    [ ( "language", "myfunnylanguage" ) ]
+  ) "Stay pure!"
+]
 ```

--- a/test/command/5549.md
+++ b/test/command/5549.md
@@ -4,6 +4,5 @@
 
 []
 ^D
-[Header 2 ("section",[],[]) []
-,Para [Str "[]"]]
+[ Header 2 ( "section", [], [] ) [], Para [ Str "[]" ] ]
 ```

--- a/test/command/5619.md
+++ b/test/command/5619.md
@@ -6,5 +6,32 @@
 
   The caption. Here's what piggybacking on caption would look like {#fig:1}
 ^D
-[Para [Image ("test",[],[("width","1in")]) [Str "The",Space,Str "caption.",Space,Str "Here's",Space,Str "what",Space,Str "piggybacking",Space,Str "on",Space,Str "caption",Space,Str "would",Space,Str "look",Space,Str "like",Space,Str "{#fig:1}"] ("img1.jpg","fig:")]]
+[ Para
+  [ Image
+    ( "test", [], [ ( "width", "1in" ) ] )
+    [ Str "The"
+    , Space
+    , Str "caption."
+    , Space
+    , Str "Here's"
+    , Space
+    , Str "what"
+    , Space
+    , Str "piggybacking"
+    , Space
+    , Str "on"
+    , Space
+    , Str "caption"
+    , Space
+    , Str "would"
+    , Space
+    , Str "look"
+    , Space
+    , Str "like"
+    , Space
+    , Str "{#fig:1}"
+    ]
+    ( "img1.jpg", "fig:" )
+  ]
+]
 ```

--- a/test/command/5682.md
+++ b/test/command/5682.md
@@ -3,6 +3,6 @@
 \newcommand{\ittakestwo}[2][defaultone]{#2}
 \ittakestwo[to]{tango}
 ^D
-[Para [Str "tango"]]
+[ Para [ Str "tango" ] ]
 ```
 

--- a/test/command/5686.md
+++ b/test/command/5686.md
@@ -4,6 +4,28 @@ FOO\t0BAR
 
 This part does not make it to the html output.
 ^D
-[Para [Str "FOO",RawInline (Format "tex") "\\t0",Str "BAR"]
-,Para [Str "This",Space,Str "part",Space,Str "does",Space,Str "not",Space,Str "make",Space,Str "it",Space,Str "to",Space,Str "the",Space,Str "html",Space,Str "output."]]
+[ Para
+  [ Str "FOO", RawInline ( Format "tex" ) "\\t0", Str "BAR" ]
+, Para
+  [ Str "This"
+  , Space
+  , Str "part"
+  , Space
+  , Str "does"
+  , Space
+  , Str "not"
+  , Space
+  , Str "make"
+  , Space
+  , Str "it"
+  , Space
+  , Str "to"
+  , Space
+  , Str "the"
+  , Space
+  , Str "html"
+  , Space
+  , Str "output."
+  ]
+]
 ```

--- a/test/command/5700.md
+++ b/test/command/5700.md
@@ -1,6 +1,40 @@
 ```
 % pandoc -t native -s --metadata-file command/5700-metadata-file-1.yml --metadata-file command/5700-metadata-file-2.yml
 ^D
-Pandoc (Meta {unMeta = fromList [("desc",MetaInlines [Str "Both",Space,Str "of",Space,Str "these",Space,Str "files",Space,Str "should",Space,Str "be",Space,Str "loaded."]),("title",MetaInlines [Str "Multiple",Space,Str "metadata",Space,Str "files",Space,Str "test"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "desc"
+        , MetaInlines
+          [ Str "Both"
+          , Space
+          , Str "of"
+          , Space
+          , Str "these"
+          , Space
+          , Str "files"
+          , Space
+          , Str "should"
+          , Space
+          , Str "be"
+          , Space
+          , Str "loaded."
+          ]
+        )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Multiple"
+          , Space
+          , Str "metadata"
+          , Space
+          , Str "files"
+          , Space
+          , Str "test"
+          ]
+        )
+      ]
+    }
+  ) []
 ```

--- a/test/command/5708.md
+++ b/test/command/5708.md
@@ -4,19 +4,33 @@
 | 123456 | :math:`a + b`  |
 +--------+----------------+
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.125)
- ,(AlignDefault,ColWidth 0.2361111111111111)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123456"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Math InlineMath "a + b"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidth 0.125 )
+  ,
+    ( AlignDefault, ColWidth 0.2361111111111111 )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123456" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "a + b" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/5711.md
+++ b/test/command/5711.md
@@ -7,16 +7,24 @@
 \end{tabular}
 \end{document}
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "d",LineBreak,Str "e"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignCenter, ColWidthDefault ) ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "d", LineBreak, Str "e" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/5714.md
+++ b/test/command/5714.md
@@ -6,8 +6,15 @@ b_
 # hi _c
 c
 ^D
-[Header 1 ("hi-_a",[],[]) [Str "hi",Space,Str "_a"]
-,Para [Str "b_"]
-,Header 1 ("hi-_c",[],[]) [Str "hi",Space,Str "_c"]
-,Para [Str "c"]]
+[ Header 1
+  ( "hi-_a", [], [] )
+  [ Str "hi", Space, Str "_a" ]
+, Para
+  [ Str "b_" ]
+, Header 1
+  ( "hi-_c", [], [] )
+  [ Str "hi", Space, Str "_c" ]
+, Para
+  [ Str "c" ]
+]
 ```

--- a/test/command/5753.md
+++ b/test/command/5753.md
@@ -10,6 +10,9 @@
 
 end
 ^D
-[Para [Math DisplayMath "q_3\n+ 4",Math DisplayMath "- 5 +\nq_5"]
-,Para [Str "end"]]
+[ Para
+  [ Math DisplayMath "q_3\n+ 4", Math DisplayMath "- 5 +\nq_5" ]
+, Para
+  [ Str "end" ]
+]
 ```

--- a/test/command/5795.md
+++ b/test/command/5795.md
@@ -9,7 +9,12 @@
 % pandoc -f html -t native
 <dfn class="dfn" id="foo" title="bax"><span>foo</span></dfn>
 ^D
-[Plain [Span ("foo",["dfn","dfn"],[("title","bax")]) [Span ("",[],[]) [Str "foo"]]]]
+[ Plain
+  [ Span
+    ( "foo", [ "dfn", "dfn" ], [ ( "title", "bax" ) ] )
+    [ Span ( "", [], [] ) [ Str "foo" ] ]
+  ]
+]
 ```
 
 ```

--- a/test/command/5797.md
+++ b/test/command/5797.md
@@ -9,7 +9,7 @@
 % pandoc -f html -t native
 <mark>Ctrl-C</mark>
 ^D
-[Plain [Span ("",["mark"],[]) [Str "Ctrl-C"]]]
+[ Plain [ Span ( "", [ "mark" ], [] ) [ Str "Ctrl-C" ] ] ]
 ```
 
 ```

--- a/test/command/5805.md
+++ b/test/command/5805.md
@@ -9,7 +9,7 @@
 % pandoc -f html -t native
 <kbd>Ctrl-C</kbd>
 ^D
-[Plain [Span ("",["kbd"],[]) [Str "Ctrl-C"]]]
+[ Plain [ Span ( "", [ "kbd" ], [] ) [ Str "Ctrl-C" ] ] ]
 ```
 
 ```

--- a/test/command/5845.md
+++ b/test/command/5845.md
@@ -2,7 +2,7 @@
 % pandoc -t native
 \parbox{1em}{#1}
 ^D
-[Para [Str "\\parbox{1em}{#1}"]]
+[ Para [ Str "\\parbox{1em}{#1}" ] ]
 ```
 
 ```
@@ -11,6 +11,20 @@
 
 Hello World
 ^D
-[Para [Str "\\newcommand{",RawInline (Format "tex") "\\highlight",Str "}[1]{\\colorbox{yellow}{\\parbox{",RawInline (Format "tex") "\\dimexpr",RawInline (Format "tex") "\\linewidth-2",RawInline (Format "tex") "\\fboxsep",Str "}{#1}}"]
-,Para [Str "Hello",Space,Str "World"]]
+[ Para
+  [ Str "\\newcommand{"
+  , RawInline
+    ( Format "tex" ) "\\highlight"
+  , Str "}[1]{\\colorbox{yellow}{\\parbox{"
+  , RawInline
+    ( Format "tex" ) "\\dimexpr"
+  , RawInline
+    ( Format "tex" ) "\\linewidth-2"
+  , RawInline
+    ( Format "tex" ) "\\fboxsep"
+  , Str "}{#1}}"
+  ]
+, Para
+  [ Str "Hello", Space, Str "World" ]
+]
 ```

--- a/test/command/5878.md
+++ b/test/command/5878.md
@@ -3,5 +3,15 @@
 Zozime^[],
 Synésius^[]
 ^D
-[Para [Str "Zozime",Note [Para []],Str ",",SoftBreak,Str "Syn\233sius",Note [Para []]]]
+[ Para
+  [ Str "Zozime"
+  , Note
+    [ Para [] ]
+  , Str ","
+  , SoftBreak
+  , Str "Syn\233sius"
+  , Note
+    [ Para [] ]
+  ]
+]
 ```

--- a/test/command/6009.md
+++ b/test/command/6009.md
@@ -9,10 +9,17 @@ x
 
     y
 ^D
-[RawBlock (Format "html") "<tr>"
-,RawBlock (Format "html") "<td>"
-,RawBlock (Format "html") "</td>"
-,RawBlock (Format "html") "</tr>"
-,Para [Str "x"]
-,CodeBlock ("",[],[]) "y"]
+[ RawBlock
+  ( Format "html" ) "<tr>"
+, RawBlock
+  ( Format "html" ) "<td>"
+, RawBlock
+  ( Format "html" ) "</td>"
+, RawBlock
+  ( Format "html" ) "</tr>"
+, Para
+  [ Str "x" ]
+, CodeBlock
+  ( "", [], [] ) "y"
+]
 ```

--- a/test/command/6026.md
+++ b/test/command/6026.md
@@ -4,8 +4,34 @@
 
 @https://openreview.net/forum?id=HkwoSDPgg
 ^D
-[Para [Cite [Citation {citationId = "https://openreview.net/forum?id=HkwoSDPgg", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 1, citationHash = 0}] [Str "@https://openreview.net/forum?id=HkwoSDPgg"]]
-,Para [Cite [Citation {citationId = "https://openreview.net/forum?id", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 2, citationHash = 0}] [Str "@https://openreview.net/forum?id"],Str "=HkwoSDPgg"]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "https://openreview.net/forum?id=HkwoSDPgg"
+      , citationPrefix = []
+      , citationSuffix = []
+      , citationMode = AuthorInText
+      , citationNoteNum = 1
+      , citationHash = 0
+      }
+    ]
+    [ Str "@https://openreview.net/forum?id=HkwoSDPgg" ]
+  ]
+, Para
+  [ Cite
+    [ Citation
+      { citationId = "https://openreview.net/forum?id"
+      , citationPrefix = []
+      , citationSuffix = []
+      , citationMode = AuthorInText
+      , citationNoteNum = 2
+      , citationHash = 0
+      }
+    ]
+    [ Str "@https://openreview.net/forum?id" ]
+  , Str "=HkwoSDPgg"
+  ]
+]
 ```
 ```
 % pandoc -t markdown

--- a/test/command/6034.md
+++ b/test/command/6034.md
@@ -7,5 +7,7 @@
   \end{overpic}
 \end{figure*}
 ^D
-[RawBlock (Format "latex") "\\begin{figure*}\n  \\centering\n  \\begin{overpic}{test_pic}\n    \\put (70,80) {Caption}\n  \\end{overpic}\n\\end{figure*}"]
+[ RawBlock
+  ( Format "latex" ) "\\begin{figure*}\n  \\centering\n  \\begin{overpic}{test_pic}\n    \\put (70,80) {Caption}\n  \\end{overpic}\n\\end{figure*}"
+]
 ```

--- a/test/command/6114.md
+++ b/test/command/6114.md
@@ -3,5 +3,11 @@
 \includegraphics[width=.85\textwidth]%
  {pic_M87star.pdf}
 ^D
-[Para [Image ("",[],[("width",".85\\textwidth")]) [Str "image"] ("pic_M87star.pdf","")]]
+[ Para
+  [ Image
+    ( "", [], [ ( "width", ".85\\textwidth" ) ] )
+    [ Str "image" ]
+    ( "pic_M87star.pdf", "" )
+  ]
+]
 ```

--- a/test/command/6137.md
+++ b/test/command/6137.md
@@ -15,33 +15,137 @@ This reference to Figure \ref{fig:label} works fine.
         \caption{A numbered caption, if I use pandoc-crossref.}\label{fig:label}
 \end{figure}
 ^D
-[Para [Str "This",Space,Str "reference",Space,Str "to",Space,Str "Table",Space,Link ("",[],[("reference-type","ref"),("reference","tbl:label")]) [Str "1"] ("#tbl:label",""),Space,Str "doesn\8217t",Space,Str "work."]
-,Div ("tbl:label",[],[])
- [Table ("",[],[]) (Caption Nothing
-  [Plain [Str "This",Space,Str "caption",Space,Str "has",Space,Str "no",Space,Str "number."]])
-  [(AlignLeft,ColWidthDefault)
-  ,(AlignCenter,ColWidthDefault)
-  ,(AlignRight,ColWidthDefault)]
-  (TableHead ("",[],[])
-  [])
-  [(TableBody ("",[],[]) (RowHeadColumns 0)
-   []
-   [Row ("",[],[])
-    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "\8212\8212\8211"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "\8212\8212\8211"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "\8212\8212\8211"]]]
-   ,Row ("",[],[])
-    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "\8212\8212\8211"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "\8212\8212\8211"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "\8212\8212\8211"]]]])]
-  (TableFoot ("",[],[])
-  [])]
-,Para [Str "This",Space,Str "reference",Space,Str "to",Space,Str "Figure",Space,Link ("",[],[("reference-type","ref"),("reference","fig:label")]) [Str "1"] ("#fig:label",""),Space,Str "works",Space,Str "fine."]
-,Para [Image ("fig:label",[],[("width","\\textwidth")]) [Str "A",Space,Str "numbered",Space,Str "caption,",Space,Str "if",Space,Str "I",Space,Str "use",Space,Str "pandoc-crossref."] ("example.png","fig:")]]
+[ Para
+  [ Str "This"
+  , Space
+  , Str "reference"
+  , Space
+  , Str "to"
+  , Space
+  , Str "Table"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "tbl:label" ) ]
+    )
+    [ Str "1" ]
+    ( "#tbl:label", "" )
+  , Space
+  , Str "doesn\8217t"
+  , Space
+  , Str "work."
+  ]
+, Div
+  ( "tbl:label", [], [] )
+  [ Table
+    ( "", [], [] )
+    ( Caption Nothing
+      [ Plain
+        [ Str "This"
+        , Space
+        , Str "caption"
+        , Space
+        , Str "has"
+        , Space
+        , Str "no"
+        , Space
+        , Str "number."
+        ]
+      ]
+    )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignRight, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\8212\8212\8211" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\8212\8212\8211" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\8212\8212\8211" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\8212\8212\8211" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\8212\8212\8211" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\8212\8212\8211" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  ]
+, Para
+  [ Str "This"
+  , Space
+  , Str "reference"
+  , Space
+  , Str "to"
+  , Space
+  , Str "Figure"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "fig:label" ) ]
+    )
+    [ Str "1" ]
+    ( "#fig:label", "" )
+  , Space
+  , Str "works"
+  , Space
+  , Str "fine."
+  ]
+, Para
+  [ Image
+    ( "fig:label", [], [ ( "width", "\\textwidth" ) ] )
+    [ Str "A"
+    , Space
+    , Str "numbered"
+    , Space
+    , Str "caption,"
+    , Space
+    , Str "if"
+    , Space
+    , Str "I"
+    , Space
+    , Str "use"
+    , Space
+    , Str "pandoc-crossref."
+    ]
+    ( "example.png", "fig:" )
+  ]
+]
 ```

--- a/test/command/6288.md
+++ b/test/command/6288.md
@@ -4,5 +4,5 @@
 <label>I</label><title>Introduction</title>
 </sec>
 ^D
-[Header 1 ("",[],[]) [Str "I.",Space,Str "Introduction"]]
+[ Header 1 ( "", [], [] ) [ Str "I.", Space, Str "Introduction" ] ]
 ```

--- a/test/command/6324.md
+++ b/test/command/6324.md
@@ -12,6 +12,14 @@ Me
 \maketitle
 \end{document}
 ^D
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "Me"]]),("title",MetaInlines [Str "Document",Space,Str "title"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author", MetaList [ MetaInlines [ Str "Me" ] ] )
+      ,
+        ( "title", MetaInlines [ Str "Document", Space, Str "title" ] )
+      ]
+    }
+  ) []
 ```

--- a/test/command/6699.md
+++ b/test/command/6699.md
@@ -7,7 +7,11 @@ title
 
 text
 ^D
-[Header 1 ("title",["allowframebreaks"],[]) [Str "title"]
-,Para [Str "text"]]
+[ Header 1
+  ( "title", [ "allowframebreaks" ], [] )
+  [ Str "title" ]
+, Para
+  [ Str "text" ]
+]
 ```
 

--- a/test/command/6709.md
+++ b/test/command/6709.md
@@ -7,5 +7,5 @@ if true; then
 fi
 ```
 ^D
-[CodeBlock ("",[],[]) "if true; then\n  echo \"yup\"\nfi"]
+[ CodeBlock ( "", [], [] ) "if true; then\n  echo \"yup\"\nfi" ]
 ````

--- a/test/command/6719.md
+++ b/test/command/6719.md
@@ -4,7 +4,7 @@
 <emphasis>emphasized </emphasis>text
 </para>
 ^D
-[Para [Emph [Str "emphasized"],Space,Str "text"]]
+[ Para [ Emph [ Str "emphasized" ], Space, Str "text" ] ]
 ```
 
 ```
@@ -13,6 +13,6 @@
 <italic> hi  </italic>there
 </p>
 ^D
-[Para [Emph [Str "hi"],Space,Str "there"]]
+[ Para [ Emph [ Str "hi" ], Space, Str "there" ] ]
 ```
 

--- a/test/command/6791.md
+++ b/test/command/6791.md
@@ -14,19 +14,29 @@
 </tgroup>
 </informaltable>
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.25)
- ,(AlignDefault,ColWidth 0.25)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignDefault, ColWidth 0.25 ), ( AlignDefault, ColWidth 0.25 ) ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "2" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/6802.md
+++ b/test/command/6802.md
@@ -2,8 +2,6 @@
 % pandoc -f latex -t native
 \blockquote[test][]{quote}
 ^D
-[BlockQuote
- [Para [Str "quote"]
- ,Para [Str "test"]]]
+[ BlockQuote [ Para [ Str "quote" ], Para [ Str "test" ] ] ]
 
 ```

--- a/test/command/6836.md
+++ b/test/command/6836.md
@@ -8,10 +8,36 @@ See @foo.
 
 [@buchanan]
 ^D
-[Para [Cite [Citation {citationId = "buchanan", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 1, citationHash = 0}] [Str "[@buchanan]"]]
-,OrderedList (1,Example,TwoParens)
- [[]]
-,Para [Str "See",Space,Str "1."]
-,Para [Cite [Citation {citationId = "buchanan", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 2, citationHash = 0}] [Str "[@buchanan]"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "buchanan"
+      , citationPrefix = []
+      , citationSuffix = []
+      , citationMode = NormalCitation
+      , citationNoteNum = 1
+      , citationHash = 0
+      }
+    ]
+    [ Str "[@buchanan]" ]
+  ]
+, OrderedList
+  ( 1, Example, TwoParens ) [ [] ]
+, Para
+  [ Str "See", Space, Str "1." ]
+, Para
+  [ Cite
+    [ Citation
+      { citationId = "buchanan"
+      , citationPrefix = []
+      , citationSuffix = []
+      , citationMode = NormalCitation
+      , citationNoteNum = 2
+      , citationHash = 0
+      }
+    ]
+    [ Str "[@buchanan]" ]
+  ]
+]
 ```
 

--- a/test/command/6844.md
+++ b/test/command/6844.md
@@ -5,7 +5,7 @@ Negative numbers with siunitx
 \SI{123}{\celsius}
 
 ^D
-[Para [Str "123\160\176C"]]
+[ Para [ Str "123\160\176C" ] ]
 ```
 
 ```
@@ -13,7 +13,7 @@ Negative numbers with siunitx
 \SI{-123}{\celsius}
 
 ^D
-[Para [Str "\8722\&123\160\176C"]]
+[ Para [ Str "\8722\&123\160\176C" ] ]
 ```
 
 ```
@@ -21,7 +21,7 @@ Negative numbers with siunitx
 \SI{+123}{\celsius}
 
 ^D
-[Para [Str "123\160\176C"]]
+[ Para [ Str "123\160\176C" ] ]
 ```
 
 

--- a/test/command/6869.md
+++ b/test/command/6869.md
@@ -2,5 +2,19 @@
 % pandoc -f latex -t native
 \cite[„Aber“]{key}
 ^D
-[Para [Cite [Citation {citationId = "key", citationPrefix = [], citationSuffix = [Str "\8222Aber\8220"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cite[\8222Aber\8220]{key}"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "key"
+      , citationPrefix = []
+      , citationSuffix =
+        [ Str "\8222Aber\8220" ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ RawInline ( Format "latex" ) "\\cite[\8222Aber\8220]{key}" ]
+  ]
+]
 ```

--- a/test/command/6873.md
+++ b/test/command/6873.md
@@ -3,5 +3,38 @@
 \cite[„Etwas […{]} auslassen“]{key}
 ^D
 [WARNING] Citeproc: citation key not found
-[Para [Cite [Citation {citationId = "key", citationPrefix = [], citationSuffix = [Str "\8222Etwas",Space,Str "[\8230",Span ("",[],[]) [Str "]"],Space,Str "auslassen\8220"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [Str "(",Strong [Str "key?"],Str "\8222Etwas",Space,Str "[\8230",Span ("",[],[]) [Str "]"],Space,Str "auslassen\8220)"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "key"
+      , citationPrefix = []
+      , citationSuffix =
+        [ Str "\8222Etwas"
+        , Space
+        , Str "[\8230"
+        , Span
+          ( "", [], [] )
+          [ Str "]" ]
+        , Space
+        , Str "auslassen\8220"
+        ]
+      , citationMode = NormalCitation
+      , citationNoteNum = 0
+      , citationHash = 0
+      }
+    ]
+    [ Str "("
+    , Strong
+      [ Str "key?" ]
+    , Str "\8222Etwas"
+    , Space
+    , Str "[\8230"
+    , Span
+      ( "", [], [] )
+      [ Str "]" ]
+    , Space
+    , Str "auslassen\8220)"
+    ]
+  ]
+]
 ```

--- a/test/command/6890.md
+++ b/test/command/6890.md
@@ -27,10 +27,113 @@ Some text.[^1]
 
 [^1]: @fruchtel-sozialer-2013a
 ^D
-[Para [Cite [Citation {citationId = "fruchtel-sozialer-2013a", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 1, citationHash = 0}] [Str "Fr\252chtel,",Space,Str "Budde,",Space,Str "and",Space,Str "Cyprian",Space,Str "(2013)"]]
-,Para [Str "Some",Space,Str "text.",Note [Para [Cite [Citation {citationId = "fruchtel-sozialer-2013a", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 2, citationHash = 0}] [Str "Fr\252chtel,",Space,Str "Budde,",Space,Str "and",Space,Str "Cyprian",Space,Str "(2013)"]]]]
-,Div ("refs",["references","csl-bib-body","hanging-indent"],[])
- [Div ("ref-fruchtel-sozialer-2013a",["csl-entry"],[])
-  [Para [Str "Fr\252chtel,",Space,Str "Frank,",Space,Str "Wolfgang",Space,Str "Budde,",Space,Str "and",Space,Str "Gudrun",Space,Str "Cyprian.",Space,Str "2013.",Space,Emph [Str "Sozialer",Space,Str "Raum",Space,Str "und",Space,Str "Soziale",Space,Str "Arbeit",Space,Str "Fieldbook:",Space,Str "Methoden",Space,Str "und",Space,Str "Techniken"],Str ".",Space,Str "3rd",Space,Str "ed.",Space,Str "Wiesbaden,",Space,Str "Germany:",Space,Str "Springer",Space,Str "VS."]]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "fruchtel-sozialer-2013a"
+      , citationPrefix = []
+      , citationSuffix = []
+      , citationMode = AuthorInText
+      , citationNoteNum = 1
+      , citationHash = 0
+      }
+    ]
+    [ Str "Fr\252chtel,"
+    , Space
+    , Str "Budde,"
+    , Space
+    , Str "and"
+    , Space
+    , Str "Cyprian"
+    , Space
+    , Str "(2013)"
+    ]
+  ]
+, Para
+  [ Str "Some"
+  , Space
+  , Str "text."
+  , Note
+    [ Para
+      [ Cite
+        [ Citation
+          { citationId = "fruchtel-sozialer-2013a"
+          , citationPrefix = []
+          , citationSuffix = []
+          , citationMode = AuthorInText
+          , citationNoteNum = 2
+          , citationHash = 0
+          }
+        ]
+        [ Str "Fr\252chtel,"
+        , Space
+        , Str "Budde,"
+        , Space
+        , Str "and"
+        , Space
+        , Str "Cyprian"
+        , Space
+        , Str "(2013)"
+        ]
+      ]
+    ]
+  ]
+, Div
+  ( "refs", [ "references", "csl-bib-body", "hanging-indent" ], [] )
+  [ Div
+    ( "ref-fruchtel-sozialer-2013a", [ "csl-entry" ], [] )
+    [ Para
+      [ Str "Fr\252chtel,"
+      , Space
+      , Str "Frank,"
+      , Space
+      , Str "Wolfgang"
+      , Space
+      , Str "Budde,"
+      , Space
+      , Str "and"
+      , Space
+      , Str "Gudrun"
+      , Space
+      , Str "Cyprian."
+      , Space
+      , Str "2013."
+      , Space
+      , Emph
+        [ Str "Sozialer"
+        , Space
+        , Str "Raum"
+        , Space
+        , Str "und"
+        , Space
+        , Str "Soziale"
+        , Space
+        , Str "Arbeit"
+        , Space
+        , Str "Fieldbook:"
+        , Space
+        , Str "Methoden"
+        , Space
+        , Str "und"
+        , Space
+        , Str "Techniken"
+        ]
+      , Str "."
+      , Space
+      , Str "3rd"
+      , Space
+      , Str "ed."
+      , Space
+      , Str "Wiesbaden,"
+      , Space
+      , Str "Germany:"
+      , Space
+      , Str "Springer"
+      , Space
+      , Str "VS."
+      ]
+    ]
+  ]
+]
 ```
 

--- a/test/command/6993.md
+++ b/test/command/6993.md
@@ -2,20 +2,20 @@
 % pandoc -f mediawiki -t native
 '''Should be bold '''
 ^D
-[Para [Strong [Str "Should",Space,Str "be",Space,Str "bold"]]]
+[ Para [ Strong [ Str "Should", Space, Str "be", Space, Str "bold" ] ] ]
 ```
 
 ```
 % pandoc -f mediawiki -t native
 ''' Should be bold'''
 ^D
-[Para [Strong [Str "Should",Space,Str "be",Space,Str "bold"]]]
+[ Para [ Strong [ Str "Should", Space, Str "be", Space, Str "bold" ] ] ]
 ```
 
 ```
 % pandoc -f mediawiki -t native
 '' Should be emph ''
 ^D
-[Para [Emph [Str "Should",Space,Str "be",Space,Str "emph"]]]
+[ Para [ Emph [ Str "Should", Space, Str "be", Space, Str "emph" ] ] ]
 ```
 

--- a/test/command/7003.md
+++ b/test/command/7003.md
@@ -30,8 +30,21 @@ This a Foo section
 \lstinputlisting{example.tex}
 \end{document}
 ^D
-[Header 1 ("with-lstlisting-environment",[],[]) [Str "With",Space,Str "lstlisting",Space,Str "environment"]
-,CodeBlock ("",[],[]) "\\documentclass{article}\n\\begin{document}\n\\section{Foo}\nThis a Foo section\n\\end{document}"
-,Header 1 ("with-lstinputlisting-command",[],[]) [Str "With",Space,Str "lstinputlisting",Space,Str "command"]
-,CodeBlock ("",["latex"],[]) "\\documentclass{article}\n\\begin{document}\n\\section{Bar}\nThis a Bar section\n\\end{document}"]
+[ Header 1
+  ( "with-lstlisting-environment", [], [] )
+  [ Str "With", Space, Str "lstlisting", Space, Str "environment" ]
+, CodeBlock
+  ( ""
+  , []
+  , []
+  ) "\\documentclass{article}\n\\begin{document}\n\\section{Foo}\nThis a Foo section\n\\end{document}"
+, Header 1
+  ( "with-lstinputlisting-command", [], [] )
+  [ Str "With", Space, Str "lstinputlisting", Space, Str "command" ]
+, CodeBlock
+  ( ""
+  , [ "latex" ]
+  , []
+  ) "\\documentclass{article}\n\\begin{document}\n\\section{Bar}\nThis a Bar section\n\\end{document}"
+]
 ```

--- a/test/command/7080.md
+++ b/test/command/7080.md
@@ -4,5 +4,10 @@
 
 [image]: image.png width=100px height=150px
 ^D
-[Para [Image ("",[],[("width","100px"),("height","150px")]) [] ("image.png","")]]
+[ Para
+  [ Image
+    ( "", [], [ ( "width", "100px" ), ( "height", "150px" ) ] ) []
+    ( "image.png", "" )
+  ]
+]
 ```

--- a/test/command/7092.md
+++ b/test/command/7092.md
@@ -4,5 +4,5 @@
 
 \em{\parseMe{foo}}
 ^D
-[Para [Emph [RawInline (Format "latex") "\\parseMe{foo}"]]]
+[ Para [ Emph [ RawInline ( Format "latex" ) "\\parseMe{foo}" ] ] ]
 ```

--- a/test/command/7129.md
+++ b/test/command/7129.md
@@ -5,23 +5,45 @@
   foo & \verb|b&r|  \\ \hline
 \end{tabular}
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "FOO"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "BAR"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "foo"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Code ("",[],[]) "b&r"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignLeft, ColWidthDefault ), ( AlignLeft, ColWidthDefault ) ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "FOO" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "BAR" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "foo" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Code ( "", [], [] ) "b&r" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/7134.md
+++ b/test/command/7134.md
@@ -8,9 +8,44 @@ This is a paragraph.
 
     This should be a second block quote.
 ^D
-[Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "paragraph."]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote."]]
-,BlockQuote
- [Para [Str "This",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "second",Space,Str "block",Space,Str "quote."]]]
+[ Para
+  [ Str "This"
+  , Space
+  , Str "is"
+  , Space
+  , Str "a"
+  , Space
+  , Str "paragraph."
+  ]
+, BlockQuote
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote."
+    ]
+  ]
+, BlockQuote
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "second"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote."
+    ]
+  ]
+]
 ```

--- a/test/command/7145.md
+++ b/test/command/7145.md
@@ -8,5 +8,68 @@ empty
 
 linebreaks</ref>  Nulla ut massa eget ex venenatis lobortis id in eros.
 ^D
-[Para [Str "Maecenas",Space,Str "at",Space,Str "sapien",Space,Str "tempor,",Space,Str "pretium",Space,Str "turpis",Space,Str "ut,",Space,Str "imperdiet",Space,Str "augue.",Note [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "multiline"],Para [Str "reference",SoftBreak,RawInline (Format "html") "<i>",Str "with",RawInline (Format "html") "</i>",SoftBreak,Str "empty"],Para [Str "linebreaks"]],Space,Str "Nulla",Space,Str "ut",Space,Str "massa",Space,Str "eget",Space,Str "ex",Space,Str "venenatis",Space,Str "lobortis",Space,Str "id",Space,Str "in",Space,Str "eros."]]
+[ Para
+  [ Str "Maecenas"
+  , Space
+  , Str "at"
+  , Space
+  , Str "sapien"
+  , Space
+  , Str "tempor,"
+  , Space
+  , Str "pretium"
+  , Space
+  , Str "turpis"
+  , Space
+  , Str "ut,"
+  , Space
+  , Str "imperdiet"
+  , Space
+  , Str "augue."
+  , Note
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "multiline"
+      ]
+    , Para
+      [ Str "reference"
+      , SoftBreak
+      , RawInline
+        ( Format "html" ) "<i>"
+      , Str "with"
+      , RawInline
+        ( Format "html" ) "</i>"
+      , SoftBreak
+      , Str "empty"
+      ]
+    , Para
+      [ Str "linebreaks" ]
+    ]
+  , Space
+  , Str "Nulla"
+  , Space
+  , Str "ut"
+  , Space
+  , Str "massa"
+  , Space
+  , Str "eget"
+  , Space
+  , Str "ex"
+  , Space
+  , Str "venenatis"
+  , Space
+  , Str "lobortis"
+  , Space
+  , Str "id"
+  , Space
+  , Str "in"
+  , Space
+  , Str "eros."
+  ]
+]
 ```

--- a/test/command/7155.md
+++ b/test/command/7155.md
@@ -3,7 +3,16 @@
 \(x\) \[x\]
 \\(x\\) \\[x\\]
 ^D
-[Para [Math InlineMath "x",Space,Math DisplayMath "x",SoftBreak,Str "\\(x\\)",Space,Str "\\[x\\]"]]
+[ Para
+  [ Math InlineMath "x"
+  , Space
+  , Math DisplayMath "x"
+  , SoftBreak
+  , Str "\\(x\\)"
+  , Space
+  , Str "\\[x\\]"
+  ]
+]
 ```
 
 ```
@@ -11,5 +20,14 @@
 \(x\) \[x\]
 \\(x\\) \\[x\\]
 ^D
-[Para [Str "(x)",Space,Str "[x]",SoftBreak,Math InlineMath "x",Space,Math DisplayMath "x"]]
+[ Para
+  [ Str "(x)"
+  , Space
+  , Str "[x]"
+  , SoftBreak
+  , Math InlineMath "x"
+  , Space
+  , Math DisplayMath "x"
+  ]
+]
 ```

--- a/test/command/7339.md
+++ b/test/command/7339.md
@@ -6,6 +6,9 @@ title: Test
 
 Hi
 ^D
-Pandoc (Meta {unMeta = fromList [("title",MetaInlines [Str "Test"])]})
-[Para [Str "Hi"]]
+Pandoc
+  ( Meta
+    { unMeta = fromList [ ( "title", MetaInlines [ Str "Test" ] ) ] }
+  )
+  [ Para [ Str "Hi" ] ]
 ```

--- a/test/command/7340.md
+++ b/test/command/7340.md
@@ -2,5 +2,5 @@
 % pandoc -f latex -t native
 \(*\)
 ^D
-[Para [Math InlineMath "*"]]
+[ Para [ Math InlineMath "*" ] ]
 ```

--- a/test/command/7400.md
+++ b/test/command/7400.md
@@ -4,6 +4,6 @@
 # Comment only
 ...
 ^D
-Pandoc (Meta {unMeta = fromList []})
-[]
+Pandoc
+  ( Meta { unMeta = fromList [] } ) []
 ```

--- a/test/command/7434.md
+++ b/test/command/7434.md
@@ -9,7 +9,15 @@
 
 [\*\a](x)
 ^D
-[RawBlock (Format "tex") "\\begin{proof}\n\\newcommand{\\x}{\\left.\\right.}\n\\left.\\right.\n\\end{proof}"
-,Para [Str "1234567890abcdefghi"]
-,Para [Link ("",[],[]) [Str "*",RawInline (Format "tex") "\\a"] ("x","")]]
+[ RawBlock
+  ( Format "tex" ) "\\begin{proof}\n\\newcommand{\\x}{\\left.\\right.}\n\\left.\\right.\n\\end{proof}"
+, Para
+  [ Str "1234567890abcdefghi" ]
+, Para
+  [ Link
+    ( "", [], [] )
+    [ Str "*", RawInline ( Format "tex" ) "\\a" ]
+    ( "x", "" )
+  ]
+]
 ```

--- a/test/command/7436.md
+++ b/test/command/7436.md
@@ -8,7 +8,26 @@
 
 .. include:: command/three.txt
 ^D
-[CodeBlock ("",[""],[("code","")]) "1st line.\n2nd line.\n3rd line.\n"
-,CodeBlock ("",[""],[("literal","")]) "1st line.\n2nd line.\n3rd line.\n"
-,Para [Str "1st",Space,Str "line.",SoftBreak,Str "2nd",Space,Str "line.",SoftBreak,Str "3rd",Space,Str "line."]]
+[ CodeBlock
+  ( "", [ "" ], [ ( "code", "" ) ] ) "1st line.\n2nd line.\n3rd line.\n"
+, CodeBlock
+  ( ""
+  , [ "" ]
+  ,
+    [ ( "literal", "" ) ]
+  ) "1st line.\n2nd line.\n3rd line.\n"
+, Para
+  [ Str "1st"
+  , Space
+  , Str "line."
+  , SoftBreak
+  , Str "2nd"
+  , Space
+  , Str "line."
+  , SoftBreak
+  , Str "3rd"
+  , Space
+  , Str "line."
+  ]
+]
 ```

--- a/test/command/7557.md
+++ b/test/command/7557.md
@@ -2,6 +2,20 @@
 % pandoc -f org -t native
 - 11. and 12. 09. meeting
 ^D
-[BulletList
- [[Plain [Str "11.",Space,Str "and",Space,Str "12.",Space,Str "09.",Space,Str "meeting"]]]]
+[ BulletList
+  [
+    [ Plain
+      [ Str "11."
+      , Space
+      , Str "and"
+      , Space
+      , Str "12."
+      , Space
+      , Str "09."
+      , Space
+      , Str "meeting"
+      ]
+    ]
+  ]
+]
 ```

--- a/test/command/934.md
+++ b/test/command/934.md
@@ -7,6 +7,37 @@
 }
 \ddb{This should be italic and in quotes}{And this is the attribution}
 ^D
-[Para [Emph [Quoted DoubleQuote [Str "This",Space,Str "should",Space,Str "be",Space,Str "italic",Space,Str "and",Space,Str "in",Space,Str "quotes"]]]
-,Para [Strong [Str "And",Space,Str "this",Space,Str "is",Space,Str "the",Space,Str "attribution"]]]
+[ Para
+  [ Emph
+    [ Quoted DoubleQuote
+      [ Str "This"
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "italic"
+      , Space
+      , Str "and"
+      , Space
+      , Str "in"
+      , Space
+      , Str "quotes"
+      ]
+    ]
+  ]
+, Para
+  [ Strong
+    [ Str "And"
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Str "the"
+    , Space
+    , Str "attribution"
+    ]
+  ]
+]
 ```

--- a/test/command/982.md
+++ b/test/command/982.md
@@ -7,5 +7,5 @@
 y=x^2
 \EEQ
 ^D
-[Para [Math DisplayMath "y=x^2"]]
+[ Para [ Math DisplayMath "y=x^2" ] ]
 ```

--- a/test/command/adjacent_latex_blocks.md
+++ b/test/command/adjacent_latex_blocks.md
@@ -4,6 +4,9 @@
 
 \listoftables
 ^D
-[RawBlock (Format "tex") "\\listoffigures"
-,RawBlock (Format "tex") "\\listoftables"]
+[ RawBlock
+  ( Format "tex" ) "\\listoffigures"
+, RawBlock
+  ( Format "tex" ) "\\listoftables"
+]
 ```

--- a/test/command/cite-in-inline-note.md
+++ b/test/command/cite-in-inline-note.md
@@ -2,5 +2,25 @@
 % pandoc -t native
 foo^[bar [@doe]]
 ^D
-[Para [Str "foo",Note [Para [Str "bar",Space,Cite [Citation {citationId = "doe", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 1, citationHash = 0}] [Str "[@doe]"]]]]]
+[ Para
+  [ Str "foo"
+  , Note
+    [ Para
+      [ Str "bar"
+      , Space
+      , Cite
+        [ Citation
+          { citationId = "doe"
+          , citationPrefix = []
+          , citationSuffix = []
+          , citationMode = NormalCitation
+          , citationNoteNum = 1
+          , citationHash = 0
+          }
+        ]
+        [ Str "[@doe]" ]
+      ]
+    ]
+  ]
+]
 ```

--- a/test/command/citeproc-author-in-text-suffix.md
+++ b/test/command/citeproc-author-in-text-suffix.md
@@ -2,5 +2,27 @@
 % pandoc -t native
 @a [p. 33; @b]
 ^D
-[Para [Cite [Citation {citationId = "a", citationPrefix = [], citationSuffix = [Str "p.\160\&33"], citationMode = AuthorInText, citationNoteNum = 1, citationHash = 0},Citation {citationId = "b", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 1, citationHash = 0}] [Str "@a",Space,Str "[p.",Space,Str "33;",Space,Str "@b]"]]]
+[ Para
+  [ Cite
+    [ Citation
+      { citationId = "a"
+      , citationPrefix = []
+      , citationSuffix =
+        [ Str "p.\160\&33" ]
+      , citationMode = AuthorInText
+      , citationNoteNum = 1
+      , citationHash = 0
+      }
+    , Citation
+      { citationId = "b"
+      , citationPrefix = []
+      , citationSuffix = []
+      , citationMode = NormalCitation
+      , citationNoteNum = 1
+      , citationHash = 0
+      }
+    ]
+    [ Str "@a", Space, Str "[p.", Space, Str "33;", Space, Str "@b]" ]
+  ]
+]
 ```

--- a/test/command/csv.md
+++ b/test/command/csv.md
@@ -5,42 +5,95 @@ Apple,25 cents,33
 """Navel"" Orange","35 cents",22
 ,,45
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Fruit"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Price"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Quantity"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Apple"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "25",Space,Str "cents"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "33"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "\"Navel\"",Space,Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "35",Space,Str "cents"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "22"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "45"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Fruit" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Price" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Quantity" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Apple" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "25", Space, Str "cents" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "33" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "\"Navel\"", Space, Str "Orange" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "35", Space, Str "cents" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "22" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "45" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/docbook-bibliography.md
+++ b/test/command/docbook-bibliography.md
@@ -13,8 +13,35 @@
 </bibliomixed>
 </bibliodiv>
 ^D
-[Header 1 ("",[],[]) [Str "Document",Space,Str "References"]
-,Para [Span ("refTheFirst",[],[]) [],Str "[1]",Space,Str "First",Space,Str "reference"]
-,Para [Span ("refTheSecond",[],[]) [],Str "[2]",Space,Str "Second",Space,Str "reference"]
-,Para [Span ("refTheThird",[],[]) [],Str "[3]",Space,Str "Third",Space,Str "reference"]]
+[ Header 1
+  ( "", [], [] )
+  [ Str "Document", Space, Str "References" ]
+, Para
+  [ Span
+    ( "refTheFirst", [], [] ) []
+  , Str "[1]"
+  , Space
+  , Str "First"
+  , Space
+  , Str "reference"
+  ]
+, Para
+  [ Span
+    ( "refTheSecond", [], [] ) []
+  , Str "[2]"
+  , Space
+  , Str "Second"
+  , Space
+  , Str "reference"
+  ]
+, Para
+  [ Span
+    ( "refTheThird", [], [] ) []
+  , Str "[3]"
+  , Space
+  , Str "Third"
+  , Space
+  , Str "reference"
+  ]
+]
 ```

--- a/test/command/dots.md
+++ b/test/command/dots.md
@@ -6,7 +6,5 @@
 
 \vdots
 ^D
-[Para [Str "\8230"]
-,Para [Str "\8230"]
-,Para [Str "\8942"]]
+[ Para [ Str "\8230" ], Para [ Str "\8230" ], Para [ Str "\8942" ] ]
 ```

--- a/test/command/empty_paragraphs.md
+++ b/test/command/empty_paragraphs.md
@@ -2,34 +2,28 @@
 % pandoc -f native -t docx -o - | pandoc -f docx -t native
 [Para [Str "hi"], Para [], Para [], Para [Str "lo"]]
 ^D
-[Para [Str "hi"]
-,Para [Str "lo"]]
+[ Para [ Str "hi" ], Para [ Str "lo" ] ]
 ```
 
 ```
 % pandoc -f native -t docx+empty_paragraphs -o - | pandoc -f docx -t native
 [Para [Str "hi"], Para [], Para [], Para [Str "lo"]]
 ^D
-[Para [Str "hi"]
-,Para [Str "lo"]]
+[ Para [ Str "hi" ], Para [ Str "lo" ] ]
 ```
 
 ```
 % pandoc -f native -t docx -o - | pandoc -f docx+empty_paragraphs -t native
 [Para [Str "hi"], Para [], Para [], Para [Str "lo"]]
 ^D
-[Para [Str "hi"]
-,Para [Str "lo"]]
+[ Para [ Str "hi" ], Para [ Str "lo" ] ]
 ```
 
 ```
 % pandoc -f native -t docx+empty_paragraphs -o - | pandoc -f docx+empty_paragraphs -t native
 [Para [Str "hi"], Para [], Para [], Para [Str "lo"]]
 ^D
-[Para [Str "hi"]
-,Para []
-,Para []
-,Para [Str "lo"]]
+[ Para [ Str "hi" ], Para [], Para [], Para [ Str "lo" ] ]
 ```
 
 ```
@@ -57,10 +51,7 @@
 <p></p>
 <p>lo</p>
 ^D
-[Para [Str "hi"]
-,Para []
-,Para []
-,Para [Str "lo"]]
+[ Para [ Str "hi" ], Para [], Para [], Para [ Str "lo" ] ]
 ```
 
 ```
@@ -70,8 +61,7 @@
 <p></p>
 <p>lo</p>
 ^D
-[Para [Str "hi"]
-,Para [Str "lo"]]
+[ Para [ Str "hi" ], Para [ Str "lo" ] ]
 ```
 
 ```

--- a/test/command/gfm.md
+++ b/test/command/gfm.md
@@ -7,37 +7,67 @@ gfm tests:
 | apple | 0.13  |
 | orange|1.12|
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Fruit"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Price"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "apple"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "0.13"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1.12"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignDefault, ColWidthDefault ), ( AlignRight, ColWidthDefault ) ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Fruit" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Price" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "apple" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "0.13" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "orange" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1.12" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 
 ```
 % pandoc -f gfm -t native
 ~~stricken out~~
 ^D
-[Para [Strikeout [Str "stricken",Space,Str "out"]]]
+[ Para [ Strikeout [ Str "stricken", Space, Str "out" ] ] ]
 ```
 
 ```
@@ -46,30 +76,47 @@ gfm tests:
 ## Header
 # -foo-bar_baz
 ^D
-[Header 1 ("header",[],[]) [Str "Header"]
-,Header 2 ("header-1",[],[]) [Str "Header"]
-,Header 1 ("-foo-bar_baz",[],[]) [Str "-foo-bar_baz"]]
+[ Header 1
+  ( "header", [], [] )
+  [ Str "Header" ]
+, Header 2
+  ( "header-1", [], [] )
+  [ Str "Header" ]
+, Header 1
+  ( "-foo-bar_baz", [], [] )
+  [ Str "-foo-bar_baz" ]
+]
 ```
 
 ```
 % pandoc -f gfm -t native
 My:thumbsup:emoji:heart:
 ^D
-[Para [Str "My",Span ("",["emoji"],[("data-emoji","thumbsup")]) [Str "\128077"],Str "emoji",Span ("",["emoji"],[("data-emoji","heart")]) [Str "\10084\65039"]]]
+[ Para
+  [ Str "My"
+  , Span
+    ( "", [ "emoji" ], [ ( "data-emoji", "thumbsup" ) ] )
+    [ Str "\128077" ]
+  , Str "emoji"
+  , Span
+    ( "", [ "emoji" ], [ ( "data-emoji", "heart" ) ] )
+    [ Str "\10084\65039" ]
+  ]
+]
 ```
 
 ```
 % pandoc -f gfm -t native
 "hi"
 ^D
-[Para [Str "\"hi\""]]
+[ Para [ Str "\"hi\"" ] ]
 ```
 
 ```
 % pandoc -f gfm+smart -t native
 "hi"
 ^D
-[Para [Quoted DoubleQuote [Str "hi"]]]
+[ Para [ Quoted DoubleQuote [ Str "hi" ] ] ]
 ```
 
 ```
@@ -133,7 +180,7 @@ The caption.
 hi
 hi
 ^D
-[Para [Str "hi",LineBreak,Str "hi"]]
+[ Para [ Str "hi", LineBreak, Str "hi" ] ]
 ```
 
 ```
@@ -141,9 +188,13 @@ hi
 - [ ] foo
 - [x] bar
 ^D
-[BulletList
- [[Plain [Str "\9744",Space,Str "foo"]]
- ,[Plain [Str "\9746",Space,Str "bar"]]]]
+[ BulletList
+  [
+    [ Plain [ Str "\9744", Space, Str "foo" ] ]
+  ,
+    [ Plain [ Str "\9746", Space, Str "bar" ] ]
+  ]
+]
 ```
 
 ```
@@ -151,9 +202,13 @@ hi
 - [ ] foo
 - [x] bar
 ^D
-[BulletList
- [[Plain [Str "[",Space,Str "]",Space,Str "foo"]]
- ,[Plain [Str "[x]",Space,Str "bar"]]]]
+[ BulletList
+  [
+    [ Plain [ Str "[", Space, Str "]", Space, Str "foo" ] ]
+  ,
+    [ Plain [ Str "[x]", Space, Str "bar" ] ]
+  ]
+]
 ```
 
 ```

--- a/test/command/hspace.md
+++ b/test/command/hspace.md
@@ -8,7 +8,9 @@ Here they need to be inline:
 \caption{lalune \hspace{2em} \vspace{1em} bloo}
 \end{figure}
 ^D
-[RawBlock (Format "tex") "\\begin{figure}\n\\includegraphics{lalune.jpg}\n\\caption{lalune \\hspace{2em} \\vspace{1em} bloo}\n\\end{figure}"]
+[ RawBlock
+  ( Format "tex" ) "\\begin{figure}\n\\includegraphics{lalune.jpg}\n\\caption{lalune \\hspace{2em} \\vspace{1em} bloo}\n\\end{figure}"
+]
 ```
 
 Here block:
@@ -32,14 +34,18 @@ F & T &\\
 F & F &\\
 \end{tabular}
 ^D
-[RawBlock (Format "tex") "\\begin{tabular}[t]{cc|c}\n\\(P\\) & \\(Q\\) & \\(P\\wedge Q\\)\\\\\n\\hline\nT & T &\\\\\nT & F &\\\\\nF & T &\\\\\nF & F &\\\\\n\\end{tabular}\n\\hspace{1em}\n\\begin{tabular}[t]{cc|c}\n\\(P\\) & \\(Q\\) & \\(P\\vee Q\\)\\\\\n\\hline\nT & T &\\\\\nT & F &\\\\\nF & T &\\\\\nF & F &\\\\\n\\end{tabular}"]
+[ RawBlock
+  ( Format "tex" ) "\\begin{tabular}[t]{cc|c}\n\\(P\\) & \\(Q\\) & \\(P\\wedge Q\\)\\\\\n\\hline\nT & T &\\\\\nT & F &\\\\\nF & T &\\\\\nF & F &\\\\\n\\end{tabular}\n\\hspace{1em}\n\\begin{tabular}[t]{cc|c}\n\\(P\\) & \\(Q\\) & \\(P\\vee Q\\)\\\\\n\\hline\nT & T &\\\\\nT & F &\\\\\nF & T &\\\\\nF & F &\\\\\n\\end{tabular}"
+]
 ```
 
 ```
 % pandoc -f markdown+raw_tex -t native
 hi\hspace{1em}there
 ^D
-[Para [Str "hi",RawInline (Format "tex") "\\hspace{1em}",Str "there"]]
+[ Para
+  [ Str "hi", RawInline ( Format "tex" ) "\\hspace{1em}", Str "there" ]
+]
 ```
 
 ```
@@ -50,7 +56,11 @@ hi
 
 there
 ^D
-[Para [Str "hi"]
-,RawBlock (Format "tex") "\\hspace{1em}"
-,Para [Str "there"]]
+[ Para
+  [ Str "hi" ]
+, RawBlock
+  ( Format "tex" ) "\\hspace{1em}"
+, Para
+  [ Str "there" ]
+]
 ```

--- a/test/command/html-read-figure.md
+++ b/test/command/html-read-figure.md
@@ -5,7 +5,9 @@
   <figcaption>bar</figcaption>
 </figure>
 ^D
-[Para [Image ("",[],[]) [Str "bar"] ("foo.png","fig:voyage")]]
+[ Para
+  [ Image ( "", [], [] ) [ Str "bar" ] ( "foo.png", "fig:voyage" ) ]
+]
 ```
 
 ```
@@ -15,7 +17,9 @@
   <img src="foo.png" title="voyage">
 </figure>
 ^D
-[Para [Image ("",[],[]) [Str "bar"] ("foo.png","fig:voyage")]]
+[ Para
+  [ Image ( "", [], [] ) [ Str "bar" ] ( "foo.png", "fig:voyage" ) ]
+]
 ```
 
 ```
@@ -24,7 +28,7 @@
   <img src="foo.png" title="voyage">
 </figure>
 ^D
-[Para [Image ("",[],[]) [] ("foo.png","fig:voyage")]]
+[ Para [ Image ( "", [], [] ) [] ( "foo.png", "fig:voyage" ) ] ]
 ```
 
 ```
@@ -34,12 +38,20 @@
   <figcaption>bar</figcaption>
 </figure>
 ^D
-[Para [Image ("",[],[]) [Str "bar"] ("foo.png","fig:voyage")]]
+[ Para
+  [ Image ( "", [], [] ) [ Str "bar" ] ( "foo.png", "fig:voyage" ) ]
+]
 ```
 
 ```
 % pandoc -f html -t native
 <figure><img src="foo.png" title="voyage" alt="this is ignored"><figcaption>bar <strong>baz</strong></figcaption></figure>
 ^D
-[Para [Image ("",[],[]) [Str "bar",Space,Strong [Str "baz"]] ("foo.png","fig:voyage")]]
+[ Para
+  [ Image
+    ( "", [], [] )
+    [ Str "bar", Space, Strong [ Str "baz" ] ]
+    ( "foo.png", "fig:voyage" )
+  ]
+]
 ```

--- a/test/command/html-trim-definition-list-terms.md
+++ b/test/command/html-trim-definition-list-terms.md
@@ -11,7 +11,13 @@
     <dd>test</dd>
 </dl>
 ^D
-[DefinitionList
- [([Str "foo",SoftBreak,Str "bar",LineBreak,Str "baz"],
-   [[Plain [Str "test"]]])]]
+[ DefinitionList
+  [
+    (
+      [ Str "foo", SoftBreak, Str "bar", LineBreak, Str "baz" ]
+    ,
+      [ [ Plain [ Str "test" ] ] ]
+    )
+  ]
+]
 ```

--- a/test/command/hyphenat.md
+++ b/test/command/hyphenat.md
@@ -2,48 +2,56 @@
 % pandoc -f latex -t native
 electromagnetic\hyp{}endioscopy
 ^D
-[Para [Str "electromagnetic-endioscopy"]]
+[ Para [ Str "electromagnetic-endioscopy" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 C\colonhyp\bshyp{}Windows\bshyp
 ^D
-[Para [Str "C:\173\\\173Windows\\\173"]]
+[ Para [ Str "C:\173\\\173Windows\\\173" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \fshyp{}usr\fshyp{}share\fshyp
 ^D
-[Para [Str "/\173usr/\173share/\173"]]
+[ Para [ Str "/\173usr/\173share/\173" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \fshyp{}home\fshyp{}schrieveslaach\fshyp\dothyp{}m2
 ^D
-[Para [Str "/\173home/\173schrieveslaach/\173.\173m2"]]
+[ Para [ Str "/\173home/\173schrieveslaach/\173.\173m2" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \nohyphens{Pneumonoultramicroscopicsilicovolcanoconiosis}
 ^D
-[Para [Str "Pneumonoultramicroscopicsilicovolcanoconiosis"]]
+[ Para [ Str "Pneumonoultramicroscopicsilicovolcanoconiosis" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 \textnhtt{Pneumonoultramicroscopicsilicovolcanoconiosis}
 ^D
-[Para [Code ("",[],[]) "Pneumonoultramicroscopicsilicovolcanoconiosis"]]
+[ Para
+  [ Code
+    ( "", [], [] ) "Pneumonoultramicroscopicsilicovolcanoconiosis"
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \nhttfamily{Pneumonoultramicroscopicsilicovolcanoconiosis}
 ^D
-[Para [Code ("",[],[]) "Pneumonoultramicroscopicsilicovolcanoconiosis"]]
+[ Para
+  [ Code
+    ( "", [], [] ) "Pneumonoultramicroscopicsilicovolcanoconiosis"
+  ]
+]
 ```
 

--- a/test/command/ifstrequal.md
+++ b/test/command/ifstrequal.md
@@ -5,5 +5,7 @@
 \h{a}
 \h{b}
 ^D
-[Para [Emph [Str "no"],SoftBreak,Str "\225",SoftBreak,Str "b"]]
+[ Para
+  [ Emph [ Str "no" ], SoftBreak, Str "\225", SoftBreak, Str "b" ]
+]
 ```

--- a/test/command/indented-fences.md
+++ b/test/command/indented-fences.md
@@ -5,7 +5,7 @@
 in y
    ```
 ^D
-[CodeBlock ("",["haskell"],[]) "let x = y\nin y"]
+[ CodeBlock ( "", [ "haskell" ], [] ) "let x = y\nin y" ]
 `````
 `````
 % pandoc -t native
@@ -16,5 +16,5 @@ y +
  y
 ~~~
 ^D
-[CodeBlock ("",["haskell"],[]) " let x = y\nin y +\ny +\ny"]
+[ CodeBlock ( "", [ "haskell" ], [] ) " let x = y\nin y +\ny +\ny" ]
 `````

--- a/test/command/input-with-endinput.md
+++ b/test/command/input-with-endinput.md
@@ -8,7 +8,11 @@ Visible
 Visible
 \end{document}
 ^D
-[Para [Str "Visible"]
-,Para [Emph [Str "hi",Space,Str "there"]]
-,Para [Str "Visible"]]
+[ Para
+  [ Str "Visible" ]
+, Para
+  [ Emph [ Str "hi", Space, Str "there" ] ]
+, Para
+  [ Str "Visible" ]
+]
 ```

--- a/test/command/latex-center.md
+++ b/test/command/latex-center.md
@@ -7,7 +7,6 @@ Hello
 \end{center}
 
 ^D
-[Div ("",["center"],[])
- [Para [Str "Hello"]]]
+[ Div ( "", [ "center" ], [] ) [ Para [ Str "Hello" ] ] ]
 ```
 

--- a/test/command/latex-color.md
+++ b/test/command/latex-color.md
@@ -4,21 +4,42 @@
 % pandoc -f latex -t native
 Hello \textcolor{red}{World}
 ^D
-[Para [Str "Hello",Space,Span ("",[],[("style","color: red")]) [Str "World"]]]
+[ Para
+  [ Str "Hello"
+  , Space
+  , Span
+    ( "", [], [ ( "style", "color: red" ) ] )
+    [ Str "World" ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \textcolor{red}{Hello} World
 ^D
-[Para [Span ("",[],[("style","color: red")]) [Str "Hello"],Space,Str "World"]]
+[ Para
+  [ Span
+    ( "", [], [ ( "style", "color: red" ) ] )
+    [ Str "Hello" ]
+  , Space
+  , Str "World"
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 Hello \textcolor{blue}{\textbf{World}}
 ^D
-[Para [Str "Hello",Space,Span ("",[],[("style","color: blue")]) [Strong [Str "World"]]]]
+[ Para
+  [ Str "Hello"
+  , Space
+  , Span
+    ( "", [], [ ( "style", "color: blue" ) ] )
+    [ Strong [ Str "World" ] ]
+  ]
+]
 ```
 
 
@@ -26,7 +47,15 @@ Hello \textcolor{blue}{\textbf{World}}
 % pandoc -f latex -t native
 Hello \textcolor{blue}{\textbf{World}}.
 ^D
-[Para [Str "Hello",Space,Span ("",[],[("style","color: blue")]) [Strong [Str "World"]],Str "."]]
+[ Para
+  [ Str "Hello"
+  , Space
+  , Span
+    ( "", [], [ ( "style", "color: blue" ) ] )
+    [ Strong [ Str "World" ] ]
+  , Str "."
+  ]
+]
 ```
 
 ```
@@ -38,10 +67,16 @@ Hello \textcolor{blue}{\textbf{World}}.
 \end{itemize}
 }
 ^D
-[Div ("",[],[("style","color: orange")])
- [BulletList
-  [[Para [Str "Item",Space,Str "1"]]
-  ,[Para [Str "Item",Space,Str "2"]]]]]
+[ Div
+  ( "", [], [ ( "style", "color: orange" ) ] )
+  [ BulletList
+    [
+      [ Para [ Str "Item", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "2" ] ]
+    ]
+  ]
+]
 ```
 
 ```
@@ -53,11 +88,18 @@ Hello \textcolor{blue}{\textbf{World}}.
 \end{itemize}
 } some more text
 ^D
-[Div ("",[],[("style","color: blue")])
- [BulletList
-  [[Para [Str "Item",Space,Str "1"]]
-  ,[Para [Str "Item",Space,Str "2"]]]]
-,Para [Str "some",Space,Str "more",Space,Str "text"]]
+[ Div
+  ( "", [], [ ( "style", "color: blue" ) ] )
+  [ BulletList
+    [
+      [ Para [ Str "Item", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "2" ] ]
+    ]
+  ]
+, Para
+  [ Str "some", Space, Str "more", Space, Str "text" ]
+]
 ```
 
 # `\colorbox{}{}`
@@ -67,28 +109,57 @@ Hello \textcolor{blue}{\textbf{World}}.
 % pandoc -f latex -t native
 Hello \colorbox{red}{World}
 ^D
-[Para [Str "Hello",Space,Span ("",[],[("style","background-color: red")]) [Str "World"]]]
+[ Para
+  [ Str "Hello"
+  , Space
+  , Span
+    ( "", [], [ ( "style", "background-color: red" ) ] )
+    [ Str "World" ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 \colorbox{red}{Hello} World
 ^D
-[Para [Span ("",[],[("style","background-color: red")]) [Str "Hello"],Space,Str "World"]]
+[ Para
+  [ Span
+    ( "", [], [ ( "style", "background-color: red" ) ] )
+    [ Str "Hello" ]
+  , Space
+  , Str "World"
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 Hello \colorbox{blue}{\textbf{World}}
 ^D
-[Para [Str "Hello",Space,Span ("",[],[("style","background-color: blue")]) [Strong [Str "World"]]]]
+[ Para
+  [ Str "Hello"
+  , Space
+  , Span
+    ( "", [], [ ( "style", "background-color: blue" ) ] )
+    [ Strong [ Str "World" ] ]
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 Hello \colorbox{blue}{\textbf{World}}.
 ^D
-[Para [Str "Hello",Space,Span ("",[],[("style","background-color: blue")]) [Strong [Str "World"]],Str "."]]
+[ Para
+  [ Str "Hello"
+  , Space
+  , Span
+    ( "", [], [ ( "style", "background-color: blue" ) ] )
+    [ Strong [ Str "World" ] ]
+  , Str "."
+  ]
+]
 ```
 
 ```
@@ -102,10 +173,16 @@ Hello \colorbox{blue}{\textbf{World}}.
 \end{minipage}
 }
 ^D
-[Div ("",[],[("style","background-color: orange")])
- [BulletList
-  [[Para [Str "Item",Space,Str "1"]]
-  ,[Para [Str "Item",Space,Str "2"]]]]]
+[ Div
+  ( "", [], [ ( "style", "background-color: orange" ) ] )
+  [ BulletList
+    [
+      [ Para [ Str "Item", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "2" ] ]
+    ]
+  ]
+]
 ```
 
 ```
@@ -119,9 +196,16 @@ Hello \colorbox{blue}{\textbf{World}}.
 \end{minipage}
 } some more text
 ^D
-[Div ("",[],[("style","background-color: blue")])
- [BulletList
-  [[Para [Str "Item",Space,Str "1"]]
-  ,[Para [Str "Item",Space,Str "2"]]]]
-,Para [Str "some",Space,Str "more",Space,Str "text"]]
+[ Div
+  ( "", [], [ ( "style", "background-color: blue" ) ] )
+  [ BulletList
+    [
+      [ Para [ Str "Item", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "2" ] ]
+    ]
+  ]
+, Para
+  [ Str "some", Space, Str "more", Space, Str "text" ]
+]
 ```

--- a/test/command/latex-command-comment.md
+++ b/test/command/latex-command-comment.md
@@ -3,5 +3,5 @@
 \emph%
 {hi}
 ^D
-[Para [Emph [Str "hi"]]]
+[ Para [ Emph [ Str "hi" ] ] ]
 ```

--- a/test/command/latex-fontawesome.md
+++ b/test/command/latex-fontawesome.md
@@ -2,12 +2,12 @@
 % pandoc -f latex -t native
 Check: \faCheck
 ^D
-[Para [Str "Check:",Space,Str "\10003"]]
+[ Para [ Str "Check:", Space, Str "\10003" ] ]
 ```
 
 ```
 % pandoc -f latex -t native
 Close: \faClose
 ^D
-[Para [Str "Close:",Space,Str "\10007"]]
+[ Para [ Str "Close:", Space, Str "\10007" ] ]
 ```

--- a/test/command/latex-tabular-column-specs.md
+++ b/test/command/latex-tabular-column-specs.md
@@ -11,35 +11,79 @@ f      & 0.5    & 5,5  \\
 \bottomrule
 \end{tabular}
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Math InlineMath ""]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Math InlineMath "f1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Math InlineMath "f2"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Math InlineMath "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Math InlineMath "0.5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Math InlineMath "4"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Math InlineMath "f"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Math InlineMath "0.5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Math InlineMath "5,5"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "f1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "f2" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "e" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "0.5" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "4" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "f" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "0.5" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Math InlineMath "5,5" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/lettrine.md
+++ b/test/command/lettrine.md
@@ -4,6 +4,23 @@
 
 \lettrine[lhang=0.17]{A}{category} is
 ^D
-[Para [Span ("",["lettrine"],[]) [Str "A"],SmallCaps [Str "category"],Space,Str "is"]
-,Para [Span ("",["lettrine"],[]) [Str "A"],SmallCaps [Str "category"],Space,Str "is"]]
+[ Para
+  [ Span
+    ( "", [ "lettrine" ], [] )
+    [ Str "A" ]
+  , SmallCaps
+    [ Str "category" ]
+  , Space
+  , Str "is"
+  ]
+, Para
+  [ Span
+    ( "", [ "lettrine" ], [] )
+    [ Str "A" ]
+  , SmallCaps
+    [ Str "category" ]
+  , Space
+  , Str "is"
+  ]
+]
 ```

--- a/test/command/lstlisting.md
+++ b/test/command/lstlisting.md
@@ -8,7 +8,19 @@ public class World {
 }
 \end{lstlisting}
 ^D
-[CodeBlock ("lst:Hello-World",["java"],[("language","Java"),("caption","Java Example"),("label","lst:Hello-World")]) "public class World {\n    public static void main(String[] args) {\n        System.out.println(\"Hello World\");\n    }\n}"]
+[ CodeBlock
+  ( "lst:Hello-World"
+  , [ "java" ]
+  ,
+    [
+      ( "language", "Java" )
+    ,
+      ( "caption", "Java Example" )
+    ,
+      ( "label", "lst:Hello-World" )
+    ]
+  ) "public class World {\n    public static void main(String[] args) {\n        System.out.println(\"Hello World\");\n    }\n}"
+]
 ```
 
 ```
@@ -21,5 +33,19 @@ public class World {
 }
 \end{lstlisting}
 ^D
-[CodeBlock ("lst:Hello-World",["java"],[("language","Java"),("escapechar","|"),("caption","Java Example"),("label","lst:Hello-World")]) "public class World {\n    public static void main(String[] args) {\n        System.out.println(\"Hello World\");\n    }\n}"]
+[ CodeBlock
+  ( "lst:Hello-World"
+  , [ "java" ]
+  ,
+    [
+      ( "language", "Java" )
+    ,
+      ( "escapechar", "|" )
+    ,
+      ( "caption", "Java Example" )
+    ,
+      ( "label", "lst:Hello-World" )
+    ]
+  ) "public class World {\n    public static void main(String[] args) {\n        System.out.println(\"Hello World\");\n    }\n}"
+]
 ```

--- a/test/command/macro-defs-in-preamble.md
+++ b/test/command/macro-defs-in-preamble.md
@@ -9,8 +9,13 @@
 $\vara \varb$
 \end{document}
 ^D
-Pandoc (Meta {unMeta = fromList []})
-[RawBlock (Format "latex") "\\newcommand{\\vara}{\\alpha}"
-,RawBlock (Format "latex") "\\newcommand{\\varb}{b}"
-,Para [Math InlineMath "\\vara \\varb"]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ RawBlock
+    ( Format "latex" ) "\\newcommand{\\vara}{\\alpha}"
+  , RawBlock
+    ( Format "latex" ) "\\newcommand{\\varb}{b}"
+  , Para
+    [ Math InlineMath "\\vara \\varb" ]
+  ]
 ```

--- a/test/command/md-abbrevs.md
+++ b/test/command/md-abbrevs.md
@@ -6,7 +6,7 @@ space from being inserted in LaTeX output).
 % pandoc -t native
 Mr. Bob
 ^D
-[Para [Str "Mr.\160Bob"]]
+[ Para [ Str "Mr.\160Bob" ] ]
 ```
 
 If you don't want this to happen you can escape the period:
@@ -15,6 +15,6 @@ If you don't want this to happen you can escape the period:
 % pandoc -t native
 Hi Mr\. Bob
 ^D
-[Para [Str "Hi",Space,Str "Mr.",Space,Str "Bob"]]
+[ Para [ Str "Hi", Space, Str "Mr.", Space, Str "Bob" ] ]
 ```
 

--- a/test/command/multiple-metadata-blocks.md
+++ b/test/command/multiple-metadata-blocks.md
@@ -10,6 +10,8 @@ foo: bar
 foo: bim
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaInlines [Str "bim"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList [ ( "foo", MetaInlines [ Str "bim" ] ) ] }
+  ) []
 ```

--- a/test/command/refs.md
+++ b/test/command/refs.md
@@ -2,21 +2,57 @@
 % pandoc -f latex -t native
 Figure \ref{fig:1}
 ^D
-[Para [Str "Figure",Space,Link ("",[],[("reference-type","ref"),("reference","fig:1")]) [Str "[fig:1]"] ("#fig:1","")]]
+[ Para
+  [ Str "Figure"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "fig:1" ) ]
+    )
+    [ Str "[fig:1]" ]
+    ( "#fig:1", "" )
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 Figure \cref{fig:1}
 ^D
-[Para [Str "Figure",Space,Link ("",[],[("reference-type","ref"),("reference","fig:1")]) [Str "[fig:1]"] ("#fig:1","")]]
+[ Para
+  [ Str "Figure"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "fig:1" ) ]
+    )
+    [ Str "[fig:1]" ]
+    ( "#fig:1", "" )
+  ]
+]
 ```
 
 ```
 % pandoc -f latex -t native
 Figure \vref{fig:1}
 ^D
-[Para [Str "Figure",Space,Link ("",[],[("reference-type","ref+page"),("reference","fig:1")]) [Str "[fig:1]"] ("#fig:1","")]]
+[ Para
+  [ Str "Figure"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref+page" ), ( "reference", "fig:1" ) ]
+    )
+    [ Str "[fig:1]" ]
+    ( "#fig:1", "" )
+  ]
+]
 ```
 
 ```
@@ -28,8 +64,38 @@ Accuracy~\eqref{eq:Accuracy} is the proportion, measuring true results among all
   Accuracy = \frac{t_p + t_n}{t_p + f_p + f_n + t_n}
 \end{equation}
 ^D
-[Para [Str "Accuracy\160",Link ("",[],[("reference-type","eqref"),("reference","eq:Accuracy")]) [Str "[eq:Accuracy]"] ("#eq:Accuracy",""),Space,Str "is",Space,Str "the",Space,Str "proportion,",Space,Str "measuring",Space,Str "true",Space,Str "results",Space,Str "among",Space,Str "all",Space,Str "results."]
-,Para [Math DisplayMath "\\label{eq:Accuracy}\n  Accuracy = \\frac{t_p + t_n}{t_p + f_p + f_n + t_n}"]]
+[ Para
+  [ Str "Accuracy\160"
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "eqref" ), ( "reference", "eq:Accuracy" ) ]
+    )
+    [ Str "[eq:Accuracy]" ]
+    ( "#eq:Accuracy", "" )
+  , Space
+  , Str "is"
+  , Space
+  , Str "the"
+  , Space
+  , Str "proportion,"
+  , Space
+  , Str "measuring"
+  , Space
+  , Str "true"
+  , Space
+  , Str "results"
+  , Space
+  , Str "among"
+  , Space
+  , Str "all"
+  , Space
+  , Str "results."
+  ]
+, Para
+  [ Math DisplayMath "\\label{eq:Accuracy}\n  Accuracy = \\frac{t_p + t_n}{t_p + f_p + f_n + t_n}" ]
+]
 ```
 
 ```
@@ -42,8 +108,33 @@ Accuracy~\eqref{eq:Accuracy} is the proportion, measuring true results among all
 
 Figure \ref{fig:Logo} illustrated the SVG logo
 ^D
-[Para [Image ("fig:Logo",[],[]) [Str "Logo"] ("command/SVG_logo.svg","fig:")]
-,Para [Str "Figure",Space,Link ("",[],[("reference-type","ref"),("reference","fig:Logo")]) [Str "1"] ("#fig:Logo",""),Space,Str "illustrated",Space,Str "the",Space,Str "SVG",Space,Str "logo"]]
+[ Para
+  [ Image
+    ( "fig:Logo", [], [] )
+    [ Str "Logo" ]
+    ( "command/SVG_logo.svg", "fig:" )
+  ]
+, Para
+  [ Str "Figure"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "fig:Logo" ) ]
+    )
+    [ Str "1" ]
+    ( "#fig:Logo", "" )
+  , Space
+  , Str "illustrated"
+  , Space
+  , Str "the"
+  , Space
+  , Str "SVG"
+  , Space
+  , Str "logo"
+  ]
+]
 ```
 
 ```
@@ -77,15 +168,94 @@ Figure \ref{fig:Logo2} illustrated the SVG logo
 
 Figure \ref{fig:Logo3} illustrated the SVG logo
 ^D
-[Header 1 ("one",[],[]) [Str "One"]
-,Para [Image ("fig:Logo",[],[]) [Str "Logo"] ("command/SVG_logo.svg","fig:")]
-,Para [Image ("fig:Logo2",[],[]) [Str "Logo2"] ("command/SVG_logo2.svg","fig:")]
-,Header 1 ("two",[],[]) [Str "Two"]
-,Header 2 ("subone",[],[]) [Str "Subone"]
-,Para [Image ("fig:Logo3",[],[]) [Str "Logo3"] ("command/SVG_logo3.svg","fig:")]
-,Para [Str "Figure",Space,Link ("",[],[("reference-type","ref"),("reference","fig:Logo")]) [Str "1.1"] ("#fig:Logo",""),Space,Str "illustrated",Space,Str "the",Space,Str "SVG",Space,Str "logo"]
-,Para [Str "Figure",Space,Link ("",[],[("reference-type","ref"),("reference","fig:Logo2")]) [Str "1.2"] ("#fig:Logo2",""),Space,Str "illustrated",Space,Str "the",Space,Str "SVG",Space,Str "logo"]
-,Para [Str "Figure",Space,Link ("",[],[("reference-type","ref"),("reference","fig:Logo3")]) [Str "2.1"] ("#fig:Logo3",""),Space,Str "illustrated",Space,Str "the",Space,Str "SVG",Space,Str "logo"]]
+[ Header 1
+  ( "one", [], [] )
+  [ Str "One" ]
+, Para
+  [ Image
+    ( "fig:Logo", [], [] )
+    [ Str "Logo" ]
+    ( "command/SVG_logo.svg", "fig:" )
+  ]
+, Para
+  [ Image
+    ( "fig:Logo2", [], [] )
+    [ Str "Logo2" ]
+    ( "command/SVG_logo2.svg", "fig:" )
+  ]
+, Header 1
+  ( "two", [], [] )
+  [ Str "Two" ]
+, Header 2
+  ( "subone", [], [] )
+  [ Str "Subone" ]
+, Para
+  [ Image
+    ( "fig:Logo3", [], [] )
+    [ Str "Logo3" ]
+    ( "command/SVG_logo3.svg", "fig:" )
+  ]
+, Para
+  [ Str "Figure"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "fig:Logo" ) ]
+    )
+    [ Str "1.1" ]
+    ( "#fig:Logo", "" )
+  , Space
+  , Str "illustrated"
+  , Space
+  , Str "the"
+  , Space
+  , Str "SVG"
+  , Space
+  , Str "logo"
+  ]
+, Para
+  [ Str "Figure"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "fig:Logo2" ) ]
+    )
+    [ Str "1.2" ]
+    ( "#fig:Logo2", "" )
+  , Space
+  , Str "illustrated"
+  , Space
+  , Str "the"
+  , Space
+  , Str "SVG"
+  , Space
+  , Str "logo"
+  ]
+, Para
+  [ Str "Figure"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "fig:Logo3" ) ]
+    )
+    [ Str "2.1" ]
+    ( "#fig:Logo3", "" )
+  , Space
+  , Str "illustrated"
+  , Space
+  , Str "the"
+  , Space
+  , Str "SVG"
+  , Space
+  , Str "logo"
+  ]
+]
 ```
 
 
@@ -93,5 +263,21 @@ Figure \ref{fig:Logo3} illustrated the SVG logo
 % pandoc -f latex -t native
 \label{section} Section \ref{section}
 ^D
-[Para [Span ("section",[],[("label","section")]) [Str "[section]"],Space,Str "Section",Space,Link ("",[],[("reference-type","ref"),("reference","section")]) [Str "[section]"] ("#section","")]]
+[ Para
+  [ Span
+    ( "section", [], [ ( "label", "section" ) ] )
+    [ Str "[section]" ]
+  , Space
+  , Str "Section"
+  , Space
+  , Link
+    ( ""
+    , []
+    ,
+      [ ( "reference-type", "ref" ), ( "reference", "section" ) ]
+    )
+    [ Str "[section]" ]
+    ( "#section", "" )
+  ]
+]
 ```

--- a/test/command/setext-fenced-div.md
+++ b/test/command/setext-fenced-div.md
@@ -4,6 +4,5 @@
 ---
 :::
 ^D
-[Div ("",["cell"],[])
- [HorizontalRule]]
+[ Div ( "", [ "cell" ], [] ) [ HorizontalRule ] ]
 ```

--- a/test/command/shift-heading-level-by.md
+++ b/test/command/shift-heading-level-by.md
@@ -8,9 +8,19 @@ title: My title
 
 ## Second
 ^D
-Pandoc (Meta {unMeta = fromList [("title",MetaInlines [Str "My",Space,Str "title"])]})
-[Header 2 ("first-heading",[],[]) [Str "First",Space,Str "heading"]
-,Header 3 ("second",[],[]) [Str "Second"]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [ ( "title", MetaInlines [ Str "My", Space, Str "title" ] ) ]
+    }
+  )
+  [ Header 2
+    ( "first-heading", [], [] )
+    [ Str "First", Space, Str "heading" ]
+  , Header 3
+    ( "second", [], [] )
+    [ Str "Second" ]
+  ]
 ```
 
 ```
@@ -25,8 +35,17 @@ title: Old title
 
 # Another top-level heading
 ^D
-Pandoc (Meta {unMeta = fromList [("title",MetaInlines [Str "First",Space,Str "heading"])]})
-[Header 1 ("second",[],[]) [Str "Second"]
-,Para [Str "Another",Space,Str "top-level",Space,Str "heading"]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [ ( "title", MetaInlines [ Str "First", Space, Str "heading" ] ) ]
+    }
+  )
+  [ Header 1
+    ( "second", [], [] )
+    [ Str "Second" ]
+  , Para
+    [ Str "Another", Space, Str "top-level", Space, Str "heading" ]
+  ]
 ```
 

--- a/test/command/sloppypar.md
+++ b/test/command/sloppypar.md
@@ -6,8 +6,111 @@ Sequi id qui facere et incidunt ut. Et fuga ut voluptate enim qui. Odit unde mag
 Qui et temporibus explicabo. Esse ab ut quidem. Vel qui perspiciatis quae odio consectetur alias non sed. Quo consectetur libero omnis quos eius ad vel.
 \end{sloppypar}
 ^D
-[Para [Str "Sequi",Space,Str "id",Space,Str "qui",Space,Str "facere",Space,Str "et",Space,Str "incidunt",Space,Str "ut.",Space,Str "Et",Space,Str "fuga",Space,Str "ut",Space,Str "voluptate",Space,Str "enim",Space,Str "qui.",Space,Str "Odit",Space,Str "unde",Space,Str "magni",Space,Str "ipsam",Space,Str "dicta",Space,Str "modi.",Space,Str "Modi",Space,Str "soluta",Space,Str "velit",Space,Str "est",Space,Str "aut",Space,Str "aut",Space,Str "possimus."]
-,Para [Str "Qui",Space,Str "et",Space,Str "temporibus",Space,Str "explicabo.",Space,Str "Esse",Space,Str "ab",Space,Str "ut",Space,Str "quidem.",Space,Str "Vel",Space,Str "qui",Space,Str "perspiciatis",Space,Str "quae",Space,Str "odio",Space,Str "consectetur",Space,Str "alias",Space,Str "non",Space,Str "sed.",Space,Str "Quo",Space,Str "consectetur",Space,Str "libero",Space,Str "omnis",Space,Str "quos",Space,Str "eius",Space,Str "ad",Space,Str "vel."]]
+[ Para
+  [ Str "Sequi"
+  , Space
+  , Str "id"
+  , Space
+  , Str "qui"
+  , Space
+  , Str "facere"
+  , Space
+  , Str "et"
+  , Space
+  , Str "incidunt"
+  , Space
+  , Str "ut."
+  , Space
+  , Str "Et"
+  , Space
+  , Str "fuga"
+  , Space
+  , Str "ut"
+  , Space
+  , Str "voluptate"
+  , Space
+  , Str "enim"
+  , Space
+  , Str "qui."
+  , Space
+  , Str "Odit"
+  , Space
+  , Str "unde"
+  , Space
+  , Str "magni"
+  , Space
+  , Str "ipsam"
+  , Space
+  , Str "dicta"
+  , Space
+  , Str "modi."
+  , Space
+  , Str "Modi"
+  , Space
+  , Str "soluta"
+  , Space
+  , Str "velit"
+  , Space
+  , Str "est"
+  , Space
+  , Str "aut"
+  , Space
+  , Str "aut"
+  , Space
+  , Str "possimus."
+  ]
+, Para
+  [ Str "Qui"
+  , Space
+  , Str "et"
+  , Space
+  , Str "temporibus"
+  , Space
+  , Str "explicabo."
+  , Space
+  , Str "Esse"
+  , Space
+  , Str "ab"
+  , Space
+  , Str "ut"
+  , Space
+  , Str "quidem."
+  , Space
+  , Str "Vel"
+  , Space
+  , Str "qui"
+  , Space
+  , Str "perspiciatis"
+  , Space
+  , Str "quae"
+  , Space
+  , Str "odio"
+  , Space
+  , Str "consectetur"
+  , Space
+  , Str "alias"
+  , Space
+  , Str "non"
+  , Space
+  , Str "sed."
+  , Space
+  , Str "Quo"
+  , Space
+  , Str "consectetur"
+  , Space
+  , Str "libero"
+  , Space
+  , Str "omnis"
+  , Space
+  , Str "quos"
+  , Space
+  , Str "eius"
+  , Space
+  , Str "ad"
+  , Space
+  , Str "vel."
+  ]
+]
 ```
 
 ```
@@ -18,6 +121,109 @@ Sequi id qui facere et incidunt ut. Et fuga ut voluptate enim qui. Odit unde mag
 Qui et temporibus explicabo. Esse ab ut quidem. Vel qui perspiciatis quae odio consectetur alias non sed. Quo consectetur libero omnis quos eius ad vel.
 \end{sloppypar}
 ^D
-[Para [Str "Sequi",Space,Str "id",Space,Str "qui",Space,Str "facere",Space,Str "et",Space,Str "incidunt",Space,Str "ut.",Space,Str "Et",Space,Str "fuga",Space,Str "ut",Space,Str "voluptate",Space,Str "enim",Space,Str "qui.",Space,Str "Odit",Space,Str "unde",Space,Str "magni",Space,Str "ipsam",Space,Str "dicta",Space,Str "modi.",Space,Str "Modi",Space,Str "soluta",Space,Str "velit",Space,Str "est",Space,Str "aut",Space,Str "aut",Space,Str "possimus."]
-,Para [Str "Qui",Space,Str "et",Space,Str "temporibus",Space,Str "explicabo.",Space,Str "Esse",Space,Str "ab",Space,Str "ut",Space,Str "quidem.",Space,Str "Vel",Space,Str "qui",Space,Str "perspiciatis",Space,Str "quae",Space,Str "odio",Space,Str "consectetur",Space,Str "alias",Space,Str "non",Space,Str "sed.",Space,Str "Quo",Space,Str "consectetur",Space,Str "libero",Space,Str "omnis",Space,Str "quos",Space,Str "eius",Space,Str "ad",Space,Str "vel."]]
+[ Para
+  [ Str "Sequi"
+  , Space
+  , Str "id"
+  , Space
+  , Str "qui"
+  , Space
+  , Str "facere"
+  , Space
+  , Str "et"
+  , Space
+  , Str "incidunt"
+  , Space
+  , Str "ut."
+  , Space
+  , Str "Et"
+  , Space
+  , Str "fuga"
+  , Space
+  , Str "ut"
+  , Space
+  , Str "voluptate"
+  , Space
+  , Str "enim"
+  , Space
+  , Str "qui."
+  , Space
+  , Str "Odit"
+  , Space
+  , Str "unde"
+  , Space
+  , Str "magni"
+  , Space
+  , Str "ipsam"
+  , Space
+  , Str "dicta"
+  , Space
+  , Str "modi."
+  , Space
+  , Str "Modi"
+  , Space
+  , Str "soluta"
+  , Space
+  , Str "velit"
+  , Space
+  , Str "est"
+  , Space
+  , Str "aut"
+  , Space
+  , Str "aut"
+  , Space
+  , Str "possimus."
+  ]
+, Para
+  [ Str "Qui"
+  , Space
+  , Str "et"
+  , Space
+  , Str "temporibus"
+  , Space
+  , Str "explicabo."
+  , Space
+  , Str "Esse"
+  , Space
+  , Str "ab"
+  , Space
+  , Str "ut"
+  , Space
+  , Str "quidem."
+  , Space
+  , Str "Vel"
+  , Space
+  , Str "qui"
+  , Space
+  , Str "perspiciatis"
+  , Space
+  , Str "quae"
+  , Space
+  , Str "odio"
+  , Space
+  , Str "consectetur"
+  , Space
+  , Str "alias"
+  , Space
+  , Str "non"
+  , Space
+  , Str "sed."
+  , Space
+  , Str "Quo"
+  , Space
+  , Str "consectetur"
+  , Space
+  , Str "libero"
+  , Space
+  , Str "omnis"
+  , Space
+  , Str "quos"
+  , Space
+  , Str "eius"
+  , Space
+  , Str "ad"
+  , Space
+  , Str "vel."
+  ]
+]
 ```

--- a/test/command/table-with-cell-align.md
+++ b/test/command/table-with-cell-align.md
@@ -13,27 +13,49 @@
 </tgroup>
 </informaltable>
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignLeft (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignRight (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignLeft
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "2" ] ]
+      , Cell
+        ( "", [], [] ) AlignRight
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "3" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "4" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 ```
 % pandoc -f native -t opendocument --quiet

--- a/test/command/table-with-column-span.md
+++ b/test/command/table-with-column-span.md
@@ -49,73 +49,163 @@
 </tgroup>
 </informaltable>
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)
- ,(AlignDefault,ColWidth 6.25e-2)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 8)
-    [Para [Strong [Str "Octet",Space,Str "no.",Space,Str "1"]]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 8)
-    [Para [Strong [Str "Octet",Space,Str "no.",Space,Str "2"]]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "16"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "15"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "14"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "13"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "12"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "11"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "10"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "9"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "8"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "7"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 8)
-    [Para [Str "Code",Space,Str "A"]]
-   ,Cell ("",[],[]) AlignCenter (RowSpan 1) (ColSpan 8)
-    [Para [Str "Code",Space,Str "B"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ,
+    ( AlignDefault, ColWidth 6.25 e- 2 )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 8 )
+        [ Para
+          [ Strong [ Str "Octet", Space, Str "no.", Space, Str "1" ] ]
+        ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 8 )
+        [ Para
+          [ Strong [ Str "Octet", Space, Str "no.", Space, Str "2" ] ]
+        ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "16" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "15" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "14" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "13" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "11" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "10" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "9" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "8" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "7" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "6" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "5" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "4" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "3" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "2" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Para [ Str "1" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 8 )
+        [ Para [ Str "Code", Space, Str "A" ] ]
+      , Cell
+        ( "", [], [] ) AlignCenter
+        ( RowSpan 1 )
+        ( ColSpan 8 )
+        [ Para [ Str "Code", Space, Str "B" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 ```
 % pandoc -f native -t opendocument --quiet

--- a/test/command/tabularx.md
+++ b/test/command/tabularx.md
@@ -20,44 +20,99 @@
 \hline
 \end{tabularx}
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.3"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "3" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.3" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.3" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.3" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 
 ```
@@ -82,44 +137,99 @@
 \hline
 \end{tabularx}
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignLeft,ColWidth 0.25)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.3"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidth 0.25 )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "3" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.3" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.3" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.3" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```
 
 ```
@@ -144,42 +254,97 @@
 \hline
 \end{tabularx}
 ^D
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidth 0.25)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignLeft,ColWidth 0.25)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Column",Space,Str "Heading",Space,Str "3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1.3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2.3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3.3"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignLeft, ColWidth 0.25 )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidth 0.25 )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Column", Space, Str "Heading", Space, Str "3" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "1.3" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "2.3" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Cell", Space, Str "3.3" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]
 ```

--- a/test/command/translations.md
+++ b/test/command/translations.md
@@ -2,14 +2,14 @@
 % pandoc -f latex -t native -M lang=en
 \figurename\ 2
 ^D
-[Para [Str "Figure\160\&2"]]
+[ Para [ Str "Figure\160\&2" ] ]
 ```
 
 ```
 % pandoc -f latex -t native -M lang=de-DE
 \figurename\ 2
 ^D
-[Para [Str "Abbildung\160\&2"]]
+[ Para [ Str "Abbildung\160\&2" ] ]
 ```
 
 ```
@@ -17,7 +17,7 @@
 \setmainlanguage{german}
 \figurename 2
 ^D
-[Para [Str "Abbildung2"]]
+[ Para [ Str "Abbildung2" ] ]
 ```
 
 ```
@@ -25,5 +25,5 @@
 \figurename~2
 \figurename.
 ^D
-[Para [Str "Slika\160\&2",SoftBreak,Str "Slika."]]
+[ Para [ Str "Slika\160\&2", SoftBreak, Str "Slika." ] ]
 ```

--- a/test/command/write18.md
+++ b/test/command/write18.md
@@ -3,12 +3,12 @@ Handle \write18{..} as raw tex:
 % pandoc -t native
 \write18{git --version}
 ^D
-[RawBlock (Format "tex") "\\write18{git --version}"]
+[ RawBlock ( Format "tex" ) "\\write18{git --version}" ]
 ```
 
 ```
 % pandoc -f latex+raw_tex -t native
 \write18{git --version}
 ^D
-[RawBlock (Format "latex") "\\write18{git --version}"]
+[ RawBlock ( Format "latex" ) "\\write18{git --version}" ]
 ```

--- a/test/command/yaml-metadata-blocks.md
+++ b/test/command/yaml-metadata-blocks.md
@@ -6,8 +6,10 @@ foo:
   bar_: as should this
 ---
 ^D
-Pandoc (Meta {unMeta = fromList [("foo",MetaMap (fromList []))]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList [ ( "foo", MetaMap ( fromList [] ) ) ] }
+  ) []
 ```
 ```
 % pandoc -s -t native
@@ -32,8 +34,47 @@ nested:
   scientific: 3.7e-5
 ---
 ^D
-Pandoc (Meta {unMeta = fromList [("bool",MetaBool True),("empty",MetaList []),("float",MetaInlines [Str "1.5"]),("int",MetaInlines [Str "7"]),("more",MetaBool False),("nested",MetaMap (fromList [("bool",MetaBool True),("empty",MetaList []),("float",MetaInlines [Str "2.5"]),("int",MetaInlines [Str "8"]),("more",MetaBool False),("nothing",MetaInlines [Str "null"]),("scientific",MetaInlines [Str "3.7e-5"])])),("nothing",MetaInlines [Str "null"]),("scientific",MetaInlines [Str "3.7e-5"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "bool", MetaBool True )
+      ,
+        ( "empty", MetaList [] )
+      ,
+        ( "float", MetaInlines [ Str "1.5" ] )
+      ,
+        ( "int", MetaInlines [ Str "7" ] )
+      ,
+        ( "more", MetaBool False )
+      ,
+        ( "nested"
+        , MetaMap
+          ( fromList
+            [
+              ( "bool", MetaBool True )
+            ,
+              ( "empty", MetaList [] )
+            ,
+              ( "float", MetaInlines [ Str "2.5" ] )
+            ,
+              ( "int", MetaInlines [ Str "8" ] )
+            ,
+              ( "more", MetaBool False )
+            ,
+              ( "nothing", MetaInlines [ Str "null" ] )
+            ,
+              ( "scientific", MetaInlines [ Str "3.7e-5" ] )
+            ]
+          )
+        )
+      ,
+        ( "nothing", MetaInlines [ Str "null" ] )
+      ,
+        ( "scientific", MetaInlines [ Str "3.7e-5" ] )
+      ]
+    }
+  ) []
 ```
 ```
 % pandoc -s -t native
@@ -43,8 +84,21 @@ array:
   - bool: True
 ---
 ^D
-Pandoc (Meta {unMeta = fromList [("array",MetaList [MetaMap (fromList [("foo",MetaInlines [Str "bar"])]),MetaMap (fromList [("bool",MetaBool True)])])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "array"
+        , MetaList
+          [ MetaMap
+            ( fromList [ ( "foo", MetaInlines [ Str "bar" ] ) ] )
+          , MetaMap
+            ( fromList [ ( "bool", MetaBool True ) ] )
+          ]
+        )
+      ]
+    }
+  ) []
 ```
 ```
 % pandoc -s -t native --metadata-file command/yaml-metadata.yaml
@@ -52,12 +106,34 @@ Pandoc (Meta {unMeta = fromList [("array",MetaList [MetaMap (fromList [("foo",Me
 title: document
 ---
 ^D
-Pandoc (Meta {unMeta = fromList [("other",MetaInlines [Emph [Str "markdown"],Space,Str "value"]),("title",MetaInlines [Str "document"])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "other"
+        , MetaInlines
+          [ Emph [ Str "markdown" ], Space, Str "value" ]
+        )
+      ,
+        ( "title", MetaInlines [ Str "document" ] )
+      ]
+    }
+  ) []
 ```
 ```
 % pandoc -s -t native --metadata-file command/yaml-metadata.yaml -M title=cmdline
 ^D
-Pandoc (Meta {unMeta = fromList [("other",MetaInlines [Emph [Str "markdown"],Space,Str "value"]),("title",MetaString "cmdline")]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "other"
+        , MetaInlines
+          [ Emph [ Str "markdown" ], Space, Str "value" ]
+        )
+      ,
+        ( "title", MetaString "cmdline" )
+      ]
+    }
+  ) []
 ```

--- a/test/command/yaml-with-chomp.md
+++ b/test/command/yaml-with-chomp.md
@@ -7,6 +7,15 @@ ml: |-
     BLOCK
 ...
 ^D
-Pandoc (Meta {unMeta = fromList [("ml",MetaBlocks [Para [Str "TEST"],Plain [Str "BLOCK"]])]})
-[]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "ml"
+        , MetaBlocks
+          [ Para [ Str "TEST" ], Plain [ Str "BLOCK" ] ]
+        )
+      ]
+    }
+  ) []
 ```

--- a/test/creole-reader.native
+++ b/test/creole-reader.native
@@ -1,132 +1,992 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("",[],[]) [Str "Top-level heading (1)"]
-,Header 2 ("",[],[]) [Str "This a test for creole 0.1 (2)"]
-,Header 3 ("",[],[]) [Str "This is a Subheading (3)"]
-,Header 4 ("",[],[]) [Str "Subsub (4)"]
-,Header 5 ("",[],[]) [Str "Subsubsub (5)"]
-,Para [Str "The",Space,Str "ending",Space,Str "equal",Space,Str "signs",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "displayed:"]
-,Header 1 ("",[],[]) [Str "Top-level heading (1)"]
-,Header 2 ("",[],[]) [Str "This a test for creole 0.1 (2)"]
-,Header 3 ("",[],[]) [Str "This is a Subheading (3)"]
-,Header 4 ("",[],[]) [Str "Subsub (4)"]
-,Header 5 ("",[],[]) [Str "Subsubsub (5)"]
-,Para [Str "You",Space,Str "can",Space,Str "make",Space,Str "things",Space,Strong [Str "bold"],Space,Str "or",Space,Emph [Str "italic"],Space,Str "or",Space,Strong [Emph [Str "both"]],Space,Str "or",Space,Emph [Strong [Str "both"]],Str "."]
-,Para [Str "Character",Space,Str "formatting",Space,Str "extends",Space,Str "across",Space,Str "line",Space,Str "breaks:",Space,Strong [Str "bold,",Space,Str "this",Space,Str "is",Space,Str "still",Space,Str "bold.",Space,Str "This",Space,Str "line",Space,Str "deliberately",Space,Str "does",Space,Str "not",Space,Str "end",Space,Str "in",Space,Str "star-star."]]
-,Para [Str "Not",Space,Str "bold.",Space,Str "Character",Space,Str "formatting",Space,Str "does",Space,Str "not",Space,Str "cross",Space,Str "paragraph",Space,Str "boundaries."]
-,Para [Str "You",Space,Str "can",Space,Str "use",Space,Link ("",[],[]) [Str "internal links"] ("internal links",""),Space,Str "or",Space,Link ("",[],[]) [Str "external links"] ("http://www.wikicreole.org",""),Str ",",Space,Str "give",Space,Str "the",Space,Str "link",Space,Str "a",Space,Link ("",[],[]) [Str "different"] ("internal links",""),Space,Str "name."]
-,Para [Str "Here's",Space,Str "another",Space,Str "sentence:",Space,Str "This",Space,Str "wisdom",Space,Str "is",Space,Str "taken",Space,Str "from",Space,Link ("",[],[]) [Str "Ward Cunningham's"] ("Ward Cunningham's",""),Space,Link ("",[],[]) [Str "Presentation at the Wikisym 06"] ("http://www.c2.com/doc/wikisym/WikiSym2006.pdf",""),Str "."]
-,Para [Str "Here's",Space,Str "a",Space,Str "external",Space,Str "link",Space,Str "without",Space,Str "a",Space,Str "description:",Space,Link ("",[],[]) [Str "http://www.wikicreole.org"] ("http://www.wikicreole.org","")]
-,Para [Str "Be",Space,Str "careful",Space,Str "that",Space,Str "italic",Space,Str "links",Space,Str "are",Space,Str "rendered",Space,Str "properly:",Space,Emph [Link ("",[],[]) [Str "My Book Title"] ("http://my.book.example/","")]]
-,Para [Str "Free",Space,Str "links",Space,Str "without",Space,Str "braces",Space,Str "should",Space,Str "be",Space,Str "rendered",Space,Str "as",Space,Str "well,",Space,Str "like",Space,Link ("",[],[]) [Str "http://www.wikicreole.org/"] ("http://www.wikicreole.org/",""),Space,Str "and",Space,Link ("",[],[]) [Str "http://www.wikicreole.org/users/~example"] ("http://www.wikicreole.org/users/~example",""),Str "."]
-,Para [Str "Creole1.0",Space,Str "specifies",Space,Str "that",Space,Link ("",[],[]) [Str "http://bar"] ("http://bar",""),Space,Str "and",Space,Link ("",[],[]) [Str "ftp://bar"] ("ftp://bar",""),Space,Str "should",Space,Str "not",Space,Str "render",Space,Str "italic,",Space,Str "something",Space,Str "like",Space,Str "foo:",Emph [Str "bar",Space,Str "should",Space,Str "render",Space,Str "as",Space,Str "italic."]]
-,Para [Str "You",Space,Str "can",Space,Str "use",Space,Str "this",Space,Str "to",Space,Str "draw",Space,Str "a",Space,Str "line",Space,Str "to",Space,Str "separate",Space,Str "the",Space,Str "page:"]
-,HorizontalRule
-,Para [Str "You",Space,Str "can",Space,Str "use",Space,Str "lists,",Space,Str "start",Space,Str "it",Space,Str "at",Space,Str "the",Space,Str "first",Space,Str "column",Space,Str "for",Space,Str "now,",Space,Str "please..."]
-,Para [Str "unnumbered",Space,Str "lists",Space,Str "are",Space,Str "like"]
-,BulletList
- [[Plain [Str "item",Space,Str "a"]]
- ,[Plain [Str "item",Space,Str "b"]]
- ,[Plain [Strong [Str "bold",Space,Str "item",Space,Str "c"]]]]
-,Para [Str "blank",Space,Str "space",Space,Str "is",Space,Str "also",Space,Str "permitted",Space,Str "before",Space,Str "lists",Space,Str "like:"]
-,BulletList
- [[Plain [Str "item",Space,Str "a"]]
- ,[Plain [Str "item",Space,Str "b"]]
- ,[Plain [Str "item",Space,Str "c"]
-  ,BulletList
-   [[Plain [Str "item",Space,Str "c.a"]]]]]
-,Para [Str "or",Space,Str "you",Space,Str "can",Space,Str "number",Space,Str "them"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Link ("",[],[]) [Str "item 1"] ("item 1","")]]
- ,[Plain [Str "item",Space,Str "2"]]
- ,[Plain [Emph [Space,Str "italic",Space,Str "item",Space,Str "3",Space]]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "item",Space,Str "3.1"]]
-   ,[Plain [Str "item",Space,Str "3.2"]]]]]
-,Para [Str "up",Space,Str "to",Space,Str "five",Space,Str "levels"]
-,BulletList
- [[Plain [Str "1"]
-  ,BulletList
-   [[Plain [Str "2"]
-    ,BulletList
-     [[Plain [Str "3"]
-      ,BulletList
-       [[Plain [Str "4"]
-        ,BulletList
-         [[Plain [Str "5"]]]]]]]]]]]
-,BulletList
- [[Plain [Str "You",Space,Str "can",Space,Str "have",Space,Str "multiline",Space,Str "list",Space,Str "items"]]
- ,[Plain [Str "this",Space,Str "is",Space,Str "a",Space,Str "second",Space,Str "multiline",Space,Str "list",Space,Str "item"]]]
-,Para [Str "You",Space,Str "can",Space,Str "use",Space,Str "nowiki",Space,Str "syntax",Space,Str "if",Space,Str "you",Space,Str "would",Space,Str "like",Space,Str "do",Space,Str "stuff",Space,Str "like",Space,Str "this:"]
-,CodeBlock ("",[],[]) "Guitar Chord C:\n\n||---|---|---|\n||-0-|---|---|\n||---|---|---|\n||---|-0-|---|\n||---|---|-0-|\n||---|---|---|"
-,Para [Str "You",Space,Str "can",Space,Str "also",Space,Str "use",Space,Str "it",Space,Str "inline",Space,Str "nowiki",Space,Code ("",[],[]) " in a sentence ",Space,Str "like",Space,Str "this."]
-,Header 1 ("",[],[]) [Str "Escapes"]
-,Para [Str "Normal",Space,Str "Link:",Space,Link ("",[],[]) [Str "http://wikicreole.org/"] ("http://wikicreole.org/",""),Space,Str "-",Space,Str "now",Space,Str "same",Space,Str "link,",Space,Str "but",Space,Str "escaped:",Space,Str "http://wikicreole.org/"]
-,Para [Str "Normal",Space,Str "asterisks:",Space,Str "**not",Space,Str "bold**"]
-,Para [Str "a",Space,Str "tilde",Space,Str "alone:",Space,Str "~"]
-,Para [Str "a",Space,Str "tilde",Space,Str "escapes",Space,Str "itself:",Space,Str "~xxx"]
-,Header 3 ("",[],[]) [Str "Creole 0.2"]
-,Para [Str "This",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "flower",Space,Str "with",Space,Str "the",Space,Str "ALT",Space,Str "text",Space,Str "\"this",Space,Str "is",Space,Str "a",Space,Str "flower\"",Space,Str "if",Space,Str "your",Space,Str "wiki",Space,Str "supports",Space,Str "ALT",Space,Str "text",Space,Str "on",Space,Str "images:"]
-,Para [Image ("",[],[]) [Str "here is a red flower"] ("Red-Flower.jpg","")]
-,Header 3 ("",[],[]) [Str "Creole 0.4"]
-,Para [Str "Tables",Space,Str "are",Space,Str "done",Space,Str "like",Space,Str "this:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "header",Space,Str "col1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "header",Space,Str "col2"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "col1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "col2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "you"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "can"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "also"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "align",LineBreak,Str "it."]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "You",Space,Str "can",Space,Str "format",Space,Str "an",Space,Str "address",Space,Str "by",Space,Str "simply",Space,Str "forcing",Space,Str "linebreaks:"]
-,Para [Str "My",Space,Str "contact",Space,Str "dates:",LineBreak,Str "Pone:",Space,Str "xyz",LineBreak,Str "Fax:",Space,Str "+45",LineBreak,Str "Mobile:",Space,Str "abc"]
-,Header 3 ("",[],[]) [Str "Creole 0.5"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Header",Space,Str "title"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Another",Space,Str "header",Space,Str "title"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Code ("",[],[]) " //not italic text// "]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Code ("",[],[]) " **not bold text** "]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Emph [Str "italic",Space,Str "text"]]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Strong [Space,Str "bold",Space,Str "text",Space]]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 3 ("",[],[]) [Str "Creole 1.0"]
-,Para [Str "If",Space,Str "interwiki",Space,Str "links",Space,Str "are",Space,Str "setup",Space,Str "in",Space,Str "your",Space,Str "wiki,",Space,Str "this",Space,Str "links",Space,Str "to",Space,Str "the",Space,Str "WikiCreole",Space,Str "page",Space,Str "about",Space,Str "Creole",Space,Str "1.0",Space,Str "test",Space,Str "cases:",Space,Link ("",[],[]) [Str "WikiCreole:Creole1.0TestCases"] ("WikiCreole:Creole1.0TestCases",""),Str "."]
-,HorizontalRule
-,Para [Str "The",Space,Str "above",Space,Str "test",Space,Str "document",Space,Str "was",Space,Str "found",Space,Str "on",Space,Link ("",[],[]) [Str "http://www.wikicreole.org/wiki/Creole1.0TestCases"] ("http://www.wikicreole.org/wiki/Creole1.0TestCases",""),Space,Str "and",Space,Str "downloaded",Space,Str "from",Space,Link ("",[],[]) [Str "http://www.wikicreole.org/attach/Creole1.0TestCases/creole1.0test.txt"] ("http://www.wikicreole.org/attach/Creole1.0TestCases/creole1.0test.txt",""),Str "."]
-,Para [Str "The",Space,Str "Creole",Space,Str "Wiki",Space,Str "is",Space,Str "licensed:",Space,Str "Copyright",Space,Str "(C)",Space,Str "by",Space,Str "the",Space,Str "contributors.",Space,Str "Some",Space,Str "rights",Space,Str "reserved,",Space,Str "license",Space,Link ("",[],[]) [Str "https://creativecommons.org/licenses/by-sa/1.0/"] ("BY-SA",""),Str "."]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "", [], [] )
+    [ Str "Top-level heading (1)" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "This a test for creole 0.1 (2)" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "This is a Subheading (3)" ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Subsub (4)" ]
+  , Header 5
+    ( "", [], [] )
+    [ Str "Subsubsub (5)" ]
+  , Para
+    [ Str "The"
+    , Space
+    , Str "ending"
+    , Space
+    , Str "equal"
+    , Space
+    , Str "signs"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "displayed:"
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Top-level heading (1)" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "This a test for creole 0.1 (2)" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "This is a Subheading (3)" ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Subsub (4)" ]
+  , Header 5
+    ( "", [], [] )
+    [ Str "Subsubsub (5)" ]
+  , Para
+    [ Str "You"
+    , Space
+    , Str "can"
+    , Space
+    , Str "make"
+    , Space
+    , Str "things"
+    , Space
+    , Strong
+      [ Str "bold" ]
+    , Space
+    , Str "or"
+    , Space
+    , Emph
+      [ Str "italic" ]
+    , Space
+    , Str "or"
+    , Space
+    , Strong
+      [ Emph [ Str "both" ] ]
+    , Space
+    , Str "or"
+    , Space
+    , Emph
+      [ Strong [ Str "both" ] ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Character"
+    , Space
+    , Str "formatting"
+    , Space
+    , Str "extends"
+    , Space
+    , Str "across"
+    , Space
+    , Str "line"
+    , Space
+    , Str "breaks:"
+    , Space
+    , Strong
+      [ Str "bold,"
+      , Space
+      , Str "this"
+      , Space
+      , Str "is"
+      , Space
+      , Str "still"
+      , Space
+      , Str "bold."
+      , Space
+      , Str "This"
+      , Space
+      , Str "line"
+      , Space
+      , Str "deliberately"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "end"
+      , Space
+      , Str "in"
+      , Space
+      , Str "star-star."
+      ]
+    ]
+  , Para
+    [ Str "Not"
+    , Space
+    , Str "bold."
+    , Space
+    , Str "Character"
+    , Space
+    , Str "formatting"
+    , Space
+    , Str "does"
+    , Space
+    , Str "not"
+    , Space
+    , Str "cross"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "boundaries."
+    ]
+  , Para
+    [ Str "You"
+    , Space
+    , Str "can"
+    , Space
+    , Str "use"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "internal links" ]
+      ( "internal links", "" )
+    , Space
+    , Str "or"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "external links" ]
+      ( "http://www.wikicreole.org", "" )
+    , Str ","
+    , Space
+    , Str "give"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "different" ]
+      ( "internal links", "" )
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "another"
+    , Space
+    , Str "sentence:"
+    , Space
+    , Str "This"
+    , Space
+    , Str "wisdom"
+    , Space
+    , Str "is"
+    , Space
+    , Str "taken"
+    , Space
+    , Str "from"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "Ward Cunningham's" ]
+      ( "Ward Cunningham's", "" )
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "Presentation at the Wikisym 06" ]
+      ( "http://www.c2.com/doc/wikisym/WikiSym2006.pdf", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "external"
+    , Space
+    , Str "link"
+    , Space
+    , Str "without"
+    , Space
+    , Str "a"
+    , Space
+    , Str "description:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.wikicreole.org" ]
+      ( "http://www.wikicreole.org", "" )
+    ]
+  , Para
+    [ Str "Be"
+    , Space
+    , Str "careful"
+    , Space
+    , Str "that"
+    , Space
+    , Str "italic"
+    , Space
+    , Str "links"
+    , Space
+    , Str "are"
+    , Space
+    , Str "rendered"
+    , Space
+    , Str "properly:"
+    , Space
+    , Emph
+      [ Link
+        ( "", [], [] )
+        [ Str "My Book Title" ]
+        ( "http://my.book.example/", "" )
+      ]
+    ]
+  , Para
+    [ Str "Free"
+    , Space
+    , Str "links"
+    , Space
+    , Str "without"
+    , Space
+    , Str "braces"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "rendered"
+    , Space
+    , Str "as"
+    , Space
+    , Str "well,"
+    , Space
+    , Str "like"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.wikicreole.org/" ]
+      ( "http://www.wikicreole.org/", "" )
+    , Space
+    , Str "and"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.wikicreole.org/users/~example" ]
+      ( "http://www.wikicreole.org/users/~example", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Creole1.0"
+    , Space
+    , Str "specifies"
+    , Space
+    , Str "that"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://bar" ]
+      ( "http://bar", "" )
+    , Space
+    , Str "and"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "ftp://bar" ]
+      ( "ftp://bar", "" )
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "render"
+    , Space
+    , Str "italic,"
+    , Space
+    , Str "something"
+    , Space
+    , Str "like"
+    , Space
+    , Str "foo:"
+    , Emph
+      [ Str "bar"
+      , Space
+      , Str "should"
+      , Space
+      , Str "render"
+      , Space
+      , Str "as"
+      , Space
+      , Str "italic."
+      ]
+    ]
+  , Para
+    [ Str "You"
+    , Space
+    , Str "can"
+    , Space
+    , Str "use"
+    , Space
+    , Str "this"
+    , Space
+    , Str "to"
+    , Space
+    , Str "draw"
+    , Space
+    , Str "a"
+    , Space
+    , Str "line"
+    , Space
+    , Str "to"
+    , Space
+    , Str "separate"
+    , Space
+    , Str "the"
+    , Space
+    , Str "page:"
+    ]
+  , HorizontalRule
+  , Para
+    [ Str "You"
+    , Space
+    , Str "can"
+    , Space
+    , Str "use"
+    , Space
+    , Str "lists,"
+    , Space
+    , Str "start"
+    , Space
+    , Str "it"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "first"
+    , Space
+    , Str "column"
+    , Space
+    , Str "for"
+    , Space
+    , Str "now,"
+    , Space
+    , Str "please..."
+    ]
+  , Para
+    [ Str "unnumbered"
+    , Space
+    , Str "lists"
+    , Space
+    , Str "are"
+    , Space
+    , Str "like"
+    ]
+  , BulletList
+    [
+      [ Plain [ Str "item", Space, Str "a" ] ]
+    ,
+      [ Plain [ Str "item", Space, Str "b" ] ]
+    ,
+      [ Plain
+        [ Strong [ Str "bold", Space, Str "item", Space, Str "c" ] ]
+      ]
+    ]
+  , Para
+    [ Str "blank"
+    , Space
+    , Str "space"
+    , Space
+    , Str "is"
+    , Space
+    , Str "also"
+    , Space
+    , Str "permitted"
+    , Space
+    , Str "before"
+    , Space
+    , Str "lists"
+    , Space
+    , Str "like:"
+    ]
+  , BulletList
+    [
+      [ Plain [ Str "item", Space, Str "a" ] ]
+    ,
+      [ Plain [ Str "item", Space, Str "b" ] ]
+    ,
+      [ Plain
+        [ Str "item", Space, Str "c" ]
+      , BulletList
+        [ [ Plain [ Str "item", Space, Str "c.a" ] ] ]
+      ]
+    ]
+  , Para
+    [ Str "or"
+    , Space
+    , Str "you"
+    , Space
+    , Str "can"
+    , Space
+    , Str "number"
+    , Space
+    , Str "them"
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Link ( "", [], [] ) [ Str "item 1" ] ( "item 1", "" ) ]
+      ]
+    ,
+      [ Plain [ Str "item", Space, Str "2" ] ]
+    ,
+      [ Plain
+        [ Emph
+          [ Space
+          , Str "italic"
+          , Space
+          , Str "item"
+          , Space
+          , Str "3"
+          , Space
+          ]
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "item", Space, Str "3.1" ] ]
+        ,
+          [ Plain [ Str "item", Space, Str "3.2" ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "up"
+    , Space
+    , Str "to"
+    , Space
+    , Str "five"
+    , Space
+    , Str "levels"
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "1" ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "2" ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "3" ]
+              , BulletList
+                [
+                  [ Plain
+                    [ Str "4" ]
+                  , BulletList
+                    [ [ Plain [ Str "5" ] ] ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "You"
+        , Space
+        , Str "can"
+        , Space
+        , Str "have"
+        , Space
+        , Str "multiline"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "second"
+        , Space
+        , Str "multiline"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        ]
+      ]
+    ]
+  , Para
+    [ Str "You"
+    , Space
+    , Str "can"
+    , Space
+    , Str "use"
+    , Space
+    , Str "nowiki"
+    , Space
+    , Str "syntax"
+    , Space
+    , Str "if"
+    , Space
+    , Str "you"
+    , Space
+    , Str "would"
+    , Space
+    , Str "like"
+    , Space
+    , Str "do"
+    , Space
+    , Str "stuff"
+    , Space
+    , Str "like"
+    , Space
+    , Str "this:"
+    ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "Guitar Chord C:\n\n||---|---|---|\n||-0-|---|---|\n||---|---|---|\n||---|-0-|---|\n||---|---|-0-|\n||---|---|---|"
+  , Para
+    [ Str "You"
+    , Space
+    , Str "can"
+    , Space
+    , Str "also"
+    , Space
+    , Str "use"
+    , Space
+    , Str "it"
+    , Space
+    , Str "inline"
+    , Space
+    , Str "nowiki"
+    , Space
+    , Code
+      ( "", [], [] ) " in a sentence "
+    , Space
+    , Str "like"
+    , Space
+    , Str "this."
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Escapes" ]
+  , Para
+    [ Str "Normal"
+    , Space
+    , Str "Link:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://wikicreole.org/" ]
+      ( "http://wikicreole.org/", "" )
+    , Space
+    , Str "-"
+    , Space
+    , Str "now"
+    , Space
+    , Str "same"
+    , Space
+    , Str "link,"
+    , Space
+    , Str "but"
+    , Space
+    , Str "escaped:"
+    , Space
+    , Str "http://wikicreole.org/"
+    ]
+  , Para
+    [ Str "Normal"
+    , Space
+    , Str "asterisks:"
+    , Space
+    , Str "**not"
+    , Space
+    , Str "bold**"
+    ]
+  , Para
+    [ Str "a", Space, Str "tilde", Space, Str "alone:", Space, Str "~" ]
+  , Para
+    [ Str "a"
+    , Space
+    , Str "tilde"
+    , Space
+    , Str "escapes"
+    , Space
+    , Str "itself:"
+    , Space
+    , Str "~xxx"
+    ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Creole 0.2" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "flower"
+    , Space
+    , Str "with"
+    , Space
+    , Str "the"
+    , Space
+    , Str "ALT"
+    , Space
+    , Str "text"
+    , Space
+    , Str "\"this"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "flower\""
+    , Space
+    , Str "if"
+    , Space
+    , Str "your"
+    , Space
+    , Str "wiki"
+    , Space
+    , Str "supports"
+    , Space
+    , Str "ALT"
+    , Space
+    , Str "text"
+    , Space
+    , Str "on"
+    , Space
+    , Str "images:"
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "here is a red flower" ]
+      ( "Red-Flower.jpg", "" )
+    ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Creole 0.4" ]
+  , Para
+    [ Str "Tables"
+    , Space
+    , Str "are"
+    , Space
+    , Str "done"
+    , Space
+    , Str "like"
+    , Space
+    , Str "this:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "header", Space, Str "col1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "header", Space, Str "col2" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "you" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "can" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "also" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "align", LineBreak, Str "it." ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "You"
+    , Space
+    , Str "can"
+    , Space
+    , Str "format"
+    , Space
+    , Str "an"
+    , Space
+    , Str "address"
+    , Space
+    , Str "by"
+    , Space
+    , Str "simply"
+    , Space
+    , Str "forcing"
+    , Space
+    , Str "linebreaks:"
+    ]
+  , Para
+    [ Str "My"
+    , Space
+    , Str "contact"
+    , Space
+    , Str "dates:"
+    , LineBreak
+    , Str "Pone:"
+    , Space
+    , Str "xyz"
+    , LineBreak
+    , Str "Fax:"
+    , Space
+    , Str "+45"
+    , LineBreak
+    , Str "Mobile:"
+    , Space
+    , Str "abc"
+    ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Creole 0.5" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Header", Space, Str "title" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Another", Space, Str "header", Space, Str "title" ]
+          ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Code ( "", [], [] ) " //not italic text// " ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Code ( "", [], [] ) " **not bold text** " ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Emph [ Str "italic", Space, Str "text" ] ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Strong [ Space, Str "bold", Space, Str "text", Space ] ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 3
+    ( "", [], [] )
+    [ Str "Creole 1.0" ]
+  , Para
+    [ Str "If"
+    , Space
+    , Str "interwiki"
+    , Space
+    , Str "links"
+    , Space
+    , Str "are"
+    , Space
+    , Str "setup"
+    , Space
+    , Str "in"
+    , Space
+    , Str "your"
+    , Space
+    , Str "wiki,"
+    , Space
+    , Str "this"
+    , Space
+    , Str "links"
+    , Space
+    , Str "to"
+    , Space
+    , Str "the"
+    , Space
+    , Str "WikiCreole"
+    , Space
+    , Str "page"
+    , Space
+    , Str "about"
+    , Space
+    , Str "Creole"
+    , Space
+    , Str "1.0"
+    , Space
+    , Str "test"
+    , Space
+    , Str "cases:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "WikiCreole:Creole1.0TestCases" ]
+      ( "WikiCreole:Creole1.0TestCases", "" )
+    , Str "."
+    ]
+  , HorizontalRule
+  , Para
+    [ Str "The"
+    , Space
+    , Str "above"
+    , Space
+    , Str "test"
+    , Space
+    , Str "document"
+    , Space
+    , Str "was"
+    , Space
+    , Str "found"
+    , Space
+    , Str "on"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.wikicreole.org/wiki/Creole1.0TestCases" ]
+      ( "http://www.wikicreole.org/wiki/Creole1.0TestCases", "" )
+    , Space
+    , Str "and"
+    , Space
+    , Str "downloaded"
+    , Space
+    , Str "from"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.wikicreole.org/attach/Creole1.0TestCases/creole1.0test.txt" ]
+      ( "http://www.wikicreole.org/attach/Creole1.0TestCases/creole1.0test.txt"
+      , ""
+      )
+    , Str "."
+    ]
+  , Para
+    [ Str "The"
+    , Space
+    , Str "Creole"
+    , Space
+    , Str "Wiki"
+    , Space
+    , Str "is"
+    , Space
+    , Str "licensed:"
+    , Space
+    , Str "Copyright"
+    , Space
+    , Str "(C)"
+    , Space
+    , Str "by"
+    , Space
+    , Str "the"
+    , Space
+    , Str "contributors."
+    , Space
+    , Str "Some"
+    , Space
+    , Str "rights"
+    , Space
+    , Str "reserved,"
+    , Space
+    , Str "license"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "https://creativecommons.org/licenses/by-sa/1.0/" ]
+      ( "BY-SA", "" )
+    , Str "."
+    ]
+  ]

--- a/test/docbook-chapter.native
+++ b/test/docbook-chapter.native
@@ -1,17 +1,167 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("",[],[]) [Str "Test",Space,Str "Chapter"]
-,Para [Str "This",Space,Str "chapter",Space,Str "uses",Space,Str "recursive",Space,Str "sections."]
-,Header 2 ("",[],[]) [Str "Like",Space,Str "a",Space,Str "Sect1"]
-,Para [Str "This",Space,Str "section",Space,Str "is",Space,Str "like",Space,Str "a",Space,Str "Sect1."]
-,Header 3 ("",[],[]) [Str "Like",Space,Str "a",Space,Str "Sect2"]
-,Para [Str "This",Space,Str "section",Space,Str "is",Space,Str "like",Space,Str "a",Space,Str "Sect2."]
-,Header 4 ("",[],[]) [Str "Like",Space,Str "a",Space,Str "Sect3"]
-,Para [Str "This",Space,Str "section",Space,Str "is",Space,Str "like",Space,Str "a",Space,Str "Sect3."]
-,Header 5 ("",[],[]) [Str "Like",Space,Str "a",Space,Str "Sect4"]
-,Para [Str "This",Space,Str "section",Space,Str "is",Space,Str "like",Space,Str "a",Space,Str "Sect4."]
-,Header 6 ("",[],[]) [Str "Like",Space,Str "a",Space,Str "Sect5"]
-,Para [Str "This",Space,Str "section",Space,Str "is",Space,Str "like",Space,Str "a",Space,Str "Sect5."]
-,Header 7 ("",[],[]) [Str "Would",Space,Str "be",Space,Str "like",Space,Str "a",Space,Str "Sect6"]
-,Para [Str "This",Space,Str "section",Space,Str "would",Space,Str "be",Space,Str "like",Space,Str "a",Space,Str "Sect6,",Space,Str "if",Space,Str "there",Space,Str "was",Space,Str "one."]
-,Header 8 ("",[],[]) [Str "Would",Space,Str "be",Space,Str "like",Space,Str "a",Space,Str "Sect7"]
-,Para [Str "This",Space,Str "section",Space,Str "would",Space,Str "be",Space,Str "like",Space,Str "a",Space,Str "Sect7,",Space,Str "if",Space,Str "there",Space,Str "was",Space,Str "one."]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "", [], [] )
+    [ Str "Test", Space, Str "Chapter" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "chapter"
+    , Space
+    , Str "uses"
+    , Space
+    , Str "recursive"
+    , Space
+    , Str "sections."
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Like", Space, Str "a", Space, Str "Sect1" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "is"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect1."
+    ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Like", Space, Str "a", Space, Str "Sect2" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "is"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect2."
+    ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Like", Space, Str "a", Space, Str "Sect3" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "is"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect3."
+    ]
+  , Header 5
+    ( "", [], [] )
+    [ Str "Like", Space, Str "a", Space, Str "Sect4" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "is"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect4."
+    ]
+  , Header 6
+    ( "", [], [] )
+    [ Str "Like", Space, Str "a", Space, Str "Sect5" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "is"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect5."
+    ]
+  , Header 7
+    ( "", [], [] )
+    [ Str "Would"
+    , Space
+    , Str "be"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect6"
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "would"
+    , Space
+    , Str "be"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect6,"
+    , Space
+    , Str "if"
+    , Space
+    , Str "there"
+    , Space
+    , Str "was"
+    , Space
+    , Str "one."
+    ]
+  , Header 8
+    ( "", [], [] )
+    [ Str "Would"
+    , Space
+    , Str "be"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect7"
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "would"
+    , Space
+    , Str "be"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "Sect7,"
+    , Space
+    , Str "if"
+    , Space
+    , Str "there"
+    , Space
+    , Str "was"
+    , Space
+    , Str "one."
+    ]
+  ]

--- a/test/docbook-reader.native
+++ b/test/docbook-reader.native
@@ -1,584 +1,3055 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",SoftBreak,Str "MacFarlane"],MetaInlines [Str "Anonymous"]]),("date",MetaInlines [Str "July",Space,Str "17,",Space,Str "2006"]),("title",MetaInlines [Str "Pandoc",Space,Str "Test",Space,Str "Suite"])]})
-[Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc.",Space,Str "Most",Space,Str "of",Space,Str "them",Space,Str "are",Space,Str "adapted",Space,Str "from",Space,Str "John",SoftBreak,Str "Gruber\8217s",Space,Str "markdown",Space,Str "test",Space,Str "suite."]
-,Header 1 ("headers",[],[]) [Str "Headers"]
-,Header 2 ("level-2-with-an-embedded-link",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Str "an",Space,Link ("",[],[]) [Str "embedded",Space,Str "link"] ("/url","")]
-,Header 3 ("level-3-with-emphasis",[],[]) [Str "Level",Space,Str "3",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 4 ("level-4",[],[]) [Str "Level",Space,Str "4"]
-,Header 5 ("level-5",[],[]) [Str "Level",Space,Str "5"]
-,Para [Str "Hi."]
-,Header 1 ("level-1",[],[]) [Str "Level",Space,Str "1"]
-,Header 2 ("level-2-with-emphasis",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 3 ("level-3",[],[]) [Str "Level",Space,Str "3"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Header 4 ("",["unnumbered"],[]) [Str "Level",Space,Str "4"]
-,Para [Str "An",Space,Str "unnumbered",Space,Str "section."]
-,Header 2 ("level-2",[],[]) [Str "Level",Space,Str "2"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "In",Space,Str "Markdown",Space,Str "1.0.0",Space,Str "and",Space,Str "earlier.",Space,Str "Version",Space,Str "8.",Space,Str "This",Space,Str "line",Space,Str "turns",Space,Str "into",Space,Str "a",Space,Str "list",SoftBreak,Str "item.",Space,Str "Because",Space,Str "a",Space,Str "hard-wrapped",Space,Str "line",Space,Str "in",Space,Str "the",Space,Str "middle",Space,Str "of",Space,Str "a",Space,Str "paragraph",Space,Str "looked",Space,Str "like",SoftBreak,Str "a",Space,Str "list",Space,Str "item."]
-,Para [Str "Here\8217s",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet.",Space,Str "*",Space,Str "criminey."]
-,Header 1 ("block-quotes",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "E-mail",Space,Str "style:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",Space,Str "It",Space,Str "is",Space,Str "pretty",Space,Str "short."]]
-,BlockQuote
- [Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"
- ,CodeBlock ("",[],[]) "% ls"
- ,Para [Str "A",Space,Str "list:"]
- ,OrderedList (1,Decimal,DefaultDelim)
-  [[Para [Str "item",Space,Str "one"]]
-  ,[Para [Str "item",Space,Str "two"]]]
- ,Para [Str "Nested",Space,Str "block",Space,Str "quotes:"]
- ,BlockQuote
-  [Para [Str "nested"]]
- ,BlockQuote
-  [Para [Str "nested"]]]
-,Para [Str "This",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "block",Space,Str "quote:",Space,Str "2",Space,Str ">",Space,Str "1."]
-,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
-,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
-,Header 1 ("lists",[],[]) [Str "Lists"]
-,Header 2 ("unordered",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks",Space,Str "loose:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Plus",Space,Str "1"]]
- ,[Para [Str "Plus",Space,Str "2"]]
- ,[Para [Str "Plus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Header 2 ("ordered",[],[]) [Str "Ordered"]
-,OrderedList (1,Decimal,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "and",Space,Str "using",Space,Str "spaces:"]
-,OrderedList (1,Decimal,DefaultDelim)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]]
- ,[Para [Str "Three"]]]
-,Para [Str "Multiple",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,DefaultDelim)
- [[Para [Str "Item",Space,Str "1,",Space,Str "graf",Space,Str "one."]
-  ,Para [Str "Item",Space,Str "1.",Space,Str "graf",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",Space,Str "dog\8217s",SoftBreak,Str "back."]]
- ,[Para [Str "Item",Space,Str "2."]]
- ,[Para [Str "Item",Space,Str "3."]]]
-,Header 2 ("nested",[],[]) [Str "Nested"]
-,BulletList
- [[Para [Str "Tab"]
-  ,BulletList
-   [[Para [Str "Tab"]
-    ,BulletList
-     [[Para [Str "Tab"]]]]]]]
-,Para [Str "Here\8217s",Space,Str "another:"]
-,OrderedList (1,Decimal,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Para [Str "Same",Space,Str "thing",Space,Str "but",Space,Str "with",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Header 2 ("tabs-and-spaces",[],[]) [Str "Tabs",Space,Str "and",Space,Str "spaces"]
-,BulletList
- [[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "tabs"]]
- ,[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "spaces"]
-  ,BulletList
-   [[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "tabs"]]
-   ,[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "spaces"]]]]]
-,Header 2 ("fancy-list-markers",[],[]) [Str "Fancy",Space,Str "list",Space,Str "markers"]
-,OrderedList (2,Decimal,DefaultDelim)
- [[Para [Str "begins",Space,Str "with",Space,Str "2"]]
- ,[Para [Str "and",Space,Str "now",Space,Str "3"]
-  ,Para [Str "with",Space,Str "a",Space,Str "continuation"]
-  ,OrderedList (4,LowerRoman,DefaultDelim)
-   [[Para [Str "sublist",Space,Str "with",Space,Str "roman",Space,Str "numerals,",Space,Str "starting",Space,Str "with",Space,Str "4"]]
-   ,[Para [Str "more",Space,Str "items"]
-    ,OrderedList (1,UpperAlpha,DefaultDelim)
-     [[Para [Str "a",Space,Str "subsublist"]]
-     ,[Para [Str "a",Space,Str "subsublist"]]]]]]]
-,Para [Str "Nesting:"]
-,OrderedList (1,UpperAlpha,DefaultDelim)
- [[Para [Str "Upper",Space,Str "Alpha"]
-  ,OrderedList (1,UpperRoman,DefaultDelim)
-   [[Para [Str "Upper",Space,Str "Roman."]
-    ,OrderedList (6,Decimal,DefaultDelim)
-     [[Para [Str "Decimal",Space,Str "start",Space,Str "with",Space,Str "6"]
-      ,OrderedList (3,LowerAlpha,DefaultDelim)
-       [[Para [Str "Lower",Space,Str "alpha",Space,Str "with",Space,Str "paren"]]]]]]]]]
-,Para [Str "Autonumbering:"]
-,OrderedList (1,Decimal,DefaultDelim)
- [[Para [Str "Autonumber."]]
- ,[Para [Str "More."]
-  ,OrderedList (1,Decimal,DefaultDelim)
-   [[Para [Str "Nested."]]]]]
-,Para [Str "Should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "list",Space,Str "item:"]
-,Para [Str "M.A.\160\&2007"]
-,Para [Str "B.",Space,Str "Williams"]
-,Header 2 ("callout",[],[]) [Str "Callout"]
-,Para [Str "Simple."]
-,BulletList
- [[Para [Str "A",Space,Code ("",[],[]) "__letrec",Space,Str "is",Space,Str "equivalent",Space,Str "to",Space,Str "a",Space,Str "normal",SoftBreak,Str "Haskell",Space,Str "LET."]]
- ,[Para [Str "GHC",Space,Str "compiled",Space,Str "the",Space,Str "body",Space,Str "of",Space,Str "our",Space,Str "list",Space,Str "comprehension",Space,Str "into",SoftBreak,Str "a",Space,Str "loop",Space,Str "named",Space,Code ("",[],[]) "go_s1YC",Str "."]]
- ,[Para [Str "If",Space,Str "our",Space,Str "CASE",Space,Str "expression",Space,Str "matches",Space,Str "the",Space,Str "empty",Space,Str "list,",Space,Str "we",SoftBreak,Str "return",Space,Str "the",Space,Str "empty",Space,Str "list.",Space,Str "This",Space,Str "is",Space,Str "reassuringly",SoftBreak,Str "familiar."]]]
-,Header 1 ("definition-lists",[],[]) [Str "Definition",Space,Str "Lists"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Para [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Multiple",Space,Str "blocks",Space,Str "with",Space,Str "italics:"]
-,DefinitionList
- [([Emph [Str "apple"]],
-   [[Para [Str "red",Space,Str "fruit"]
-    ,Para [Str "contains",Space,Str "seeds,",Space,Str "crisp,",Space,Str "pleasant",Space,Str "to",Space,Str "taste"]]])
- ,([Emph [Str "orange"]],
-   [[Para [Str "orange",Space,Str "fruit"]
-    ,CodeBlock ("",[],[]) "{ orange code block }"
-    ,BlockQuote
-     [Para [Str "orange",Space,Str "block",Space,Str "quote"]]]])]
-,Para [Str "Multiple",Space,Str "definitions,",Space,Str "loose:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]
-   ,[Para [Str "computer"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]
-   ,[Para [Str "bank"]]])]
-,Para [Str "Blank",Space,Str "line",Space,Str "after",Space,Str "term,",Space,Str "indented",Space,Str "marker,",Space,Str "alternate",Space,Str "markers:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]
-   ,[Para [Str "computer"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]
-    ,OrderedList (1,Decimal,DefaultDelim)
-     [[Para [Str "sublist"]]
-     ,[Para [Str "sublist"]]]]])]
-,Header 1 ("inline-markup",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ",",Space,Str "and",Space,Str "so",Space,Emph [Str "is",SoftBreak,Str "this"],Str "."]
-,Para [Str "This",Space,Str "is",Space,Strong [Str "strong"],Str ",",Space,Str "and",Space,Str "so",SoftBreak,Strong [Str "is",Space,Str "this"],Str "."]
-,Para [Str "An",Space,Emph [Link ("",[],[]) [Str "emphasized",Space,Str "link"] ("/url","")],Str "."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",SoftBreak,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",SoftBreak,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Str "This",Space,Str "is",Space,Str "code:",Space,Code ("",[],[]) ">",Str ",",Space,Code ("",[],[]) "$",Str ",",SoftBreak,Code ("",[],[]) "\\",Str ",",Space,Code ("",[],[]) "\\$",Str ",",SoftBreak,Code ("",[],[]) "<html>",Str "."]
-,Para [Str "More",Space,Str "code:",Space,Code ("",[],[]) "Class",Space,Str "and",Space,Code ("",[],[]) "Type"]
-,Para [Str "Referencing",Space,Str "a",Space,Str "man",Space,Str "page:",Space,Code ("",["citerefentry"],[]) "nix.conf(5)"]
-,Para [Strikeout [Str "This",Space,Str "is",SoftBreak,Emph [Str "strikeout"],Str "."]]
-,Para [Str "Superscripts:",Space,Str "a",Superscript [Str "bc"],Str "d",SoftBreak,Str "a",Superscript [Emph [Str "hello"]],SoftBreak,Str "a",Superscript [Str "hello\160there"],Str "."]
-,Para [Str "Subscripts:",Space,Str "H",Subscript [Str "2"],Str "O,",Space,Str "H",Subscript [Str "23"],Str "O,",SoftBreak,Str "H",Subscript [Str "many\160of\160them"],Str "O."]
-,Para [Str "These",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "superscripts",Space,Str "or",Space,Str "subscripts,",Space,Str "because",Space,Str "of",Space,Str "the",Space,Str "unescaped",SoftBreak,Str "spaces:",Space,Str "a^b",Space,Str "c^d,",Space,Str "a~b",Space,Str "c~d."]
-,Header 1 ("smart-quotes-ellipses-dashes",[],[]) [Str "Smart",Space,Str "quotes,",Space,Str "ellipses,",Space,Str "dashes"]
-,Para [Quoted DoubleQuote [Str "Hello,"],Space,Str "said",Space,Str "the",Space,Str "spider.",Space,Quoted DoubleQuote [Quoted SingleQuote [Str "Shelob"],Space,Str "is",Space,Str "my",SoftBreak,Str "name."]]
-,Para [Quoted DoubleQuote [Str "A"],Str ",",Space,Quoted DoubleQuote [Str "B"],Str ",",Space,Str "and",Space,Quoted DoubleQuote [Str "C"],Space,Str "are",Space,Str "letters."]
-,Para [Quoted DoubleQuote [Str "He",Space,Str "said,",Space,Quoted SingleQuote [Str "I",Space,Str "want",Space,Str "to",Space,Str "go."]],Space,Str "Were",Space,Str "you",Space,Str "alive",Space,Str "in",Space,Str "the",SoftBreak,Str "70\8217s?"]
-,Para [Str "Some",Space,Str "dashes:",Space,Str "one\8212two",Space,Str "\8212",Space,Str "three\8212four",Space,Str "\8212",Space,Str "five."]
-,Para [Str "Dashes",Space,Str "between",Space,Str "numbers:",Space,Str "5\8211\&7,",Space,Str "255\8211\&66,",Space,Str "1987\8211\&1999."]
-,Para [Str "Ellipses\8230and\8230and\8230."]
-,Header 1 ("math",[],[]) []
-,Para [Math DisplayMath "e = mc^{2}",Math DisplayMath "1",SoftBreak,Math InlineMath "e = mc^{2}",SoftBreak,Math DisplayMath "e = mc^{2}"]
-,Header 1 ("special-characters",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "unicode:"]
-,BulletList
- [[Para [Str "I",Space,Str "hat:",Space,Str "\206"]]
- ,[Para [Str "o",Space,Str "umlaut:",Space,Str "\246"]]
- ,[Para [Str "section:",Space,Str "\167"]]
- ,[Para [Str "set",Space,Str "membership:",Space,Str "\8712"]]
- ,[Para [Str "copyright:",Space,Str "\169"]]]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "AT&T",Space,Str "is",Space,Str "another",Space,Str "way",Space,Str "to",Space,Str "write",Space,Str "it."]
-,Para [Str "This",Space,Str "&",Space,Str "that."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "`"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,Header 1 ("links",[],[]) [Str "Links"]
-,Header 2 ("explicit",[],[]) [Str "Explicit"]
-,Para [Str "Just",Space,Str "a",Space,Link ("",[],[]) [Str "URL"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","")]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","")]
-,Para [Link ("",[],[]) [Str "with_underscore"] ("/url/with_underscore","")]
-,Para [Link ("",[],[]) [Str "nobody@nowhere.net"] ("mailto:nobody@nowhere.net","")]
-,Para [Link ("",[],[]) [Str "Empty"] ("",""),Str "."]
-,Header 2 ("reference",[],[]) [Str "Reference"]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "With",Space,Link ("",[],[]) [Str "embedded",Space,Str "[brackets]"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "b"] ("/url/",""),Space,Str "by",Space,Str "itself",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "link."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "once"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "twice"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "thrice"] ("/url",""),Str "."]
-,Para [Str "This",Space,Str "should",Space,Str "[not][]",Space,Str "be",Space,Str "a",Space,Str "link."]
-,CodeBlock ("",[],[]) "[not]: /url"
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "biz"] ("/url/",""),Str "."]
-,Header 2 ("with-ampersands",[],[]) [Str "With",Space,Str "ampersands"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Link ("",[],[]) [Str "link",Space,Str "with",Space,Str "an",SoftBreak,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "URL"] ("http://example.com/?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "link",Space,Str "with",Space,Str "an",Space,Str "amersand",Space,Str "in",Space,Str "the",Space,Str "link",Space,Str "text:",SoftBreak,Link ("",[],[]) [Str "AT&T"] ("http://att.com/",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link"] ("/script?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link",Space,Str "in",Space,Str "pointy",SoftBreak,Str "braces"] ("/script?foo=1&bar=2",""),Str "."]
-,Header 2 ("autolinks",[],[]) [Str "Autolinks"]
-,Para [Str "With",Space,Str "an",Space,Str "ampersand:",SoftBreak,Link ("",[],[]) [Str "http://example.com/?foo=1&bar=2"] ("http://example.com/?foo=1&bar=2","")]
-,BulletList
- [[Para [Str "In",Space,Str "a",Space,Str "list?"]]
- ,[Para [Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
- ,[Para [Str "It",Space,Str "should."]]]
-,Para [Str "An",Space,Str "e-mail",Space,Str "address:",Space,Link ("",[],[]) [Str "nobody@nowhere.net"] ("mailto:nobody@nowhere.net","")]
-,BlockQuote
- [Para [Str "Blockquoted:",SoftBreak,Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
-,Para [Str "Auto-links",Space,Str "should",Space,Str "not",Space,Str "occur",Space,Str "here:",SoftBreak,Code ("",[],[]) "<http://example.com/>"]
-,CodeBlock ("",[],[]) "or here: <http://example.com/>"
-,Header 1 ("images",[],[]) [Str "Images"]
-,Para [Str "From",Space,Quoted DoubleQuote [Str "Voyage",Space,Str "dans",Space,Str "la",Space,Str "Lune"],Space,Str "by",Space,Str "Georges",Space,Str "Melies",Space,Str "(1902):"]
-,Para [Image ("",[],[]) [Str "lalune",Space,Str "fig",Space,Str "caption"] ("lalune.jpg","fig:")]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "movie",Space,Image ("",[],[]) [] ("movie.jpg",""),Space,Str "icon.",SoftBreak,Str "And",Space,Str "here",Space,Str "a",Space,Str "second",Space,Str "movie",Space,Image ("",[],[]) [Str "alt",Space,Str "text"] ("movie.jpg",""),Space,Str "icon.",SoftBreak,Str "And",Space,Str "here",Space,Str "a",Space,Str "third",Space,Str "movie",Space,Image ("",[],[]) [Str "alt",Space,Str "text"] ("movie.jpg",""),Space,Str "icon."]
-,Para [Image ("",[],[]) [Str "lalune",Space,Str "no",Space,Str "figure",Space,Str "alt",Space,Str "text"] ("lalune.jpg","")]
-,Header 1 ("footnotes",[],[]) [Str "Footnotes"]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "footnote",Space,Str "reference,",Note [Para [Str "Here",Space,Str "is",Space,Str "the",Space,Str "footnote.",Space,Str "It",Space,Str "can",Space,Str "go",Space,Str "anywhere",Space,Str "after",Space,Str "the",Space,Str "footnote",Space,Str "reference.",SoftBreak,Str "It",Space,Str "need",Space,Str "not",Space,Str "be",Space,Str "placed",Space,Str "at",Space,Str "the",Space,Str "end",Space,Str "of",Space,Str "the",Space,Str "document."]],Space,Str "and",Space,Str "another.",Note [Para [Str "Here\8217s",Space,Str "the",Space,Str "long",Space,Str "note.",Space,Str "This",Space,Str "one",Space,Str "contains",Space,Str "multiple",Space,Str "blocks."],Para [Str "Subsequent",Space,Str "blocks",Space,Str "are",Space,Str "indented",Space,Str "to",Space,Str "show",Space,Str "that",Space,Str "they",Space,Str "belong",Space,Str "to",Space,Str "the",SoftBreak,Str "footnote",Space,Str "(as",Space,Str "with",Space,Str "list",Space,Str "items)."],CodeBlock ("",[],[]) "  { <code> }",Para [Str "If",Space,Str "you",Space,Str "want,",Space,Str "you",Space,Str "can",Space,Str "indent",Space,Str "every",Space,Str "line,",Space,Str "but",Space,Str "you",Space,Str "can",Space,Str "also",Space,Str "be",Space,Str "lazy",Space,Str "and",SoftBreak,Str "just",Space,Str "indent",Space,Str "the",Space,Str "first",Space,Str "line",Space,Str "of",Space,Str "each",Space,Str "block."]],Space,Str "This",Space,Str "should",Space,Emph [Str "not"],Space,Str "be",Space,Str "a",Space,Str "footnote",Space,Str "reference,",SoftBreak,Str "because",Space,Str "it",Space,Str "contains",Space,Str "a",Space,Str "space.[^my",Space,Str "note]",Space,Str "Here",Space,Str "is",Space,Str "an",Space,Str "inline",Space,Str "note.",Note [Para [Str "This",Space,Str "is",Space,Emph [Str "easier"],Space,Str "to",Space,Str "type.",Space,Str "Inline",Space,Str "notes",Space,Str "may",Space,Str "contain",SoftBreak,Link ("",[],[]) [Str "links"] ("http://google.com",""),Space,Str "and",Space,Code ("",[],[]) "]",SoftBreak,Str "verbatim",Space,Str "characters,",Space,Str "as",Space,Str "well",Space,Str "as",Space,Str "[bracketed",Space,Str "text]."]]]
-,BlockQuote
- [Para [Str "Notes",Space,Str "can",Space,Str "go",Space,Str "in",Space,Str "quotes.",Note [Para [Str "In",Space,Str "quote."]]]]
-,OrderedList (1,Decimal,DefaultDelim)
- [[Para [Str "And",Space,Str "in",Space,Str "list",Space,Str "items.",Note [Para [Str "In",Space,Str "list."]]]]]
-,Para [Str "This",Space,Str "paragraph",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "part",Space,Str "of",Space,Str "the",Space,Str "note,",Space,Str "as",Space,Str "it",Space,Str "is",Space,Str "not",Space,Str "indented."]
-,Header 1 ("tables",[],[]) [Str "Tables"]
-,Para [Str "Simple",Space,Str "table",Space,Str "with",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Demonstration",Space,Str "of",Space,Str "simple",Space,Str "table",Space,Str "syntax."]])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Simple",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Simple",Space,Str "table",Space,Str "indented",Space,Str "two",Space,Str "spaces:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Demonstration",Space,Str "of",Space,Str "simple",Space,Str "table",Space,Str "syntax."]])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "with",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Here's",Space,Str "the",Space,Str "caption.",Space,Str "It",Space,Str "may",Space,Str "span",Space,Str "multiple",Space,Str "lines."]])
- [(AlignCenter,ColWidth 0.2)
- ,(AlignLeft,ColWidth 0.2)
- ,(AlignRight,ColWidth 0.3)
- ,(AlignLeft,ColWidth 0.3)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Centered",Space,Str "Header"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left",Space,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right",Space,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default",Space,Str "aligned"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",Space,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here's",Space,Str "another",Space,Str "one.",Space,Str "Note",Space,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",Space,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidth 0.1)
- ,(AlignLeft,ColWidth 0.2)
- ,(AlignRight,ColWidth 0.3)
- ,(AlignLeft,ColWidth 0.4)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Centered",Space,Str "Header"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left",Space,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right",Space,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default",Space,Str "aligned"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",Space,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here's",Space,Str "another",Space,Str "one.",Space,Str "Note",Space,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",Space,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Table",Space,Str "without",Space,Str "column",Space,Str "headers:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "without",Space,Str "column",Space,Str "headers:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidth 0.25)
- ,(AlignLeft,ColWidth 0.25)
- ,(AlignRight,ColWidth 0.25)
- ,(AlignLeft,ColWidth 0.25)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",Space,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here's",Space,Str "another",Space,Str "one.",Space,Str "Note",Space,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",Space,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])
-,BulletList
- [[Para [Str "A",Space,Str "Step"]]
- ,[Para [Str "Another",Space,Str "Step"]
-  ,Para [Str "Substeps",Space,Str "can",Space,Str "be",Space,Str "nested",Space,Str "indefinitely",Space,Str "deep."]]
- ,[Para [Str "A",Space,Str "Final",Space,Str "Step"]]]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaList
+          [ MetaInlines
+            [ Str "John", SoftBreak, Str "MacFarlane" ]
+          , MetaInlines
+            [ Str "Anonymous" ]
+          ]
+        )
+      ,
+        ( "date"
+        , MetaInlines
+          [ Str "July", Space, Str "17,", Space, Str "2006" ]
+        )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Pandoc", Space, Str "Test", Space, Str "Suite" ]
+        )
+      ]
+    }
+  )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc."
+    , Space
+    , Str "Most"
+    , Space
+    , Str "of"
+    , Space
+    , Str "them"
+    , Space
+    , Str "are"
+    , Space
+    , Str "adapted"
+    , Space
+    , Str "from"
+    , Space
+    , Str "John"
+    , SoftBreak
+    , Str "Gruber\8217s"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "test"
+    , Space
+    , Str "suite."
+    ]
+  , Header 1
+    ( "headers", [], [] )
+    [ Str "Headers" ]
+  , Header 2
+    ( "level-2-with-an-embedded-link", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "link" ]
+      ( "/url", "" )
+    ]
+  , Header 3
+    ( "level-3-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "3"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 4
+    ( "level-4", [], [] )
+    [ Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "level-5", [], [] )
+    [ Str "Level", Space, Str "5" ]
+  , Para
+    [ Str "Hi." ]
+  , Header 1
+    ( "level-1", [], [] )
+    [ Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "level-2-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 3
+    ( "level-3", [], [] )
+    [ Str "Level", Space, Str "3" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , Header 4
+    ( "", [ "unnumbered" ], [] )
+    [ Str "Level", Space, Str "4" ]
+  , Para
+    [ Str "An", Space, Str "unnumbered", Space, Str "section." ]
+  , Header 2
+    ( "level-2", [], [] )
+    [ Str "Level", Space, Str "2" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , Header 1
+    ( "paragraphs", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "In"
+    , Space
+    , Str "Markdown"
+    , Space
+    , Str "1.0.0"
+    , Space
+    , Str "and"
+    , Space
+    , Str "earlier."
+    , Space
+    , Str "Version"
+    , Space
+    , Str "8."
+    , Space
+    , Str "This"
+    , Space
+    , Str "line"
+    , Space
+    , Str "turns"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , SoftBreak
+    , Str "item."
+    , Space
+    , Str "Because"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard-wrapped"
+    , Space
+    , Str "line"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "middle"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "looked"
+    , Space
+    , Str "like"
+    , SoftBreak
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    , Space
+    , Str "*"
+    , Space
+    , Str "criminey."
+    ]
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "E-mail", Space, Str "style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , Space
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "pretty"
+      , Space
+      , Str "short."
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Code"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    , CodeBlock
+      ( "", [], [] ) "% ls"
+    , Para
+      [ Str "A", Space, Str "list:" ]
+    , OrderedList
+      ( 1, Decimal, DefaultDelim )
+      [
+        [ Para [ Str "item", Space, Str "one" ] ]
+      ,
+        [ Para [ Str "item", Space, Str "two" ] ]
+      ]
+    , Para
+      [ Str "Nested", Space, Str "block", Space, Str "quotes:" ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote:"
+    , Space
+    , Str "2"
+    , Space
+    , Str ">"
+    , Space
+    , Str "1."
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "a"
+    , Space
+    , Str "following"
+    , Space
+    , Str "paragraph."
+    ]
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "unordered", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "ordered", [], [] )
+    [ Str "Ordered" ]
+  , OrderedList
+    ( 1, Decimal, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and", Space, Str "using", Space, Str "spaces:" ]
+  , OrderedList
+    ( 1, Decimal, DefaultDelim )
+    [
+      [ Para [ Str "One" ] ]
+    ,
+      [ Para [ Str "Two" ] ]
+    ,
+      [ Para [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "paragraphs:" ]
+  , OrderedList
+    ( 1, Decimal, DefaultDelim )
+    [
+      [ Para
+        [ Str "Item"
+        , Space
+        , Str "1,"
+        , Space
+        , Str "graf"
+        , Space
+        , Str "one."
+        ]
+      , Para
+        [ Str "Item"
+        , Space
+        , Str "1."
+        , Space
+        , Str "graf"
+        , Space
+        , Str "two."
+        , Space
+        , Str "The"
+        , Space
+        , Str "quick"
+        , Space
+        , Str "brown"
+        , Space
+        , Str "fox"
+        , Space
+        , Str "jumped"
+        , Space
+        , Str "over"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lazy"
+        , Space
+        , Str "dog\8217s"
+        , SoftBreak
+        , Str "back."
+        ]
+      ]
+    ,
+      [ Para [ Str "Item", Space, Str "2." ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "3." ] ]
+    ]
+  , Header 2
+    ( "nested", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "Tab" ]
+      , BulletList
+        [
+          [ Para [ Str "Tab" ], BulletList [ [ Para [ Str "Tab" ] ] ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s", Space, Str "another:" ]
+  , OrderedList
+    ( 1, Decimal, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Same"
+    , Space
+    , Str "thing"
+    , Space
+    , Str "but"
+    , Space
+    , Str "with"
+    , Space
+    , Str "paragraphs:"
+    ]
+  , OrderedList
+    ( 1, Decimal, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "tabs-and-spaces", [], [] )
+    [ Str "Tabs", Space, Str "and", Space, Str "spaces" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "tabs"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "spaces"
+        ]
+      , BulletList
+        [
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "tabs"
+            ]
+          ]
+        ,
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "spaces"
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "fancy-list-markers", [], [] )
+    [ Str "Fancy", Space, Str "list", Space, Str "markers" ]
+  , OrderedList
+    ( 2, Decimal, DefaultDelim )
+    [
+      [ Para [ Str "begins", Space, Str "with", Space, Str "2" ] ]
+    ,
+      [ Para
+        [ Str "and", Space, Str "now", Space, Str "3" ]
+      , Para
+        [ Str "with", Space, Str "a", Space, Str "continuation" ]
+      , OrderedList
+        ( 4, LowerRoman, DefaultDelim )
+        [
+          [ Para
+            [ Str "sublist"
+            , Space
+            , Str "with"
+            , Space
+            , Str "roman"
+            , Space
+            , Str "numerals,"
+            , Space
+            , Str "starting"
+            , Space
+            , Str "with"
+            , Space
+            , Str "4"
+            ]
+          ]
+        ,
+          [ Para
+            [ Str "more", Space, Str "items" ]
+          , OrderedList
+            ( 1, UpperAlpha, DefaultDelim )
+            [
+              [ Para [ Str "a", Space, Str "subsublist" ] ]
+            ,
+              [ Para [ Str "a", Space, Str "subsublist" ] ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Nesting:" ]
+  , OrderedList
+    ( 1, UpperAlpha, DefaultDelim )
+    [
+      [ Para
+        [ Str "Upper", Space, Str "Alpha" ]
+      , OrderedList
+        ( 1, UpperRoman, DefaultDelim )
+        [
+          [ Para
+            [ Str "Upper", Space, Str "Roman." ]
+          , OrderedList
+            ( 6, Decimal, DefaultDelim )
+            [
+              [ Para
+                [ Str "Decimal"
+                , Space
+                , Str "start"
+                , Space
+                , Str "with"
+                , Space
+                , Str "6"
+                ]
+              , OrderedList
+                ( 3, LowerAlpha, DefaultDelim )
+                [
+                  [ Para
+                    [ Str "Lower"
+                    , Space
+                    , Str "alpha"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "paren"
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Autonumbering:" ]
+  , OrderedList
+    ( 1, Decimal, DefaultDelim )
+    [
+      [ Para [ Str "Autonumber." ] ]
+    ,
+      [ Para
+        [ Str "More." ]
+      , OrderedList
+        ( 1, Decimal, DefaultDelim )
+        [ [ Para [ Str "Nested." ] ] ]
+      ]
+    ]
+  , Para
+    [ Str "Should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item:"
+    ]
+  , Para
+    [ Str "M.A.\160\&2007" ]
+  , Para
+    [ Str "B.", Space, Str "Williams" ]
+  , Header 2
+    ( "callout", [], [] )
+    [ Str "Callout" ]
+  , Para
+    [ Str "Simple." ]
+  , BulletList
+    [
+      [ Para
+        [ Str "A"
+        , Space
+        , Code
+          ( "", [], [] ) "__letrec"
+        , Space
+        , Str "is"
+        , Space
+        , Str "equivalent"
+        , Space
+        , Str "to"
+        , Space
+        , Str "a"
+        , Space
+        , Str "normal"
+        , SoftBreak
+        , Str "Haskell"
+        , Space
+        , Str "LET."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "GHC"
+        , Space
+        , Str "compiled"
+        , Space
+        , Str "the"
+        , Space
+        , Str "body"
+        , Space
+        , Str "of"
+        , Space
+        , Str "our"
+        , Space
+        , Str "list"
+        , Space
+        , Str "comprehension"
+        , Space
+        , Str "into"
+        , SoftBreak
+        , Str "a"
+        , Space
+        , Str "loop"
+        , Space
+        , Str "named"
+        , Space
+        , Code
+          ( "", [], [] ) "go_s1YC"
+        , Str "."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "If"
+        , Space
+        , Str "our"
+        , Space
+        , Str "CASE"
+        , Space
+        , Str "expression"
+        , Space
+        , Str "matches"
+        , Space
+        , Str "the"
+        , Space
+        , Str "empty"
+        , Space
+        , Str "list,"
+        , Space
+        , Str "we"
+        , SoftBreak
+        , Str "return"
+        , Space
+        , Str "the"
+        , Space
+        , Str "empty"
+        , Space
+        , Str "list."
+        , Space
+        , Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "reassuringly"
+        , SoftBreak
+        , Str "familiar."
+        ]
+      ]
+    ]
+  , Header 1
+    ( "definition-lists", [], [] )
+    [ Str "Definition", Space, Str "Lists" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [ [ Para [ Str "red", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [ [ Para [ Str "orange", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "banana" ]
+      ,
+        [ [ Para [ Str "yellow", Space, Str "fruit" ] ] ]
+      )
+    ]
+  , Para
+    [ Str "Multiple"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "with"
+    , Space
+    , Str "italics:"
+    ]
+  , DefinitionList
+    [
+      (
+        [ Emph [ Str "apple" ] ]
+      ,
+        [
+          [ Para
+            [ Str "red", Space, Str "fruit" ]
+          , Para
+            [ Str "contains"
+            , Space
+            , Str "seeds,"
+            , Space
+            , Str "crisp,"
+            , Space
+            , Str "pleasant"
+            , Space
+            , Str "to"
+            , Space
+            , Str "taste"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Emph [ Str "orange" ] ]
+      ,
+        [
+          [ Para
+            [ Str "orange", Space, Str "fruit" ]
+          , CodeBlock
+            ( "", [], [] ) "{ orange code block }"
+          , BlockQuote
+            [ Para
+              [ Str "orange", Space, Str "block", Space, Str "quote" ]
+            ]
+          ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "definitions,", Space, Str "loose:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [
+          [ Para [ Str "red", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "computer" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [
+          [ Para [ Str "orange", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "bank" ] ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Blank"
+    , Space
+    , Str "line"
+    , Space
+    , Str "after"
+    , Space
+    , Str "term,"
+    , Space
+    , Str "indented"
+    , Space
+    , Str "marker,"
+    , Space
+    , Str "alternate"
+    , Space
+    , Str "markers:"
+    ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [
+          [ Para [ Str "red", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "computer" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [
+          [ Para
+            [ Str "orange", Space, Str "fruit" ]
+          , OrderedList
+            ( 1, Decimal, DefaultDelim )
+            [ [ Para [ Str "sublist" ] ], [ Para [ Str "sublist" ] ] ]
+          ]
+        ]
+      )
+    ]
+  , Header 1
+    ( "inline-markup", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Emph
+      [ Str "is", SoftBreak, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , SoftBreak
+    , Strong
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Emph
+      [ Link
+        ( "", [], [] )
+        [ Str "emphasized", Space, Str "link" ]
+        ( "/url", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , SoftBreak
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , SoftBreak
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) ">"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "$"
+    , Str ","
+    , SoftBreak
+    , Code
+      ( "", [], [] ) "\\"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\$"
+    , Str ","
+    , SoftBreak
+    , Code
+      ( "", [], [] ) "<html>"
+    , Str "."
+    ]
+  , Para
+    [ Str "More"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) "Class"
+    , Space
+    , Str "and"
+    , Space
+    , Code
+      ( "", [], [] ) "Type"
+    ]
+  , Para
+    [ Str "Referencing"
+    , Space
+    , Str "a"
+    , Space
+    , Str "man"
+    , Space
+    , Str "page:"
+    , Space
+    , Code
+      ( "", [ "citerefentry" ], [] ) "nix.conf(5)"
+    ]
+  , Para
+    [ Strikeout
+      [ Str "This"
+      , Space
+      , Str "is"
+      , SoftBreak
+      , Emph
+        [ Str "strikeout" ]
+      , Str "."
+      ]
+    ]
+  , Para
+    [ Str "Superscripts:"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "bc" ]
+    , Str "d"
+    , SoftBreak
+    , Str "a"
+    , Superscript
+      [ Emph [ Str "hello" ] ]
+    , SoftBreak
+    , Str "a"
+    , Superscript
+      [ Str "hello\160there" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Subscripts:"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "2" ]
+    , Str "O,"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "23" ]
+    , Str "O,"
+    , SoftBreak
+    , Str "H"
+    , Subscript
+      [ Str "many\160of\160them" ]
+    , Str "O."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "superscripts"
+    , Space
+    , Str "or"
+    , Space
+    , Str "subscripts,"
+    , Space
+    , Str "because"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "unescaped"
+    , SoftBreak
+    , Str "spaces:"
+    , Space
+    , Str "a^b"
+    , Space
+    , Str "c^d,"
+    , Space
+    , Str "a~b"
+    , Space
+    , Str "c~d."
+    ]
+  , Header 1
+    ( "smart-quotes-ellipses-dashes", [], [] )
+    [ Str "Smart"
+    , Space
+    , Str "quotes,"
+    , Space
+    , Str "ellipses,"
+    , Space
+    , Str "dashes"
+    ]
+  , Para
+    [ Quoted DoubleQuote
+      [ Str "Hello," ]
+    , Space
+    , Str "said"
+    , Space
+    , Str "the"
+    , Space
+    , Str "spider."
+    , Space
+    , Quoted DoubleQuote
+      [ Quoted SingleQuote
+        [ Str "Shelob" ]
+      , Space
+      , Str "is"
+      , Space
+      , Str "my"
+      , SoftBreak
+      , Str "name."
+      ]
+    ]
+  , Para
+    [ Quoted DoubleQuote
+      [ Str "A" ]
+    , Str ","
+    , Space
+    , Quoted DoubleQuote
+      [ Str "B" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Quoted DoubleQuote
+      [ Str "C" ]
+    , Space
+    , Str "are"
+    , Space
+    , Str "letters."
+    ]
+  , Para
+    [ Quoted DoubleQuote
+      [ Str "He"
+      , Space
+      , Str "said,"
+      , Space
+      , Quoted SingleQuote
+        [ Str "I"
+        , Space
+        , Str "want"
+        , Space
+        , Str "to"
+        , Space
+        , Str "go."
+        ]
+      ]
+    , Space
+    , Str "Were"
+    , Space
+    , Str "you"
+    , Space
+    , Str "alive"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "70\8217s?"
+    ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Str "dashes:"
+    , Space
+    , Str "one\8212two"
+    , Space
+    , Str "\8212"
+    , Space
+    , Str "three\8212four"
+    , Space
+    , Str "\8212"
+    , Space
+    , Str "five."
+    ]
+  , Para
+    [ Str "Dashes"
+    , Space
+    , Str "between"
+    , Space
+    , Str "numbers:"
+    , Space
+    , Str "5\8211\&7,"
+    , Space
+    , Str "255\8211\&66,"
+    , Space
+    , Str "1987\8211\&1999."
+    ]
+  , Para
+    [ Str "Ellipses\8230and\8230and\8230." ]
+  , Header 1
+    ( "math", [], [] ) []
+  , Para
+    [ Math DisplayMath "e = mc^{2}"
+    , Math DisplayMath "1"
+    , SoftBreak
+    , Math InlineMath "e = mc^{2}"
+    , SoftBreak
+    , Math DisplayMath "e = mc^{2}"
+    ]
+  , Header 1
+    ( "special-characters", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "unicode:"
+    ]
+  , BulletList
+    [
+      [ Para [ Str "I", Space, Str "hat:", Space, Str "\206" ] ]
+    ,
+      [ Para [ Str "o", Space, Str "umlaut:", Space, Str "\246" ] ]
+    ,
+      [ Para [ Str "section:", Space, Str "\167" ] ]
+    ,
+      [ Para
+        [ Str "set", Space, Str "membership:", Space, Str "\8712" ]
+      ]
+    ,
+      [ Para [ Str "copyright:", Space, Str "\169" ] ]
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "is"
+    , Space
+    , Str "another"
+    , Space
+    , Str "way"
+    , Space
+    , Str "to"
+    , Space
+    , Str "write"
+    , Space
+    , Str "it."
+    ]
+  , Para
+    [ Str "This", Space, Str "&", Space, Str "that." ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "`" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , Header 1
+    ( "links", [], [] )
+    [ Str "Links" ]
+  , Header 2
+    ( "explicit", [], [] )
+    [ Str "Explicit" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "URL" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "with_underscore" ]
+      ( "/url/with_underscore", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "nobody@nowhere.net" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Empty" ] ( "", "" ), Str "." ]
+  , Header 2
+    ( "reference", [], [] )
+    [ Str "Reference" ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "With"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "[brackets]" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "b" ]
+      ( "/url/", "" )
+    , Space
+    , Str "by"
+    , Space
+    , Str "itself"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "once" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "twice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "thrice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "[not][]"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , CodeBlock
+    ( "", [], [] ) "[not]: /url"
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "biz" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "with-ampersands", [], [] )
+    [ Str "With", Space, Str "ampersands" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link"
+      , Space
+      , Str "with"
+      , Space
+      , Str "an"
+      , SoftBreak
+      , Str "ampersand"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "URL"
+      ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Str "amersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "text:"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "AT&T" ]
+      ( "http://att.com/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline", Space, Str "link" ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline"
+      , Space
+      , Str "link"
+      , Space
+      , Str "in"
+      , Space
+      , Str "pointy"
+      , SoftBreak
+      , Str "braces"
+      ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "autolinks", [], [] )
+    [ Str "Autolinks" ]
+  , Para
+    [ Str "With"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand:"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://example.com/?foo=1&bar=2" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    ]
+  , BulletList
+    [
+      [ Para [ Str "In", Space, Str "a", Space, Str "list?" ] ]
+    ,
+      [ Para
+        [ Link
+          ( "", [], [] )
+          [ Str "http://example.com/" ]
+          ( "http://example.com/", "" )
+        ]
+      ]
+    ,
+      [ Para [ Str "It", Space, Str "should." ] ]
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Str "e-mail"
+    , Space
+    , Str "address:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "nobody@nowhere.net" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Blockquoted:"
+      , SoftBreak
+      , Link
+        ( "", [], [] )
+        [ Str "http://example.com/" ]
+        ( "http://example.com/", "" )
+      ]
+    ]
+  , Para
+    [ Str "Auto-links"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "occur"
+    , Space
+    , Str "here:"
+    , SoftBreak
+    , Code
+      ( "", [], [] ) "<http://example.com/>"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "or here: <http://example.com/>"
+  , Header 1
+    ( "images", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "From"
+    , Space
+    , Quoted DoubleQuote
+      [ Str "Voyage"
+      , Space
+      , Str "dans"
+      , Space
+      , Str "la"
+      , Space
+      , Str "Lune"
+      ]
+    , Space
+    , Str "by"
+    , Space
+    , Str "Georges"
+    , Space
+    , Str "Melies"
+    , Space
+    , Str "(1902):"
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "lalune", Space, Str "fig", Space, Str "caption" ]
+      ( "lalune.jpg", "fig:" )
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] ) []
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    , SoftBreak
+    , Str "And"
+    , Space
+    , Str "here"
+    , Space
+    , Str "a"
+    , Space
+    , Str "second"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "alt", Space, Str "text" ]
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    , SoftBreak
+    , Str "And"
+    , Space
+    , Str "here"
+    , Space
+    , Str "a"
+    , Space
+    , Str "third"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "alt", Space, Str "text" ]
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "lalune"
+      , Space
+      , Str "no"
+      , Space
+      , Str "figure"
+      , Space
+      , Str "alt"
+      , Space
+      , Str "text"
+      ]
+      ( "lalune.jpg", "" )
+    ]
+  , Header 1
+    ( "footnotes", [], [] )
+    [ Str "Footnotes" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , Note
+      [ Para
+        [ Str "Here"
+        , Space
+        , Str "is"
+        , Space
+        , Str "the"
+        , Space
+        , Str "footnote."
+        , Space
+        , Str "It"
+        , Space
+        , Str "can"
+        , Space
+        , Str "go"
+        , Space
+        , Str "anywhere"
+        , Space
+        , Str "after"
+        , Space
+        , Str "the"
+        , Space
+        , Str "footnote"
+        , Space
+        , Str "reference."
+        , SoftBreak
+        , Str "It"
+        , Space
+        , Str "need"
+        , Space
+        , Str "not"
+        , Space
+        , Str "be"
+        , Space
+        , Str "placed"
+        , Space
+        , Str "at"
+        , Space
+        , Str "the"
+        , Space
+        , Str "end"
+        , Space
+        , Str "of"
+        , Space
+        , Str "the"
+        , Space
+        , Str "document."
+        ]
+      ]
+    , Space
+    , Str "and"
+    , Space
+    , Str "another."
+    , Note
+      [ Para
+        [ Str "Here\8217s"
+        , Space
+        , Str "the"
+        , Space
+        , Str "long"
+        , Space
+        , Str "note."
+        , Space
+        , Str "This"
+        , Space
+        , Str "one"
+        , Space
+        , Str "contains"
+        , Space
+        , Str "multiple"
+        , Space
+        , Str "blocks."
+        ]
+      , Para
+        [ Str "Subsequent"
+        , Space
+        , Str "blocks"
+        , Space
+        , Str "are"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "to"
+        , Space
+        , Str "show"
+        , Space
+        , Str "that"
+        , Space
+        , Str "they"
+        , Space
+        , Str "belong"
+        , Space
+        , Str "to"
+        , Space
+        , Str "the"
+        , SoftBreak
+        , Str "footnote"
+        , Space
+        , Str "(as"
+        , Space
+        , Str "with"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items)."
+        ]
+      , CodeBlock
+        ( "", [], [] ) "  { <code> }"
+      , Para
+        [ Str "If"
+        , Space
+        , Str "you"
+        , Space
+        , Str "want,"
+        , Space
+        , Str "you"
+        , Space
+        , Str "can"
+        , Space
+        , Str "indent"
+        , Space
+        , Str "every"
+        , Space
+        , Str "line,"
+        , Space
+        , Str "but"
+        , Space
+        , Str "you"
+        , Space
+        , Str "can"
+        , Space
+        , Str "also"
+        , Space
+        , Str "be"
+        , Space
+        , Str "lazy"
+        , Space
+        , Str "and"
+        , SoftBreak
+        , Str "just"
+        , Space
+        , Str "indent"
+        , Space
+        , Str "the"
+        , Space
+        , Str "first"
+        , Space
+        , Str "line"
+        , Space
+        , Str "of"
+        , Space
+        , Str "each"
+        , Space
+        , Str "block."
+        ]
+      ]
+    , Space
+    , Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Emph
+      [ Str "not" ]
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , SoftBreak
+    , Str "because"
+    , Space
+    , Str "it"
+    , Space
+    , Str "contains"
+    , Space
+    , Str "a"
+    , Space
+    , Str "space.[^my"
+    , Space
+    , Str "note]"
+    , Space
+    , Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "an"
+    , Space
+    , Str "inline"
+    , Space
+    , Str "note."
+    , Note
+      [ Para
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Emph
+          [ Str "easier" ]
+        , Space
+        , Str "to"
+        , Space
+        , Str "type."
+        , Space
+        , Str "Inline"
+        , Space
+        , Str "notes"
+        , Space
+        , Str "may"
+        , Space
+        , Str "contain"
+        , SoftBreak
+        , Link
+          ( "", [], [] )
+          [ Str "links" ]
+          ( "http://google.com", "" )
+        , Space
+        , Str "and"
+        , Space
+        , Code
+          ( "", [], [] ) "]"
+        , SoftBreak
+        , Str "verbatim"
+        , Space
+        , Str "characters,"
+        , Space
+        , Str "as"
+        , Space
+        , Str "well"
+        , Space
+        , Str "as"
+        , Space
+        , Str "[bracketed"
+        , Space
+        , Str "text]."
+        ]
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Notes"
+      , Space
+      , Str "can"
+      , Space
+      , Str "go"
+      , Space
+      , Str "in"
+      , Space
+      , Str "quotes."
+      , Note
+        [ Para [ Str "In", Space, Str "quote." ] ]
+      ]
+    ]
+  , OrderedList
+    ( 1, Decimal, DefaultDelim )
+    [
+      [ Para
+        [ Str "And"
+        , Space
+        , Str "in"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items."
+        , Note
+          [ Para [ Str "In", Space, Str "list." ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "part"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "note,"
+    , Space
+    , Str "as"
+    , Space
+    , Str "it"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "indented."
+    ]
+  , Header 1
+    ( "tables", [], [] )
+    [ Str "Tables" ]
+  , Para
+    [ Str "Simple"
+    , Space
+    , Str "table"
+    , Space
+    , Str "with"
+    , Space
+    , Str "caption:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing
+      [ Plain
+        [ Str "Demonstration"
+        , Space
+        , Str "of"
+        , Space
+        , Str "simple"
+        , Space
+        , Str "table"
+        , Space
+        , Str "syntax."
+        ]
+      ]
+    )
+    [
+      ( AlignRight, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Right" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Center" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Default" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Simple"
+    , Space
+    , Str "table"
+    , Space
+    , Str "without"
+    , Space
+    , Str "caption:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignRight, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Right" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Center" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Default" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Simple"
+    , Space
+    , Str "table"
+    , Space
+    , Str "indented"
+    , Space
+    , Str "two"
+    , Space
+    , Str "spaces:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing
+      [ Plain
+        [ Str "Demonstration"
+        , Space
+        , Str "of"
+        , Space
+        , Str "simple"
+        , Space
+        , Str "table"
+        , Space
+        , Str "syntax."
+        ]
+      ]
+    )
+    [
+      ( AlignRight, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Right" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Center" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Default" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Multiline"
+    , Space
+    , Str "table"
+    , Space
+    , Str "with"
+    , Space
+    , Str "caption:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing
+      [ Plain
+        [ Str "Here's"
+        , Space
+        , Str "the"
+        , Space
+        , Str "caption."
+        , Space
+        , Str "It"
+        , Space
+        , Str "may"
+        , Space
+        , Str "span"
+        , Space
+        , Str "multiple"
+        , Space
+        , Str "lines."
+        ]
+      ]
+    )
+    [
+      ( AlignCenter, ColWidth 0.2 )
+    ,
+      ( AlignLeft, ColWidth 0.2 )
+    ,
+      ( AlignRight, ColWidth 0.3 )
+    ,
+      ( AlignLeft, ColWidth 0.3 )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Centered", Space, Str "Header" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left", Space, Str "Aligned" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Right", Space, Str "Aligned" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Default", Space, Str "aligned" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "First" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "row" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Example"
+            , Space
+            , Str "of"
+            , Space
+            , Str "a"
+            , Space
+            , Str "row"
+            , Space
+            , Str "that"
+            , Space
+            , Str "spans"
+            , Space
+            , Str "multiple"
+            , Space
+            , Str "lines."
+            ]
+          ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Second" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "row" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Here's"
+            , Space
+            , Str "another"
+            , Space
+            , Str "one."
+            , Space
+            , Str "Note"
+            , Space
+            , Str "the"
+            , Space
+            , Str "blank"
+            , Space
+            , Str "line"
+            , Space
+            , Str "between"
+            , Space
+            , Str "rows."
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Multiline"
+    , Space
+    , Str "table"
+    , Space
+    , Str "without"
+    , Space
+    , Str "caption:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidth 0.1 )
+    ,
+      ( AlignLeft, ColWidth 0.2 )
+    ,
+      ( AlignRight, ColWidth 0.3 )
+    ,
+      ( AlignLeft, ColWidth 0.4 )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Centered", Space, Str "Header" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left", Space, Str "Aligned" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Right", Space, Str "Aligned" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Default", Space, Str "aligned" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "First" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "row" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Example"
+            , Space
+            , Str "of"
+            , Space
+            , Str "a"
+            , Space
+            , Str "row"
+            , Space
+            , Str "that"
+            , Space
+            , Str "spans"
+            , Space
+            , Str "multiple"
+            , Space
+            , Str "lines."
+            ]
+          ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Second" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "row" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Here's"
+            , Space
+            , Str "another"
+            , Space
+            , Str "one."
+            , Space
+            , Str "Note"
+            , Space
+            , Str "the"
+            , Space
+            , Str "blank"
+            , Space
+            , Str "line"
+            , Space
+            , Str "between"
+            , Space
+            , Str "rows."
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Table"
+    , Space
+    , Str "without"
+    , Space
+    , Str "column"
+    , Space
+    , Str "headers:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignRight, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignRight, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Multiline"
+    , Space
+    , Str "table"
+    , Space
+    , Str "without"
+    , Space
+    , Str "column"
+    , Space
+    , Str "headers:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidth 0.25 )
+    ,
+      ( AlignLeft, ColWidth 0.25 )
+    ,
+      ( AlignRight, ColWidth 0.25 )
+    ,
+      ( AlignLeft, ColWidth 0.25 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "First" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "row" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Example"
+            , Space
+            , Str "of"
+            , Space
+            , Str "a"
+            , Space
+            , Str "row"
+            , Space
+            , Str "that"
+            , Space
+            , Str "spans"
+            , Space
+            , Str "multiple"
+            , Space
+            , Str "lines."
+            ]
+          ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Second" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "row" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Here's"
+            , Space
+            , Str "another"
+            , Space
+            , Str "one."
+            , Space
+            , Str "Note"
+            , Space
+            , Str "the"
+            , Space
+            , Str "blank"
+            , Space
+            , Str "line"
+            , Space
+            , Str "between"
+            , Space
+            , Str "rows."
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , BulletList
+    [
+      [ Para [ Str "A", Space, Str "Step" ] ]
+    ,
+      [ Para
+        [ Str "Another", Space, Str "Step" ]
+      , Para
+        [ Str "Substeps"
+        , Space
+        , Str "can"
+        , Space
+        , Str "be"
+        , Space
+        , Str "nested"
+        , Space
+        , Str "indefinitely"
+        , Space
+        , Str "deep."
+        ]
+      ]
+    ,
+      [ Para [ Str "A", Space, Str "Final", Space, Str "Step" ] ]
+    ]
+  ]

--- a/test/docbook-xref.native
+++ b/test/docbook-xref.native
@@ -1,29 +1,184 @@
-Pandoc (Meta {unMeta = fromList [("title",MetaInlines [Str "An",Space,Str "Example",Space,Str "Book"])]})
-[Header 1 ("ch01",[],[]) [Str "XRef",Space,Str "Samples"]
-,Para [Str "This",Space,Str "paragraph",Space,Str "demonstrates",Space,Str "several",Space,Str "features",Space,Str "of",SoftBreak,Str "XRef."]
-,BulletList
- [[Para [Str "A",Space,Str "straight",Space,Str "link",Space,Str "generates",Space,Str "the",SoftBreak,Str "cross-reference",Space,Str "text:",Space,Link ("",[],[]) [Str "The",Space,Str "Second",Space,Str "Chapter"] ("#ch02",""),Str "."]]
- ,[Para [Str "A",Space,Str "link",Space,Str "to",Space,Str "an",Space,Str "element",Space,Str "with",Space,Str "an",SoftBreak,Str "XRefLabel:",SoftBreak,Link ("",[],[]) [Str "Chapter",Space,Str "the",Space,Str "Third"] ("#ch03",""),Str "."]]
- ,[Para [Str "A",Space,Str "link",Space,Str "with",Space,Str "an",SoftBreak,Str "EndTerm:",SoftBreak,Link ("",[],[]) [Str "Chapter",Space,Str "4"] ("#ch04",""),Str "."]]
- ,[Para [Str "A",Space,Str "link",Space,Str "to",Space,Str "an",SoftBreak,Str "cmdsynopsis",Space,Str "element:",Space,Link ("",[],[]) [Str "chgrp"] ("#cmd01",""),Str "."]]
- ,[Para [Str "A",Space,Str "link",Space,Str "to",Space,Str "an",SoftBreak,Str "funcsynopsis",Space,Str "element:",Space,Link ("",[],[]) [Str "max"] ("#func01",""),Str "."]]]
-,Header 1 ("ch02",[],[]) [Str "The",Space,Str "Second",Space,Str "Chapter"]
-,Para [Str "Some",Space,Str "content",Space,Str "here"]
-,Header 1 ("ch03",[],[]) [Str "The",Space,Str "Third",Space,Str "Chapter"]
-,Para [Str "Some",Space,Str "content",Space,Str "here"]
-,Header 1 ("ch04",[],[]) [Str "The",Space,Str "Fourth",Space,Str "Chapter"]
-,Para [Str "Some",Space,Str "content",Space,Str "here"]
-,Plain [Str "chgrp"]
-,Plain [Str "-R"]
-,Plain [Str "-H"]
-,Plain [Str "-L"]
-,Plain [Str "-P"]
-,Plain [Str "-f"]
-,Plain [Str "group"]
-,Plain [Str "file"]
-,Plain [Str "int"]
-,Plain [Str "max"]
-,Plain [Str "int"]
-,Plain [Str "int1"]
-,Plain [Str "int"]
-,Plain [Str "int2"]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "title"
+        , MetaInlines
+          [ Str "An", Space, Str "Example", Space, Str "Book" ]
+        )
+      ]
+    }
+  )
+  [ Header 1
+    ( "ch01", [], [] )
+    [ Str "XRef", Space, Str "Samples" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "demonstrates"
+    , Space
+    , Str "several"
+    , Space
+    , Str "features"
+    , Space
+    , Str "of"
+    , SoftBreak
+    , Str "XRef."
+    ]
+  , BulletList
+    [
+      [ Para
+        [ Str "A"
+        , Space
+        , Str "straight"
+        , Space
+        , Str "link"
+        , Space
+        , Str "generates"
+        , Space
+        , Str "the"
+        , SoftBreak
+        , Str "cross-reference"
+        , Space
+        , Str "text:"
+        , Space
+        , Link
+          ( "", [], [] )
+          [ Str "The", Space, Str "Second", Space, Str "Chapter" ]
+          ( "#ch02", "" )
+        , Str "."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "A"
+        , Space
+        , Str "link"
+        , Space
+        , Str "to"
+        , Space
+        , Str "an"
+        , Space
+        , Str "element"
+        , Space
+        , Str "with"
+        , Space
+        , Str "an"
+        , SoftBreak
+        , Str "XRefLabel:"
+        , SoftBreak
+        , Link
+          ( "", [], [] )
+          [ Str "Chapter", Space, Str "the", Space, Str "Third" ]
+          ( "#ch03", "" )
+        , Str "."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "A"
+        , Space
+        , Str "link"
+        , Space
+        , Str "with"
+        , Space
+        , Str "an"
+        , SoftBreak
+        , Str "EndTerm:"
+        , SoftBreak
+        , Link
+          ( "", [], [] )
+          [ Str "Chapter", Space, Str "4" ]
+          ( "#ch04", "" )
+        , Str "."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "A"
+        , Space
+        , Str "link"
+        , Space
+        , Str "to"
+        , Space
+        , Str "an"
+        , SoftBreak
+        , Str "cmdsynopsis"
+        , Space
+        , Str "element:"
+        , Space
+        , Link
+          ( "", [], [] )
+          [ Str "chgrp" ]
+          ( "#cmd01", "" )
+        , Str "."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "A"
+        , Space
+        , Str "link"
+        , Space
+        , Str "to"
+        , Space
+        , Str "an"
+        , SoftBreak
+        , Str "funcsynopsis"
+        , Space
+        , Str "element:"
+        , Space
+        , Link
+          ( "", [], [] )
+          [ Str "max" ]
+          ( "#func01", "" )
+        , Str "."
+        ]
+      ]
+    ]
+  , Header 1
+    ( "ch02", [], [] )
+    [ Str "The", Space, Str "Second", Space, Str "Chapter" ]
+  , Para
+    [ Str "Some", Space, Str "content", Space, Str "here" ]
+  , Header 1
+    ( "ch03", [], [] )
+    [ Str "The", Space, Str "Third", Space, Str "Chapter" ]
+  , Para
+    [ Str "Some", Space, Str "content", Space, Str "here" ]
+  , Header 1
+    ( "ch04", [], [] )
+    [ Str "The", Space, Str "Fourth", Space, Str "Chapter" ]
+  , Para
+    [ Str "Some", Space, Str "content", Space, Str "here" ]
+  , Plain
+    [ Str "chgrp" ]
+  , Plain
+    [ Str "-R" ]
+  , Plain
+    [ Str "-H" ]
+  , Plain
+    [ Str "-L" ]
+  , Plain
+    [ Str "-P" ]
+  , Plain
+    [ Str "-f" ]
+  , Plain
+    [ Str "group" ]
+  , Plain
+    [ Str "file" ]
+  , Plain
+    [ Str "int" ]
+  , Plain
+    [ Str "max" ]
+  , Plain
+    [ Str "int" ]
+  , Plain
+    [ Str "int1" ]
+  , Plain
+    [ Str "int" ]
+  , Plain
+    [ Str "int2" ]
+  ]

--- a/test/epub/features.native
+++ b/test/epub/features.native
@@ -1,93 +1,1744 @@
-[Para [Span ("front.xhtml",[],[]) []]
-,Div ("",["section"],[])
- [Header 1 ("",[],[]) [Str "Reflowable",Space,Str "EPUB",Space,Str "3",Space,Str "Conformance",Space,Str "Test",Space,Str "Document:",Space,Str "0100"]
- ,Div ("",["section"],[])
-  [Header 2 ("",[],[]) [Str "Status",Space,Str "of",Space,Str "this",Space,Str "Document"]
-  ,Para [Str "This",Space,Str "publication",Space,Str "is",Space,Str "currently",Space,Str "considered",Space,Span ("",["status"],[]) [Str "[UNDER",Space,Str "DEVELOPMENT]"],Space,Str "by",Space,Str "the",Space,Str "IDPF."]
-  ,Para [Str "This",Space,Str "publication",Space,Str "is",Space,Str "part",Space,Str "of",Space,Str "version",Space,Span ("",["version"],[]) [Str "X.X"],Space,Str "of",Space,Str "the",Space,Str "EPUB",Space,Str "3.0",Space,Str "Compliance",Space,Str "Test",Space,Str "Suite",Space,Str "released",SoftBreak,Str "on",Space,RawInline (Format "html") "<time class=\"release\">",Str "TBD",RawInline (Format "html") "</time>",Str "."]
-  ,Para [Str "Before",Space,Str "using",Space,Str "this",Space,Str "publication",Space,Str "to",Space,Str "evaluate",Space,Str "reading",Space,Str "systems,",Space,Str "testers",Space,Str "are",Space,Str "strongly",Space,Str "encouraged",Space,Str "to",SoftBreak,Str "verify",Space,Str "that",Space,Str "they",Space,Str "have",Space,Str "the",Space,Str "latest",Space,Str "release",Space,Str "by",Space,Str "checking",Space,Str "the",Space,Str "current",Space,Str "release",Space,Str "version",Space,Str "and",Space,Str "date",Space,Str "of",SoftBreak,Str "the",Space,Str "test",Space,Str "suite",Space,Str "at",Space,Link ("",[],[]) [Str "TBD"] ("http://idpf.org/","")]
-  ,Para [Str "This",Space,Str "publication",Space,Str "is",Space,Str "one",Space,Str "of",Space,Str "several",Space,Str "that",Space,Str "currently",Space,Str "comprise",Space,Str "the",Space,Str "EPUB",Space,Str "3",Space,Str "conformance",Space,Str "test",Space,Str "suite",SoftBreak,Str "for",Space,Str "reflowable",Space,Str "content.",Space,Str "The",Space,Str "complete",Space,Str "test",Space,Str "suite",Space,Str "includes",Space,Str "all",Space,Str "of",Space,Str "the",Space,Str "following",Space,Str "publications:"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "."]]]]
- ,Div ("",["section"],[])
-  [Header 2 ("",[],[]) [Str "About",Space,Str "this",Space,Str "Document"]
-  ,Para [Str "This",Space,Str "document",Space,Str "focuses",Space,Str "on",Space,Str "human-evaluated",Space,Str "binary",Space,Str "(pass/fail)",Space,Str "tests",Space,Str "in",Space,Str "a",SoftBreak,Str "reflowable",Space,Str "context.",Space,Str "Tests",Space,Str "for",Space,Str "fixed-layout",Space,Str "content",Space,Str "and",Space,Str "other",Space,Str "individual",Space,Str "tests",Space,Str "that",SoftBreak,Str "require",Space,Str "a",Space,Str "dedicated",Space,Str "epub",Space,Str "file",Space,Str "are",Space,Str "available",Space,Str "in",Space,Str "additional",Space,Str "sibling",Space,Str "documents;",Space,Str "refer",Space,Str "to",SoftBreak,Str "the",Space,Link ("",[],[]) [Str "test",Space,Str "suite",SoftBreak,Str "wiki"] ("https://github.com/mgylling/epub-testsuite/wiki/Overview",""),Space,Str "(",Code ("",[],[]) "https://github.com/mgylling/epub-testsuite/wiki/Overview",Str ")",Space,Str "for",Space,Str "additional",SoftBreak,Str "information."]]
- ,Div ("",["section"],[])
-  [Header 2 ("",[],[]) [Str "Conventions"]
-  ,Para [Str "The",Space,Str "following",Space,Str "conventions",Space,Str "are",Space,Str "used",Space,Str "throughout",Space,Str "the",Space,Str "document:"]
-  ,DefinitionList
-   [([Str "1.",Space,Str "Locating",Space,Str "a",Space,Str "test"],
-     [[Div ("",["ctest"],[])
-       [Para [Str "Tests",Space,Str "for",Space,Emph [Str "required"],Space,Str "Reading",Space,Str "System",Space,Str "functionality",Space,Str "are",SoftBreak,Str "preceded",Space,Str "by",Space,Str "the",Space,Str "label:",Space,Span ("",["nature"],[("style","display: inline; font-size: 100%")]) [Str "[REQUIRED]"]]]
-      ,Div ("",["otest"],[])
-       [Para [Str "Tests",Space,Str "for",Space,Emph [Str "optional"],Space,Str "Reading",Space,Str "System",Space,Str "functionality",Space,Str "are",SoftBreak,Str "preceded",Space,Str "by",Space,Str "the",Space,Str "label:",Space,Span ("",["nature"],[("style","display: inline; font-size: 100%")]) [Str "[OPTIONAL]"]]]]])
-   ,([Str "2.",Space,Str "Performing",Space,Str "the",Space,Str "test"],
-     [[Plain [Str "Each",Space,Str "test",Space,Str "includes",Space,Str "a",Space,Str "description",Space,Str "of",Space,Str "its",Space,Str "purpose",Space,Str "followed",Space,Str "by",Space,Str "the",Space,Str "actual",Space,Strong [Str "test",Space,Str "statement,",SoftBreak,Str "which",Space,Str "can",Space,Str "always",Space,Str "be",Space,Str "evaluated",Space,Str "to",Space,Str "true",Space,Str "or",Space,Str "false"],Str ".",Space,Str "These",Space,Str "statements",Space,Str "typically",Space,Str "have",Space,Str "the",Space,Str "form:",SoftBreak,Str "\"If",Space,Str "[some",Space,Str "condition],",Space,Str "the",Space,Str "test",Space,Str "passes\"."]]])
-   ,([Str "3.",Space,Str "Scoring",Space,Str "in",Space,Str "the",Space,Str "results",Space,Str "form"],
-     [[Plain [Str "@@@TODO",Space,Str "provide",Space,Str "info",Space,Str "on",Space,Str "where",Space,Str "to",Space,Str "get",Space,Str "the",Space,Str "results",Space,Str "form"]]])]]]
-,Para [Span ("content-mathml-001.xhtml",[],[]) []]
-,Div ("",["section"],[])
- [Header 2 ("content-mathml-001.xhtml#mathml",[],[]) [Str "MathML"]
- ,Div ("content-mathml-001.xhtml#mathml-010",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-010"],Space,Str "Rendering"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "MathML",Space,Str "equation",Space,Str "rendering",Space,Str "is",Space,Str "supported."]
-  ,Plain [Math DisplayMath "\\int_{- \\infty}^{\\infty}e^{- x^{2}}\\, dx = \\sqrt{\\pi}",SoftBreak,Math DisplayMath "\\sum\\limits_{n = 1}^{\\infty}\\frac{1}{n^{2}} = \\frac{\\pi^{2}}{6}",SoftBreak,Math DisplayMath "x = \\frac{- b \\pm \\sqrt{b^{2} - 4ac}}{2a}"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "equations",Space,Str "are",Space,Str "not",Space,Str "presented",Space,Str "as",Space,Str "linear",Space,Str "text",Space,Str "(e.g.,",Space,Str "x=-b\177b2-4ac2a),",SoftBreak,Str "the",Space,Str "test",Space,Str "passes."]]
- ,Div ("content-mathml-001.xhtml#mathml-020",["section","otest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[OPTIONAL]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-020"],Space,Str "CSS",Space,Str "Styling",Space,Str "of",Space,Str "the",Space,Code ("",[],[]) "math",Space,Str "element"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "basic",Space,Str "CSS",Space,Str "styling",Space,Str "of",Space,Str "MathML",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "the",Space,Code ("",[],[]) "math",Space,Str "element."]
-  ,Plain [Math InlineMath "{2x}{+ y - z}"]
-  ,Para [Str "The",Space,Str "test",Space,Str "passes",Space,Str "if",Space,Str "the",Space,Str "equation",Space,Str "has",Space,Str "a",Space,Str "yellow",Space,Str "background",Space,Str "and",Space,Str "a",Space,Str "dashed",Space,Str "border."]
-  ,Para [Str "If",Space,Str "the",Space,Str "reading",Space,Str "system",Space,Str "does",Space,Str "not",Space,Str "have",Space,Str "a",Space,Str "viewport,",Space,Str "or",Space,Str "does",Space,Str "not",Space,Str "support",SoftBreak,Str "CSS",Space,Str "styles,",Space,Str "this",Space,Str "test",Space,Str "should",Space,Str "be",Space,Str "marked",Space,Code ("",[],[]) "Not Supported",Str "."]]
- ,Div ("content-mathml-001.xhtml#mathml-021",["section","otest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[OPTIONAL]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-021"],Space,Str "CSS",Space,Str "Styling",Space,Str "of",Space,Str "the",Space,Code ("",[],[]) "mo",Space,Str "element"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "basic",Space,Str "CSS",Space,Str "styling",Space,Str "of",Space,Str "MathML",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "the",Space,Code ("",[],[]) "mo",Space,Str "element."]
-  ,Plain [Math InlineMath "{2x}{+ y - z}"]
-  ,Para [Str "The",Space,Str "test",Space,Str "passes",Space,Str "if",Space,Str "the",Space,Str "operators",Space,Str "are",Space,Str "enlarged",Space,Str "relative",Space,Str "to",Space,Str "the",Space,Str "other",Space,Str "symbols",Space,Str "and",Space,Str "numbers."]
-  ,Para [Str "If",Space,Str "the",Space,Str "reading",Space,Str "system",Space,Str "does",Space,Str "not",Space,Str "have",Space,Str "a",Space,Str "viewport,",Space,Str "or",Space,Str "does",Space,Str "not",Space,Str "support",SoftBreak,Str "CSS",Space,Str "styles,",Space,Str "this",Space,Str "test",Space,Str "should",Space,Str "be",Space,Str "marked",Space,Code ("",[],[]) "Not Supported",Str "."]]
- ,Div ("content-mathml-001.xhtml#mathml-022",["section","otest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[OPTIONAL]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-022"],Space,Str "CSS",Space,Str "Styling",Space,Str "of",Space,Str "the",Space,Code ("",[],[]) "mi",Space,Str "element"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "basic",Space,Str "CSS",Space,Str "styling",Space,Str "of",Space,Str "MathML",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "the",Space,Code ("",[],[]) "mi",Space,Str "element."]
-  ,Plain [Math InlineMath "{2x}{+ y - z}"]
-  ,Para [Str "The",Space,Str "test",Space,Str "passes",Space,Str "if",Space,Str "the",Space,Str "identifiers",Space,Str "are",Space,Str "bolded",Space,Str "and",Space,Str "blue."]
-  ,Para [Str "If",Space,Str "the",Space,Str "reading",Space,Str "system",Space,Str "does",Space,Str "not",Space,Str "have",Space,Str "a",Space,Str "viewport,",Space,Str "or",Space,Str "does",Space,Str "not",Space,Str "support",SoftBreak,Str "CSS",Space,Str "styles,",Space,Str "this",Space,Str "test",Space,Str "should",Space,Str "be",Space,Str "marked",Space,Code ("",[],[]) "Not Supported",Str "."]]
- ,Div ("content-mathml-001.xhtml#mathml-023",["section","otest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[OPTIONAL]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-023"],Space,Str "CSS",Space,Str "Styling",Space,Str "of",Space,Str "the",Space,Code ("",[],[]) "mn",Space,Str "element"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "basic",Space,Str "CSS",Space,Str "styling",Space,Str "of",Space,Str "MathML",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "the",Space,Code ("",[],[]) "mn",Space,Str "element."]
-  ,Plain [Math InlineMath "{2x}{+ y - z}"]
-  ,Para [Str "The",Space,Str "test",Space,Str "passes",Space,Str "if",Space,Str "the",Space,Str "number",Space,Str "2",Space,Str "is",Space,Str "italicized",Space,Str "and",Space,Str "blue."]
-  ,Para [Str "If",Space,Str "the",Space,Str "reading",Space,Str "system",Space,Str "does",Space,Str "not",Space,Str "have",Space,Str "a",Space,Str "viewport,",Space,Str "or",Space,Str "does",Space,Str "not",Space,Str "support",SoftBreak,Str "CSS",Space,Str "styles,",Space,Str "this",Space,Str "test",Space,Str "should",Space,Str "be",Space,Str "marked",Space,Code ("",[],[]) "Not Supported",Str "."]]
- ,Div ("content-mathml-001.xhtml#mathml-024",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-024"],Str "Horizontal",Space,Str "stretch,",Space,Code ("",[],[]) "mover",Str ",",Space,Code ("",[],[]) "munder",Str ",",Space,Str "and",Space,Code ("",[],[]) "mspace",Space,Str "elements"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "horizontal",Space,Str "stretch,",Space,Code ("",[],[]) "mover",Str ",",Space,Code ("",[],[]) "munder",Str ",",Space,Code ("",[],[]) "mspace",Space,Str "elements",Space,Str "are",Space,Str "supported."]
-  ,Plain [Math DisplayMath "c = \\overset{\\text{complex\\ number}}{\\overbrace{\\underset{\\text{real}}{\\underbrace{\\mspace{20mu} a\\mspace{20mu}}} + \\underset{\\text{imaginary}}{\\underbrace{\\quad b{\\mathbb{i}}\\quad}}}}"]
-  ,Para [Str "The",Space,Str "test",Space,Str "passes",Space,Str "if",Space,Str "the",Space,Str "rendering",Space,Str "looks",Space,Str "like",Space,Str "."]]
- ,Div ("content-mathml-001.xhtml#mathml-025",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-025"],Str "Testing",Space,Code ("",[],[]) "mtable",Space,Str "with",Space,Code ("",[],[]) "colspan",Space,Str "and",Space,Code ("",[],[]) "rowspan",Space,Str "attributes,",Space,Str "Hebrew",Space,Str "and",Space,Str "Script",Space,Str "fonts"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Code ("",[],[]) "mtable",Space,Str "with",Space,Code ("",[],[]) "colspan",Space,Str "and",Space,Code ("",[],[]) "mspace",Space,Str "attributes",Space,Str "(column",Space,Str "and",Space,Str "row",Space,Str "spanning)",Space,Str "are",Space,Str "supported;",Space,Str "uses",Space,Str "Hebrew",Space,Str "and",Space,Str "Script",Space,Str "alphabets."]
-  ,Plain [Math DisplayMath "\\begin{matrix}\n & {\\operatorname{cov}(\\mathcal{L})} & \\longrightarrow & {\\operatorname{non}(\\mathcal{K})} & \\longrightarrow & {\\operatorname{cof}(\\mathcal{K})} & \\longrightarrow & {\\operatorname{cof}(\\mathcal{L})} & \\longrightarrow & 2^{\\aleph_{0}} \\\\\n & \\uparrow & & \\uparrow & & \\uparrow & & \\uparrow & & \\\\\n & {\\mathfrak{b}} & \\longrightarrow & {\\mathfrak{d}} & & & & & & \\\\\n & \\uparrow & & \\uparrow & & & & & & \\\\\n\\aleph_{1} & \\longrightarrow & {\\operatorname{add}(\\mathcal{L})} & \\longrightarrow & {\\operatorname{add}(\\mathcal{K})} & \\longrightarrow & {\\operatorname{cov}(\\mathcal{K})} & \\longrightarrow & {\\operatorname{non}(\\mathcal{L})} & \\\\\n\\end{matrix}"]
-  ,Para [Str "The",Space,Str "test",Space,Str "passes",Space,Str "if",Space,Str "the",Space,Str "rendering",Space,Str "looks",Space,Str "like",Space,Link ("",[],[]) [Str "Cicho\324's",Space,Str "Diagram"] ("http://en.wikipedia.org/wiki/Cicho%C5%84's_diagram",""),Str ":",Space,Str "."]]
- ,Div ("content-mathml-001.xhtml#mathml-026",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-026"],Str "BiDi,",Space,Str "RTL",Space,Str "and",Space,Str "Arabic",Space,Str "alphabets"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "right-to-left",Space,Str "and",Space,Str "Arabic",Space,Str "alphabets",Space,Str "are",Space,Str "supported."]
-  ,Plain [Math DisplayMath "{\1583(\1587)} = \\left\\{ \\begin{matrix}\n{\\sum\\limits_{\1646 = 1}^{\1589}\1587^{\1646}} & {\\text{\1573\1584\1575\1603\1575\1606}\1587 > 0} \\\\\n{\\int_{1}^{\1589}{\1587^{\1646}\1569\1587}} & {\\text{\1573\1584\1575\1603\1575\1606}\1587 \\in \1605} \\\\\n{{\1591\1575}\\pi} & {\\text{\1594\1610\1585\1584\1604\1603}\\left( \\text{\1605\1593}\\pi \\simeq 3,141 \\right)} \\\\\n\\end{matrix} \\right."]
-  ,Para [Str "The",Space,Str "test",Space,Str "passes",Space,Str "if",Space,Str "the",Space,Str "rendering",Space,Str "looks",Space,Str "like",Space,Str "the",Space,Str "following",Space,Str "image:"]]
- ,Div ("content-mathml-001.xhtml#mathml-027",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],SoftBreak,Span ("",["test-id"],[]) [Str "mathml-027"],Str "Elementary",Space,Str "math:",Space,Str "long",Space,Str "division",Space,Str "notation"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Code ("",[],[]) "mlongdiv",Space,Str "elements",Space,Str "(from",Space,Str "elementary",Space,Str "math)",Space,Str "are",Space,Str "supported."]
-  ,Plain [Span ("",["math"],[("xmlns","http://www.w3.org/1998/Math/MathML")]) [SoftBreak,Str "3",SoftBreak,Str "435.3",SoftBreak,Str "1306",SoftBreak,Str "12",SoftBreak,Str "10",SoftBreak,Str "9",SoftBreak,Str "16",SoftBreak,Str "15",SoftBreak,Str "1.0",SoftBreak,Str "9",SoftBreak,Str "1",SoftBreak]]
-  ,Para [Str "The",Space,Str "test",Space,Str "passes",Space,Str "if",Space,Str "the",Space,Str "rendering",Space,Str "looks",Space,Str "like",Space,Str "the",Space,Str "following",Space,Str "image:",Space,Str "."]]]
-,Para [Span ("content-switch-001.xhtml",[],[]) []]
-,Div ("content-switch-001.xhtml#epub-switch",["section"],[])
- [Header 3 ("",[],[]) [Code ("",[],[]) "epub:switch"]
- ,Div ("content-switch-001.xhtml#switch-010",["section","ctest"],[])
-  [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "switch-010"],Space,Str "Support"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "epub:switch",Space,Str "element",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "PASS"]
-  ,Para [Str "If",Space,Str "only",Space,Str "the",Space,Str "word",Space,Str "\"PASS\"",Space,Str "is",Space,Str "rendered",Space,Str "before",Space,Str "this",Space,Str "paragraph,",Space,Str "the",Space,Str "test",Space,Str "passes.",Space,Str "If",Space,Str "both",Space,Str "\"PASS\"",Space,Str "and",Space,Str "\"FAIL\"",Space,Str "are",Space,Str "rendered,",Space,Str "or",Space,Str "neither",SoftBreak,Str "\"PASS\"",Space,Str "nor",Space,Str "\"FAIL\"",Space,Str "is",Space,Str "rendered,",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("content-switch-001.xhtml#switch-020",["section","otest"],[])
-  [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[OPTIONAL]"],SoftBreak,Span ("",["test-id"],[]) [Str "switch-020"],SoftBreak,Str "MathML",Space,Str "Embedding"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Str "MathML",Space,Str "namespace",Space,Str "is",Space,Str "recognized",Space,Str "when",Space,Str "used",Space,Str "in",Space,Str "an",Space,Code ("",[],[]) "epub:case",Space,Str "element."]
-  ,Para [Math InlineMath "{2x}{+ y - z}"]
-  ,Para [Str "If",Space,Str "a",Space,Str "MathML",Space,Str "equation",Space,Str "is",Space,Str "rendered",Space,Str "before",Space,Str "this",Space,Str "paragraph,",Space,Str "the",Space,Str "test",Space,Str "passes."]
-  ,Para [Str "If",Space,Str "test",Space,Code ("",[],[]) "switch-010",Space,Str "did",Space,Str "not",Space,Str "pass,",Space,Str "this",Space,Str "test",Space,Str "should",Space,Str "be",Space,Str "marked",Space,Code ("",[],[]) "Not Supported",Str "."]]]]
+[ Para
+  [ Span ( "front.xhtml", [], [] ) [] ]
+, Div
+  ( "", [ "section" ], [] )
+  [ Header 1
+    ( "", [], [] )
+    [ Str "Reflowable"
+    , Space
+    , Str "EPUB"
+    , Space
+    , Str "3"
+    , Space
+    , Str "Conformance"
+    , Space
+    , Str "Test"
+    , Space
+    , Str "Document:"
+    , Space
+    , Str "0100"
+    ]
+  , Div
+    ( "", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "Status"
+      , Space
+      , Str "of"
+      , Space
+      , Str "this"
+      , Space
+      , Str "Document"
+      ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "publication"
+      , Space
+      , Str "is"
+      , Space
+      , Str "currently"
+      , Space
+      , Str "considered"
+      , Space
+      , Span
+        ( "", [ "status" ], [] )
+        [ Str "[UNDER", Space, Str "DEVELOPMENT]" ]
+      , Space
+      , Str "by"
+      , Space
+      , Str "the"
+      , Space
+      , Str "IDPF."
+      ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "publication"
+      , Space
+      , Str "is"
+      , Space
+      , Str "part"
+      , Space
+      , Str "of"
+      , Space
+      , Str "version"
+      , Space
+      , Span
+        ( "", [ "version" ], [] )
+        [ Str "X.X" ]
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "EPUB"
+      , Space
+      , Str "3.0"
+      , Space
+      , Str "Compliance"
+      , Space
+      , Str "Test"
+      , Space
+      , Str "Suite"
+      , Space
+      , Str "released"
+      , SoftBreak
+      , Str "on"
+      , Space
+      , RawInline
+        ( Format "html" ) "<time class=\"release\">"
+      , Str "TBD"
+      , RawInline
+        ( Format "html" ) "</time>"
+      , Str "."
+      ]
+    , Para
+      [ Str "Before"
+      , Space
+      , Str "using"
+      , Space
+      , Str "this"
+      , Space
+      , Str "publication"
+      , Space
+      , Str "to"
+      , Space
+      , Str "evaluate"
+      , Space
+      , Str "reading"
+      , Space
+      , Str "systems,"
+      , Space
+      , Str "testers"
+      , Space
+      , Str "are"
+      , Space
+      , Str "strongly"
+      , Space
+      , Str "encouraged"
+      , Space
+      , Str "to"
+      , SoftBreak
+      , Str "verify"
+      , Space
+      , Str "that"
+      , Space
+      , Str "they"
+      , Space
+      , Str "have"
+      , Space
+      , Str "the"
+      , Space
+      , Str "latest"
+      , Space
+      , Str "release"
+      , Space
+      , Str "by"
+      , Space
+      , Str "checking"
+      , Space
+      , Str "the"
+      , Space
+      , Str "current"
+      , Space
+      , Str "release"
+      , Space
+      , Str "version"
+      , Space
+      , Str "and"
+      , Space
+      , Str "date"
+      , Space
+      , Str "of"
+      , SoftBreak
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "suite"
+      , Space
+      , Str "at"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "TBD" ]
+        ( "http://idpf.org/", "" )
+      ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "publication"
+      , Space
+      , Str "is"
+      , Space
+      , Str "one"
+      , Space
+      , Str "of"
+      , Space
+      , Str "several"
+      , Space
+      , Str "that"
+      , Space
+      , Str "currently"
+      , Space
+      , Str "comprise"
+      , Space
+      , Str "the"
+      , Space
+      , Str "EPUB"
+      , Space
+      , Str "3"
+      , Space
+      , Str "conformance"
+      , Space
+      , Str "test"
+      , Space
+      , Str "suite"
+      , SoftBreak
+      , Str "for"
+      , Space
+      , Str "reflowable"
+      , Space
+      , Str "content."
+      , Space
+      , Str "The"
+      , Space
+      , Str "complete"
+      , Space
+      , Str "test"
+      , Space
+      , Str "suite"
+      , Space
+      , Str "includes"
+      , Space
+      , Str "all"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "following"
+      , Space
+      , Str "publications:"
+      ]
+    , OrderedList
+      ( 1, DefaultStyle, DefaultDelim )
+      [ [ Plain [ Str "." ] ] ]
+    ]
+  , Div
+    ( "", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "About", Space, Str "this", Space, Str "Document" ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "document"
+      , Space
+      , Str "focuses"
+      , Space
+      , Str "on"
+      , Space
+      , Str "human-evaluated"
+      , Space
+      , Str "binary"
+      , Space
+      , Str "(pass/fail)"
+      , Space
+      , Str "tests"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , SoftBreak
+      , Str "reflowable"
+      , Space
+      , Str "context."
+      , Space
+      , Str "Tests"
+      , Space
+      , Str "for"
+      , Space
+      , Str "fixed-layout"
+      , Space
+      , Str "content"
+      , Space
+      , Str "and"
+      , Space
+      , Str "other"
+      , Space
+      , Str "individual"
+      , Space
+      , Str "tests"
+      , Space
+      , Str "that"
+      , SoftBreak
+      , Str "require"
+      , Space
+      , Str "a"
+      , Space
+      , Str "dedicated"
+      , Space
+      , Str "epub"
+      , Space
+      , Str "file"
+      , Space
+      , Str "are"
+      , Space
+      , Str "available"
+      , Space
+      , Str "in"
+      , Space
+      , Str "additional"
+      , Space
+      , Str "sibling"
+      , Space
+      , Str "documents;"
+      , Space
+      , Str "refer"
+      , Space
+      , Str "to"
+      , SoftBreak
+      , Str "the"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "test", Space, Str "suite", SoftBreak, Str "wiki" ]
+        ( "https://github.com/mgylling/epub-testsuite/wiki/Overview"
+        , ""
+        )
+      , Space
+      , Str "("
+      , Code
+        ( ""
+        , []
+        , []
+        ) "https://github.com/mgylling/epub-testsuite/wiki/Overview"
+      , Str ")"
+      , Space
+      , Str "for"
+      , Space
+      , Str "additional"
+      , SoftBreak
+      , Str "information."
+      ]
+    ]
+  , Div
+    ( "", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "Conventions" ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "following"
+      , Space
+      , Str "conventions"
+      , Space
+      , Str "are"
+      , Space
+      , Str "used"
+      , Space
+      , Str "throughout"
+      , Space
+      , Str "the"
+      , Space
+      , Str "document:"
+      ]
+    , DefinitionList
+      [
+        (
+          [ Str "1."
+          , Space
+          , Str "Locating"
+          , Space
+          , Str "a"
+          , Space
+          , Str "test"
+          ]
+        ,
+          [
+            [ Div
+              ( "", [ "ctest" ], [] )
+              [ Para
+                [ Str "Tests"
+                , Space
+                , Str "for"
+                , Space
+                , Emph
+                  [ Str "required" ]
+                , Space
+                , Str "Reading"
+                , Space
+                , Str "System"
+                , Space
+                , Str "functionality"
+                , Space
+                , Str "are"
+                , SoftBreak
+                , Str "preceded"
+                , Space
+                , Str "by"
+                , Space
+                , Str "the"
+                , Space
+                , Str "label:"
+                , Space
+                , Span
+                  ( ""
+                  , [ "nature" ]
+                  ,
+                    [ ( "style", "display: inline; font-size: 100%" ) ]
+                  )
+                  [ Str "[REQUIRED]" ]
+                ]
+              ]
+            , Div
+              ( "", [ "otest" ], [] )
+              [ Para
+                [ Str "Tests"
+                , Space
+                , Str "for"
+                , Space
+                , Emph
+                  [ Str "optional" ]
+                , Space
+                , Str "Reading"
+                , Space
+                , Str "System"
+                , Space
+                , Str "functionality"
+                , Space
+                , Str "are"
+                , SoftBreak
+                , Str "preceded"
+                , Space
+                , Str "by"
+                , Space
+                , Str "the"
+                , Space
+                , Str "label:"
+                , Space
+                , Span
+                  ( ""
+                  , [ "nature" ]
+                  ,
+                    [ ( "style", "display: inline; font-size: 100%" ) ]
+                  )
+                  [ Str "[OPTIONAL]" ]
+                ]
+              ]
+            ]
+          ]
+        )
+      ,
+        (
+          [ Str "2."
+          , Space
+          , Str "Performing"
+          , Space
+          , Str "the"
+          , Space
+          , Str "test"
+          ]
+        ,
+          [
+            [ Plain
+              [ Str "Each"
+              , Space
+              , Str "test"
+              , Space
+              , Str "includes"
+              , Space
+              , Str "a"
+              , Space
+              , Str "description"
+              , Space
+              , Str "of"
+              , Space
+              , Str "its"
+              , Space
+              , Str "purpose"
+              , Space
+              , Str "followed"
+              , Space
+              , Str "by"
+              , Space
+              , Str "the"
+              , Space
+              , Str "actual"
+              , Space
+              , Strong
+                [ Str "test"
+                , Space
+                , Str "statement,"
+                , SoftBreak
+                , Str "which"
+                , Space
+                , Str "can"
+                , Space
+                , Str "always"
+                , Space
+                , Str "be"
+                , Space
+                , Str "evaluated"
+                , Space
+                , Str "to"
+                , Space
+                , Str "true"
+                , Space
+                , Str "or"
+                , Space
+                , Str "false"
+                ]
+              , Str "."
+              , Space
+              , Str "These"
+              , Space
+              , Str "statements"
+              , Space
+              , Str "typically"
+              , Space
+              , Str "have"
+              , Space
+              , Str "the"
+              , Space
+              , Str "form:"
+              , SoftBreak
+              , Str "\"If"
+              , Space
+              , Str "[some"
+              , Space
+              , Str "condition],"
+              , Space
+              , Str "the"
+              , Space
+              , Str "test"
+              , Space
+              , Str "passes\"."
+              ]
+            ]
+          ]
+        )
+      ,
+        (
+          [ Str "3."
+          , Space
+          , Str "Scoring"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "results"
+          , Space
+          , Str "form"
+          ]
+        ,
+          [
+            [ Plain
+              [ Str "@@@TODO"
+              , Space
+              , Str "provide"
+              , Space
+              , Str "info"
+              , Space
+              , Str "on"
+              , Space
+              , Str "where"
+              , Space
+              , Str "to"
+              , Space
+              , Str "get"
+              , Space
+              , Str "the"
+              , Space
+              , Str "results"
+              , Space
+              , Str "form"
+              ]
+            ]
+          ]
+        )
+      ]
+    ]
+  ]
+, Para
+  [ Span ( "content-mathml-001.xhtml", [], [] ) [] ]
+, Div
+  ( "", [ "section" ], [] )
+  [ Header 2
+    ( "content-mathml-001.xhtml#mathml", [], [] )
+    [ Str "MathML" ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-010"
+    ,
+      [ "section", "ctest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-010" ]
+      , Space
+      , Str "Rendering"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "MathML"
+      , Space
+      , Str "equation"
+      , Space
+      , Str "rendering"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Plain
+      [ Math DisplayMath "\\int_{- \\infty}^{\\infty}e^{- x^{2}}\\, dx = \\sqrt{\\pi}"
+      , SoftBreak
+      , Math DisplayMath "\\sum\\limits_{n = 1}^{\\infty}\\frac{1}{n^{2}} = \\frac{\\pi^{2}}{6}"
+      , SoftBreak
+      , Math DisplayMath "x = \\frac{- b \\pm \\sqrt{b^{2} - 4ac}}{2a}"
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "equations"
+      , Space
+      , Str "are"
+      , Space
+      , Str "not"
+      , Space
+      , Str "presented"
+      , Space
+      , Str "as"
+      , Space
+      , Str "linear"
+      , Space
+      , Str "text"
+      , Space
+      , Str "(e.g.,"
+      , Space
+      , Str "x=-b\177b2-4ac2a),"
+      , SoftBreak
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      ]
+    ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-020"
+    ,
+      [ "section", "otest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[OPTIONAL]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-020" ]
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "Styling"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "math"
+      , Space
+      , Str "element"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "basic"
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "styling"
+      , Space
+      , Str "of"
+      , Space
+      , Str "MathML"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported"
+      , Space
+      , Str "on"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "math"
+      , Space
+      , Str "element."
+      ]
+    , Plain
+      [ Math InlineMath "{2x}{+ y - z}" ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes"
+      , Space
+      , Str "if"
+      , Space
+      , Str "the"
+      , Space
+      , Str "equation"
+      , Space
+      , Str "has"
+      , Space
+      , Str "a"
+      , Space
+      , Str "yellow"
+      , Space
+      , Str "background"
+      , Space
+      , Str "and"
+      , Space
+      , Str "a"
+      , Space
+      , Str "dashed"
+      , Space
+      , Str "border."
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "reading"
+      , Space
+      , Str "system"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "have"
+      , Space
+      , Str "a"
+      , Space
+      , Str "viewport,"
+      , Space
+      , Str "or"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "support"
+      , SoftBreak
+      , Str "CSS"
+      , Space
+      , Str "styles,"
+      , Space
+      , Str "this"
+      , Space
+      , Str "test"
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "marked"
+      , Space
+      , Code
+        ( "", [], [] ) "Not Supported"
+      , Str "."
+      ]
+    ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-021"
+    ,
+      [ "section", "otest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[OPTIONAL]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-021" ]
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "Styling"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "mo"
+      , Space
+      , Str "element"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "basic"
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "styling"
+      , Space
+      , Str "of"
+      , Space
+      , Str "MathML"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported"
+      , Space
+      , Str "on"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "mo"
+      , Space
+      , Str "element."
+      ]
+    , Plain
+      [ Math InlineMath "{2x}{+ y - z}" ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes"
+      , Space
+      , Str "if"
+      , Space
+      , Str "the"
+      , Space
+      , Str "operators"
+      , Space
+      , Str "are"
+      , Space
+      , Str "enlarged"
+      , Space
+      , Str "relative"
+      , Space
+      , Str "to"
+      , Space
+      , Str "the"
+      , Space
+      , Str "other"
+      , Space
+      , Str "symbols"
+      , Space
+      , Str "and"
+      , Space
+      , Str "numbers."
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "reading"
+      , Space
+      , Str "system"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "have"
+      , Space
+      , Str "a"
+      , Space
+      , Str "viewport,"
+      , Space
+      , Str "or"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "support"
+      , SoftBreak
+      , Str "CSS"
+      , Space
+      , Str "styles,"
+      , Space
+      , Str "this"
+      , Space
+      , Str "test"
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "marked"
+      , Space
+      , Code
+        ( "", [], [] ) "Not Supported"
+      , Str "."
+      ]
+    ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-022"
+    ,
+      [ "section", "otest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[OPTIONAL]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-022" ]
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "Styling"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "mi"
+      , Space
+      , Str "element"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "basic"
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "styling"
+      , Space
+      , Str "of"
+      , Space
+      , Str "MathML"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported"
+      , Space
+      , Str "on"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "mi"
+      , Space
+      , Str "element."
+      ]
+    , Plain
+      [ Math InlineMath "{2x}{+ y - z}" ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes"
+      , Space
+      , Str "if"
+      , Space
+      , Str "the"
+      , Space
+      , Str "identifiers"
+      , Space
+      , Str "are"
+      , Space
+      , Str "bolded"
+      , Space
+      , Str "and"
+      , Space
+      , Str "blue."
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "reading"
+      , Space
+      , Str "system"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "have"
+      , Space
+      , Str "a"
+      , Space
+      , Str "viewport,"
+      , Space
+      , Str "or"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "support"
+      , SoftBreak
+      , Str "CSS"
+      , Space
+      , Str "styles,"
+      , Space
+      , Str "this"
+      , Space
+      , Str "test"
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "marked"
+      , Space
+      , Code
+        ( "", [], [] ) "Not Supported"
+      , Str "."
+      ]
+    ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-023"
+    ,
+      [ "section", "otest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[OPTIONAL]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-023" ]
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "Styling"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "mn"
+      , Space
+      , Str "element"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "basic"
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "styling"
+      , Space
+      , Str "of"
+      , Space
+      , Str "MathML"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported"
+      , Space
+      , Str "on"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "mn"
+      , Space
+      , Str "element."
+      ]
+    , Plain
+      [ Math InlineMath "{2x}{+ y - z}" ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes"
+      , Space
+      , Str "if"
+      , Space
+      , Str "the"
+      , Space
+      , Str "number"
+      , Space
+      , Str "2"
+      , Space
+      , Str "is"
+      , Space
+      , Str "italicized"
+      , Space
+      , Str "and"
+      , Space
+      , Str "blue."
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "reading"
+      , Space
+      , Str "system"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "have"
+      , Space
+      , Str "a"
+      , Space
+      , Str "viewport,"
+      , Space
+      , Str "or"
+      , Space
+      , Str "does"
+      , Space
+      , Str "not"
+      , Space
+      , Str "support"
+      , SoftBreak
+      , Str "CSS"
+      , Space
+      , Str "styles,"
+      , Space
+      , Str "this"
+      , Space
+      , Str "test"
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "marked"
+      , Space
+      , Code
+        ( "", [], [] ) "Not Supported"
+      , Str "."
+      ]
+    ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-024"
+    ,
+      [ "section", "ctest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-024" ]
+      , Str "Horizontal"
+      , Space
+      , Str "stretch,"
+      , Space
+      , Code
+        ( "", [], [] ) "mover"
+      , Str ","
+      , Space
+      , Code
+        ( "", [], [] ) "munder"
+      , Str ","
+      , Space
+      , Str "and"
+      , Space
+      , Code
+        ( "", [], [] ) "mspace"
+      , Space
+      , Str "elements"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "horizontal"
+      , Space
+      , Str "stretch,"
+      , Space
+      , Code
+        ( "", [], [] ) "mover"
+      , Str ","
+      , Space
+      , Code
+        ( "", [], [] ) "munder"
+      , Str ","
+      , Space
+      , Code
+        ( "", [], [] ) "mspace"
+      , Space
+      , Str "elements"
+      , Space
+      , Str "are"
+      , Space
+      , Str "supported."
+      ]
+    , Plain
+      [ Math DisplayMath "c = \\overset{\\text{complex\\ number}}{\\overbrace{\\underset{\\text{real}}{\\underbrace{\\mspace{20mu} a\\mspace{20mu}}} + \\underset{\\text{imaginary}}{\\underbrace{\\quad b{\\mathbb{i}}\\quad}}}}" ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes"
+      , Space
+      , Str "if"
+      , Space
+      , Str "the"
+      , Space
+      , Str "rendering"
+      , Space
+      , Str "looks"
+      , Space
+      , Str "like"
+      , Space
+      , Str "."
+      ]
+    ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-025"
+    ,
+      [ "section", "ctest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-025" ]
+      , Str "Testing"
+      , Space
+      , Code
+        ( "", [], [] ) "mtable"
+      , Space
+      , Str "with"
+      , Space
+      , Code
+        ( "", [], [] ) "colspan"
+      , Space
+      , Str "and"
+      , Space
+      , Code
+        ( "", [], [] ) "rowspan"
+      , Space
+      , Str "attributes,"
+      , Space
+      , Str "Hebrew"
+      , Space
+      , Str "and"
+      , Space
+      , Str "Script"
+      , Space
+      , Str "fonts"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Code
+        ( "", [], [] ) "mtable"
+      , Space
+      , Str "with"
+      , Space
+      , Code
+        ( "", [], [] ) "colspan"
+      , Space
+      , Str "and"
+      , Space
+      , Code
+        ( "", [], [] ) "mspace"
+      , Space
+      , Str "attributes"
+      , Space
+      , Str "(column"
+      , Space
+      , Str "and"
+      , Space
+      , Str "row"
+      , Space
+      , Str "spanning)"
+      , Space
+      , Str "are"
+      , Space
+      , Str "supported;"
+      , Space
+      , Str "uses"
+      , Space
+      , Str "Hebrew"
+      , Space
+      , Str "and"
+      , Space
+      , Str "Script"
+      , Space
+      , Str "alphabets."
+      ]
+    , Plain
+      [ Math DisplayMath "\\begin{matrix}\n & {\\operatorname{cov}(\\mathcal{L})} & \\longrightarrow & {\\operatorname{non}(\\mathcal{K})} & \\longrightarrow & {\\operatorname{cof}(\\mathcal{K})} & \\longrightarrow & {\\operatorname{cof}(\\mathcal{L})} & \\longrightarrow & 2^{\\aleph_{0}} \\\\\n & \\uparrow & & \\uparrow & & \\uparrow & & \\uparrow & & \\\\\n & {\\mathfrak{b}} & \\longrightarrow & {\\mathfrak{d}} & & & & & & \\\\\n & \\uparrow & & \\uparrow & & & & & & \\\\\n\\aleph_{1} & \\longrightarrow & {\\operatorname{add}(\\mathcal{L})} & \\longrightarrow & {\\operatorname{add}(\\mathcal{K})} & \\longrightarrow & {\\operatorname{cov}(\\mathcal{K})} & \\longrightarrow & {\\operatorname{non}(\\mathcal{L})} & \\\\\n\\end{matrix}" ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes"
+      , Space
+      , Str "if"
+      , Space
+      , Str "the"
+      , Space
+      , Str "rendering"
+      , Space
+      , Str "looks"
+      , Space
+      , Str "like"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "Cicho\324's", Space, Str "Diagram" ]
+        ( "http://en.wikipedia.org/wiki/Cicho%C5%84's_diagram", "" )
+      , Str ":"
+      , Space
+      , Str "."
+      ]
+    ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-026"
+    ,
+      [ "section", "ctest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-026" ]
+      , Str "BiDi,"
+      , Space
+      , Str "RTL"
+      , Space
+      , Str "and"
+      , Space
+      , Str "Arabic"
+      , Space
+      , Str "alphabets"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "right-to-left"
+      , Space
+      , Str "and"
+      , Space
+      , Str "Arabic"
+      , Space
+      , Str "alphabets"
+      , Space
+      , Str "are"
+      , Space
+      , Str "supported."
+      ]
+    , Plain
+      [ Math DisplayMath "{\1583(\1587)} = \\left\\{ \\begin{matrix}\n{\\sum\\limits_{\1646 = 1}^{\1589}\1587^{\1646}} & {\\text{\1573\1584\1575\1603\1575\1606}\1587 > 0} \\\\\n{\\int_{1}^{\1589}{\1587^{\1646}\1569\1587}} & {\\text{\1573\1584\1575\1603\1575\1606}\1587 \\in \1605} \\\\\n{{\1591\1575}\\pi} & {\\text{\1594\1610\1585\1584\1604\1603}\\left( \\text{\1605\1593}\\pi \\simeq 3,141 \\right)} \\\\\n\\end{matrix} \\right." ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes"
+      , Space
+      , Str "if"
+      , Space
+      , Str "the"
+      , Space
+      , Str "rendering"
+      , Space
+      , Str "looks"
+      , Space
+      , Str "like"
+      , Space
+      , Str "the"
+      , Space
+      , Str "following"
+      , Space
+      , Str "image:"
+      ]
+    ]
+  , Div
+    ( "content-mathml-001.xhtml#mathml-027"
+    ,
+      [ "section", "ctest" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "mathml-027" ]
+      , Str "Elementary"
+      , Space
+      , Str "math:"
+      , Space
+      , Str "long"
+      , Space
+      , Str "division"
+      , Space
+      , Str "notation"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Code
+        ( "", [], [] ) "mlongdiv"
+      , Space
+      , Str "elements"
+      , Space
+      , Str "(from"
+      , Space
+      , Str "elementary"
+      , Space
+      , Str "math)"
+      , Space
+      , Str "are"
+      , Space
+      , Str "supported."
+      ]
+    , Plain
+      [ Span
+        ( ""
+        , [ "math" ]
+        ,
+          [ ( "xmlns", "http://www.w3.org/1998/Math/MathML" ) ]
+        )
+        [ SoftBreak
+        , Str "3"
+        , SoftBreak
+        , Str "435.3"
+        , SoftBreak
+        , Str "1306"
+        , SoftBreak
+        , Str "12"
+        , SoftBreak
+        , Str "10"
+        , SoftBreak
+        , Str "9"
+        , SoftBreak
+        , Str "16"
+        , SoftBreak
+        , Str "15"
+        , SoftBreak
+        , Str "1.0"
+        , SoftBreak
+        , Str "9"
+        , SoftBreak
+        , Str "1"
+        , SoftBreak
+        ]
+      ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes"
+      , Space
+      , Str "if"
+      , Space
+      , Str "the"
+      , Space
+      , Str "rendering"
+      , Space
+      , Str "looks"
+      , Space
+      , Str "like"
+      , Space
+      , Str "the"
+      , Space
+      , Str "following"
+      , Space
+      , Str "image:"
+      , Space
+      , Str "."
+      ]
+    ]
+  ]
+, Para
+  [ Span ( "content-switch-001.xhtml", [], [] ) [] ]
+, Div
+  ( "content-switch-001.xhtml#epub-switch", [ "section" ], [] )
+  [ Header 3
+    ( "", [], [] )
+    [ Code ( "", [], [] ) "epub:switch" ]
+  , Div
+    ( "content-switch-001.xhtml#switch-010"
+    ,
+      [ "section", "ctest" ]
+    , []
+    )
+    [ Header 4
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "switch-010" ]
+      , Space
+      , Str "Support"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "epub:switch"
+      , Space
+      , Str "element"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "PASS" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "only"
+      , Space
+      , Str "the"
+      , Space
+      , Str "word"
+      , Space
+      , Str "\"PASS\""
+      , Space
+      , Str "is"
+      , Space
+      , Str "rendered"
+      , Space
+      , Str "before"
+      , Space
+      , Str "this"
+      , Space
+      , Str "paragraph,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      , Space
+      , Str "If"
+      , Space
+      , Str "both"
+      , Space
+      , Str "\"PASS\""
+      , Space
+      , Str "and"
+      , Space
+      , Str "\"FAIL\""
+      , Space
+      , Str "are"
+      , Space
+      , Str "rendered,"
+      , Space
+      , Str "or"
+      , Space
+      , Str "neither"
+      , SoftBreak
+      , Str "\"PASS\""
+      , Space
+      , Str "nor"
+      , Space
+      , Str "\"FAIL\""
+      , Space
+      , Str "is"
+      , Space
+      , Str "rendered,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "content-switch-001.xhtml#switch-020"
+    ,
+      [ "section", "otest" ]
+    , []
+    )
+    [ Header 4
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[OPTIONAL]" ]
+      , SoftBreak
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "switch-020" ]
+      , SoftBreak
+      , Str "MathML"
+      , Space
+      , Str "Embedding"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Str "MathML"
+      , Space
+      , Str "namespace"
+      , Space
+      , Str "is"
+      , Space
+      , Str "recognized"
+      , Space
+      , Str "when"
+      , Space
+      , Str "used"
+      , Space
+      , Str "in"
+      , Space
+      , Str "an"
+      , Space
+      , Code
+        ( "", [], [] ) "epub:case"
+      , Space
+      , Str "element."
+      ]
+    , Para
+      [ Math InlineMath "{2x}{+ y - z}" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "a"
+      , Space
+      , Str "MathML"
+      , Space
+      , Str "equation"
+      , Space
+      , Str "is"
+      , Space
+      , Str "rendered"
+      , Space
+      , Str "before"
+      , Space
+      , Str "this"
+      , Space
+      , Str "paragraph,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "test"
+      , Space
+      , Code
+        ( "", [], [] ) "switch-010"
+      , Space
+      , Str "did"
+      , Space
+      , Str "not"
+      , Space
+      , Str "pass,"
+      , Space
+      , Str "this"
+      , Space
+      , Str "test"
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "marked"
+      , Space
+      , Code
+        ( "", [], [] ) "Not Supported"
+      , Str "."
+      ]
+    ]
+  ]
+]

--- a/test/epub/formatting.native
+++ b/test/epub/formatting.native
@@ -1,402 +1,6389 @@
-[Para [Span ("front.xhtml",[],[]) []]
-,Div ("",["section"],[])
- [Header 1 ("",[],[]) [Str "EPUB",Space,Str "3",Space,Str "Styling",Space,Str "Test",Space,Str "Document:",Space,Str "0101"]
- ,Div ("",["section"],[])
-  [Header 2 ("",[],[]) [Str "Status",Space,Str "of",Space,Str "this",Space,Str "Document"]
-  ,Para [Str "This",Space,Str "publication",Space,Str "is",Space,Str "currently",Space,Str "considered",Space,Span ("",["status"],[]) [Str "[UNDER",Space,Str "DEVELOPMENT]"],Space,Str "by",Space,Str "the",Space,Str "IDPF."]
-  ,Para [Str "This",Space,Str "publication",Space,Str "is",Space,Str "part",Space,Str "of",Space,Str "version",Space,Span ("",["version"],[]) [Str "X.X"],Space,Str "of",Space,Str "the",Space,Str "EPUB",Space,Str "3.0",Space,Str "Compliance",Space,Str "Test",Space,Str "Suite",Space,Str "released",SoftBreak,Str "on",Space,RawInline (Format "html") "<time class=\"release\">",Str "TBD",RawInline (Format "html") "</time>",Str "."]
-  ,Para [Str "Before",Space,Str "using",Space,Str "this",Space,Str "publication",Space,Str "to",Space,Str "evaluate",Space,Str "reading",Space,Str "systems,",Space,Str "testers",Space,Str "are",Space,Str "strongly",Space,Str "encouraged",Space,Str "to",SoftBreak,Str "verify",Space,Str "that",Space,Str "they",Space,Str "have",Space,Str "the",Space,Str "latest",Space,Str "release",Space,Str "by",Space,Str "checking",Space,Str "the",Space,Str "current",Space,Str "release",Space,Str "version",Space,Str "and",Space,Str "date",Space,Str "of",SoftBreak,Str "the",Space,Str "test",Space,Str "suite",Space,Str "at",Space,Link ("",[],[]) [Str "TBD"] ("http://idpf.org/","")]
-  ,Para [Str "This",Space,Str "publication",Space,Str "is",Space,Str "one",Space,Str "of",Space,Str "several",Space,Str "that",Space,Str "currently",Space,Str "comprise",Space,Str "the",Space,Str "EPUB",Space,Str "3",Space,Str "conformance",Space,Str "test",Space,Str "suite",SoftBreak,Str "for",Space,Str "reflowable",Space,Str "content.",Space,Str "The",Space,Str "complete",Space,Str "test",Space,Str "suite",Space,Str "includes",Space,Str "all",Space,Str "of",Space,Str "the",Space,Str "following",Space,Str "publications:"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "."]]]]
- ,Div ("",["section"],[])
-  [Header 2 ("",[],[]) [Str "About",Space,Str "this",Space,Str "Document"]
-  ,Para [Str "This",Space,Str "document",Space,Str "focuses",Space,Str "on",Space,Str "human-evaluated",Space,Str "binary",Space,Str "(pass/fail)",Space,Str "tests",Space,Str "in",Space,Str "a",SoftBreak,Str "reflowable",Space,Str "context.",Space,Str "Tests",Space,Str "for",Space,Str "fixed-layout",Space,Str "content",Space,Str "and",Space,Str "other",Space,Str "individual",Space,Str "tests",Space,Str "that",SoftBreak,Str "require",Space,Str "a",Space,Str "dedicated",Space,Str "epub",Space,Str "file",Space,Str "are",Space,Str "available",Space,Str "in",Space,Str "additional",Space,Str "sibling",Space,Str "documents;",Space,Str "refer",Space,Str "to",SoftBreak,Str "the",Space,Link ("",[],[]) [Str "test",Space,Str "suite",SoftBreak,Str "wiki"] ("https://github.com/mgylling/epub-testsuite/wiki/Overview",""),Space,Str "(",Code ("",[],[]) "https://github.com/mgylling/epub-testsuite/wiki/Overview",Str ")",Space,Str "for",Space,Str "additional",SoftBreak,Str "information."]]
- ,Div ("",["section"],[])
-  [Header 2 ("",[],[]) [Str "Conventions"]
-  ,Para [Str "The",Space,Str "following",Space,Str "conventions",Space,Str "are",Space,Str "used",Space,Str "throughout",Space,Str "the",Space,Str "document:"]
-  ,DefinitionList
-   [([Str "1.",Space,Str "Locating",Space,Str "a",Space,Str "test"],
-     [[Div ("",["ctest"],[])
-       [Para [Str "Tests",Space,Str "for",Space,Emph [Str "required"],Space,Str "Reading",Space,Str "System",Space,Str "functionality",Space,Str "are",SoftBreak,Str "preceded",Space,Str "by",Space,Str "the",Space,Str "label:",Space,Span ("",["nature"],[("style","display: inline; font-size: 100%")]) [Str "[REQUIRED]"]]]
-      ,Div ("",["otest"],[])
-       [Para [Str "Tests",Space,Str "for",Space,Emph [Str "optional"],Space,Str "Reading",Space,Str "System",Space,Str "functionality",Space,Str "are",SoftBreak,Str "preceded",Space,Str "by",Space,Str "the",Space,Str "label:",Space,Span ("",["nature"],[("style","display: inline; font-size: 100%")]) [Str "[OPTIONAL]"]]]]])
-   ,([Str "2.",Space,Str "Performing",Space,Str "the",Space,Str "test"],
-     [[Plain [Str "Each",Space,Str "test",Space,Str "includes",Space,Str "a",Space,Str "description",Space,Str "of",Space,Str "its",Space,Str "purpose",Space,Str "followed",Space,Str "by",Space,Str "the",Space,Str "actual",Space,Strong [Str "test",Space,Str "statement,",SoftBreak,Str "which",Space,Str "can",Space,Str "always",Space,Str "be",Space,Str "evaluated",Space,Str "to",Space,Str "true",Space,Str "or",Space,Str "false"],Str ".",Space,Str "These",Space,Str "statements",Space,Str "typically",Space,Str "have",Space,Str "the",Space,Str "form:",SoftBreak,Str "\"If",Space,Str "[some",Space,Str "condition],",Space,Str "the",Space,Str "test",Space,Str "passes\"."]]])
-   ,([Str "3.",Space,Str "Scoring",Space,Str "in",Space,Str "the",Space,Str "results",Space,Str "form"],
-     [[Plain [Str "@@@TODO",Space,Str "provide",Space,Str "info",Space,Str "on",Space,Str "where",Space,Str "to",Space,Str "get",Space,Str "the",Space,Str "results",Space,Str "form"]]])]]]
-,Para [Span ("styling-xhtml-001.xhtml",[],[]) []]
-,Div ("styling-xhtml-001.xhtml#epub-css",["section"],[])
- [Header 1 ("",[],[]) [Str "EPUB",Space,Str "Style",Space,Str "Sheets"]
- ,Para [Str "This",Space,Str "section",Space,Str "contains",Space,Str "tests",Space,Str "for",Space,Str "styling",Space,Str "and",Space,Str "layout."]]
-,Para [Span ("styling-xhtml-003.xhtml",[],[]) []]
-,Div ("styling-xhtml-003.xhtml#style-110",["section","ctest"],[])
- [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-110"],Space,Str "Multi-Column",Space,Str "Layouts"]
- ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "CSS Multi-Column Layout",Space,Str "properties",Space,Str "are",Space,Str "supported."]
- ,Div ("",["multicol"],[])
-  [Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]]
- ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "text",Space,Str "is",Space,Str "rendered",Space,Str "in",Space,Str "three",Space,Str "columns,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-,Para [Span ("styling-xhtml-002.xhtml",[],[]) []]
-,Div ("styling-xhtml-002.xhtml#style-lists",["section"],[])
- [Header 2 ("",[],[]) [Str "Lists"]
- ,Div ("styling-xhtml-002.xhtml#style-list-style-type",["section"],[])
-  [Header 3 ("",[],[]) [Str "The",Space,Code ("",[],[]) "list-style-type",Space,Str "property"]
-  ,Div ("styling-xhtml-002.xhtml#style-009",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-009"],Space,Code ("",[],[]) "decimal"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "decimal",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "decimal",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-010",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-010"],Space,Code ("",[],[]) "circle"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "circle",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ul",Space,Str "element."]
-   ,BulletList
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "circle",Space,Str "markers,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-011",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-011"],Space,Code ("",[],[]) "square"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "square",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ul",Space,Str "element."]
-   ,BulletList
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "square",Space,Str "markers,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-012",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-012"],Space,Code ("",[],[]) "disc"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "disc",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ul",Space,Str "element."]
-   ,BulletList
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "disc",Space,Str "markers,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-013",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-013"],Space,Code ("",[],[]) "lower-latin"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "lower-latin",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "lower-latin",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-014",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-014"],Space,Code ("",[],[]) "lower-roman"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "lower-roman",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "lower-roman",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-015",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-015"],Space,Code ("",[],[]) "upper-alpha"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "upper-alpha",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "upper-alpha",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-016",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-016"],Space,Code ("",[],[]) "hiragana"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "hiragana",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "hiragana",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-017",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-017"],Space,Code ("",[],[]) "hiragana-iroha"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "hiragana-iroha",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "hiragana-iroha",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-018",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-018"],Space,Code ("",[],[]) "katakana"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "katakana",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "katakana",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-019",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-019"],Space,Code ("",[],[]) "katakana-iroha"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "katakana-iroha",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "katakana-iroha",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-020",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-020"],Space,Code ("",[],[]) "upper-roman"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "upper-roman",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "upper-roman",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-021",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-021"],Space,Code ("",[],[]) "upper-latin"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "upper-latin",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "upper-latin",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-022",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-022"],Space,Code ("",[],[]) "lower-alpha"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "lower-alpha",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "lower-alpha",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-023",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-023"],Space,Code ("",[],[]) "lower-greek"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "lower-greek",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "lower-greek",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-024",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-024"],Space,Code ("",[],[]) "armenian"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "armenian",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "armenian",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-025",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-025"],Space,Code ("",[],[]) "cjk-ideographic"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "cjk-ideographic",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "cjk-ideographic",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-026",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-026"],Space,Code ("",[],[]) "decimal-leading-zero"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "decimal-leading-zero",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "decimal-leading-zero",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-027",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-027"],Space,Code ("",[],[]) "georgian"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "georgian",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "georgian",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-028",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-028"],Space,Code ("",[],[]) "hebrew"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "hebrew",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "hebrew",Space,Str "markers",Space,Str "in",Space,Str "ascending",Space,Str "order,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-029",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-029"],Space,Code ("",[],[]) "none"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-type",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "none",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element."]
-   ,OrderedList (1,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "no",Space,Str "markers,",Space,Str "the",Space,Str "test",Space,Str "passes."]]]
- ,Div ("styling-xhtml-002.xhtml#style-list-style",["section"],[])
-  [Header 3 ("",[],[]) [Str "The",Space,Code ("",[],[]) "list-style",Space,Str "property"]
-  ,Div ("styling-xhtml-002.xhtml#style-030",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-030"],Space,Str "images"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style",Space,Str "shorthand",Space,Str "property",Space,Str "is",Space,Str "supported",Space,Str "using",Space,Str "a",Space,Str "gif",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ul",Space,Str "element."]
-   ,BulletList
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "the",Space,Str "purple",Space,Str "and",Space,Str "aqua",Space,Str "square",Space,Str "bullet",Space,Str "the",Space,Str "test",Space,Str "passes."]]]
- ,Div ("styling-xhtml-002.xhtml#style-list-style-position",["section"],[])
-  [Header 3 ("",[],[]) [Str "The",Space,Code ("",[],[]) "list-style-position",Space,Str "property"]
-  ,Div ("styling-xhtml-002.xhtml#style-040",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-040"],Space,Str "The",Space,Code ("",[],[]) "list-style-position",Space,Str "property:",Space,Code ("",[],[]) "inside"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-position",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "inside",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ul",Space,Str "element."]
-   ,BulletList
-    [[Plain [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat."]]
-    ,[Plain [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat."]]
-    ,[Plain [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat."]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "markers",Space,Str "inside",Space,Str "the",Space,Str "indentation,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-041",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-041"],Space,Str "The",Space,Code ("",[],[]) "list-style-position",Space,Str "property:",Space,Code ("",[],[]) "outside"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "list-style-position",Space,Str "property",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "outside",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ul",Space,Str "element."]
-   ,BulletList
-    [[Plain [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat."]]
-    ,[Plain [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat."]]
-    ,[Plain [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat."]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "has",Space,Str "the",Space,Str "default",Space,Str "setting",Space,Str "(marker",Space,Str "outside",Space,Str "the",Space,Str "indentation),",Space,Str "the",Space,Str "test",Space,Str "passes."]]]
- ,Div ("styling-xhtml-002.xhtml#style-list-start",["section"],[])
-  [Header 3 ("",[],[]) [Str "The",Space,Str "HTML",Space,Code ("",[],[]) "start",Space,Str "attribute"]
-  ,Div ("styling-xhtml-002.xhtml#style-050",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-050"],Space,Str "Without",Space,Code ("",[],[]) "list-style-type",Space,Str "set"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "start",Space,Str "attribute",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element",Space,Str "with",Space,Str "no",Space,Code ("",[],[]) "list-style-type",Space,Str "property."]
-   ,OrderedList (25,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "starts",Space,Str "at",Space,Str "25,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
-  ,Div ("styling-xhtml-002.xhtml#style-051",["section","ctest"],[])
-   [Header 4 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-051"],Space,Str "With",Space,Code ("",[],[]) "list-style-type",Space,Str "set"]
-   ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "start",Space,Str "attribute",Space,Str "is",Space,Str "supported",Space,Str "on",Space,Str "a",Space,Code ("",[],[]) "ol",Space,Str "element",Space,Str "with",Space,Str "a",Space,Code ("",[],[]) "list-style-type",Space,Str "property."]
-   ,OrderedList (50,DefaultStyle,DefaultDelim)
-    [[Plain [Str "Lorem"]]
-    ,[Plain [Str "Ipsum"]]
-    ,[Plain [Str "Dolor"]]
-    ,[Plain [Str "Sit"]]
-    ,[Plain [Str "Amet"]]]
-   ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "list",Space,Str "starts",Space,Str "at",Space,Str "'L'",Space,Str "(50),",Space,Str "the",Space,Str "test",Space,Str "passes."]]]]
-,Para [Span ("styling-xhtml-004.xhtml",[],[]) []]
-,Div ("styling-xhtml-004.xhtml#style-media-rules",["section"],[])
- [Header 2 ("",[],[]) [Code ("",[],[]) "@media",Space,Str "Rules"]
- ,Div ("styling-xhtml-004.xhtml#style-210",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-210"],Space,Code ("",[],[]) "all"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "all",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\",",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-211",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-211"],Space,Code ("",[],[]) "screen"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "screen",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\",",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-212",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-212"],Space,Code ("",[],[]) "handheld"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "handheld",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\",",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-213",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-213"],Space,Code ("",[],[]) "tv"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "tv",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\",",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-220",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-220"],Space,Code ("",[],[]) "orientation:landscape"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "orientation:landscape",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\"",Space,Str "when",Space,Str "the",Space,Str "device",Space,Str "is",Space,Str "held",Space,Str "in",Space,Str "landscape",Space,Str "mode,",Space,Str "and",Space,Str "the",Space,Str "device",Space,Str "supports",Space,Str "multiple",Space,Str "orientations,",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-221",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-221"],Space,Code ("",[],[]) "orientation:portrait"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "orientation:portrait",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\"",Space,Str "when",Space,Str "the",Space,Str "device",Space,Str "is",Space,Str "held",Space,Str "in",Space,Str "portrait",Space,Str "mode,",Space,Str "and",Space,Str "the",Space,Str "device",Space,Str "supports",Space,Str "multiple",Space,Str "orientations,",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-230",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-230"],Space,Code ("",[],[]) "min-width"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "min-width:200px",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\",",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-231",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-231"],Space,Code ("",[],[]) "max-width"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "max-width:2000px",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\",",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-240",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-240"],Space,Code ("",[],[]) "min-device-width"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "min-device-width:200px",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\",",Space,Str "the",Space,Str "test",Space,Str "fails."]]
- ,Div ("styling-xhtml-004.xhtml#style-241",["section","ctest"],[])
-  [Header 3 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-241"],Space,Code ("",[],[]) "max-device-width"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "@media",Space,Str "rule",Space,Str "set",Space,Str "to",Space,Code ("",[],[]) "max-device-width:2000px",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "FAIL"]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "reads",Space,Str "\"FAIL\",",Space,Str "the",Space,Str "test",Space,Str "fails."]]]
-,Para [Span ("styling-xhtml-005.xhtml",[],[]) []]
-,Div ("styling-xhtml-005.xhtml#style-text-xform",["section"],[])
- [Header 2 ("",[],[]) [Str "The",Space,Code ("",[],[]) "text-transform",Space,Str "property"]
- ,Div ("styling-xhtml-005.xhtml#style-310",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-310"],Space,Code ("",[],[]) "uppercase"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "text-transform",Space,Str "property",Space,Str "set",Space,Str "to",Space,Str "uppercase",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "is",Space,Str "in",Space,Str "upper",Space,Str "case,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
- ,Div ("styling-xhtml-005.xhtml#style-311",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-311"],Space,Code ("",[],[]) "capitalize"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "text-transform",Space,Str "property",Space,Str "set",Space,Str "to",Space,Str "capitalize",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "If",Space,Str "each",Space,Str "first",Space,Str "letter",Space,Str "of",Space,Str "each",Space,Str "word",Space,Str "in",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "is",Space,Str "in",Space,Str "upper",Space,Str "case,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
- ,Div ("styling-xhtml-005.xhtml#style-312",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-312"],Space,Code ("",[],[]) "lowercase"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "text-transform",Space,Str "property",Space,Str "set",Space,Str "to",Space,Str "lowercase",Space,Str "is",Space,Str "supported."]
-  ,Para [Str "Lorem",Space,Str "ipsum",Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipisicing",Space,Str "elit,",Space,Str "sed",Space,Str "do",Space,Str "eiusmod",Space,Str "tempor",Space,Str "incididunt",Space,Str "ut",Space,Str "labore",Space,Str "et",Space,Str "dolore",Space,Str "magna",Space,Str "aliqua.",Space,Str "Ut",Space,Str "enim",Space,Str "ad",Space,Str "minim",Space,Str "veniam,",Space,Str "quis",Space,Str "nostrud",Space,Str "exercitation",Space,Str "ullamco",Space,Str "laboris",Space,Str "nisi",Space,Str "ut",Space,Str "aliquip",Space,Str "ex",Space,Str "ea",Space,Str "commodo",Space,Str "consequat.",Space,Str "Duis",Space,Str "aute",Space,Str "irure",Space,Str "dolor",Space,Str "in",Space,Str "reprehenderit",Space,Str "in",Space,Str "voluptate",Space,Str "velit",Space,Str "esse",Space,Str "cillum",Space,Str "dolore",Space,Str "eu",Space,Str "fugiat",Space,Str "nulla",Space,Str "pariatur.",Space,Str "Excepteur",Space,Str "sint",Space,Str "occaecat",Space,Str "cupidatat",Space,Str "non",Space,Str "proident,",Space,Str "sunt",Space,Str "in",Space,Str "culpa",Space,Str "qui",Space,Str "officia",Space,Str "deserunt",Space,Str "mollit",Space,Str "anim",Space,Str "id",Space,Str "est",Space,Str "laborum."]
-  ,Para [Str "If",Space,Str "the",Space,Str "preceding",Space,Str "paragraph",Space,Str "is",Space,Str "in",Space,Str "lower",Space,Str "case,",Space,Str "the",Space,Str "test",Space,Str "passes."]]]
-,Para [Span ("styling-xhtml-006.xhtml",[],[]) []]
-,Div ("styling-xhtml-006.xhtml#style-ruby",["section"],[])
- [Header 2 ("",[],[]) [Str "The",Space,Code ("",[],[]) "epub-ruby-position",Space,Str "property"]
- ,Div ("styling-xhtml-006.xhtml#style-410",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-410"],Space,Code ("",[],[]) "over"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "-epub-ruby-position",Space,Str "property",Space,Str "set",Space,Str "to",Space,Str "over",Space,Str "is",Space,Str "supported."]
-  ,Plain [RawInline (Format "html") "<ruby class=\"ruby-over\">",Strong [Str "Lorem",Space,Str "Ipsum"],Space,RawInline (Format "html") "<rp>",Str "(",RawInline (Format "html") "</rp>",RawInline (Format "html") "<rt>",Str "Lorem",Space,Str "Ipsum",RawInline (Format "html") "</rt>",RawInline (Format "html") "<rp>",Str ")",RawInline (Format "html") "</rp>",RawInline (Format "html") "</ruby>"]
-  ,Para [Str "If",Space,Str "the",Space,Str "Ruby",Space,Str "text",Space,Str "is",Space,Str "positioned",Space,Str "on",Space,Str "the",Space,Link ("",[],[]) [Str "over"] ("http://www.w3.org/TR/css3-writing-modes/#over",""),Space,Str "side",Space,Str "of",Space,Str "the",Space,Str "ruby",Space,Str "base,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
- ,Div ("styling-xhtml-006.xhtml#style-411",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-411"],Space,Code ("",[],[]) "under"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "-epub-ruby-position",Space,Str "property",Space,Str "set",Space,Str "to",Space,Str "under",Space,Str "is",Space,Str "supported."]
-  ,Plain [RawInline (Format "html") "<ruby class=\"ruby-under\">",Strong [Str "Lorem",Space,Str "Ipsum"],Space,RawInline (Format "html") "<rp>",Str "(",RawInline (Format "html") "</rp>",RawInline (Format "html") "<rt>",Str "Lorem",Space,Str "Ipsum",RawInline (Format "html") "</rt>",RawInline (Format "html") "<rp>",Str ")",RawInline (Format "html") "</rp>",RawInline (Format "html") "</ruby>"]
-  ,Para [Str "If",Space,Str "the",Space,Str "Ruby",Space,Str "text",Space,Str "is",Space,Str "positioned",Space,Str "on",Space,Str "the",Space,Link ("",[],[]) [Str "under"] ("http://www.w3.org/TR/css3-writing-modes/#under",""),Space,Str "side",Space,Str "of",Space,Str "the",Space,Str "ruby",Space,Str "base,",Space,Str "the",Space,Str "test",Space,Str "passes."]]
- ,Div ("styling-xhtml-006.xhtml#style-412",["section","ctest"],[])
-  [Header 2 ("",[],[]) [Span ("",["nature"],[]) [Str "[REQUIRED]"],Space,Span ("",["test-id"],[]) [Str "style-412"],Space,Code ("",[],[]) "inter-character"]
-  ,Para [Str "Tests",Space,Str "whether",Space,Str "the",Space,Code ("",[],[]) "-epub-ruby-position",Space,Str "property",Space,Str "set",Space,Str "to",Space,Str "inter-caracter",Space,Str "is",Space,Str "supported."]
-  ,Plain [RawInline (Format "html") "<ruby class=\"ruby-inter-character\">",Strong [Str "Lorem",Space,Str "Ipsum"],Space,RawInline (Format "html") "<rp>",Str "(",RawInline (Format "html") "</rp>",RawInline (Format "html") "<rt>",Str "Lorem",Space,Str "Ipsum",RawInline (Format "html") "</rt>",RawInline (Format "html") "<rp>",Str ")",RawInline (Format "html") "</rp>",RawInline (Format "html") "</ruby>"]
-  ,Para [Str "If",Space,Str "the",Space,Str "Ruby",Space,Str "text",Space,Str "is",Space,Str "positioned",Space,Str "on",Space,Str "the",Space,Str "right",Space,Str "side",Space,Str "of",Space,Str "the",Space,Str "base",Space,Str "text,",Space,Str "the",Space,Str "test",Space,Str "passes."]]]]
+[ Para
+  [ Span ( "front.xhtml", [], [] ) [] ]
+, Div
+  ( "", [ "section" ], [] )
+  [ Header 1
+    ( "", [], [] )
+    [ Str "EPUB"
+    , Space
+    , Str "3"
+    , Space
+    , Str "Styling"
+    , Space
+    , Str "Test"
+    , Space
+    , Str "Document:"
+    , Space
+    , Str "0101"
+    ]
+  , Div
+    ( "", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "Status"
+      , Space
+      , Str "of"
+      , Space
+      , Str "this"
+      , Space
+      , Str "Document"
+      ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "publication"
+      , Space
+      , Str "is"
+      , Space
+      , Str "currently"
+      , Space
+      , Str "considered"
+      , Space
+      , Span
+        ( "", [ "status" ], [] )
+        [ Str "[UNDER", Space, Str "DEVELOPMENT]" ]
+      , Space
+      , Str "by"
+      , Space
+      , Str "the"
+      , Space
+      , Str "IDPF."
+      ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "publication"
+      , Space
+      , Str "is"
+      , Space
+      , Str "part"
+      , Space
+      , Str "of"
+      , Space
+      , Str "version"
+      , Space
+      , Span
+        ( "", [ "version" ], [] )
+        [ Str "X.X" ]
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "EPUB"
+      , Space
+      , Str "3.0"
+      , Space
+      , Str "Compliance"
+      , Space
+      , Str "Test"
+      , Space
+      , Str "Suite"
+      , Space
+      , Str "released"
+      , SoftBreak
+      , Str "on"
+      , Space
+      , RawInline
+        ( Format "html" ) "<time class=\"release\">"
+      , Str "TBD"
+      , RawInline
+        ( Format "html" ) "</time>"
+      , Str "."
+      ]
+    , Para
+      [ Str "Before"
+      , Space
+      , Str "using"
+      , Space
+      , Str "this"
+      , Space
+      , Str "publication"
+      , Space
+      , Str "to"
+      , Space
+      , Str "evaluate"
+      , Space
+      , Str "reading"
+      , Space
+      , Str "systems,"
+      , Space
+      , Str "testers"
+      , Space
+      , Str "are"
+      , Space
+      , Str "strongly"
+      , Space
+      , Str "encouraged"
+      , Space
+      , Str "to"
+      , SoftBreak
+      , Str "verify"
+      , Space
+      , Str "that"
+      , Space
+      , Str "they"
+      , Space
+      , Str "have"
+      , Space
+      , Str "the"
+      , Space
+      , Str "latest"
+      , Space
+      , Str "release"
+      , Space
+      , Str "by"
+      , Space
+      , Str "checking"
+      , Space
+      , Str "the"
+      , Space
+      , Str "current"
+      , Space
+      , Str "release"
+      , Space
+      , Str "version"
+      , Space
+      , Str "and"
+      , Space
+      , Str "date"
+      , Space
+      , Str "of"
+      , SoftBreak
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "suite"
+      , Space
+      , Str "at"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "TBD" ]
+        ( "http://idpf.org/", "" )
+      ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "publication"
+      , Space
+      , Str "is"
+      , Space
+      , Str "one"
+      , Space
+      , Str "of"
+      , Space
+      , Str "several"
+      , Space
+      , Str "that"
+      , Space
+      , Str "currently"
+      , Space
+      , Str "comprise"
+      , Space
+      , Str "the"
+      , Space
+      , Str "EPUB"
+      , Space
+      , Str "3"
+      , Space
+      , Str "conformance"
+      , Space
+      , Str "test"
+      , Space
+      , Str "suite"
+      , SoftBreak
+      , Str "for"
+      , Space
+      , Str "reflowable"
+      , Space
+      , Str "content."
+      , Space
+      , Str "The"
+      , Space
+      , Str "complete"
+      , Space
+      , Str "test"
+      , Space
+      , Str "suite"
+      , Space
+      , Str "includes"
+      , Space
+      , Str "all"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "following"
+      , Space
+      , Str "publications:"
+      ]
+    , OrderedList
+      ( 1, DefaultStyle, DefaultDelim )
+      [ [ Plain [ Str "." ] ] ]
+    ]
+  , Div
+    ( "", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "About", Space, Str "this", Space, Str "Document" ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "document"
+      , Space
+      , Str "focuses"
+      , Space
+      , Str "on"
+      , Space
+      , Str "human-evaluated"
+      , Space
+      , Str "binary"
+      , Space
+      , Str "(pass/fail)"
+      , Space
+      , Str "tests"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , SoftBreak
+      , Str "reflowable"
+      , Space
+      , Str "context."
+      , Space
+      , Str "Tests"
+      , Space
+      , Str "for"
+      , Space
+      , Str "fixed-layout"
+      , Space
+      , Str "content"
+      , Space
+      , Str "and"
+      , Space
+      , Str "other"
+      , Space
+      , Str "individual"
+      , Space
+      , Str "tests"
+      , Space
+      , Str "that"
+      , SoftBreak
+      , Str "require"
+      , Space
+      , Str "a"
+      , Space
+      , Str "dedicated"
+      , Space
+      , Str "epub"
+      , Space
+      , Str "file"
+      , Space
+      , Str "are"
+      , Space
+      , Str "available"
+      , Space
+      , Str "in"
+      , Space
+      , Str "additional"
+      , Space
+      , Str "sibling"
+      , Space
+      , Str "documents;"
+      , Space
+      , Str "refer"
+      , Space
+      , Str "to"
+      , SoftBreak
+      , Str "the"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "test", Space, Str "suite", SoftBreak, Str "wiki" ]
+        ( "https://github.com/mgylling/epub-testsuite/wiki/Overview"
+        , ""
+        )
+      , Space
+      , Str "("
+      , Code
+        ( ""
+        , []
+        , []
+        ) "https://github.com/mgylling/epub-testsuite/wiki/Overview"
+      , Str ")"
+      , Space
+      , Str "for"
+      , Space
+      , Str "additional"
+      , SoftBreak
+      , Str "information."
+      ]
+    ]
+  , Div
+    ( "", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "Conventions" ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "following"
+      , Space
+      , Str "conventions"
+      , Space
+      , Str "are"
+      , Space
+      , Str "used"
+      , Space
+      , Str "throughout"
+      , Space
+      , Str "the"
+      , Space
+      , Str "document:"
+      ]
+    , DefinitionList
+      [
+        (
+          [ Str "1."
+          , Space
+          , Str "Locating"
+          , Space
+          , Str "a"
+          , Space
+          , Str "test"
+          ]
+        ,
+          [
+            [ Div
+              ( "", [ "ctest" ], [] )
+              [ Para
+                [ Str "Tests"
+                , Space
+                , Str "for"
+                , Space
+                , Emph
+                  [ Str "required" ]
+                , Space
+                , Str "Reading"
+                , Space
+                , Str "System"
+                , Space
+                , Str "functionality"
+                , Space
+                , Str "are"
+                , SoftBreak
+                , Str "preceded"
+                , Space
+                , Str "by"
+                , Space
+                , Str "the"
+                , Space
+                , Str "label:"
+                , Space
+                , Span
+                  ( ""
+                  , [ "nature" ]
+                  ,
+                    [ ( "style", "display: inline; font-size: 100%" ) ]
+                  )
+                  [ Str "[REQUIRED]" ]
+                ]
+              ]
+            , Div
+              ( "", [ "otest" ], [] )
+              [ Para
+                [ Str "Tests"
+                , Space
+                , Str "for"
+                , Space
+                , Emph
+                  [ Str "optional" ]
+                , Space
+                , Str "Reading"
+                , Space
+                , Str "System"
+                , Space
+                , Str "functionality"
+                , Space
+                , Str "are"
+                , SoftBreak
+                , Str "preceded"
+                , Space
+                , Str "by"
+                , Space
+                , Str "the"
+                , Space
+                , Str "label:"
+                , Space
+                , Span
+                  ( ""
+                  , [ "nature" ]
+                  ,
+                    [ ( "style", "display: inline; font-size: 100%" ) ]
+                  )
+                  [ Str "[OPTIONAL]" ]
+                ]
+              ]
+            ]
+          ]
+        )
+      ,
+        (
+          [ Str "2."
+          , Space
+          , Str "Performing"
+          , Space
+          , Str "the"
+          , Space
+          , Str "test"
+          ]
+        ,
+          [
+            [ Plain
+              [ Str "Each"
+              , Space
+              , Str "test"
+              , Space
+              , Str "includes"
+              , Space
+              , Str "a"
+              , Space
+              , Str "description"
+              , Space
+              , Str "of"
+              , Space
+              , Str "its"
+              , Space
+              , Str "purpose"
+              , Space
+              , Str "followed"
+              , Space
+              , Str "by"
+              , Space
+              , Str "the"
+              , Space
+              , Str "actual"
+              , Space
+              , Strong
+                [ Str "test"
+                , Space
+                , Str "statement,"
+                , SoftBreak
+                , Str "which"
+                , Space
+                , Str "can"
+                , Space
+                , Str "always"
+                , Space
+                , Str "be"
+                , Space
+                , Str "evaluated"
+                , Space
+                , Str "to"
+                , Space
+                , Str "true"
+                , Space
+                , Str "or"
+                , Space
+                , Str "false"
+                ]
+              , Str "."
+              , Space
+              , Str "These"
+              , Space
+              , Str "statements"
+              , Space
+              , Str "typically"
+              , Space
+              , Str "have"
+              , Space
+              , Str "the"
+              , Space
+              , Str "form:"
+              , SoftBreak
+              , Str "\"If"
+              , Space
+              , Str "[some"
+              , Space
+              , Str "condition],"
+              , Space
+              , Str "the"
+              , Space
+              , Str "test"
+              , Space
+              , Str "passes\"."
+              ]
+            ]
+          ]
+        )
+      ,
+        (
+          [ Str "3."
+          , Space
+          , Str "Scoring"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "results"
+          , Space
+          , Str "form"
+          ]
+        ,
+          [
+            [ Plain
+              [ Str "@@@TODO"
+              , Space
+              , Str "provide"
+              , Space
+              , Str "info"
+              , Space
+              , Str "on"
+              , Space
+              , Str "where"
+              , Space
+              , Str "to"
+              , Space
+              , Str "get"
+              , Space
+              , Str "the"
+              , Space
+              , Str "results"
+              , Space
+              , Str "form"
+              ]
+            ]
+          ]
+        )
+      ]
+    ]
+  ]
+, Para
+  [ Span ( "styling-xhtml-001.xhtml", [], [] ) [] ]
+, Div
+  ( "styling-xhtml-001.xhtml#epub-css", [ "section" ], [] )
+  [ Header 1
+    ( "", [], [] )
+    [ Str "EPUB", Space, Str "Style", Space, Str "Sheets" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "contains"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "styling"
+    , Space
+    , Str "and"
+    , Space
+    , Str "layout."
+    ]
+  ]
+, Para
+  [ Span ( "styling-xhtml-003.xhtml", [], [] ) [] ]
+, Div
+  ( "styling-xhtml-003.xhtml#style-110", [ "section", "ctest" ], [] )
+  [ Header 2
+    ( "", [], [] )
+    [ Span
+      ( "", [ "nature" ], [] )
+      [ Str "[REQUIRED]" ]
+    , Space
+    , Span
+      ( "", [ "test-id" ], [] )
+      [ Str "style-110" ]
+    , Space
+    , Str "Multi-Column"
+    , Space
+    , Str "Layouts"
+    ]
+  , Para
+    [ Str "Tests"
+    , Space
+    , Str "whether"
+    , Space
+    , Str "the"
+    , Space
+    , Code
+      ( "", [], [] ) "CSS Multi-Column Layout"
+    , Space
+    , Str "properties"
+    , Space
+    , Str "are"
+    , Space
+    , Str "supported."
+    ]
+  , Div
+    ( "", [ "multicol" ], [] )
+    [ Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    ]
+  , Para
+    [ Str "If"
+    , Space
+    , Str "the"
+    , Space
+    , Str "preceding"
+    , Space
+    , Str "text"
+    , Space
+    , Str "is"
+    , Space
+    , Str "rendered"
+    , Space
+    , Str "in"
+    , Space
+    , Str "three"
+    , Space
+    , Str "columns,"
+    , Space
+    , Str "the"
+    , Space
+    , Str "test"
+    , Space
+    , Str "passes."
+    ]
+  ]
+, Para
+  [ Span ( "styling-xhtml-002.xhtml", [], [] ) [] ]
+, Div
+  ( "styling-xhtml-002.xhtml#style-lists", [ "section" ], [] )
+  [ Header 2
+    ( "", [], [] )
+    [ Str "Lists" ]
+  , Div
+    ( "styling-xhtml-002.xhtml#style-list-style-type"
+    , [ "section" ]
+    , []
+    )
+    [ Header 3
+      ( "", [], [] )
+      [ Str "The"
+      , Space
+      , Code
+        ( "", [], [] ) "list-style-type"
+      , Space
+      , Str "property"
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-009"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-009" ]
+        , Space
+        , Code
+          ( "", [], [] ) "decimal"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "decimal"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "decimal"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-010"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-010" ]
+        , Space
+        , Code
+          ( "", [], [] ) "circle"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "circle"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ul"
+        , Space
+        , Str "element."
+        ]
+      , BulletList
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "circle"
+        , Space
+        , Str "markers,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-011"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-011" ]
+        , Space
+        , Code
+          ( "", [], [] ) "square"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "square"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ul"
+        , Space
+        , Str "element."
+        ]
+      , BulletList
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "square"
+        , Space
+        , Str "markers,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-012"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-012" ]
+        , Space
+        , Code
+          ( "", [], [] ) "disc"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "disc"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ul"
+        , Space
+        , Str "element."
+        ]
+      , BulletList
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "disc"
+        , Space
+        , Str "markers,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-013"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-013" ]
+        , Space
+        , Code
+          ( "", [], [] ) "lower-latin"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "lower-latin"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "lower-latin"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-014"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-014" ]
+        , Space
+        , Code
+          ( "", [], [] ) "lower-roman"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "lower-roman"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "lower-roman"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-015"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-015" ]
+        , Space
+        , Code
+          ( "", [], [] ) "upper-alpha"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "upper-alpha"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "upper-alpha"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-016"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-016" ]
+        , Space
+        , Code
+          ( "", [], [] ) "hiragana"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "hiragana"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "hiragana"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-017"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-017" ]
+        , Space
+        , Code
+          ( "", [], [] ) "hiragana-iroha"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "hiragana-iroha"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "hiragana-iroha"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-018"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-018" ]
+        , Space
+        , Code
+          ( "", [], [] ) "katakana"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "katakana"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "katakana"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-019"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-019" ]
+        , Space
+        , Code
+          ( "", [], [] ) "katakana-iroha"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "katakana-iroha"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "katakana-iroha"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-020"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-020" ]
+        , Space
+        , Code
+          ( "", [], [] ) "upper-roman"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "upper-roman"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "upper-roman"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-021"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-021" ]
+        , Space
+        , Code
+          ( "", [], [] ) "upper-latin"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "upper-latin"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "upper-latin"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-022"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-022" ]
+        , Space
+        , Code
+          ( "", [], [] ) "lower-alpha"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "lower-alpha"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "lower-alpha"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-023"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-023" ]
+        , Space
+        , Code
+          ( "", [], [] ) "lower-greek"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "lower-greek"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "lower-greek"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-024"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-024" ]
+        , Space
+        , Code
+          ( "", [], [] ) "armenian"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "armenian"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "armenian"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-025"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-025" ]
+        , Space
+        , Code
+          ( "", [], [] ) "cjk-ideographic"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "cjk-ideographic"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "cjk-ideographic"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-026"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-026" ]
+        , Space
+        , Code
+          ( "", [], [] ) "decimal-leading-zero"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "decimal-leading-zero"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "decimal-leading-zero"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-027"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-027" ]
+        , Space
+        , Code
+          ( "", [], [] ) "georgian"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "georgian"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "georgian"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-028"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-028" ]
+        , Space
+        , Code
+          ( "", [], [] ) "hebrew"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "hebrew"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "hebrew"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "in"
+        , Space
+        , Str "ascending"
+        , Space
+        , Str "order,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-029"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-029" ]
+        , Space
+        , Code
+          ( "", [], [] ) "none"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "none"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "no"
+        , Space
+        , Str "markers,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-002.xhtml#style-list-style", [ "section" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Str "The"
+      , Space
+      , Code
+        ( "", [], [] ) "list-style"
+      , Space
+      , Str "property"
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-030"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-030" ]
+        , Space
+        , Str "images"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style"
+        , Space
+        , Str "shorthand"
+        , Space
+        , Str "property"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "using"
+        , Space
+        , Str "a"
+        , Space
+        , Str "gif"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ul"
+        , Space
+        , Str "element."
+        ]
+      , BulletList
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "the"
+        , Space
+        , Str "purple"
+        , Space
+        , Str "and"
+        , Space
+        , Str "aqua"
+        , Space
+        , Str "square"
+        , Space
+        , Str "bullet"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-002.xhtml#style-list-style-position"
+    , [ "section" ]
+    , []
+    )
+    [ Header 3
+      ( "", [], [] )
+      [ Str "The"
+      , Space
+      , Code
+        ( "", [], [] ) "list-style-position"
+      , Space
+      , Str "property"
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-040"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-040" ]
+        , Space
+        , Str "The"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-position"
+        , Space
+        , Str "property:"
+        , Space
+        , Code
+          ( "", [], [] ) "inside"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-position"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "inside"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ul"
+        , Space
+        , Str "element."
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "Lorem"
+            , Space
+            , Str "ipsum"
+            , Space
+            , Str "dolor"
+            , Space
+            , Str "sit"
+            , Space
+            , Str "amet,"
+            , Space
+            , Str "consectetur"
+            , Space
+            , Str "adipisicing"
+            , Space
+            , Str "elit,"
+            , Space
+            , Str "sed"
+            , Space
+            , Str "do"
+            , Space
+            , Str "eiusmod"
+            , Space
+            , Str "tempor"
+            , Space
+            , Str "incididunt"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "labore"
+            , Space
+            , Str "et"
+            , Space
+            , Str "dolore"
+            , Space
+            , Str "magna"
+            , Space
+            , Str "aliqua."
+            , Space
+            , Str "Ut"
+            , Space
+            , Str "enim"
+            , Space
+            , Str "ad"
+            , Space
+            , Str "minim"
+            , Space
+            , Str "veniam,"
+            , Space
+            , Str "quis"
+            , Space
+            , Str "nostrud"
+            , Space
+            , Str "exercitation"
+            , Space
+            , Str "ullamco"
+            , Space
+            , Str "laboris"
+            , Space
+            , Str "nisi"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "aliquip"
+            , Space
+            , Str "ex"
+            , Space
+            , Str "ea"
+            , Space
+            , Str "commodo"
+            , Space
+            , Str "consequat."
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Lorem"
+            , Space
+            , Str "ipsum"
+            , Space
+            , Str "dolor"
+            , Space
+            , Str "sit"
+            , Space
+            , Str "amet,"
+            , Space
+            , Str "consectetur"
+            , Space
+            , Str "adipisicing"
+            , Space
+            , Str "elit,"
+            , Space
+            , Str "sed"
+            , Space
+            , Str "do"
+            , Space
+            , Str "eiusmod"
+            , Space
+            , Str "tempor"
+            , Space
+            , Str "incididunt"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "labore"
+            , Space
+            , Str "et"
+            , Space
+            , Str "dolore"
+            , Space
+            , Str "magna"
+            , Space
+            , Str "aliqua."
+            , Space
+            , Str "Ut"
+            , Space
+            , Str "enim"
+            , Space
+            , Str "ad"
+            , Space
+            , Str "minim"
+            , Space
+            , Str "veniam,"
+            , Space
+            , Str "quis"
+            , Space
+            , Str "nostrud"
+            , Space
+            , Str "exercitation"
+            , Space
+            , Str "ullamco"
+            , Space
+            , Str "laboris"
+            , Space
+            , Str "nisi"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "aliquip"
+            , Space
+            , Str "ex"
+            , Space
+            , Str "ea"
+            , Space
+            , Str "commodo"
+            , Space
+            , Str "consequat."
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Lorem"
+            , Space
+            , Str "ipsum"
+            , Space
+            , Str "dolor"
+            , Space
+            , Str "sit"
+            , Space
+            , Str "amet,"
+            , Space
+            , Str "consectetur"
+            , Space
+            , Str "adipisicing"
+            , Space
+            , Str "elit,"
+            , Space
+            , Str "sed"
+            , Space
+            , Str "do"
+            , Space
+            , Str "eiusmod"
+            , Space
+            , Str "tempor"
+            , Space
+            , Str "incididunt"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "labore"
+            , Space
+            , Str "et"
+            , Space
+            , Str "dolore"
+            , Space
+            , Str "magna"
+            , Space
+            , Str "aliqua."
+            , Space
+            , Str "Ut"
+            , Space
+            , Str "enim"
+            , Space
+            , Str "ad"
+            , Space
+            , Str "minim"
+            , Space
+            , Str "veniam,"
+            , Space
+            , Str "quis"
+            , Space
+            , Str "nostrud"
+            , Space
+            , Str "exercitation"
+            , Space
+            , Str "ullamco"
+            , Space
+            , Str "laboris"
+            , Space
+            , Str "nisi"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "aliquip"
+            , Space
+            , Str "ex"
+            , Space
+            , Str "ea"
+            , Space
+            , Str "commodo"
+            , Space
+            , Str "consequat."
+            ]
+          ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "markers"
+        , Space
+        , Str "inside"
+        , Space
+        , Str "the"
+        , Space
+        , Str "indentation,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-041"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-041" ]
+        , Space
+        , Str "The"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-position"
+        , Space
+        , Str "property:"
+        , Space
+        , Code
+          ( "", [], [] ) "outside"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-position"
+        , Space
+        , Str "property"
+        , Space
+        , Str "set"
+        , Space
+        , Str "to"
+        , Space
+        , Code
+          ( "", [], [] ) "outside"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ul"
+        , Space
+        , Str "element."
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "Lorem"
+            , Space
+            , Str "ipsum"
+            , Space
+            , Str "dolor"
+            , Space
+            , Str "sit"
+            , Space
+            , Str "amet,"
+            , Space
+            , Str "consectetur"
+            , Space
+            , Str "adipisicing"
+            , Space
+            , Str "elit,"
+            , Space
+            , Str "sed"
+            , Space
+            , Str "do"
+            , Space
+            , Str "eiusmod"
+            , Space
+            , Str "tempor"
+            , Space
+            , Str "incididunt"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "labore"
+            , Space
+            , Str "et"
+            , Space
+            , Str "dolore"
+            , Space
+            , Str "magna"
+            , Space
+            , Str "aliqua."
+            , Space
+            , Str "Ut"
+            , Space
+            , Str "enim"
+            , Space
+            , Str "ad"
+            , Space
+            , Str "minim"
+            , Space
+            , Str "veniam,"
+            , Space
+            , Str "quis"
+            , Space
+            , Str "nostrud"
+            , Space
+            , Str "exercitation"
+            , Space
+            , Str "ullamco"
+            , Space
+            , Str "laboris"
+            , Space
+            , Str "nisi"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "aliquip"
+            , Space
+            , Str "ex"
+            , Space
+            , Str "ea"
+            , Space
+            , Str "commodo"
+            , Space
+            , Str "consequat."
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Lorem"
+            , Space
+            , Str "ipsum"
+            , Space
+            , Str "dolor"
+            , Space
+            , Str "sit"
+            , Space
+            , Str "amet,"
+            , Space
+            , Str "consectetur"
+            , Space
+            , Str "adipisicing"
+            , Space
+            , Str "elit,"
+            , Space
+            , Str "sed"
+            , Space
+            , Str "do"
+            , Space
+            , Str "eiusmod"
+            , Space
+            , Str "tempor"
+            , Space
+            , Str "incididunt"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "labore"
+            , Space
+            , Str "et"
+            , Space
+            , Str "dolore"
+            , Space
+            , Str "magna"
+            , Space
+            , Str "aliqua."
+            , Space
+            , Str "Ut"
+            , Space
+            , Str "enim"
+            , Space
+            , Str "ad"
+            , Space
+            , Str "minim"
+            , Space
+            , Str "veniam,"
+            , Space
+            , Str "quis"
+            , Space
+            , Str "nostrud"
+            , Space
+            , Str "exercitation"
+            , Space
+            , Str "ullamco"
+            , Space
+            , Str "laboris"
+            , Space
+            , Str "nisi"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "aliquip"
+            , Space
+            , Str "ex"
+            , Space
+            , Str "ea"
+            , Space
+            , Str "commodo"
+            , Space
+            , Str "consequat."
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Lorem"
+            , Space
+            , Str "ipsum"
+            , Space
+            , Str "dolor"
+            , Space
+            , Str "sit"
+            , Space
+            , Str "amet,"
+            , Space
+            , Str "consectetur"
+            , Space
+            , Str "adipisicing"
+            , Space
+            , Str "elit,"
+            , Space
+            , Str "sed"
+            , Space
+            , Str "do"
+            , Space
+            , Str "eiusmod"
+            , Space
+            , Str "tempor"
+            , Space
+            , Str "incididunt"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "labore"
+            , Space
+            , Str "et"
+            , Space
+            , Str "dolore"
+            , Space
+            , Str "magna"
+            , Space
+            , Str "aliqua."
+            , Space
+            , Str "Ut"
+            , Space
+            , Str "enim"
+            , Space
+            , Str "ad"
+            , Space
+            , Str "minim"
+            , Space
+            , Str "veniam,"
+            , Space
+            , Str "quis"
+            , Space
+            , Str "nostrud"
+            , Space
+            , Str "exercitation"
+            , Space
+            , Str "ullamco"
+            , Space
+            , Str "laboris"
+            , Space
+            , Str "nisi"
+            , Space
+            , Str "ut"
+            , Space
+            , Str "aliquip"
+            , Space
+            , Str "ex"
+            , Space
+            , Str "ea"
+            , Space
+            , Str "commodo"
+            , Space
+            , Str "consequat."
+            ]
+          ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "has"
+        , Space
+        , Str "the"
+        , Space
+        , Str "default"
+        , Space
+        , Str "setting"
+        , Space
+        , Str "(marker"
+        , Space
+        , Str "outside"
+        , Space
+        , Str "the"
+        , Space
+        , Str "indentation),"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-002.xhtml#style-list-start", [ "section" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Str "The"
+      , Space
+      , Str "HTML"
+      , Space
+      , Code
+        ( "", [], [] ) "start"
+      , Space
+      , Str "attribute"
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-050"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-050" ]
+        , Space
+        , Str "Without"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "set"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "start"
+        , Space
+        , Str "attribute"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element"
+        , Space
+        , Str "with"
+        , Space
+        , Str "no"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property."
+        ]
+      , OrderedList
+        ( 25, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "starts"
+        , Space
+        , Str "at"
+        , Space
+        , Str "25,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    , Div
+      ( "styling-xhtml-002.xhtml#style-051"
+      ,
+        [ "section", "ctest" ]
+      , []
+      )
+      [ Header 4
+        ( "", [], [] )
+        [ Span
+          ( "", [ "nature" ], [] )
+          [ Str "[REQUIRED]" ]
+        , Space
+        , Span
+          ( "", [ "test-id" ], [] )
+          [ Str "style-051" ]
+        , Space
+        , Str "With"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "set"
+        ]
+      , Para
+        [ Str "Tests"
+        , Space
+        , Str "whether"
+        , Space
+        , Str "the"
+        , Space
+        , Code
+          ( "", [], [] ) "start"
+        , Space
+        , Str "attribute"
+        , Space
+        , Str "is"
+        , Space
+        , Str "supported"
+        , Space
+        , Str "on"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "ol"
+        , Space
+        , Str "element"
+        , Space
+        , Str "with"
+        , Space
+        , Str "a"
+        , Space
+        , Code
+          ( "", [], [] ) "list-style-type"
+        , Space
+        , Str "property."
+        ]
+      , OrderedList
+        ( 50, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "Lorem" ] ]
+        ,
+          [ Plain [ Str "Ipsum" ] ]
+        ,
+          [ Plain [ Str "Dolor" ] ]
+        ,
+          [ Plain [ Str "Sit" ] ]
+        ,
+          [ Plain [ Str "Amet" ] ]
+        ]
+      , Para
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "preceding"
+        , Space
+        , Str "list"
+        , Space
+        , Str "starts"
+        , Space
+        , Str "at"
+        , Space
+        , Str "'L'"
+        , Space
+        , Str "(50),"
+        , Space
+        , Str "the"
+        , Space
+        , Str "test"
+        , Space
+        , Str "passes."
+        ]
+      ]
+    ]
+  ]
+, Para
+  [ Span ( "styling-xhtml-004.xhtml", [], [] ) [] ]
+, Div
+  ( "styling-xhtml-004.xhtml#style-media-rules", [ "section" ], [] )
+  [ Header 2
+    ( "", [], [] )
+    [ Code ( "", [], [] ) "@media", Space, Str "Rules" ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-210", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-210" ]
+      , Space
+      , Code
+        ( "", [], [] ) "all"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "all"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\","
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-211", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-211" ]
+      , Space
+      , Code
+        ( "", [], [] ) "screen"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "screen"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\","
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-212", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-212" ]
+      , Space
+      , Code
+        ( "", [], [] ) "handheld"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "handheld"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\","
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-213", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-213" ]
+      , Space
+      , Code
+        ( "", [], [] ) "tv"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "tv"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\","
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-220", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-220" ]
+      , Space
+      , Code
+        ( "", [], [] ) "orientation:landscape"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "orientation:landscape"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\""
+      , Space
+      , Str "when"
+      , Space
+      , Str "the"
+      , Space
+      , Str "device"
+      , Space
+      , Str "is"
+      , Space
+      , Str "held"
+      , Space
+      , Str "in"
+      , Space
+      , Str "landscape"
+      , Space
+      , Str "mode,"
+      , Space
+      , Str "and"
+      , Space
+      , Str "the"
+      , Space
+      , Str "device"
+      , Space
+      , Str "supports"
+      , Space
+      , Str "multiple"
+      , Space
+      , Str "orientations,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-221", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-221" ]
+      , Space
+      , Code
+        ( "", [], [] ) "orientation:portrait"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "orientation:portrait"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\""
+      , Space
+      , Str "when"
+      , Space
+      , Str "the"
+      , Space
+      , Str "device"
+      , Space
+      , Str "is"
+      , Space
+      , Str "held"
+      , Space
+      , Str "in"
+      , Space
+      , Str "portrait"
+      , Space
+      , Str "mode,"
+      , Space
+      , Str "and"
+      , Space
+      , Str "the"
+      , Space
+      , Str "device"
+      , Space
+      , Str "supports"
+      , Space
+      , Str "multiple"
+      , Space
+      , Str "orientations,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-230", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-230" ]
+      , Space
+      , Code
+        ( "", [], [] ) "min-width"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "min-width:200px"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\","
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-231", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-231" ]
+      , Space
+      , Code
+        ( "", [], [] ) "max-width"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "max-width:2000px"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\","
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-240", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-240" ]
+      , Space
+      , Code
+        ( "", [], [] ) "min-device-width"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "min-device-width:200px"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\","
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-004.xhtml#style-241", [ "section", "ctest" ], [] )
+    [ Header 3
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-241" ]
+      , Space
+      , Code
+        ( "", [], [] ) "max-device-width"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "@media"
+      , Space
+      , Str "rule"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Code
+        ( "", [], [] ) "max-device-width:2000px"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "FAIL" ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "reads"
+      , Space
+      , Str "\"FAIL\","
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "fails."
+      ]
+    ]
+  ]
+, Para
+  [ Span ( "styling-xhtml-005.xhtml", [], [] ) [] ]
+, Div
+  ( "styling-xhtml-005.xhtml#style-text-xform", [ "section" ], [] )
+  [ Header 2
+    ( "", [], [] )
+    [ Str "The"
+    , Space
+    , Code
+      ( "", [], [] ) "text-transform"
+    , Space
+    , Str "property"
+    ]
+  , Div
+    ( "styling-xhtml-005.xhtml#style-310", [ "section", "ctest" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-310" ]
+      , Space
+      , Code
+        ( "", [], [] ) "uppercase"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "text-transform"
+      , Space
+      , Str "property"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Str "uppercase"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "is"
+      , Space
+      , Str "in"
+      , Space
+      , Str "upper"
+      , Space
+      , Str "case,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-005.xhtml#style-311", [ "section", "ctest" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-311" ]
+      , Space
+      , Code
+        ( "", [], [] ) "capitalize"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "text-transform"
+      , Space
+      , Str "property"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Str "capitalize"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "each"
+      , Space
+      , Str "first"
+      , Space
+      , Str "letter"
+      , Space
+      , Str "of"
+      , Space
+      , Str "each"
+      , Space
+      , Str "word"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "is"
+      , Space
+      , Str "in"
+      , Space
+      , Str "upper"
+      , Space
+      , Str "case,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-005.xhtml#style-312", [ "section", "ctest" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-312" ]
+      , Space
+      , Code
+        ( "", [], [] ) "lowercase"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "text-transform"
+      , Space
+      , Str "property"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Str "lowercase"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Para
+      [ Str "Lorem"
+      , Space
+      , Str "ipsum"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipisicing"
+      , Space
+      , Str "elit,"
+      , Space
+      , Str "sed"
+      , Space
+      , Str "do"
+      , Space
+      , Str "eiusmod"
+      , Space
+      , Str "tempor"
+      , Space
+      , Str "incididunt"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "labore"
+      , Space
+      , Str "et"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "magna"
+      , Space
+      , Str "aliqua."
+      , Space
+      , Str "Ut"
+      , Space
+      , Str "enim"
+      , Space
+      , Str "ad"
+      , Space
+      , Str "minim"
+      , Space
+      , Str "veniam,"
+      , Space
+      , Str "quis"
+      , Space
+      , Str "nostrud"
+      , Space
+      , Str "exercitation"
+      , Space
+      , Str "ullamco"
+      , Space
+      , Str "laboris"
+      , Space
+      , Str "nisi"
+      , Space
+      , Str "ut"
+      , Space
+      , Str "aliquip"
+      , Space
+      , Str "ex"
+      , Space
+      , Str "ea"
+      , Space
+      , Str "commodo"
+      , Space
+      , Str "consequat."
+      , Space
+      , Str "Duis"
+      , Space
+      , Str "aute"
+      , Space
+      , Str "irure"
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "in"
+      , Space
+      , Str "reprehenderit"
+      , Space
+      , Str "in"
+      , Space
+      , Str "voluptate"
+      , Space
+      , Str "velit"
+      , Space
+      , Str "esse"
+      , Space
+      , Str "cillum"
+      , Space
+      , Str "dolore"
+      , Space
+      , Str "eu"
+      , Space
+      , Str "fugiat"
+      , Space
+      , Str "nulla"
+      , Space
+      , Str "pariatur."
+      , Space
+      , Str "Excepteur"
+      , Space
+      , Str "sint"
+      , Space
+      , Str "occaecat"
+      , Space
+      , Str "cupidatat"
+      , Space
+      , Str "non"
+      , Space
+      , Str "proident,"
+      , Space
+      , Str "sunt"
+      , Space
+      , Str "in"
+      , Space
+      , Str "culpa"
+      , Space
+      , Str "qui"
+      , Space
+      , Str "officia"
+      , Space
+      , Str "deserunt"
+      , Space
+      , Str "mollit"
+      , Space
+      , Str "anim"
+      , Space
+      , Str "id"
+      , Space
+      , Str "est"
+      , Space
+      , Str "laborum."
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "preceding"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "is"
+      , Space
+      , Str "in"
+      , Space
+      , Str "lower"
+      , Space
+      , Str "case,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      ]
+    ]
+  ]
+, Para
+  [ Span ( "styling-xhtml-006.xhtml", [], [] ) [] ]
+, Div
+  ( "styling-xhtml-006.xhtml#style-ruby", [ "section" ], [] )
+  [ Header 2
+    ( "", [], [] )
+    [ Str "The"
+    , Space
+    , Code
+      ( "", [], [] ) "epub-ruby-position"
+    , Space
+    , Str "property"
+    ]
+  , Div
+    ( "styling-xhtml-006.xhtml#style-410", [ "section", "ctest" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-410" ]
+      , Space
+      , Code
+        ( "", [], [] ) "over"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "-epub-ruby-position"
+      , Space
+      , Str "property"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Str "over"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Plain
+      [ RawInline
+        ( Format "html" ) "<ruby class=\"ruby-over\">"
+      , Strong
+        [ Str "Lorem", Space, Str "Ipsum" ]
+      , Space
+      , RawInline
+        ( Format "html" ) "<rp>"
+      , Str "("
+      , RawInline
+        ( Format "html" ) "</rp>"
+      , RawInline
+        ( Format "html" ) "<rt>"
+      , Str "Lorem"
+      , Space
+      , Str "Ipsum"
+      , RawInline
+        ( Format "html" ) "</rt>"
+      , RawInline
+        ( Format "html" ) "<rp>"
+      , Str ")"
+      , RawInline
+        ( Format "html" ) "</rp>"
+      , RawInline
+        ( Format "html" ) "</ruby>"
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "Ruby"
+      , Space
+      , Str "text"
+      , Space
+      , Str "is"
+      , Space
+      , Str "positioned"
+      , Space
+      , Str "on"
+      , Space
+      , Str "the"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "over" ]
+        ( "http://www.w3.org/TR/css3-writing-modes/#over", "" )
+      , Space
+      , Str "side"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "ruby"
+      , Space
+      , Str "base,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-006.xhtml#style-411", [ "section", "ctest" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-411" ]
+      , Space
+      , Code
+        ( "", [], [] ) "under"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "-epub-ruby-position"
+      , Space
+      , Str "property"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Str "under"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Plain
+      [ RawInline
+        ( Format "html" ) "<ruby class=\"ruby-under\">"
+      , Strong
+        [ Str "Lorem", Space, Str "Ipsum" ]
+      , Space
+      , RawInline
+        ( Format "html" ) "<rp>"
+      , Str "("
+      , RawInline
+        ( Format "html" ) "</rp>"
+      , RawInline
+        ( Format "html" ) "<rt>"
+      , Str "Lorem"
+      , Space
+      , Str "Ipsum"
+      , RawInline
+        ( Format "html" ) "</rt>"
+      , RawInline
+        ( Format "html" ) "<rp>"
+      , Str ")"
+      , RawInline
+        ( Format "html" ) "</rp>"
+      , RawInline
+        ( Format "html" ) "</ruby>"
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "Ruby"
+      , Space
+      , Str "text"
+      , Space
+      , Str "is"
+      , Space
+      , Str "positioned"
+      , Space
+      , Str "on"
+      , Space
+      , Str "the"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "under" ]
+        ( "http://www.w3.org/TR/css3-writing-modes/#under", "" )
+      , Space
+      , Str "side"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "ruby"
+      , Space
+      , Str "base,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      ]
+    ]
+  , Div
+    ( "styling-xhtml-006.xhtml#style-412", [ "section", "ctest" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Span
+        ( "", [ "nature" ], [] )
+        [ Str "[REQUIRED]" ]
+      , Space
+      , Span
+        ( "", [ "test-id" ], [] )
+        [ Str "style-412" ]
+      , Space
+      , Code
+        ( "", [], [] ) "inter-character"
+      ]
+    , Para
+      [ Str "Tests"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "the"
+      , Space
+      , Code
+        ( "", [], [] ) "-epub-ruby-position"
+      , Space
+      , Str "property"
+      , Space
+      , Str "set"
+      , Space
+      , Str "to"
+      , Space
+      , Str "inter-caracter"
+      , Space
+      , Str "is"
+      , Space
+      , Str "supported."
+      ]
+    , Plain
+      [ RawInline
+        ( Format "html" ) "<ruby class=\"ruby-inter-character\">"
+      , Strong
+        [ Str "Lorem", Space, Str "Ipsum" ]
+      , Space
+      , RawInline
+        ( Format "html" ) "<rp>"
+      , Str "("
+      , RawInline
+        ( Format "html" ) "</rp>"
+      , RawInline
+        ( Format "html" ) "<rt>"
+      , Str "Lorem"
+      , Space
+      , Str "Ipsum"
+      , RawInline
+        ( Format "html" ) "</rt>"
+      , RawInline
+        ( Format "html" ) "<rp>"
+      , Str ")"
+      , RawInline
+        ( Format "html" ) "</rp>"
+      , RawInline
+        ( Format "html" ) "</ruby>"
+      ]
+    , Para
+      [ Str "If"
+      , Space
+      , Str "the"
+      , Space
+      , Str "Ruby"
+      , Space
+      , Str "text"
+      , Space
+      , Str "is"
+      , Space
+      , Str "positioned"
+      , Space
+      , Str "on"
+      , Space
+      , Str "the"
+      , Space
+      , Str "right"
+      , Space
+      , Str "side"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "base"
+      , Space
+      , Str "text,"
+      , Space
+      , Str "the"
+      , Space
+      , Str "test"
+      , Space
+      , Str "passes."
+      ]
+    ]
+  ]
+]

--- a/test/epub/wasteland.native
+++ b/test/epub/wasteland.native
@@ -1,938 +1,11409 @@
-[Para [Image ("",[],[]) [] ("wasteland-cover.jpg","")]
-,Para [Span ("wasteland-content.xhtml",[],[]) []]
-,Div ("wasteland-content.xhtml#frontmatter",["section","frontmatter"],[])
- []
-,Div ("wasteland-content.xhtml#bodymatter",["section","bodymatter"],[])
- [Div ("wasteland-content.xhtml#ch1",["section"],[])
-  [Header 2 ("",[],[]) [Str "I.",Space,Str "THE",Space,Str "BURIAL",Space,Str "OF",Space,Str "THE",Space,Str "DEAD"]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "April",Space,Str "is",Space,Str "the",Space,Str "cruellest",Space,Str "month,",Space,Str "breeding"]]
-   ,Div ("",[],[])
-    [Plain [Str "Lilacs",Space,Str "out",Space,Str "of",Space,Str "the",Space,Str "dead",Space,Str "land,",Space,Str "mixing"]]
-   ,Div ("",[],[])
-    [Plain [Str "Memory",Space,Str "and",Space,Str "desire,",Space,Str "stirring"]]
-   ,Div ("",[],[])
-    [Plain [Str "Dull",Space,Str "roots",Space,Str "with",Space,Str "spring",Space,Str "rain."]]
-   ,Div ("",[],[])
-    [Plain [Str "Winter",Space,Str "kept",Space,Str "us",Space,Str "warm,",Space,Str "covering"]]
-   ,Div ("",[],[])
-    [Plain [Str "Earth",Space,Str "in",Space,Str "forgetful",Space,Str "snow,",Space,Str "feeding"]]
-   ,Div ("",[],[])
-    [Plain [Str "A",Space,Str "little",Space,Str "life",Space,Str "with",Space,Str "dried",Space,Str "tubers."]]
-   ,Div ("",[],[])
-    [Plain [Str "Summer",Space,Str "surprised",Space,Str "us,",Space,Str "coming",Space,Str "over",Space,Str "the",Space,Str "Starnbergersee"]]
-   ,Div ("",[],[])
-    [Plain [Str "With",Space,Str "a",Space,Str "shower",Space,Str "of",Space,Str "rain;",Space,Str "we",Space,Str "stopped",Space,Str "in",Space,Str "the",Space,Str "colonnade,"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "went",Space,Str "on",Space,Str "in",Space,Str "sunlight,",Space,Str "into",Space,Str "the",Space,Str "Hofgarten,",Span ("",["lnum"],[]) [Str "10"]]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "drank",Space,Str "coffee,",Space,Str "and",Space,Str "talked",Space,Str "for",Space,Str "an",Space,Str "hour."]]
-   ,Div ("",[],[("lang","de")])
-    [Plain [Str "Bin",Space,Str "gar",Space,Str "keine",Space,Str "Russin,",Space,Str "stamm'",Space,Str "aus",Space,Str "Litauen,",Space,Str "echt",SoftBreak,Str "deutsch."]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "when",Space,Str "we",Space,Str "were",Space,Str "children,",Space,Str "staying",Space,Str "at",Space,Str "the",Space,Str "archduke's,"]]
-   ,Div ("",[],[])
-    [Plain [Str "My",Space,Str "cousin's,",Space,Str "he",Space,Str "took",Space,Str "me",Space,Str "out",Space,Str "on",Space,Str "a",Space,Str "sled,"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "I",Space,Str "was",Space,Str "frightened.",Space,Str "He",Space,Str "said,",Space,Str "Marie,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Marie,",Space,Str "hold",Space,Str "on",Space,Str "tight.",Space,Str "And",Space,Str "down",Space,Str "we",Space,Str "went."]]
-   ,Div ("",[],[])
-    [Plain [Str "In",Space,Str "the",Space,Str "mountains,",Space,Str "there",Space,Str "you",Space,Str "feel",Space,Str "free."]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "read,",Space,Str "much",Space,Str "of",Space,Str "the",Space,Str "night,",Space,Str "and",Space,Str "go",Space,Str "south",Space,Str "in",Space,Str "the",Space,Str "winter."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "What",Space,Str "are",Space,Str "the",Space,Str "roots",Space,Str "that",Space,Str "clutch,",Space,Str "what",Space,Str "branches",Space,Str "grow"]]
-   ,Div ("wasteland-content.xhtml#ln20",[],[])
-    [Plain [Str "Out",Space,Str "of",Space,Str "this",Space,Str "stony",Space,Str "rubbish?",Space,Str "Son",Space,Str "of",Space,Str "man,",Note [Para [Link ("",[],[]) [Str "Line",Space,Str "20."] ("#wasteland-content.xhtml#ln20",""),Space,Str "Cf.",Space,Str "Ezekiel",Space,Str "2:1."]],Span ("",["lnum"],[]) [Str "20"]]]
-   ,Div ("",[],[])
-    [Plain [Str "You",Space,Str "cannot",Space,Str "say,",Space,Str "or",Space,Str "guess,",Space,Str "for",Space,Str "you",Space,Str "know",Space,Str "only"]]
-   ,Div ("",[],[])
-    [Plain [Str "A",Space,Str "heap",Space,Str "of",Space,Str "broken",Space,Str "images,",Space,Str "where",Space,Str "the",Space,Str "sun",Space,Str "beats,"]]
-   ,Div ("wasteland-content.xhtml#ln23",[],[])
-    [Plain [Str "And",Space,Str "the",Space,Str "dead",Space,Str "tree",Space,Str "gives",Space,Str "no",Space,Str "shelter,",Space,Str "the",Space,Str "cricket",Space,Str "no",Space,Str "relief,",Note [Para [Link ("",[],[]) [Str "23."] ("#wasteland-content.xhtml#ln23",""),Space,Str "Cf.",Space,Str "Ecclesiastes",Space,Str "12:5."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "the",Space,Str "dry",Space,Str "stone",Space,Str "no",Space,Str "sound",Space,Str "of",Space,Str "water.",Space,Str "Only"]]
-   ,Div ("",[],[])
-    [Plain [Str "There",Space,Str "is",Space,Str "shadow",Space,Str "under",Space,Str "this",Space,Str "red",Space,Str "rock,"]]
-   ,Div ("",[],[])
-    [Plain [Str "(Come",Space,Str "in",Space,Str "under",Space,Str "the",Space,Str "shadow",Space,Str "of",Space,Str "this",Space,Str "red",Space,Str "rock),"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "I",Space,Str "will",Space,Str "show",Space,Str "you",Space,Str "something",Space,Str "different",Space,Str "from",Space,Str "either"]]
-   ,Div ("",[],[])
-    [Plain [Str "Your",Space,Str "shadow",Space,Str "at",Space,Str "morning",Space,Str "striding",Space,Str "behind",Space,Str "you"]]
-   ,Div ("",[],[])
-    [Plain [Str "Or",Space,Str "your",Space,Str "shadow",Space,Str "at",Space,Str "evening",Space,Str "rising",Space,Str "to",Space,Str "meet",Space,Str "you;"]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "will",Space,Str "show",Space,Str "you",Space,Str "fear",Space,Str "in",Space,Str "a",Space,Str "handful",Space,Str "of",Space,Str "dust.",Span ("",["lnum"],[]) [Str "30"]]]
-   ,BlockQuote
-    [Div ("",[],[])
-     [Div ("wasteland-content.xhtml#ln31",[],[])
-      [Plain [Str "Frisch",Space,Str "weht",Space,Str "der",Space,Str "Wind",Note [Para [Link ("",[],[]) [Str "31."] ("#wasteland-content.xhtml#ln31",""),Space,Str "V.",Space,Str "Tristan",Space,Str "und",Space,Str "Isolde,",Space,Str "i,",Space,Str "verses",Space,Str "5-8."]]]]
-     ,Div ("",[],[])
-      [Plain [Str "Der",Space,Str "Heimat",Space,Str "zu"]]
-     ,Div ("",[],[])
-      [Plain [Str "Mein",Space,Str "Irisch",Space,Str "Kind,"]]
-     ,Div ("",[],[])
-      [Plain [Str "Wo",Space,Str "weilest",Space,Str "du?"]]]]
-   ,Div ("",[],[])
-    [Plain [Str "\"You",Space,Str "gave",Space,Str "me",Space,Str "hyacinths",Space,Str "first",Space,Str "a",Space,Str "year",Space,Str "ago;"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"They",Space,Str "called",Space,Str "me",Space,Str "the",Space,Str "hyacinth",Space,Str "girl.\""]]
-   ,Div ("",[],[])
-    [Plain [Str "\8213Yet",Space,Str "when",Space,Str "we",Space,Str "came",Space,Str "back,",Space,Str "late,",Space,Str "from",Space,Str "the",Space,Str "Hyacinth",SoftBreak,Str "garden,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Your",Space,Str "arms",Space,Str "full,",Space,Str "and",Space,Str "your",Space,Str "hair",Space,Str "wet,",Space,Str "I",Space,Str "could",Space,Str "not"]]
-   ,Div ("",[],[])
-    [Plain [Str "Speak,",Space,Str "and",Space,Str "my",Space,Str "eyes",Space,Str "failed,",Space,Str "I",Space,Str "was",Space,Str "neither"]]
-   ,Div ("",[],[])
-    [Plain [Str "Living",Space,Str "nor",Space,Str "dead,",Space,Str "and",Space,Str "I",Space,Str "knew",Space,Str "nothing,",Span ("",["lnum"],[]) [Str "40"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Looking",Space,Str "into",Space,Str "the",Space,Str "heart",Space,Str "of",Space,Str "light,",Space,Str "the",Space,Str "silence."]]
-   ,Div ("wasteland-content.xhtml#ln42",[],[("lang","de")])
-    [Plain [Emph [Str "Od'",Space,Str "und",Space,Str "leer",Space,Str "das",Space,Str "Meer"],Str ".",Note [Para [Link ("",[],[]) [Str "42."] ("#wasteland-content.xhtml#ln42",""),Space,Str "Id.",Space,Str "iii,",Space,Str "verse",Space,Str "24."]]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "Madame",Space,Str "Sosostris,",Space,Str "famous",Space,Str "clairvoyante,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Had",Space,Str "a",Space,Str "bad",Space,Str "cold,",Space,Str "nevertheless"]]
-   ,Div ("",[],[])
-    [Plain [Str "Is",Space,Str "known",Space,Str "to",Space,Str "be",Space,Str "the",Space,Str "wisest",Space,Str "woman",Space,Str "in",Space,Str "Europe,"]]
-   ,Div ("wasteland-content.xhtml#ln46",[],[])
-    [Plain [Str "With",Space,Str "a",Space,Str "wicked",Space,Str "pack",Space,Str "of",Space,Str "cards.",Space,Str "Here,",Space,Str "said",Space,Str "she,",Note [Para [Link ("",[],[]) [Str "46."] ("#wasteland-content.xhtml#ln46",""),Space,Str "I",Space,Str "am",Space,Str "not",Space,Str "familiar",Space,Str "with",Space,Str "the",Space,Str "exact",Space,Str "constitution",Space,Str "of",Space,Str "the",Space,Str "Tarot",Space,Str "pack",Space,Str "of",SoftBreak,Str "cards,",Space,Str "from",Space,Str "which",Space,Str "I",Space,Str "have",Space,Str "obviously",Space,Str "departed",Space,Str "to",Space,Str "suit",Space,Str "my",Space,Str "own",Space,Str "convenience.",SoftBreak,Str "The",Space,Str "Hanged",Space,Str "Man,",Space,Str "a",Space,Str "member",Space,Str "of",Space,Str "the",Space,Str "traditional",Space,Str "pack,",Space,Str "fits",Space,Str "my",Space,Str "purpose",Space,Str "in",Space,Str "two",SoftBreak,Str "ways:",Space,Str "because",Space,Str "he",Space,Str "is",Space,Str "associated",Space,Str "in",Space,Str "my",Space,Str "mind",Space,Str "with",Space,Str "the",Space,Str "Hanged",Space,Str "God",Space,Str "of",Space,Str "Frazer,",SoftBreak,Str "and",Space,Str "because",Space,Str "I",Space,Str "associate",Space,Str "him",Space,Str "with",Space,Str "the",Space,Str "hooded",Space,Str "figure",Space,Str "in",Space,Str "the",Space,Str "passage",Space,Str "of",Space,Str "the",SoftBreak,Str "disciples",Space,Str "to",Space,Str "Emmaus",Space,Str "in",Space,Str "Part",Space,Str "V.",Space,Str "The",Space,Str "Phoenician",Space,Str "Sailor",Space,Str "and",Space,Str "the",Space,Str "Merchant",SoftBreak,Str "appear",Space,Str "later;",Space,Str "also",Space,Str "the",Space,Str "\"crowds",Space,Str "of",Space,Str "people,\"",Space,Str "and",Space,Str "Death",Space,Str "by",Space,Str "Water",Space,Str "is",SoftBreak,Str "executed",Space,Str "in",Space,Str "Part",Space,Str "IV.",Space,Str "The",Space,Str "Man",Space,Str "with",Space,Str "Three",Space,Str "Staves",Space,Str "(an",Space,Str "authentic",Space,Str "member",Space,Str "of",SoftBreak,Str "the",Space,Str "Tarot",Space,Str "pack)",Space,Str "I",Space,Str "associate,",Space,Str "quite",Space,Str "arbitrarily,",Space,Str "with",Space,Str "the",Space,Str "Fisher",Space,Str "King",SoftBreak,Str "himself."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Is",Space,Str "your",Space,Str "card,",Space,Str "the",Space,Str "drowned",Space,Str "Phoenician",Space,Str "Sailor,"]]
-   ,Div ("",[],[])
-    [Plain [Str "(Those",Space,Str "are",Space,Str "pearls",Space,Str "that",Space,Str "were",Space,Str "his",Space,Str "eyes.",Space,Str "Look!)"]]
-   ,Div ("",[],[])
-    [Plain [Str "Here",Space,Str "is",Space,Str "Belladonna,",Space,Str "the",Space,Str "Lady",Space,Str "of",Space,Str "the",Space,Str "Rocks,"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "lady",Space,Str "of",Space,Str "situations.",Span ("",["lnum"],[]) [Str "50"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Here",Space,Str "is",Space,Str "the",Space,Str "man",Space,Str "with",Space,Str "three",Space,Str "staves,",Space,Str "and",Space,Str "here",Space,Str "the",Space,Str "Wheel,"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "here",Space,Str "is",Space,Str "the",Space,Str "one-eyed",Space,Str "merchant,",Space,Str "and",Space,Str "this",Space,Str "card,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Which",Space,Str "is",Space,Str "blank,",Space,Str "is",Space,Str "something",Space,Str "he",Space,Str "carries",Space,Str "on",Space,Str "his",Space,Str "back,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Which",Space,Str "I",Space,Str "am",Space,Str "forbidden",Space,Str "to",Space,Str "see.",Space,Str "I",Space,Str "do",Space,Str "not",Space,Str "find"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "Hanged",Space,Str "Man.",Space,Str "Fear",Space,Str "death",Space,Str "by",Space,Str "water."]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "see",Space,Str "crowds",Space,Str "of",Space,Str "people,",Space,Str "walking",Space,Str "round",Space,Str "in",Space,Str "a",Space,Str "ring."]]
-   ,Div ("",[],[])
-    [Plain [Str "Thank",Space,Str "you.",Space,Str "If",Space,Str "you",Space,Str "see",Space,Str "dear",Space,Str "Mrs.",Space,Str "Equitone,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Tell",Space,Str "her",Space,Str "I",Space,Str "bring",Space,Str "the",Space,Str "horoscope",Space,Str "myself:"]]
-   ,Div ("",[],[])
-    [Plain [Str "One",Space,Str "must",Space,Str "be",Space,Str "so",Space,Str "careful",Space,Str "these",Space,Str "days."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("wasteland-content.xhtml#ln60",[],[])
-    [Plain [Str "Unreal",Space,Str "City,",Note [Para [Link ("",[],[]) [Str "60."] ("#wasteland-content.xhtml#ln60",""),Space,Str "Cf.",Space,Str "Baudelaire:"],BlockQuote [Para [Str "\"Fourmillante",Space,Str "cite;,",Space,Str "cite;",Space,Str "pleine",Space,Str "de",Space,Str "reves,",LineBreak,Str "Ou",Space,Str "le",Space,Str "spectre",Space,Str "en",SoftBreak,Str "plein",Space,Str "jour",Space,Str "raccroche",Space,Str "le",Space,Str "passant.\""]]],Span ("",["lnum"],[]) [Str "60"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Under",Space,Str "the",Space,Str "brown",Space,Str "fog",Space,Str "of",Space,Str "a",Space,Str "winter",Space,Str "dawn,"]]
-   ,Div ("",[],[])
-    [Plain [Str "A",Space,Str "crowd",Space,Str "flowed",Space,Str "over",Space,Str "London",Space,Str "Bridge,",Space,Str "so",Space,Str "many,"]]
-   ,Div ("wasteland-content.xhtml#ln63",[],[])
-    [Plain [Str "I",Space,Str "had",Space,Str "not",Space,Str "thought",Space,Str "death",Space,Str "had",Space,Str "undone",Space,Str "so",Space,Str "many.",Note [Para [Link ("",[],[]) [Str "63."] ("#wasteland-content.xhtml#ln63",""),Space,Str "Cf.",Space,Str "Inferno,",Space,Str "iii.",Space,Str "55-7."],BlockQuote [Para [Str "\"si",Space,Str "lunga",Space,Str "tratta",LineBreak,Str "di",Space,Str "gente,",Space,Str "ch'io",Space,Str "non",Space,Str "avrei",Space,Str "mai",Space,Str "creduto",LineBreak,Str "che",SoftBreak,Str "morte",Space,Str "tanta",Space,Str "n'avesse",Space,Str "disfatta.\""]]]]]
-   ,Div ("wasteland-content.xhtml#ln64",[],[])
-    [Plain [Str "Sighs,",Space,Str "short",Space,Str "and",Space,Str "infrequent,",Space,Str "were",Space,Str "exhaled,",Note [Para [Link ("",[],[]) [Str "64."] ("#wasteland-content.xhtml#ln64",""),Space,Str "Cf.",Space,Str "Inferno,",Space,Str "iv.",Space,Str "25-7:"],BlockQuote [Para [Str "\"Quivi,",Space,Str "secondo",Space,Str "che",Space,Str "per",Space,Str "ascoltahre,",LineBreak,Str "\"non",Space,Str "avea",Space,Str "pianto,",Space,Str "ma'",Space,Str "che",Space,Str "di",SoftBreak,Str "sospiri,",LineBreak,Str "\"che",Space,Str "l'aura",Space,Str "eterna",Space,Str "facevan",Space,Str "tremare.\""]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "each",Space,Str "man",Space,Str "fixed",Space,Str "his",Space,Str "eyes",Space,Str "before",Space,Str "his",Space,Str "feet."]]
-   ,Div ("",[],[])
-    [Plain [Str "Flowed",Space,Str "up",Space,Str "the",Space,Str "hill",Space,Str "and",Space,Str "down",Space,Str "King",Space,Str "William",Space,Str "Street,"]]
-   ,Div ("",[],[])
-    [Plain [Str "To",Space,Str "where",Space,Str "Saint",Space,Str "Mary",Space,Str "Woolnoth",Space,Str "kept",Space,Str "the",Space,Str "hours"]]
-   ,Div ("wasteland-content.xhtml#ln68",[],[])
-    [Plain [Str "With",Space,Str "a",Space,Str "dead",Space,Str "sound",Space,Str "on",Space,Str "the",Space,Str "final",Space,Str "stroke",Space,Str "of",Space,Str "nine.",Note [Para [Link ("",[],[]) [Str "68."] ("#wasteland-content.xhtml#ln68",""),Space,Str "A",Space,Str "phenomenon",Space,Str "which",Space,Str "I",Space,Str "have",Space,Str "often",Space,Str "noticed."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "There",Space,Str "I",Space,Str "saw",Space,Str "one",Space,Str "I",Space,Str "knew,",Space,Str "and",Space,Str "stopped",Space,Str "him,",Space,Str "crying",SoftBreak,Str "\"Stetson!"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"You",Space,Str "who",Space,Str "were",Space,Str "with",Space,Str "me",Space,Str "in",Space,Str "the",Space,Str "ships",Space,Str "at",Space,Str "Mylae!",Span ("",["lnum"],[]) [Str "70"]]]
-   ,Div ("",[],[])
-    [Plain [Str "\"That",Space,Str "corpse",Space,Str "you",Space,Str "planted",Space,Str "last",Space,Str "year",Space,Str "in",Space,Str "your",Space,Str "garden,"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"Has",Space,Str "it",Space,Str "begun",Space,Str "to",Space,Str "sprout?",Space,Str "Will",Space,Str "it",Space,Str "bloom",Space,Str "this",Space,Str "year?"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"Or",Space,Str "has",Space,Str "the",Space,Str "sudden",Space,Str "frost",Space,Str "disturbed",Space,Str "its",Space,Str "bed?"]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("wasteland-content.xhtml#ln74",[],[])
-    [Plain [Str "\"Oh",Space,Str "keep",Space,Str "the",Space,Str "Dog",Space,Str "far",Space,Str "hence,",Space,Str "that's",Space,Str "friend",Space,Str "to",Space,Str "men,",Note [Para [Link ("",[],[]) [Str "74."] ("#wasteland-content.xhtml#ln74",""),Space,Str "Cf.",Space,Str "the",Space,Str "Dirge",Space,Str "in",Space,Str "Webster's",Space,Str "White",Space,Str "Devil",Space,Str "."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "\"Or",Space,Str "with",Space,Str "his",Space,Str "nails",Space,Str "he'll",Space,Str "dig",Space,Str "it",Space,Str "up",Space,Str "again!"]]
-   ,Div ("wasteland-content.xhtml#ln76",[],[])
-    [Plain [Str "\"You!",Space,Span ("",[],[("lang","fr")]) [Str "hypocrite",Space,Str "lecteur!",Space,Str "-",Space,Str "mon",Space,Str "semblable,",Space,Str "-",SoftBreak,Str "mon",Space,Str "frere"],Space,Str "!\"",Note [Para [Link ("",[],[]) [Str "76."] ("#wasteland-content.xhtml#ln76",""),Space,Str "V.",Space,Str "Baudelaire,",Space,Str "Preface",Space,Str "to",Space,Str "Fleurs",Space,Str "du",Space,Str "Mal."]]]]]]
- ,Div ("wasteland-content.xhtml#ch2",["section"],[])
-  [Header 2 ("",[],[]) [Str "II.",Space,Str "A",Space,Str "GAME",Space,Str "OF",Space,Str "CHESS"]
-  ,Div ("",["linegroup"],[])
-   [Div ("wasteland-content.xhtml#ln77",[],[])
-    [Plain [Str "The",Space,Str "Chair",Space,Str "she",Space,Str "sat",Space,Str "in,",Space,Str "like",Space,Str "a",Space,Str "burnished",Space,Str "throne,",Note [Para [Link ("",[],[]) [Str "77."] ("#wasteland-content.xhtml#ln77",""),Space,Str "Cf.",Space,Str "Antony",Space,Str "and",Space,Str "Cleopatra,",Space,Str "II.",Space,Str "ii.,",Space,Str "l.",Space,Str "190."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Glowed",Space,Str "on",Space,Str "the",Space,Str "marble,",Space,Str "where",Space,Str "the",Space,Str "glass"]]
-   ,Div ("",[],[])
-    [Plain [Str "Held",Space,Str "up",Space,Str "by",Space,Str "standards",Space,Str "wrought",Space,Str "with",Space,Str "fruited",Space,Str "vines"]]
-   ,Div ("",[],[])
-    [Plain [Str "From",Space,Str "which",Space,Str "a",Space,Str "golden",Space,Str "Cupidon",Space,Str "peeped",Space,Str "out",Span ("",["lnum"],[]) [Str "80"]]]
-   ,Div ("",[],[])
-    [Plain [Str "(Another",Space,Str "hid",Space,Str "his",Space,Str "eyes",Space,Str "behind",Space,Str "his",Space,Str "wing)"]]
-   ,Div ("",[],[])
-    [Plain [Str "Doubled",Space,Str "the",Space,Str "flames",Space,Str "of",Space,Str "sevenbranched",Space,Str "candelabra"]]
-   ,Div ("",[],[])
-    [Plain [Str "Reflecting",Space,Str "light",Space,Str "upon",Space,Str "the",Space,Str "table",Space,Str "as"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "glitter",Space,Str "of",Space,Str "her",Space,Str "jewels",Space,Str "rose",Space,Str "to",Space,Str "meet",Space,Str "it,"]]
-   ,Div ("",[],[])
-    [Plain [Str "From",Space,Str "satin",Space,Str "cases",Space,Str "poured",Space,Str "in",Space,Str "rich",Space,Str "profusion;"]]
-   ,Div ("",[],[])
-    [Plain [Str "In",Space,Str "vials",Space,Str "of",Space,Str "ivory",Space,Str "and",Space,Str "coloured",Space,Str "glass"]]
-   ,Div ("",[],[])
-    [Plain [Str "Unstoppered,",Space,Str "lurked",Space,Str "her",Space,Str "strange",Space,Str "synthetic",Space,Str "perfumes,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Unguent,",Space,Str "powdered,",Space,Str "or",Space,Str "liquid",Space,Str "-",Space,Str "troubled,",Space,Str "confused"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "drowned",Space,Str "the",Space,Str "sense",Space,Str "in",Space,Str "odours;",Space,Str "stirred",Space,Str "by",Space,Str "the",Space,Str "air"]]
-   ,Div ("",[],[])
-    [Plain [Str "That",Space,Str "freshened",Space,Str "from",Space,Str "the",Space,Str "window,",Space,Str "these",Space,Str "ascended",Span ("",["lnum"],[]) [Str "90"]]]
-   ,Div ("",[],[])
-    [Plain [Str "In",Space,Str "fattening",Space,Str "the",Space,Str "prolonged",Space,Str "candle-flames,"]]
-   ,Div ("wasteland-content.xhtml#ln92",[],[])
-    [Plain [Str "Flung",Space,Str "their",Space,Str "smoke",Space,Str "into",Space,Str "the",Space,Str "laquearia,",Note [Para [Link ("",[],[]) [Str "92."] ("#wasteland-content.xhtml#ln92",""),Space,Str "Laquearia.",Space,Str "V.",Space,Str "Aeneid,",Space,Str "I.",Space,Str "726:"],BlockQuote [Para [Str "dependent",Space,Str "lychni",Space,Str "laquearibus",Space,Str "aureis",Space,Str "incensi,",Space,Str "et",Space,Str "noctem",SoftBreak,Str "flammis",LineBreak,Str "funalia",Space,Str "vincunt."]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Stirring",Space,Str "the",Space,Str "pattern",Space,Str "on",Space,Str "the",Space,Str "coffered",Space,Str "ceiling."]]
-   ,Div ("",[],[])
-    [Plain [Str "Huge",Space,Str "sea-wood",Space,Str "fed",Space,Str "with",Space,Str "copper"]]
-   ,Div ("",[],[])
-    [Plain [Str "Burned",Space,Str "green",Space,Str "and",Space,Str "orange,",Space,Str "framed",Space,Str "by",Space,Str "the",Space,Str "coloured",Space,Str "stone,"]]
-   ,Div ("",[],[])
-    [Plain [Str "In",Space,Str "which",Space,Str "sad",Space,Str "light",Space,Str "a",Space,Str "carved",Space,Str "dolphin",Space,Str "swam."]]
-   ,Div ("",[],[])
-    [Plain [Str "Above",Space,Str "the",Space,Str "antique",Space,Str "mantel",Space,Str "was",Space,Str "displayed"]]
-   ,Div ("wasteland-content.xhtml#ln98",[],[])
-    [Plain [Str "As",Space,Str "though",Space,Str "a",Space,Str "window",Space,Str "gave",Space,Str "upon",Space,Str "the",Space,Str "sylvan",Space,Str "scene",Note [Para [Link ("",[],[]) [Str "98."] ("#wasteland-content.xhtml#ln98",""),Space,Str "Sylvan",Space,Str "scene.",Space,Str "V.",Space,Str "Milton,",Space,Str "Paradise",Space,Str "Lost,",Space,Str "iv.",Space,Str "140."]]]]
-   ,Div ("wasteland-content.xhtml#ln99",[],[])
-    [Plain [Str "The",Space,Str "change",Space,Str "of",Space,Str "Philomel,",Space,Str "by",Space,Str "the",Space,Str "barbarous",Space,Str "king",Note [Para [Link ("",[],[]) [Str "99."] ("#wasteland-content.xhtml#ln99",""),Space,Str "V.",Space,Str "Ovid,",Space,Str "Metamorphoses,",Space,Str "vi,",Space,Str "Philomela."]]]]
-   ,Div ("wasteland-content.xhtml#ln100",[],[])
-    [Plain [Str "So",Space,Str "rudely",Space,Str "forced;",Space,Str "yet",Space,Str "there",Space,Str "the",Space,Str "nightingale",Note [Para [Link ("",[],[]) [Str "100."] ("#wasteland-content.xhtml#ln100",""),Space,Str "Cf.",Space,Str "Part",Space,Str "III,",Space,Str "l.",Space,Str "204."]],SoftBreak,Span ("",["lnum"],[]) [Str "100"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Filled",Space,Str "all",Space,Str "the",Space,Str "desert",Space,Str "with",Space,Str "inviolable",Space,Str "voice"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "still",Space,Str "she",Space,Str "cried,",Space,Str "and",Space,Str "still",Space,Str "the",Space,Str "world",Space,Str "pursues,"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"Jug",Space,Str "Jug\"",Space,Str "to",Space,Str "dirty",Space,Str "ears."]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "other",Space,Str "withered",Space,Str "stumps",Space,Str "of",Space,Str "time"]]
-   ,Div ("",[],[])
-    [Plain [Str "Were",Space,Str "told",Space,Str "upon",Space,Str "the",Space,Str "walls;",Space,Str "staring",Space,Str "forms"]]
-   ,Div ("",[],[])
-    [Plain [Str "Leaned",Space,Str "out,",Space,Str "leaning,",Space,Str "hushing",Space,Str "the",Space,Str "room",Space,Str "enclosed."]]
-   ,Div ("",[],[])
-    [Plain [Str "Footsteps",Space,Str "shuffled",Space,Str "on",Space,Str "the",Space,Str "stair."]]
-   ,Div ("",[],[])
-    [Plain [Str "Under",Space,Str "the",Space,Str "firelight,",Space,Str "under",Space,Str "the",Space,Str "brush,",Space,Str "her",Space,Str "hair"]]
-   ,Div ("",[],[])
-    [Plain [Str "Spread",Space,Str "out",Space,Str "in",Space,Str "fiery",Space,Str "points"]]
-   ,Div ("",[],[])
-    [Plain [Str "Glowed",Space,Str "into",Space,Str "words,",Space,Str "then",Space,Str "would",Space,Str "be",Space,Str "savagely",Space,Str "still.",Span ("",["lnum"],[]) [Str "110"]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",["linegroup"],[])
-    [Div ("",[],[])
-     [Plain [Str "\"My",Space,Str "nerves",Space,Str "are",Space,Str "bad",Space,Str "to-night.",Space,Str "Yes,",Space,Str "bad.",Space,Str "Stay",Space,Str "with",Space,Str "me."]]
-    ,Div ("",[],[])
-     [Plain [Str "\"Speak",Space,Str "to",Space,Str "me.",Space,Str "Why",Space,Str "do",Space,Str "you",Space,Str "never",Space,Str "speak.",Space,Str "Speak."]]
-    ,Div ("",[],[])
-     [Plain [Str "\"What",Space,Str "are",Space,Str "you",Space,Str "thinking",Space,Str "of?",Space,Str "What",Space,Str "thinking?",Space,Str "What?"]]
-    ,Div ("",[],[])
-     [Plain [Str "\"I",Space,Str "never",Space,Str "know",Space,Str "what",Space,Str "you",Space,Str "are",Space,Str "thinking.",Space,Str "Think.\""]]]
-   ,Div ("",["linegroup"],[])
-    [Div ("wasteland-content.xhtml#ln115",[],[])
-     [Plain [Str "I",Space,Str "think",Space,Str "we",Space,Str "are",Space,Str "in",Space,Str "rats'",Space,Str "alley",Note [Para [Link ("",[],[]) [Str "115."] ("#wasteland-content.xhtml#ln115",""),Space,Str "Cf.",Space,Str "Part",Space,Str "III,",Space,Str "l.",Space,Str "195."]]]]
-    ,Div ("",[],[])
-     [Plain [Str "Where",Space,Str "the",Space,Str "dead",Space,Str "men",Space,Str "lost",Space,Str "their",Space,Str "bones."]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "\"What",Space,Str "is",Space,Str "that",Space,Str "noise?\""]]
-   ,Div ("wasteland-content.xhtml#ln118",["indent"],[])
-    [Plain [Str "The",Space,Str "wind",Space,Str "under",Space,Str "the",Space,Str "door.",Note [Para [Link ("",[],[]) [Str "118."] ("#wasteland-content.xhtml#ln118",""),Space,Str "Cf.",Space,Str "Webster:"],BlockQuote [Para [Str "\"Is",Space,Str "the",Space,Str "wind",Space,Str "in",Space,Str "that",Space,Str "door",Space,Str "still?\""]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "\"What",Space,Str "is",Space,Str "that",Space,Str "noise",Space,Str "now?",Space,Str "What",Space,Str "is",Space,Str "the",Space,Str "wind",Space,Str "doing?\""]]
-   ,Div ("",["indent"],[])
-    [Plain [Str "Nothing",Space,Str "again",Space,Str "nothing.",Span ("",["lnum"],[]) [Str "120"]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "\"Do"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"You",Space,Str "know",Space,Str "nothing?",Space,Str "Do",Space,Str "you",Space,Str "see",Space,Str "nothing?",Space,Str "Do",Space,Str "you",Space,Str "remember"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"Nothing?\""]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "I",Space,Str "remember"]]
-   ,Div ("",[],[])
-    [Plain [Str "Those",Space,Str "are",Space,Str "pearls",Space,Str "that",Space,Str "were",Space,Str "his",Space,Str "eyes."]]
-   ,Div ("wasteland-content.xhtml#ln126",[],[])
-    [Plain [Str "\"Are",Space,Str "you",Space,Str "alive,",Space,Str "or",Space,Str "not?",Space,Str "Is",Space,Str "there",Space,Str "nothing",Space,Str "in",Space,Str "your",Space,Str "head?\"",Note [Para [Link ("",[],[]) [Str "126."] ("#wasteland-content.xhtml#ln126",""),Space,Str "Cf.",Space,Str "Part",Space,Str "I,",Space,Str "l.",Space,Str "37,",Space,Str "48."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "But"]]
-   ,Div ("",[],[])
-    [Plain [Str "O",Space,Str "O",Space,Str "O",Space,Str "O",Space,Str "that",Space,Str "Shakespeherian",Space,Str "Rag\8213"]]
-   ,Div ("",[],[])
-    [Plain [Str "It's",Space,Str "so",Space,Str "elegant"]]
-   ,Div ("",[],[])
-    [Plain [Str "So",Space,Str "intelligent",Span ("",["lnum"],[]) [Str "130"]]]
-   ,Div ("",[],[])
-    [Plain [Str "\"What",Space,Str "shall",Space,Str "I",Space,Str "do",Space,Str "now?",Space,Str "What",Space,Str "shall",Space,Str "I",Space,Str "do?\""]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "shall",Space,Str "rush",Space,Str "out",Space,Str "as",Space,Str "I",Space,Str "am,",Space,Str "and",Space,Str "walk",Space,Str "the",Space,Str "street"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"With",Space,Str "my",Space,Str "hair",Space,Str "down,",Space,Str "so.",Space,Str "What",Space,Str "shall",Space,Str "we",Space,Str "do",Space,Str "to-morrow?"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"What",Space,Str "shall",Space,Str "we",Space,Str "ever",Space,Str "do?\""]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "hot",Space,Str "water",Space,Str "at",Space,Str "ten."]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "if",Space,Str "it",Space,Str "rains,",Space,Str "a",Space,Str "closed",Space,Str "car",Space,Str "at",Space,Str "four."]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "we",Space,Str "shall",Space,Str "play",Space,Str "a",Space,Str "game",Space,Str "of",Space,Str "chess,"]]
-   ,Div ("wasteland-content.xhtml#ln138",[],[])
-    [Plain [Str "Pressing",Space,Str "lidless",Space,Str "eyes",Space,Str "and",Space,Str "waiting",Space,Str "for",Space,Str "a",Space,Str "knock",Space,Str "upon",Space,Str "the",Space,Str "door.",Note [Para [Link ("",[],[]) [Str "138."] ("#wasteland-content.xhtml#ln138",""),Space,Str "Cf.",Space,Str "the",Space,Str "game",Space,Str "of",Space,Str "chess",Space,Str "in",Space,Str "Middleton's",Space,Str "Women",Space,Str "beware",Space,Str "Women."]]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "When",Space,Str "Lil's",Space,Str "husband",Space,Str "got",Space,Str "demobbed,",Space,Str "I",Space,Str "said",Space,Str "-"]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "didn't",Space,Str "mince",Space,Str "my",Space,Str "words,",Space,Str "I",Space,Str "said",Space,Str "to",Space,Str "her",Space,Str "myself,",Span ("",["lnum"],[]) [Str "140"]]]
-   ,Div ("",[],[])
-    [Plain [Str "HURRY",Space,Str "UP",Space,Str "PLEASE",Space,Str "ITS",Space,Str "TIME"]]
-   ,Div ("",[],[])
-    [Plain [Str "Now",Space,Str "Albert's",Space,Str "coming",Space,Str "back,",Space,Str "make",Space,Str "yourself",Space,Str "a",Space,Str "bit",Space,Str "smart."]]
-   ,Div ("",[],[])
-    [Plain [Str "He'll",Space,Str "want",Space,Str "to",Space,Str "know",Space,Str "what",Space,Str "you",Space,Str "done",Space,Str "with",Space,Str "that",Space,Str "money",Space,Str "he",Space,Str "gave",SoftBreak,Str "you"]]
-   ,Div ("",[],[])
-    [Plain [Str "To",Space,Str "get",Space,Str "yourself",Space,Str "some",Space,Str "teeth.",Space,Str "He",Space,Str "did,",Space,Str "I",Space,Str "was",Space,Str "there."]]
-   ,Div ("",[],[])
-    [Plain [Str "You",Space,Str "have",Space,Str "them",Space,Str "all",Space,Str "out,",Space,Str "Lil,",Space,Str "and",Space,Str "get",Space,Str "a",Space,Str "nice",Space,Str "set,"]]
-   ,Div ("",[],[])
-    [Plain [Str "He",Space,Str "said,",Space,Str "I",Space,Str "swear,",Space,Str "I",Space,Str "can't",Space,Str "bear",Space,Str "to",Space,Str "look",Space,Str "at",Space,Str "you."]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "no",Space,Str "more",Space,Str "can't",Space,Str "I,",Space,Str "I",Space,Str "said,",Space,Str "and",Space,Str "think",Space,Str "of",Space,Str "poor",Space,Str "Albert,"]]
-   ,Div ("",[],[])
-    [Plain [Str "He's",Space,Str "been",Space,Str "in",Space,Str "the",Space,Str "army",Space,Str "four",Space,Str "years,",Space,Str "he",Space,Str "wants",Space,Str "a",Space,Str "good",Space,Str "time,"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "if",Space,Str "you",Space,Str "don't",Space,Str "give",Space,Str "it",Space,Str "him,",Space,Str "there's",Space,Str "others",Space,Str "will,",Space,Str "I",SoftBreak,Str "said."]]
-   ,Div ("",[],[])
-    [Plain [Str "Oh",Space,Str "is",Space,Str "there,",Space,Str "she",Space,Str "said.",Space,Str "Something",Space,Str "o'",Space,Str "that,",Space,Str "I",Space,Str "said.",Span ("",["lnum"],[]) [Str "150"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Then",Space,Str "I'll",Space,Str "know",Space,Str "who",Space,Str "to",Space,Str "thank,",Space,Str "she",Space,Str "said,",Space,Str "and",Space,Str "give",Space,Str "me",Space,Str "a",Space,Str "straight",SoftBreak,Str "look."]]
-   ,Div ("",[],[])
-    [Plain [Str "HURRY",Space,Str "UP",Space,Str "PLEASE",Space,Str "ITS",Space,Str "TIME"]]
-   ,Div ("",[],[])
-    [Plain [Str "If",Space,Str "you",Space,Str "don't",Space,Str "like",Space,Str "it",Space,Str "you",Space,Str "can",Space,Str "get",Space,Str "on",Space,Str "with",Space,Str "it,",Space,Str "I",Space,Str "said."]]
-   ,Div ("",[],[])
-    [Plain [Str "Others",Space,Str "can",Space,Str "pick",Space,Str "and",Space,Str "choose",Space,Str "if",Space,Str "you",Space,Str "can't."]]
-   ,Div ("",[],[])
-    [Plain [Str "But",Space,Str "if",Space,Str "Albert",Space,Str "makes",Space,Str "off,",Space,Str "it",Space,Str "won't",Space,Str "be",Space,Str "for",Space,Str "lack",Space,Str "of",SoftBreak,Str "telling."]]
-   ,Div ("",[],[])
-    [Plain [Str "You",Space,Str "ought",Space,Str "to",Space,Str "be",Space,Str "ashamed,",Space,Str "I",Space,Str "said,",Space,Str "to",Space,Str "look",Space,Str "so",Space,Str "antique."]]
-   ,Div ("",[],[])
-    [Plain [Str "(And",Space,Str "her",Space,Str "only",Space,Str "thirty-one.)"]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "can't",Space,Str "help",Space,Str "it,",Space,Str "she",Space,Str "said,",Space,Str "pulling",Space,Str "a",Space,Str "long",Space,Str "face,"]]
-   ,Div ("",[],[])
-    [Plain [Str "It's",Space,Str "them",Space,Str "pills",Space,Str "I",Space,Str "took,",Space,Str "to",Space,Str "bring",Space,Str "it",Space,Str "off,",Space,Str "she",Space,Str "said."]]
-   ,Div ("",[],[])
-    [Plain [Str "(She's",Space,Str "had",Space,Str "five",Space,Str "already,",Space,Str "and",Space,Str "nearly",Space,Str "died",Space,Str "of",Space,Str "young",Space,Str "George.)",Span ("",["lnum"],[]) [Str "160"]]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "chemist",Space,Str "said",Space,Str "it",Space,Str "would",Space,Str "be",Space,Str "all",Space,Str "right,",Space,Str "but",Space,Str "I've",Space,Str "never",Space,Str "been",Space,Str "the",SoftBreak,Str "same."]]
-   ,Div ("",[],[])
-    [Plain [Str "You",Space,Emph [Str "are"],Space,Str "a",Space,Str "proper",Space,Str "fool,",Space,Str "I",Space,Str "said."]]
-   ,Div ("",[],[])
-    [Plain [Str "Well,",Space,Str "if",Space,Str "Albert",Space,Str "won't",Space,Str "leave",Space,Str "you",Space,Str "alone,",Space,Str "there",Space,Str "it",Space,Str "is,",Space,Str "I",SoftBreak,Str "said,"]]
-   ,Div ("",[],[])
-    [Plain [Str "What",Space,Str "you",Space,Str "get",Space,Str "married",Space,Str "for",Space,Str "if",Space,Str "you",Space,Str "don't",Space,Str "want",Space,Str "children?"]]
-   ,Div ("",[],[])
-    [Plain [Str "HURRY",Space,Str "UP",Space,Str "PLEASE",Space,Str "ITS",Space,Str "TIME"]]
-   ,Div ("",[],[])
-    [Plain [Str "Well,",Space,Str "that",Space,Str "Sunday",Space,Str "Albert",Space,Str "was",Space,Str "home,",Space,Str "they",Space,Str "had",Space,Str "a",Space,Str "hot",SoftBreak,Str "gammon,"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "they",Space,Str "asked",Space,Str "me",Space,Str "in",Space,Str "to",Space,Str "dinner,",Space,Str "to",Space,Str "get",Space,Str "the",Space,Str "beauty",Space,Str "of",Space,Str "it",SoftBreak,Str "hot\8213"]]
-   ,Div ("",[],[])
-    [Plain [Str "HURRY",Space,Str "UP",Space,Str "PLEASE",Space,Str "ITS",Space,Str "TIME"]]
-   ,Div ("",[],[])
-    [Plain [Str "HURRY",Space,Str "UP",Space,Str "PLEASE",Space,Str "ITS",Space,Str "TIME"]]
-   ,Div ("",[],[])
-    [Plain [Str "Goonight",Space,Str "Bill.",Space,Str "Goonight",Space,Str "Lou.",Space,Str "Goonight",Space,Str "May.",Space,Str "Goonight.",Span ("",["lnum"],[]) [Str "170"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Ta",Space,Str "ta.",Space,Str "Goonight.",Space,Str "Goonight."]]
-   ,Div ("",[],[])
-    [Plain [Str "Good",Space,Str "night,",Space,Str "ladies,",Space,Str "good",Space,Str "night,",Space,Str "sweet",Space,Str "ladies,",Space,Str "good",Space,Str "night,",Space,Str "good",SoftBreak,Str "night."]]]]
- ,Div ("wasteland-content.xhtml#ch3",["section"],[])
-  [Header 2 ("",[],[]) [Str "III.",Space,Str "THE",Space,Str "FIRE",Space,Str "SERMON"]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "The",Space,Str "river's",Space,Str "tent",Space,Str "is",Space,Str "broken:",Space,Str "the",Space,Str "last",Space,Str "fingers",Space,Str "of",Space,Str "leaf"]]
-   ,Div ("",[],[])
-    [Plain [Str "Clutch",Space,Str "and",Space,Str "sink",Space,Str "into",Space,Str "the",Space,Str "wet",Space,Str "bank.",Space,Str "The",Space,Str "wind"]]
-   ,Div ("",[],[])
-    [Plain [Str "Crosses",Space,Str "the",Space,Str "brown",Space,Str "land,",Space,Str "unheard.",Space,Str "The",Space,Str "nymphs",Space,Str "are",SoftBreak,Str "departed."]]
-   ,Div ("wasteland-content.xhtml#ln176",[],[])
-    [Plain [Str "Sweet",Space,Str "Thames,",Space,Str "run",Space,Str "softly,",Space,Str "till",Space,Str "I",Space,Str "end",Space,Str "my",Space,Str "song.",Note [Para [Link ("",[],[]) [Str "176."] ("#wasteland-content.xhtml#ln176",""),Space,Str "V.",Space,Str "Spenser,",Space,Str "Prothalamion."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "river",Space,Str "bears",Space,Str "no",Space,Str "empty",Space,Str "bottles,",Space,Str "sandwich",Space,Str "papers,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Silk",Space,Str "handkerchiefs,",Space,Str "cardboard",Space,Str "boxes,",Space,Str "cigarette",Space,Str "ends"]]
-   ,Div ("",[],[])
-    [Plain [Str "Or",Space,Str "other",Space,Str "testimony",Space,Str "of",Space,Str "summer",Space,Str "nights.",Space,Str "The",Space,Str "nymphs",Space,Str "are",SoftBreak,Str "departed."]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "their",Space,Str "friends,",Space,Str "the",Space,Str "loitering",Space,Str "heirs",Space,Str "of",Space,Str "city",Space,Str "directors;",Span ("",["lnum"],[]) [Str "180"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Departed,",Space,Str "have",Space,Str "left",Space,Str "no",Space,Str "addresses."]]
-   ,Div ("",[],[])
-    [Plain [Str "By",Space,Str "the",Space,Str "waters",Space,Str "of",Space,Str "Leman",Space,Str "I",Space,Str "sat",Space,Str "down",Space,Str "and",Space,Str "wept",Space,Str ".",Space,Str ".",Space,Str "."]]
-   ,Div ("",[],[])
-    [Plain [Str "Sweet",Space,Str "Thames,",Space,Str "run",Space,Str "softly",Space,Str "till",Space,Str "I",Space,Str "end",Space,Str "my",Space,Str "song,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Sweet",Space,Str "Thames,",Space,Str "run",Space,Str "softly,",Space,Str "for",Space,Str "I",Space,Str "speak",Space,Str "not",Space,Str "loud",Space,Str "or",Space,Str "long."]]
-   ,Div ("",[],[])
-    [Plain [Str "But",Space,Str "at",Space,Str "my",Space,Str "back",Space,Str "in",Space,Str "a",Space,Str "cold",Space,Str "blast",Space,Str "I",Space,Str "hear"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "rattle",Space,Str "of",Space,Str "the",Space,Str "bones,",Space,Str "and",Space,Str "chuckle",Space,Str "spread",Space,Str "from",Space,Str "ear",Space,Str "to",SoftBreak,Str "ear."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "A",Space,Str "rat",Space,Str "crept",Space,Str "softly",Space,Str "through",Space,Str "the",Space,Str "vegetation"]]
-   ,Div ("",[],[])
-    [Plain [Str "Dragging",Space,Str "its",Space,Str "slimy",Space,Str "belly",Space,Str "on",Space,Str "the",Space,Str "bank"]]
-   ,Div ("",[],[])
-    [Plain [Str "While",Space,Str "I",Space,Str "was",Space,Str "fishing",Space,Str "in",Space,Str "the",Space,Str "dull",Space,Str "canal"]]
-   ,Div ("",[],[])
-    [Plain [Str "On",Space,Str "a",Space,Str "winter",Space,Str "evening",Space,Str "round",Space,Str "behind",Space,Str "the",Space,Str "gashouse",Span ("",["lnum"],[]) [Str "190"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Musing",Space,Str "upon",Space,Str "the",Space,Str "king",Space,Str "my",Space,Str "brother's",Space,Str "wreck"]]
-   ,Div ("wasteland-content.xhtml#ln192",[],[])
-    [Plain [Str "And",Space,Str "on",Space,Str "the",Space,Str "king",Space,Str "my",Space,Str "father's",Space,Str "death",Space,Str "before",Space,Str "him.",Note [Para [Link ("",[],[]) [Str "192."] ("#wasteland-content.xhtml#ln192",""),Space,Str "Cf.",Space,Str "The",Space,Str "Tempest,",Space,Str "I.",Space,Str "ii."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "White",Space,Str "bodies",Space,Str "naked",Space,Str "on",Space,Str "the",Space,Str "low",Space,Str "damp",Space,Str "ground"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "bones",Space,Str "cast",Space,Str "in",Space,Str "a",Space,Str "little",Space,Str "low",Space,Str "dry",Space,Str "garret,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Rattled",Space,Str "by",Space,Str "the",Space,Str "rat's",Space,Str "foot",Space,Str "only,",Space,Str "year",Space,Str "to",Space,Str "year."]]
-   ,Div ("wasteland-content.xhtml#ln196",[],[])
-    [Plain [Str "But",Space,Str "at",Space,Str "my",Space,Str "back",Space,Str "from",Space,Str "time",Space,Str "to",Space,Str "time",Space,Str "I",Space,Str "hear",Note [Para [Link ("",[],[]) [Str "196."] ("#wasteland-content.xhtml#ln196",""),Space,Str "Cf.",Space,Str "Marvell,",Space,Str "To",Space,Str "His",Space,Str "Coy",Space,Str "Mistress."]]]]
-   ,Div ("wasteland-content.xhtml#ln197",[],[])
-    [Plain [Str "The",Space,Str "sound",Space,Str "of",Space,Str "horns",Space,Str "and",Space,Str "motors,",Space,Str "which",Space,Str "shall",Space,Str "bring",Note [Para [Link ("",[],[]) [Str "197."] ("#wasteland-content.xhtml#ln197",""),Space,Str "Cf.",Space,Str "Day,",Space,Str "Parliament",Space,Str "of",Space,Str "Bees:"],BlockQuote [Div ("",[],[]) [Div ("",[],[]) [Plain [Str "\"When",Space,Str "of",Space,Str "the",Space,Str "sudden,",Space,Str "listening,",Space,Str "you",Space,Str "shall",SoftBreak,Str "hear,"]],Div ("",[],[]) [Plain [Str "\"A",Space,Str "noise",Space,Str "of",Space,Str "horns",Space,Str "and",Space,Str "hunting,",Space,Str "which",Space,Str "shall",SoftBreak,Str "bring"]],Div ("",[],[]) [Plain [Str "\"Actaeon",Space,Str "to",Space,Str "Diana",Space,Str "in",Space,Str "the",Space,Str "spring,"]],Div ("",[],[]) [Plain [Str "\"Where",Space,Str "all",Space,Str "shall",Space,Str "see",Space,Str "her",Space,Str "naked",Space,Str "skin",Space,Str ".",Space,Str ".",Space,Str ".\""]]]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Sweeney",Space,Str "to",Space,Str "Mrs.",Space,Str "Porter",Space,Str "in",Space,Str "the",Space,Str "spring."]]
-   ,Div ("wasteland-content.xhtml#ln199",[],[])
-    [Plain [Str "O",Space,Str "the",Space,Str "moon",Space,Str "shone",Space,Str "bright",Space,Str "on",Space,Str "Mrs.",Space,Str "Porter",Note [Para [Link ("",[],[]) [Str "199."] ("#wasteland-content.xhtml#ln199",""),Space,Str "I",Space,Str "do",Space,Str "not",Space,Str "know",Space,Str "the",Space,Str "origin",Space,Str "of",Space,Str "the",Space,Str "ballad",Space,Str "from",Space,Str "which",Space,Str "these",Space,Str "lines",Space,Str "are",SoftBreak,Str "taken:",Space,Str "it",Space,Str "was",Space,Str "reported",Space,Str "to",Space,Str "me",Space,Str "from",Space,Str "Sydney,",Space,Str "Australia."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "on",Space,Str "her",Space,Str "daughter",Span ("",["lnum"],[]) [Str "200"]]]
-   ,Div ("",[],[])
-    [Plain [Str "They",Space,Str "wash",Space,Str "their",Space,Str "feet",Space,Str "in",Space,Str "soda",Space,Str "water"]]
-   ,Div ("wasteland-content.xhtml#ln202",[],[("lang","fr")])
-    [Plain [Emph [Str "Et",Space,Str "O",Space,Str "ces",Space,Str "voix",Space,Str "d'enfants,",Space,Str "chantant",Space,Str "dans",Space,Str "la",Space,Str "coupole"],Str "!",Note [Para [Link ("",[],[]) [Str "202."] ("#wasteland-content.xhtml#ln202",""),Space,Str "V.",Space,Str "Verlaine,",Space,Str "Parsifal."]]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "Twit",Space,Str "twit",Space,Str "twit"]]
-   ,Div ("",[],[])
-    [Plain [Str "Jug",Space,Str "jug",Space,Str "jug",Space,Str "jug",Space,Str "jug",Space,Str "jug"]]
-   ,Div ("",[],[])
-    [Plain [Str "So",Space,Str "rudely",Space,Str "forc'd."]]
-   ,Div ("",[],[])
-    [Plain [Str "Tereu"]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "Unreal",Space,Str "City"]]
-   ,Div ("",[],[])
-    [Plain [Str "Under",Space,Str "the",Space,Str "brown",Space,Str "fog",Space,Str "of",Space,Str "a",Space,Str "winter",Space,Str "noon"]]
-   ,Div ("",[],[])
-    [Plain [Str "Mr.",Space,Str "Eugenides,",Space,Str "the",Space,Str "Smyrna",Space,Str "merchant"]]
-   ,Div ("wasteland-content.xhtml#ln210",[],[])
-    [Plain [Str "Unshaven,",Space,Str "with",Space,Str "a",Space,Str "pocket",Space,Str "full",Space,Str "of",Space,Str "currants",Note [Para [Link ("",[],[]) [Str "210."] ("#wasteland-content.xhtml#ln210",""),Space,Str "The",Space,Str "currants",Space,Str "were",Space,Str "quoted",Space,Str "at",Space,Str "a",Space,Str "price",Space,Str "\"cost",Space,Str "insurance",Space,Str "and",Space,Str "freight",Space,Str "to",SoftBreak,Str "London\";",Space,Str "and",Space,Str "the",Space,Str "Bill",Space,Str "of",Space,Str "Lading",Space,Str "etc.",Space,Str "were",Space,Str "to",Space,Str "be",Space,Str "handed",Space,Str "to",Space,Str "the",Space,Str "buyer",Space,Str "upon",SoftBreak,Str "payment",Space,Str "of",Space,Str "the",Space,Str "sight",Space,Str "draft."]],SoftBreak,Span ("",["lnum"],[]) [Str "210"]]]
-   ,Div ("",[],[])
-    [Plain [Str "C.i.f.",Space,Str "London:",Space,Str "documents",Space,Str "at",Space,Str "sight,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Asked",Space,Str "me",Space,Str "in",Space,Str "demotic",Space,Str "French"]]
-   ,Div ("",[],[])
-    [Plain [Str "To",Space,Str "luncheon",Space,Str "at",Space,Str "the",Space,Str "Cannon",Space,Str "Street",Space,Str "Hotel"]]
-   ,Div ("",[],[])
-    [Plain [Str "Followed",Space,Str "by",Space,Str "a",Space,Str "weekend",Space,Str "at",Space,Str "the",Space,Str "Metropole."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "At",Space,Str "the",Space,Str "violet",Space,Str "hour,",Space,Str "when",Space,Str "the",Space,Str "eyes",Space,Str "and",Space,Str "back"]]
-   ,Div ("",[],[])
-    [Plain [Str "Turn",Space,Str "upward",Space,Str "from",Space,Str "the",Space,Str "desk,",Space,Str "when",Space,Str "the",Space,Str "human",Space,Str "engine",Space,Str "waits"]]
-   ,Div ("",[],[])
-    [Plain [Str "Like",Space,Str "a",Space,Str "taxi",Space,Str "throbbing",Space,Str "waiting,"]]
-   ,Div ("wasteland-content.xhtml#ln218",[],[])
-    [Plain [Str "I",Space,Str "Tiresias,",Space,Str "though",Space,Str "blind,",Space,Str "throbbing",Space,Str "between",Space,Str "two",Space,Str "lives,",Note [Para [Link ("",[],[]) [Str "218."] ("#wasteland-content.xhtml#ln218",""),Space,Str "Tiresias,",Space,Str "although",Space,Str "a",Space,Str "mere",Space,Str "spectator",Space,Str "and",Space,Str "not",Space,Str "indeed",Space,Str "a",Space,Str "\"character,\"",Space,Str "is",SoftBreak,Str "yet",Space,Str "the",Space,Str "most",Space,Str "important",Space,Str "personage",Space,Str "in",Space,Str "the",Space,Str "poem,",Space,Str "uniting",Space,Str "all",Space,Str "the",Space,Str "rest.",Space,Str "Just",SoftBreak,Str "as",Space,Str "the",Space,Str "one-eyed",Space,Str "merchant,",Space,Str "seller",Space,Str "of",Space,Str "currants,",Space,Str "melts",Space,Str "into",Space,Str "the",Space,Str "Phoenician",SoftBreak,Str "Sailor,",Space,Str "and",Space,Str "the",Space,Str "latter",Space,Str "is",Space,Str "not",Space,Str "wholly",Space,Str "distinct",Space,Str "from",Space,Str "Ferdinand",Space,Str "Prince",Space,Str "of",SoftBreak,Str "Naples,",Space,Str "so",Space,Str "all",Space,Str "the",Space,Str "women",Space,Str "are",Space,Str "one",Space,Str "woman,",Space,Str "and",Space,Str "the",Space,Str "two",Space,Str "sexes",Space,Str "meet",Space,Str "in",SoftBreak,Str "Tiresias.",Space,Str "What",Space,Str "Tiresias",Space,Str "sees,",Space,Str "in",Space,Str "fact,",Space,Str "is",Space,Str "the",Space,Str "substance",Space,Str "of",Space,Str "the",Space,Str "poem.",Space,Str "The",SoftBreak,Str "whole",Space,Str "passage",Space,Str "from",Space,Str "Ovid",Space,Str "is",Space,Str "of",Space,Str "great",Space,Str "anthropological",Space,Str "interest:"],BlockQuote [Para [Str "'.",Space,Str ".",Space,Str ".",Space,Str "Cum",Space,Str "Iunone",Space,Str "iocos",Space,Str "et",Space,Str "maior",Space,Str "vestra",Space,Str "profecto",Space,Str "est",LineBreak,Str "Quam,",Space,Str "quae",SoftBreak,Str "contingit",Space,Str "maribus,'",Space,Str "dixisse,",Space,Str "'voluptas.'",LineBreak,Str "Illa",Space,Str "negat;",Space,Str "placuit",SoftBreak,Str "quae",Space,Str "sit",Space,Str "sententia",Space,Str "docti",LineBreak,Str "Quaerere",Space,Str "Tiresiae:",Space,Str "venus",Space,Str "huic",Space,Str "erat",SoftBreak,Str "utraque",Space,Str "nota.",LineBreak,Str "Nam",Space,Str "duo",Space,Str "magnorum",Space,Str "viridi",Space,Str "coeuntia",Space,Str "silva",LineBreak,Str "Corpora",Space,Str "serpentum",Space,Str "baculi",Space,Str "violaverat",Space,Str "ictu",LineBreak,Str "Deque",Space,Str "viro",Space,Str "factus,",SoftBreak,Str "mirabile,",Space,Str "femina",Space,Str "septem",LineBreak,Str "Egerat",Space,Str "autumnos;",Space,Str "octavo",Space,Str "rursus",SoftBreak,Str "eosdem",LineBreak,Str "Vidit",Space,Str "et",Space,Str "'est",Space,Str "vestrae",Space,Str "si",Space,Str "tanta",Space,Str "potentia",Space,Str "plagae,'",LineBreak,Str "Dixit",Space,Str "'ut",Space,Str "auctoris",Space,Str "sortem",Space,Str "in",Space,Str "contraria",Space,Str "mutet,",LineBreak,Str "Nunc",Space,Str "quoque",Space,Str "vos",SoftBreak,Str "feriam!'",Space,Str "percussis",Space,Str "anguibus",Space,Str "isdem",LineBreak,Str "Forma",Space,Str "prior",Space,Str "rediit",SoftBreak,Str "genetivaque",Space,Str "venit",Space,Str "imago.",LineBreak,Str "Arbiter",Space,Str "hic",Space,Str "igitur",Space,Str "sumptus",Space,Str "de",Space,Str "lite",SoftBreak,Str "iocosa",LineBreak,Str "Dicta",Space,Str "Iovis",Space,Str "firmat;",Space,Str "gravius",Space,Str "Saturnia",Space,Str "iusto",LineBreak,Str "Nec",SoftBreak,Str "pro",Space,Str "materia",Space,Str "fertur",Space,Str "doluisse",Space,Str "suique",LineBreak,Str "Iudicis",Space,Str "aeterna",Space,Str "damnavit",SoftBreak,Str "lumina",Space,Str "nocte,",LineBreak,Str "At",Space,Str "pater",Space,Str "omnipotens",Space,Str "(neque",Space,Str "enim",Space,Str "licet",Space,Str "inrita",SoftBreak,Str "cuiquam",LineBreak,Str "Facta",Space,Str "dei",Space,Str "fecisse",Space,Str "deo)",Space,Str "pro",Space,Str "lumine",Space,Str "adempto",LineBreak,Str "Scire",SoftBreak,Str "futura",Space,Str "dedit",Space,Str "poenamque",Space,Str "levavit",Space,Str "honore.",LineBreak]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Old",Space,Str "man",Space,Str "with",Space,Str "wrinkled",Space,Str "female",Space,Str "breasts,",Space,Str "can",Space,Str "see"]]
-   ,Div ("",[],[])
-    [Plain [Str "At",Space,Str "the",Space,Str "violet",Space,Str "hour,",Space,Str "the",Space,Str "evening",Space,Str "hour",Space,Str "that",Space,Str "strives",Span ("",["lnum"],[]) [Str "220"]]]
-   ,Div ("wasteland-content.xhtml#ln221",[],[])
-    [Plain [Str "Homeward,",Space,Str "and",Space,Str "brings",Space,Str "the",Space,Str "sailor",Space,Str "home",Space,Str "from",Space,Str "sea,",Note [Para [Link ("",[],[]) [Str "221."] ("#wasteland-content.xhtml#ln221",""),Space,Str "This",Space,Str "may",Space,Str "not",Space,Str "appear",Space,Str "as",Space,Str "exact",Space,Str "as",Space,Str "Sappho's",Space,Str "lines,",Space,Str "but",Space,Str "I",Space,Str "had",Space,Str "in",Space,Str "mind",SoftBreak,Str "the",Space,Str "\"longshore\"",Space,Str "or",Space,Str "\"dory\"",Space,Str "fisherman,",Space,Str "who",Space,Str "returns",Space,Str "at",Space,Str "nightfall."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "typist",Space,Str "home",Space,Str "at",Space,Str "teatime,",Space,Str "clears",Space,Str "her",Space,Str "breakfast,",Space,Str "lights"]]
-   ,Div ("",[],[])
-    [Plain [Str "Her",Space,Str "stove,",Space,Str "and",Space,Str "lays",Space,Str "out",Space,Str "food",Space,Str "in",Space,Str "tins."]]
-   ,Div ("",[],[])
-    [Plain [Str "Out",Space,Str "of",Space,Str "the",Space,Str "window",Space,Str "perilously",Space,Str "spread"]]
-   ,Div ("",[],[])
-    [Plain [Str "Her",Space,Str "drying",Space,Str "combinations",Space,Str "touched",Space,Str "by",Space,Str "the",Space,Str "sun's",Space,Str "last",Space,Str "rays,"]]
-   ,Div ("",[],[])
-    [Plain [Str "On",Space,Str "the",Space,Str "divan",Space,Str "are",Space,Str "piled",Space,Str "(at",Space,Str "night",Space,Str "her",Space,Str "bed)"]]
-   ,Div ("",[],[])
-    [Plain [Str "Stockings,",Space,Str "slippers,",Space,Str "camisoles,",Space,Str "and",Space,Str "stays."]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "Tiresias,",Space,Str "old",Space,Str "man",Space,Str "with",Space,Str "wrinkled",Space,Str "dugs"]]
-   ,Div ("",[],[])
-    [Plain [Str "Perceived",Space,Str "the",Space,Str "scene,",Space,Str "and",Space,Str "foretold",Space,Str "the",Space,Str "rest",Space,Str "-"]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "too",Space,Str "awaited",Space,Str "the",Space,Str "expected",Space,Str "guest.",Span ("",["lnum"],[]) [Str "230"]]]
-   ,Div ("",[],[])
-    [Plain [Str "He,",Space,Str "the",Space,Str "young",Space,Str "man",Space,Str "carbuncular,",Space,Str "arrives,"]]
-   ,Div ("",[],[])
-    [Plain [Str "A",Space,Str "small",Space,Str "house",Space,Str "agent's",Space,Str "clerk,",Space,Str "with",Space,Str "one",Space,Str "bold",Space,Str "stare,"]]
-   ,Div ("",[],[])
-    [Plain [Str "One",Space,Str "of",Space,Str "the",Space,Str "low",Space,Str "on",Space,Str "whom",Space,Str "assurance",Space,Str "sits"]]
-   ,Div ("",[],[])
-    [Plain [Str "As",Space,Str "a",Space,Str "silk",Space,Str "hat",Space,Str "on",Space,Str "a",Space,Str "Bradford",Space,Str "millionaire."]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "time",Space,Str "is",Space,Str "now",Space,Str "propitious,",Space,Str "as",Space,Str "he",Space,Str "guesses,"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "meal",Space,Str "is",Space,Str "ended,",Space,Str "she",Space,Str "is",Space,Str "bored",Space,Str "and",Space,Str "tired,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Endeavours",Space,Str "to",Space,Str "engage",Space,Str "her",Space,Str "in",Space,Str "caresses"]]
-   ,Div ("",[],[])
-    [Plain [Str "Which",Space,Str "still",Space,Str "are",Space,Str "unreproved,",Space,Str "if",Space,Str "undesired."]]
-   ,Div ("",[],[])
-    [Plain [Str "Flushed",Space,Str "and",Space,Str "decided,",Space,Str "he",Space,Str "assaults",Space,Str "at",Space,Str "once;"]]
-   ,Div ("",[],[])
-    [Plain [Str "Exploring",Space,Str "hands",Space,Str "encounter",Space,Str "no",Space,Str "defence;",Span ("",["lnum"],[]) [Str "240"]]]
-   ,Div ("",[],[])
-    [Plain [Str "His",Space,Str "vanity",Space,Str "requires",Space,Str "no",Space,Str "response,"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "makes",Space,Str "a",Space,Str "welcome",Space,Str "of",Space,Str "indifference."]]
-   ,Div ("",[],[])
-    [Plain [Str "(And",Space,Str "I",Space,Str "Tiresias",Space,Str "have",Space,Str "foresuffered",Space,Str "all"]]
-   ,Div ("",[],[])
-    [Plain [Str "Enacted",Space,Str "on",Space,Str "this",Space,Str "same",Space,Str "divan",Space,Str "or",Space,Str "bed;"]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "who",Space,Str "have",Space,Str "sat",Space,Str "by",Space,Str "Thebes",Space,Str "below",Space,Str "the",Space,Str "wall"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "walked",Space,Str "among",Space,Str "the",Space,Str "lowest",Space,Str "of",Space,Str "the",Space,Str "dead.)"]]
-   ,Div ("",[],[])
-    [Plain [Str "Bestows",Space,Str "one",Space,Str "final",Space,Str "patronising",Space,Str "kiss,"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "gropes",Space,Str "his",Space,Str "way,",Space,Str "finding",Space,Str "the",Space,Str "stairs",Space,Str "unlit",Space,Str ".",Space,Str ".",Space,Str "."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "She",Space,Str "turns",Space,Str "and",Space,Str "looks",Space,Str "a",Space,Str "moment",Space,Str "in",Space,Str "the",Space,Str "glass,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Hardly",Space,Str "aware",Space,Str "of",Space,Str "her",Space,Str "departed",Space,Str "lover;",Span ("",["lnum"],[]) [Str "250"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Her",Space,Str "brain",Space,Str "allows",Space,Str "one",Space,Str "half-formed",Space,Str "thought",Space,Str "to",Space,Str "pass:"]]
-   ,Div ("",[],[])
-    [Plain [Str "\"Well",Space,Str "now",Space,Str "that's",Space,Str "done:",Space,Str "and",Space,Str "I'm",Space,Str "glad",Space,Str "it's",Space,Str "over.\""]]
-   ,Div ("wasteland-content.xhtml#ln253",[],[])
-    [Plain [Str "When",Space,Str "lovely",Space,Str "woman",Space,Str "stoops",Space,Str "to",Space,Str "folly",Space,Str "and",Note [Para [Link ("",[],[]) [Str "253."] ("#wasteland-content.xhtml#ln253",""),Space,Str "V.",Space,Str "Goldsmith,",Space,Str "the",Space,Str "song",Space,Str "in",Space,Str "The",Space,Str "Vicar",Space,Str "of",Space,Str "Wakefield."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Paces",Space,Str "about",Space,Str "her",Space,Str "room",Space,Str "again,",Space,Str "alone,"]]
-   ,Div ("",[],[])
-    [Plain [Str "She",Space,Str "smoothes",Space,Str "her",Space,Str "hair",Space,Str "with",Space,Str "automatic",Space,Str "hand,"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "puts",Space,Str "a",Space,Str "record",Space,Str "on",Space,Str "the",Space,Str "gramophone."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("wasteland-content.xhtml#ln257",[],[])
-    [Plain [Str "\"This",Space,Str "music",Space,Str "crept",Space,Str "by",Space,Str "me",Space,Str "upon",Space,Str "the",Space,Str "waters\"",Note [Para [Link ("",[],[]) [Str "257."] ("#wasteland-content.xhtml#ln257",""),Space,Str "V.",Space,Str "The",Space,Str "Tempest,",Space,Str "as",Space,Str "above."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "along",Space,Str "the",Space,Str "Strand,",Space,Str "up",Space,Str "Queen",Space,Str "Victoria",Space,Str "Street."]]
-   ,Div ("",[],[])
-    [Plain [Str "O",Space,Str "City",Space,Str "city,",Space,Str "I",Space,Str "can",Space,Str "sometimes",Space,Str "hear"]]
-   ,Div ("",[],[])
-    [Plain [Str "Beside",Space,Str "a",Space,Str "public",Space,Str "bar",Space,Str "in",Space,Str "Lower",Space,Str "Thames",Space,Str "Street,",Span ("",["lnum"],[]) [Str "260"]]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "pleasant",Space,Str "whining",Space,Str "of",Space,Str "a",Space,Str "mandoline"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "a",Space,Str "clatter",Space,Str "and",Space,Str "a",Space,Str "chatter",Space,Str "from",Space,Str "within"]]
-   ,Div ("",[],[])
-    [Plain [Str "Where",Space,Str "fishmen",Space,Str "lounge",Space,Str "at",Space,Str "noon:",Space,Str "where",Space,Str "the",Space,Str "walls"]]
-   ,Div ("wasteland-content.xhtml#ln264",[],[])
-    [Plain [Str "Of",Space,Str "Magnus",Space,Str "Martyr",Space,Str "hold",Note [Para [Link ("",[],[]) [Str "264."] ("#wasteland-content.xhtml#ln264",""),Space,Str "The",Space,Str "interior",Space,Str "of",Space,Str "St.",Space,Str "Magnus",Space,Str "Martyr",Space,Str "is",Space,Str "to",Space,Str "my",Space,Str "mind",Space,Str "one",Space,Str "of",Space,Str "the",Space,Str "finest",SoftBreak,Str "among",Space,Str "Wren's",Space,Str "interiors.",Space,Str "See",Space,Str "The",Space,Str "Proposed",Space,Str "Demolition",Space,Str "of",Space,Str "Nineteen",Space,Str "City",SoftBreak,Str "Churches",Space,Str "(P.",Space,Str "S.",Space,Str "King",Space,Str "&",Space,Str "Son,",Space,Str "Ltd.)."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Inexplicable",Space,Str "splendour",Space,Str "of",Space,Str "Ionian",Space,Str "white",Space,Str "and",Space,Str "gold."]]]
-  ,Div ("",["linegroup","indent"],[])
-   [Div ("wasteland-content.xhtml#ln266",[],[])
-    [Plain [Str "The",Space,Str "river",Space,Str "sweats",Note [Para [Link ("",[],[]) [Str "266."] ("#wasteland-content.xhtml#ln266",""),Space,Str "The",Space,Str "Song",Space,Str "of",Space,Str "the",Space,Str "(three)",Space,Str "Thames-daughters",Space,Str "begins",Space,Str "here.",Space,Str "From",Space,Str "line",Space,Str "292",SoftBreak,Str "to",Space,Str "306",Space,Str "inclusive",Space,Str "they",Space,Str "speak",Space,Str "in",Space,Str "turn.",Space,Str "V.",Space,Str "Gutterdsammerung,",Space,Str "III.",Space,Str "i:",Space,Str "the",SoftBreak,Str "Rhine-daughters."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Oil",Space,Str "and",Space,Str "tar"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "barges",Space,Str "drift"]]
-   ,Div ("",[],[])
-    [Plain [Str "With",Space,Str "the",Space,Str "turning",Space,Str "tide"]]
-   ,Div ("",[],[])
-    [Plain [Str "Red",Space,Str "sails",Span ("",["lnum"],[]) [Str "270"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Wide"]]
-   ,Div ("",[],[])
-    [Plain [Str "To",Space,Str "leeward,",Space,Str "swing",Space,Str "on",Space,Str "the",Space,Str "heavy",Space,Str "spar."]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "barges",Space,Str "wash"]]
-   ,Div ("",[],[])
-    [Plain [Str "Drifting",Space,Str "logs"]]
-   ,Div ("",[],[])
-    [Plain [Str "Down",Space,Str "Greenwich",Space,Str "reach"]]
-   ,Div ("",[],[])
-    [Plain [Str "Past",Space,Str "the",Space,Str "Isle",Space,Str "of",Space,Str "Dogs."]]
-   ,Div ("",["indent"],[])
-    [Plain [Str "Weialala",Space,Str "leia"]]
-   ,Div ("",["indent"],[])
-    [Plain [Str "Wallala",Space,Str "leialala"]]]
-  ,Div ("",["linegroup","indent"],[])
-   [Div ("wasteland-content.xhtml#ln279",[],[])
-    [Plain [Str "Elizabeth",Space,Str "and",Space,Str "Leicester",Note [Para [Link ("",[],[]) [Str "279."] ("#wasteland-content.xhtml#ln279",""),Space,Str "V.",Space,Str "Froude,",Space,Str "Elizabeth,",Space,Str "Vol.",Space,Str "I,",Space,Str "ch.",Space,Str "iv,",Space,Str "letter",Space,Str "of",Space,Str "De",Space,Str "Quadra",Space,Str "to",Space,Str "Philip",SoftBreak,Str "of",Space,Str "Spain:"],BlockQuote [Div ("",[],[]) [Div ("",[],[]) [Plain [Str "\"In",Space,Str "the",Space,Str "afternoon",Space,Str "we",Space,Str "were",Space,Str "in",Space,Str "a",Space,Str "barge,",Space,Str "watching",Space,Str "the",SoftBreak,Str "games",Space,Str "on",Space,Str "the",Space,Str "river."]],Div ("",[],[]) [Plain [Str "(The",Space,Str "queen)",Space,Str "was",Space,Str "alone",Space,Str "with",Space,Str "Lord",Space,Str "Robert",Space,Str "and",Space,Str "myself",SoftBreak,Str "on",Space,Str "the",Space,Str "poop,"]],Div ("",[],[]) [Plain [Str "when",Space,Str "they",Space,Str "began",Space,Str "to",Space,Str "talk",Space,Str "nonsense,",Space,Str "and",Space,Str "went",Space,Str "so",Space,Str "far",SoftBreak,Str "that",Space,Str "Lord",Space,Str "Robert"]],Div ("",[],[]) [Plain [Str "at",Space,Str "last",Space,Str "said,",Space,Str "as",Space,Str "I",Space,Str "was",Space,Str "on",Space,Str "the",Space,Str "spot",Space,Str "there",Space,Str "was",Space,Str "no",SoftBreak,Str "reason",Space,Str "why",Space,Str "they"]],Div ("",[],[]) [Plain [Str "should",Space,Str "not",Space,Str "be",Space,Str "married",Space,Str "if",Space,Str "the",Space,Str "queen",Space,Str "pleased.\""]]]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Beating",Space,Str "oars",Span ("",["lnum"],[]) [Str "280"]]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "stern",Space,Str "was",Space,Str "formed"]]
-   ,Div ("",[],[])
-    [Plain [Str "A",Space,Str "gilded",Space,Str "shell"]]
-   ,Div ("",[],[])
-    [Plain [Str "Red",Space,Str "and",Space,Str "gold"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "brisk",Space,Str "swell"]]
-   ,Div ("",[],[])
-    [Plain [Str "Rippled",Space,Str "both",Space,Str "shores"]]
-   ,Div ("",[],[])
-    [Plain [Str "Southwest",Space,Str "wind"]]
-   ,Div ("",[],[])
-    [Plain [Str "Carried",Space,Str "down",Space,Str "stream"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "peal",Space,Str "of",Space,Str "bells"]]
-   ,Div ("",[],[])
-    [Plain [Str "White",Space,Str "towers"]]
-   ,Div ("",["indent"],[])
-    [Plain [Str "Weialala",Space,Str "leia",Span ("",["lnum"],[]) [Str "290"]]]
-   ,Div ("",["indent"],[])
-    [Plain [Str "Wallala",Space,Str "leialala"]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "\"Trams",Space,Str "and",Space,Str "dusty",Space,Str "trees."]]
-   ,Div ("wasteland-content.xhtml#ln293",[],[])
-    [Plain [Str "Highbury",Space,Str "bore",Space,Str "me.",Space,Str "Richmond",Space,Str "and",Space,Str "Kew",Note [Para [Link ("",[],[]) [Str "293."] ("#wasteland-content.xhtml#ln293",""),Space,Str "Cf.",Space,Str "Purgatorio,",Space,Str "v.",Space,Str "133:"],BlockQuote [Para [Str "\"Ricorditi",Space,Str "di",Space,Str "me,",Space,Str "che",Space,Str "son",Space,Str "la",Space,Str "Pia;",LineBreak,Str "Siena",Space,Str "mi",Space,Str "fe',",Space,Str "disfecemi",SoftBreak,Str "Maremma.\""]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Undid",Space,Str "me.",Space,Str "By",Space,Str "Richmond",Space,Str "I",Space,Str "raised",Space,Str "my",Space,Str "knees"]]
-   ,Div ("",[],[])
-    [Plain [Str "Supine",Space,Str "on",Space,Str "the",Space,Str "floor",Space,Str "of",Space,Str "a",Space,Str "narrow",Space,Str "canoe.\""]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "\"My",Space,Str "feet",Space,Str "are",Space,Str "at",Space,Str "Moorgate,",Space,Str "and",Space,Str "my",Space,Str "heart"]]
-   ,Div ("",[],[])
-    [Plain [Str "Under",Space,Str "my",Space,Str "feet.",Space,Str "After",Space,Str "the",Space,Str "event"]]
-   ,Div ("",[],[])
-    [Plain [Str "He",Space,Str "wept.",Space,Str "He",Space,Str "promised",Space,Str "'a",Space,Str "new",Space,Str "start'."]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "made",Space,Str "no",Space,Str "comment.",Space,Str "What",Space,Str "should",Space,Str "I",Space,Str "resent?\""]]
-   ,Div ("",[],[])
-    [Plain [Str "\"On",Space,Str "Margate",Space,Str "Sands.",Span ("",["lnum"],[]) [Str "300"]]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "can",Space,Str "connect"]]
-   ,Div ("",[],[])
-    [Plain [Str "Nothing",Space,Str "with",Space,Str "nothing."]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "broken",Space,Str "fingernails",Space,Str "of",Space,Str "dirty",Space,Str "hands."]]
-   ,Div ("",[],[])
-    [Plain [Str "My",Space,Str "people",Space,Str "humble",Space,Str "people",Space,Str "who",Space,Str "expect"]]
-   ,Div ("",[],[])
-    [Plain [Str "Nothing.\""]]
-   ,Div ("",["indent"],[])
-    [Plain [Str "la",Space,Str "la"]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("wasteland-content.xhtml#ln307",[],[])
-    [Plain [Str "To",Space,Str "Carthage",Space,Str "then",Space,Str "I",Space,Str "came",Note [Para [Link ("",[],[]) [Str "307."] ("#wasteland-content.xhtml#ln307",""),Space,Str "V.",Space,Str "St.",Space,Str "Augustine's",Space,Str "Confessions:",Space,Str "\"to",Space,Str "Carthage",Space,Str "then",Space,Str "I",Space,Str "came,",Space,Str "where",Space,Str "a",SoftBreak,Str "cauldron",Space,Str "of",Space,Str "unholy",Space,Str "loves",Space,Str "sang",Space,Str "all",Space,Str "about",Space,Str "mine",Space,Str "ears.\""]]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("wasteland-content.xhtml#ln308",[],[])
-    [Plain [Str "Burning",Space,Str "burning",Space,Str "burning",Space,Str "burning",Note [Para [Link ("",[],[]) [Str "308."] ("#wasteland-content.xhtml#ln308",""),Space,Str "The",Space,Str "complete",Space,Str "text",Space,Str "of",Space,Str "the",Space,Str "Buddha's",Space,Str "Fire",Space,Str "Sermon",Space,Str "(which",Space,Str "corresponds",Space,Str "in",SoftBreak,Str "importance",Space,Str "to",Space,Str "the",Space,Str "Sermon",Space,Str "on",Space,Str "the",Space,Str "Mount)",Space,Str "from",Space,Str "which",Space,Str "these",Space,Str "words",Space,Str "are",Space,Str "taken,",SoftBreak,Str "will",Space,Str "be",Space,Str "found",Space,Str "translated",Space,Str "in",Space,Str "the",Space,Str "late",Space,Str "Henry",Space,Str "Clarke",Space,Str "Warren's",Space,Str "Buddhism",Space,Str "in",SoftBreak,Str "Translation",Space,Str "(Harvard",Space,Str "Oriental",Space,Str "Series).",Space,Str "Mr.",Space,Str "Warren",Space,Str "was",Space,Str "one",Space,Str "of",Space,Str "the",Space,Str "great",SoftBreak,Str "pioneers",Space,Str "of",Space,Str "Buddhist",Space,Str "studies",Space,Str "in",Space,Str "the",Space,Str "Occident."]]]]
-   ,Div ("wasteland-content.xhtml#ln309",[],[])
-    [Plain [Str "O",Space,Str "Lord",Space,Str "Thou",Space,Str "pluckest",Space,Str "me",Space,Str "out",Note [Para [Link ("",[],[]) [Str "309."] ("#wasteland-content.xhtml#ln309",""),Space,Str "From",Space,Str "St.",Space,Str "Augustine's",Space,Str "Confessions",Space,Str "again.",Space,Str "The",Space,Str "collocation",Space,Str "of",Space,Str "these",Space,Str "two",SoftBreak,Str "representatives",Space,Str "of",Space,Str "eastern",Space,Str "and",Space,Str "western",Space,Str "asceticism,",Space,Str "as",Space,Str "the",Space,Str "culmination",Space,Str "of",SoftBreak,Str "this",Space,Str "part",Space,Str "of",Space,Str "the",Space,Str "poem,",Space,Str "is",Space,Str "not",Space,Str "an",Space,Str "accident."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "O",Space,Str "Lord",Space,Str "Thou",Space,Str "pluckest",Span ("",["lnum"],[]) [Str "310"]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "burning"]]]]
- ,Div ("wasteland-content.xhtml#ch4",["section"],[])
-  [Header 2 ("",[],[]) [Str "IV.",Space,Str "DEATH",Space,Str "BY",Space,Str "WATER"]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "Phlebas",Space,Str "the",Space,Str "Phoenician,",Space,Str "a",Space,Str "fortnight",Space,Str "dead,"]]
-   ,Div ("",[],[])
-    [Plain [Str "Forgot",Space,Str "the",Space,Str "cry",Space,Str "of",Space,Str "gulls,",Space,Str "and",Space,Str "the",Space,Str "deep",Space,Str "sea",Space,Str "swell"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "the",Space,Str "profit",Space,Str "and",Space,Str "loss."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",["indent2"],[])
-    [Plain [Str "A",Space,Str "current",Space,Str "under",Space,Str "sea"]]
-   ,Div ("",[],[])
-    [Plain [Str "Picked",Space,Str "his",Space,Str "bones",Space,Str "in",Space,Str "whispers.",Space,Str "As",Space,Str "he",Space,Str "rose",Space,Str "and",Space,Str "fell"]]
-   ,Div ("",[],[])
-    [Plain [Str "He",Space,Str "passed",Space,Str "the",Space,Str "stages",Space,Str "of",Space,Str "his",Space,Str "age",Space,Str "and",Space,Str "youth"]]
-   ,Div ("",[],[])
-    [Plain [Str "Entering",Space,Str "the",Space,Str "whirlpool."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",["indent2"],[])
-    [Plain [Str "Gentile",Space,Str "or",Space,Str "Jew"]]
-   ,Div ("",[],[])
-    [Plain [Str "O",Space,Str "you",Space,Str "who",Space,Str "turn",Space,Str "the",Space,Str "wheel",Space,Str "and",Space,Str "look",Space,Str "to",Space,Str "windward,",Span ("",["lnum"],[]) [Str "320"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Consider",Space,Str "Phlebas,",Space,Str "who",Space,Str "was",Space,Str "once",Space,Str "handsome",Space,Str "and",Space,Str "tall",Space,Str "as",Space,Str "you."]]]]
- ,Div ("wasteland-content.xhtml#ch5",["section"],[])
-  [Header 2 ("",[],[]) [Str "V.",Space,Str "WHAT",Space,Str "THE",Space,Str "THUNDER",Space,Str "SAID"]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "After",Space,Str "the",Space,Str "torchlight",Space,Str "red",Space,Str "on",Space,Str "sweaty",Space,Str "faces"]]
-   ,Div ("",[],[])
-    [Plain [Str "After",Space,Str "the",Space,Str "frosty",Space,Str "silence",Space,Str "in",Space,Str "the",Space,Str "gardens"]]
-   ,Div ("",[],[])
-    [Plain [Str "After",Space,Str "the",Space,Str "agony",Space,Str "in",Space,Str "stony",Space,Str "places"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "shouting",Space,Str "and",Space,Str "the",Space,Str "crying"]]
-   ,Div ("",[],[])
-    [Plain [Str "Prison",Space,Str "and",Space,Str "palace",Space,Str "and",Space,Str "reverberation"]]
-   ,Div ("",[],[])
-    [Plain [Str "Of",Space,Str "thunder",Space,Str "of",Space,Str "spring",Space,Str "over",Space,Str "distant",Space,Str "mountains"]]
-   ,Div ("",[],[])
-    [Plain [Str "He",Space,Str "who",Space,Str "was",Space,Str "living",Space,Str "is",Space,Str "now",Space,Str "dead"]]
-   ,Div ("",[],[])
-    [Plain [Str "We",Space,Str "who",Space,Str "were",Space,Str "living",Space,Str "are",Space,Str "now",Space,Str "dying"]]
-   ,Div ("",[],[])
-    [Plain [Str "With",Space,Str "a",Space,Str "little",Space,Str "patience",Span ("",["lnum"],[]) [Str "330"]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "Here",Space,Str "is",Space,Str "no",Space,Str "water",Space,Str "but",Space,Str "only",Space,Str "rock"]]
-   ,Div ("",[],[])
-    [Plain [Str "Rock",Space,Str "and",Space,Str "no",Space,Str "water",Space,Str "and",Space,Str "the",Space,Str "sandy",Space,Str "road"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "road",Space,Str "winding",Space,Str "above",Space,Str "among",Space,Str "the",Space,Str "mountains"]]
-   ,Div ("",[],[])
-    [Plain [Str "Which",Space,Str "are",Space,Str "mountains",Space,Str "of",Space,Str "rock",Space,Str "without",Space,Str "water"]]
-   ,Div ("",[],[])
-    [Plain [Str "If",Space,Str "there",Space,Str "were",Space,Str "water",Space,Str "we",Space,Str "should",Space,Str "stop",Space,Str "and",Space,Str "drink"]]
-   ,Div ("",[],[])
-    [Plain [Str "Amongst",Space,Str "the",Space,Str "rock",Space,Str "one",Space,Str "cannot",Space,Str "stop",Space,Str "or",Space,Str "think"]]
-   ,Div ("",[],[])
-    [Plain [Str "Sweat",Space,Str "is",Space,Str "dry",Space,Str "and",Space,Str "feet",Space,Str "are",Space,Str "in",Space,Str "the",Space,Str "sand"]]
-   ,Div ("",[],[])
-    [Plain [Str "If",Space,Str "there",Space,Str "were",Space,Str "only",Space,Str "water",Space,Str "amongst",Space,Str "the",Space,Str "rock"]]
-   ,Div ("",[],[])
-    [Plain [Str "Dead",Space,Str "mountain",Space,Str "mouth",Space,Str "of",Space,Str "carious",Space,Str "teeth",Space,Str "that",Space,Str "cannot",Space,Str "spit"]]
-   ,Div ("",[],[])
-    [Plain [Str "Here",Space,Str "one",Space,Str "can",Space,Str "neither",Space,Str "stand",Space,Str "nor",Space,Str "lie",Space,Str "nor",Space,Str "sit",Span ("",["lnum"],[]) [Str "340"]]]
-   ,Div ("",[],[])
-    [Plain [Str "There",Space,Str "is",Space,Str "not",Space,Str "even",Space,Str "silence",Space,Str "in",Space,Str "the",Space,Str "mountains"]]
-   ,Div ("",[],[])
-    [Plain [Str "But",Space,Str "dry",Space,Str "sterile",Space,Str "thunder",Space,Str "without",Space,Str "rain"]]
-   ,Div ("",[],[])
-    [Plain [Str "There",Space,Str "is",Space,Str "not",Space,Str "even",Space,Str "solitude",Space,Str "in",Space,Str "the",Space,Str "mountains"]]
-   ,Div ("",[],[])
-    [Plain [Str "But",Space,Str "red",Space,Str "sullen",Space,Str "faces",Space,Str "sneer",Space,Str "and",Space,Str "snarl"]]
-   ,Div ("",[],[])
-    [Plain [Str "From",Space,Str "doors",Space,Str "of",Space,Str "mudcracked",Space,Str "houses"]]
-   ,Div ("",["linegroup"],[])
-    [Div ("",["indent2"],[])
-     [Plain [Str "If",Space,Str "there",Space,Str "were",Space,Str "water"]]
-    ,Div ("",[],[])
-     [Plain [Str "And",Space,Str "no",Space,Str "rock"]]
-    ,Div ("",[],[])
-     [Plain [Str "If",Space,Str "there",Space,Str "were",Space,Str "rock"]]
-    ,Div ("",[],[])
-     [Plain [Str "And",Space,Str "also",Space,Str "water"]]
-    ,Div ("",[],[])
-     [Plain [Str "And",Space,Str "water",Span ("",["lnum"],[]) [Str "350"]]]
-    ,Div ("",[],[])
-     [Plain [Str "A",Space,Str "spring"]]
-    ,Div ("",[],[])
-     [Plain [Str "A",Space,Str "pool",Space,Str "among",Space,Str "the",Space,Str "rock"]]
-    ,Div ("",[],[])
-     [Plain [Str "If",Space,Str "there",Space,Str "were",Space,Str "the",Space,Str "sound",Space,Str "of",Space,Str "water",Space,Str "only"]]
-    ,Div ("",[],[])
-     [Plain [Str "Not",Space,Str "the",Space,Str "cicada"]]
-    ,Div ("",[],[])
-     [Plain [Str "And",Space,Str "dry",Space,Str "grass",Space,Str "singing"]]
-    ,Div ("",[],[])
-     [Plain [Str "But",Space,Str "sound",Space,Str "of",Space,Str "water",Space,Str "over",Space,Str "a",Space,Str "rock"]]
-    ,Div ("wasteland-content.xhtml#ln357",[],[])
-     [Plain [Str "Where",Space,Str "the",Space,Str "hermit-thrush",Space,Str "sings",Space,Str "in",Space,Str "the",Space,Str "pine",Space,Str "trees",Note [Para [Link ("",[],[]) [Str "357."] ("#wasteland-content.xhtml#ln357",""),Space,Str "This",Space,Str "is",Space,Str "Turdus",Space,Str "aonalaschkae",Space,Str "pallasii,",Space,Str "the",Space,Str "hermit-thrush",Space,Str "which",Space,Str "I",Space,Str "have",SoftBreak,Str "heard",Space,Str "in",Space,Str "Quebec",Space,Str "County.",Space,Str "Chapman",Space,Str "says",Space,Str "(Handbook",Space,Str "of",Space,Str "Birds",Space,Str "of",Space,Str "Eastern",Space,Str "North",SoftBreak,Str "America)",Space,Str "\"it",Space,Str "is",Space,Str "most",Space,Str "at",Space,Str "home",Space,Str "in",Space,Str "secluded",Space,Str "woodland",Space,Str "and",Space,Str "thickety",Space,Str "retreats.",SoftBreak,Str ".",Space,Str ".",Space,Str ".",Space,Str "Its",Space,Str "notes",Space,Str "are",Space,Str "not",Space,Str "remarkable",Space,Str "for",Space,Str "variety",Space,Str "or",Space,Str "volume,",Space,Str "but",Space,Str "in",Space,Str "purity",SoftBreak,Str "and",Space,Str "sweetness",Space,Str "of",Space,Str "tone",Space,Str "and",Space,Str "exquisite",Space,Str "modulation",Space,Str "they",Space,Str "are",Space,Str "unequalled.\"",Space,Str "Its",SoftBreak,Str "\"water-dripping",Space,Str "song\"",Space,Str "is",Space,Str "justly",Space,Str "celebrated."]]]]
-    ,Div ("",[],[])
-     [Plain [Str "Drip",Space,Str "drop",Space,Str "drip",Space,Str "drop",Space,Str "drop",Space,Str "drop",Space,Str "drop"]]
-    ,Div ("",[],[])
-     [Plain [Str "But",Space,Str "there",Space,Str "is",Space,Str "no",Space,Str "water"]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("wasteland-content.xhtml#ln360",[],[])
-    [Plain [Str "Who",Space,Str "is",Space,Str "the",Space,Str "third",Space,Str "who",Space,Str "walks",Space,Str "always",Space,Str "beside",Space,Str "you?",Note [Para [Link ("",[],[]) [Str "360."] ("#wasteland-content.xhtml#ln360",""),Space,Str "The",Space,Str "following",Space,Str "lines",Space,Str "were",Space,Str "stimulated",Space,Str "by",Space,Str "the",Space,Str "account",Space,Str "of",Space,Str "one",Space,Str "of",Space,Str "the",SoftBreak,Str "Antarctic",Space,Str "expeditions",Space,Str "(I",Space,Str "forget",Space,Str "which,",Space,Str "but",Space,Str "I",Space,Str "think",Space,Str "one",Space,Str "of",Space,Str "Shackleton's):",SoftBreak,Str "it",Space,Str "was",Space,Str "related",Space,Str "that",Space,Str "the",Space,Str "party",Space,Str "of",Space,Str "explorers,",Space,Str "at",Space,Str "the",Space,Str "extremity",Space,Str "of",Space,Str "their",SoftBreak,Str "strength,",Space,Str "had",Space,Str "the",Space,Str "constant",Space,Str "delusion",Space,Str "that",Space,Str "there",Space,Str "was",Space,Str "one",Space,Str "more",Space,Str "member",Space,Str "than",SoftBreak,Str "could",Space,Str "actually",Space,Str "be",Space,Str "counted."]],SoftBreak,Span ("",["lnum"],[]) [Str "360"]]]
-   ,Div ("",[],[])
-    [Plain [Str "When",Space,Str "I",Space,Str "count,",Space,Str "there",Space,Str "are",Space,Str "only",Space,Str "you",Space,Str "and",Space,Str "I",Space,Str "together"]]
-   ,Div ("",[],[])
-    [Plain [Str "But",Space,Str "when",Space,Str "I",Space,Str "look",Space,Str "ahead",Space,Str "up",Space,Str "the",Space,Str "white",Space,Str "road"]]
-   ,Div ("",[],[])
-    [Plain [Str "There",Space,Str "is",Space,Str "always",Space,Str "another",Space,Str "one",Space,Str "walking",Space,Str "beside",Space,Str "you"]]
-   ,Div ("",[],[])
-    [Plain [Str "Gliding",Space,Str "wrapt",Space,Str "in",Space,Str "a",Space,Str "brown",Space,Str "mantle,",Space,Str "hooded"]]
-   ,Div ("",[],[])
-    [Plain [Str "I",Space,Str "do",Space,Str "not",Space,Str "know",Space,Str "whether",Space,Str "a",Space,Str "man",Space,Str "or",Space,Str "a",Space,Str "woman"]]
-   ,Div ("wasteland-content.xhtml#ln367",[],[])
-    [Plain [Str "\8213But",Space,Str "who",Space,Str "is",Space,Str "that",Space,Str "on",Space,Str "the",Space,Str "other",Space,Str "side",Space,Str "of",Space,Str "you?",Note [Para [Link ("",[],[]) [Str "367-77."] ("#wasteland-content.xhtml#ln367",""),Space,Str "Cf.",Space,Str "Hermann",Space,Str "Hesse,",Space,Str "Blick",Space,Str "ins",Space,Str "Chaos:"],BlockQuote [Para [Str "\"Schon",Space,Str "ist",Space,Str "halb",Space,Str "Europa,",Space,Str "schon",Space,Str "ist",Space,Str "zumindest",Space,Str "der",Space,Str "halbe",Space,Str "Osten",Space,Str "Europas",SoftBreak,Str "auf",Space,Str "dem",LineBreak,Str "Wege",Space,Str "zum",Space,Str "Chaos,",Space,Str "fhrt",Space,Str "betrunken",Space,Str "im",Space,Str "heiligem",Space,Str "Wahn",Space,Str "am",SoftBreak,Str "Abgrund",Space,Str "entlang",LineBreak,Str "und",Space,Str "singt",Space,Str "dazu,",Space,Str "singt",Space,Str "betrunken",Space,Str "und",Space,Str "hymnisch",SoftBreak,Str "wie",Space,Str "Dmitri",Space,Str "Karamasoff",Space,Str "sang.",LineBreak,Str "Ueber",Space,Str "diese",Space,Str "Lieder",Space,Str "lacht",Space,Str "der",SoftBreak,Str "Bsrger",Space,Str "beleidigt,",Space,Str "der",Space,Str "Heilige",LineBreak,Str "und",Space,Str "Seher",Space,Str "hrt",Space,Str "sie",Space,Str "mit",SoftBreak,Str "Trvnen.\""]]]]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "What",Space,Str "is",Space,Str "that",Space,Str "sound",Space,Str "high",Space,Str "in",Space,Str "the",Space,Str "air"]]
-   ,Div ("",[],[])
-    [Plain [Str "Murmur",Space,Str "of",Space,Str "maternal",Space,Str "lamentation"]]
-   ,Div ("",[],[])
-    [Plain [Str "Who",Space,Str "are",Space,Str "those",Space,Str "hooded",Space,Str "hordes",Space,Str "swarming"]]
-   ,Div ("",[],[])
-    [Plain [Str "Over",Space,Str "endless",Space,Str "plains,",Space,Str "stumbling",Space,Str "in",Space,Str "cracked",Space,Str "earth",Span ("",["lnum"],[]) [Str "370"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Ringed",Space,Str "by",Space,Str "the",Space,Str "flat",Space,Str "horizon",Space,Str "only"]]
-   ,Div ("",[],[])
-    [Plain [Str "What",Space,Str "is",Space,Str "the",Space,Str "city",Space,Str "over",Space,Str "the",Space,Str "mountains"]]
-   ,Div ("",[],[])
-    [Plain [Str "Cracks",Space,Str "and",Space,Str "reforms",Space,Str "and",Space,Str "bursts",Space,Str "in",Space,Str "the",Space,Str "violet",Space,Str "air"]]
-   ,Div ("",[],[])
-    [Plain [Str "Falling",Space,Str "towers"]]
-   ,Div ("",[],[])
-    [Plain [Str "Jerusalem",Space,Str "Athens",Space,Str "Alexandria"]]
-   ,Div ("",[],[])
-    [Plain [Str "Vienna",Space,Str "London"]]
-   ,Div ("",[],[])
-    [Plain [Str "Unreal"]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "A",Space,Str "woman",Space,Str "drew",Space,Str "her",Space,Str "long",Space,Str "black",Space,Str "hair",Space,Str "out",Space,Str "tight"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "fiddled",Space,Str "whisper",Space,Str "music",Space,Str "on",Space,Str "those",Space,Str "strings"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "bats",Space,Str "with",Space,Str "baby",Space,Str "faces",Space,Str "in",Space,Str "the",Space,Str "violet",Space,Str "light",Span ("",["lnum"],[]) [Str "380"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Whistled,",Space,Str "and",Space,Str "beat",Space,Str "their",Space,Str "wings"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "crawled",Space,Str "head",Space,Str "downward",Space,Str "down",Space,Str "a",Space,Str "blackened",Space,Str "wall"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "upside",Space,Str "down",Space,Str "in",Space,Str "air",Space,Str "were",Space,Str "towers"]]
-   ,Div ("",[],[])
-    [Plain [Str "Tolling",Space,Str "reminiscent",Space,Str "bells,",Space,Str "that",Space,Str "kept",Space,Str "the",Space,Str "hours"]]
-   ,Div ("",[],[])
-    [Plain [Str "And",Space,Str "voices",Space,Str "singing",Space,Str "out",Space,Str "of",Space,Str "empty",Space,Str "cisterns",Space,Str "and",Space,Str "exhausted",SoftBreak,Str "wells."]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "In",Space,Str "this",Space,Str "decayed",Space,Str "hole",Space,Str "among",Space,Str "the",Space,Str "mountains"]]
-   ,Div ("",[],[])
-    [Plain [Str "In",Space,Str "the",Space,Str "faint",Space,Str "moonlight,",Space,Str "the",Space,Str "grass",Space,Str "is",Space,Str "singing"]]
-   ,Div ("",[],[])
-    [Plain [Str "Over",Space,Str "the",Space,Str "tumbled",Space,Str "graves,",Space,Str "about",Space,Str "the",Space,Str "chapel"]]
-   ,Div ("",[],[])
-    [Plain [Str "There",Space,Str "is",Space,Str "the",Space,Str "empty",Space,Str "chapel,",Space,Str "only",Space,Str "the",Space,Str "wind's",Space,Str "home."]]
-   ,Div ("",[],[])
-    [Plain [Str "It",Space,Str "has",Space,Str "no",Space,Str "windows,",Space,Str "and",Space,Str "the",Space,Str "door",Space,Str "swings,",Span ("",["lnum"],[]) [Str "390"]]]
-   ,Div ("",[],[])
-    [Plain [Str "Dry",Space,Str "bones",Space,Str "can",Space,Str "harm",Space,Str "no",Space,Str "one."]]
-   ,Div ("",[],[])
-    [Plain [Str "Only",Space,Str "a",Space,Str "cock",Space,Str "stood",Space,Str "on",Space,Str "the",Space,Str "rooftree"]]
-   ,Div ("",[],[])
-    [Plain [Str "Co",Space,Str "co",Space,Str "rico",Space,Str "co",Space,Str "co",Space,Str "rico"]]
-   ,Div ("",[],[])
-    [Plain [Str "In",Space,Str "a",Space,Str "flash",Space,Str "of",Space,Str "lightning.",Space,Str "Then",Space,Str "a",Space,Str "damp",Space,Str "gust"]]
-   ,Div ("",[],[])
-    [Plain [Str "Bringing",Space,Str "rain"]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",[],[])
-    [Plain [Str "Ganga",Space,Str "was",Space,Str "sunken,",Space,Str "and",Space,Str "the",Space,Str "limp",Space,Str "leaves"]]
-   ,Div ("",[],[])
-    [Plain [Str "Waited",Space,Str "for",Space,Str "rain,",Space,Str "while",Space,Str "the",Space,Str "black",Space,Str "clouds"]]
-   ,Div ("",[],[])
-    [Plain [Str "Gathered",Space,Str "far",Space,Str "distant,",Space,Str "over",Space,Str "Himavant."]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "jungle",Space,Str "crouched,",Space,Str "humped",Space,Str "in",Space,Str "silence."]]
-   ,Div ("",[],[])
-    [Plain [Str "Then",Space,Str "spoke",Space,Str "the",Space,Str "thunder",Span ("",["lnum"],[]) [Str "400"]]]
-   ,Div ("",[],[])
-    [Plain [Str "DA"]]
-   ,Div ("wasteland-content.xhtml#ln402",[],[])
-    [Plain [Span ("",[],[("lang","sa")]) [Str "Datta"],Str ":",Space,Str "what",Space,Str "have",Space,Str "we",Space,Str "given?",Note [Para [Link ("",[],[]) [Str "402."] ("#wasteland-content.xhtml#ln402",""),Space,Quoted DoubleQuote [Str "\"Datta,",Space,Str "dayadhvam,",Space,Str "damyata\""],Space,Str "(Give,",Space,Str "sympathize,",SoftBreak,Str "control).",Space,Str "The",Space,Str "fable",Space,Str "of",Space,Str "the",Space,Str "meaning",Space,Str "of",Space,Str "the",Space,Str "Thunder",Space,Str "is",Space,Str "found",Space,Str "in",Space,Str "the",SoftBreak,Str "Brihadaranyaka-Upanishad,",Space,Str "5,",Space,Str "1.",Space,Str "A",Space,Str "translation",Space,Str "is",Space,Str "found",Space,Str "in",Space,Str "Deussen's",SoftBreak,Str "Sechzig",Space,Str "Upanishads",Space,Str "des",Space,Str "Veda,",Space,Str "p.",Space,Str "489."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "My",Space,Str "friend,",Space,Str "blood",Space,Str "shaking",Space,Str "my",Space,Str "heart"]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "awful",Space,Str "daring",Space,Str "of",Space,Str "a",Space,Str "moment's",Space,Str "surrender"]]
-   ,Div ("",[],[])
-    [Plain [Str "Which",Space,Str "an",Space,Str "age",Space,Str "of",Space,Str "prudence",Space,Str "can",Space,Str "never",Space,Str "retract"]]
-   ,Div ("",[],[])
-    [Plain [Str "By",Space,Str "this,",Space,Str "and",Space,Str "this",Space,Str "only,",Space,Str "we",Space,Str "have",Space,Str "existed"]]
-   ,Div ("",[],[])
-    [Plain [Str "Which",Space,Str "is",Space,Str "not",Space,Str "to",Space,Str "be",Space,Str "found",Space,Str "in",Space,Str "our",Space,Str "obituaries"]]
-   ,Div ("wasteland-content.xhtml#ln408",[],[])
-    [Plain [Str "Or",Space,Str "in",Space,Str "memories",Space,Str "draped",Space,Str "by",Space,Str "the",Space,Str "beneficent",Space,Str "spider",Note [Para [Link ("",[],[]) [Str "408."] ("#wasteland-content.xhtml#ln408",""),Space,Str "Cf.",Space,Str "Webster,",Space,Str "The",Space,Str "White",Space,Str "Devil,",Space,Str "v.",Space,Str "vi:"],BlockQuote [Para [Str "\".",Space,Str ".",Space,Str ".",Space,Str "they'll",Space,Str "remarry",LineBreak,Str "Ere",Space,Str "the",Space,Str "worm",Space,Str "pierce",Space,Str "your",Space,Str "winding-sheet,",SoftBreak,Str "ere",Space,Str "the",Space,Str "spider",LineBreak,Str "Make",Space,Str "a",Space,Str "thin",Space,Str "curtain",Space,Str "for",Space,Str "your",Space,Str "epitaphs.\""]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Or",Space,Str "under",Space,Str "seals",Space,Str "broken",Space,Str "by",Space,Str "the",Space,Str "lean",Space,Str "solicitor"]]
-   ,Div ("",[],[])
-    [Plain [Str "In",Space,Str "our",Space,Str "empty",Space,Str "rooms",Span ("",["lnum"],[]) [Str "410"]]]
-   ,Div ("",[],[])
-    [Plain [Str "DA"]]
-   ,Div ("wasteland-content.xhtml#ln412",[],[])
-    [Plain [Span ("",[],[("lang","sa")]) [Str "Dayadhvam"],Str ":",Space,Str "I",Space,Str "have",Space,Str "heard",Space,Str "the",Space,Str "key",Note [Para [Link ("",[],[]) [Str "412."] ("#wasteland-content.xhtml#ln412",""),Space,Str "Cf.",Space,Str "Inferno,",Space,Str "xxxiii.",Space,Str "46:"],BlockQuote [Para [Str "\"ed",Space,Str "io",Space,Str "sentii",Space,Str "chiavar",Space,Str "l'uscio",Space,Str "di",Space,Str "sotto",LineBreak,Str "all'orribile",Space,Str "torre.\""]],Para [Str "Also",Space,Str "F.",Space,Str "H.",Space,Str "Bradley,",Space,Str "Appearance",Space,Str "and",Space,Str "Reality,",Space,Str "p.",Space,Str "346:"],BlockQuote [Para [Str "\"My",Space,Str "external",Space,Str "sensations",Space,Str "are",Space,Str "no",Space,Str "less",Space,Str "private",Space,Str "to",Space,Str "myself",Space,Str "than",Space,Str "are",Space,Str "my",SoftBreak,Str "thoughts",Space,Str "or",Space,Str "my",Space,Str "feelings.",Space,Str "In",Space,Str "either",Space,Str "case",Space,Str "my",Space,Str "experience",Space,Str "falls",Space,Str "within",SoftBreak,Str "my",Space,Str "own",Space,Str "circle,",Space,Str "a",Space,Str "circle",Space,Str "closed",Space,Str "on",Space,Str "the",Space,Str "outside;",Space,Str "and,",Space,Str "with",Space,Str "all",Space,Str "its",SoftBreak,Str "elements",Space,Str "alike,",Space,Str "every",Space,Str "sphere",Space,Str "is",Space,Str "opaque",Space,Str "to",Space,Str "the",Space,Str "others",Space,Str "which",Space,Str "surround",SoftBreak,Str "it.",Space,Str ".",Space,Str ".",Space,Str ".",Space,Str "In",Space,Str "brief,",Space,Str "regarded",Space,Str "as",Space,Str "an",Space,Str "existence",Space,Str "which",Space,Str "appears",Space,Str "in",Space,Str "a",SoftBreak,Str "soul,",Space,Str "the",Space,Str "whole",Space,Str "world",Space,Str "for",Space,Str "each",Space,Str "is",Space,Str "peculiar",Space,Str "and",Space,Str "private",Space,Str "to",Space,Str "that",SoftBreak,Str "soul.\""]]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Turn",Space,Str "in",Space,Str "the",Space,Str "door",Space,Str "once",Space,Str "and",Space,Str "turn",Space,Str "once",Space,Str "only"]]
-   ,Div ("",[],[])
-    [Plain [Str "We",Space,Str "think",Space,Str "of",Space,Str "the",Space,Str "key,",Space,Str "each",Space,Str "in",Space,Str "his",Space,Str "prison"]]
-   ,Div ("",[],[])
-    [Plain [Str "Thinking",Space,Str "of",Space,Str "the",Space,Str "key,",Space,Str "each",Space,Str "confirms",Space,Str "a",Space,Str "prison"]]
-   ,Div ("",[],[])
-    [Plain [Str "Only",Space,Str "at",Space,Str "nightfall,",Space,Str "aetherial",Space,Str "rumours"]]
-   ,Div ("",[],[])
-    [Plain [Str "Revive",Space,Str "for",Space,Str "a",Space,Str "moment",Space,Str "a",Space,Str "broken",Space,Str "Coriolanus"]]
-   ,Div ("",[],[])
-    [Plain [Str "DA"]]
-   ,Div ("",[],[])
-    [Plain [Span ("",[],[("lang","sa")]) [Str "Damyata"],Str ":",Space,Str "The",Space,Str "boat",Space,Str "responded"]]
-   ,Div ("",[],[])
-    [Plain [Str "Gaily,",Space,Str "to",Space,Str "the",Space,Str "hand",Space,Str "expert",Space,Str "with",Space,Str "sail",Space,Str "and",Space,Str "oar",Span ("",["lnum"],[]) [Str "420"]]]
-   ,Div ("",[],[])
-    [Plain [Str "The",Space,Str "sea",Space,Str "was",Space,Str "calm,",Space,Str "your",Space,Str "heart",Space,Str "would",Space,Str "have",Space,Str "responded"]]
-   ,Div ("",[],[])
-    [Plain [Str "Gaily,",Space,Str "when",Space,Str "invited,",Space,Str "beating",Space,Str "obedient"]]
-   ,Div ("",[],[])
-    [Plain [Str "To",Space,Str "controlling",Space,Str "hands"]]]
-  ,Div ("",["linegroup"],[])
-   [Div ("",["indent"],[])
-    [Plain [Str "I",Space,Str "sat",Space,Str "upon",Space,Str "the",Space,Str "shore"]]
-   ,Div ("wasteland-content.xhtml#ln425",[],[])
-    [Plain [Str "Fishing,",Space,Str "with",Space,Str "the",Space,Str "arid",Space,Str "plain",Space,Str "behind",Space,Str "me",Note [Para [Link ("",[],[]) [Str "425."] ("#wasteland-content.xhtml#ln425",""),Space,Str "V.",Space,Str "Weston,",Space,Str "From",Space,Str "Ritual",Space,Str "to",Space,Str "Romance;",Space,Str "chapter",Space,Str "on",Space,Str "the",Space,Str "Fisher",Space,Str "King."]]]]
-   ,Div ("",[],[])
-    [Plain [Str "Shall",Space,Str "I",Space,Str "at",Space,Str "least",Space,Str "set",Space,Str "my",Space,Str "lands",Space,Str "in",Space,Str "order?"]]
-   ,Div ("",[],[])
-    [Plain [Str "London",Space,Str "Bridge",Space,Str "is",Space,Str "falling",Space,Str "down",Space,Str "falling",Space,Str "down",Space,Str "falling",Space,Str "down"]]
-   ,Div ("wasteland-content.xhtml#ln428",[],[("lang","it")])
-    [Plain [Emph [Str "Poi",Space,Str "s'ascose",Space,Str "nel",Space,Str "foco",Space,Str "che",Space,Str "gli",Space,Str "affina"],SoftBreak,Note [Para [Link ("",[],[]) [Str "428."] ("#wasteland-content.xhtml#ln428",""),Space,Str "V.",Space,Str "Purgatorio,",Space,Str "xxvi.",Space,Str "148."],BlockQuote [Para [Str "\"'Ara",Space,Str "vos",Space,Str "prec",Space,Str "per",Space,Str "aquella",Space,Str "valor",LineBreak,Str "'que",Space,Str "vos",Space,Str "guida",Space,Str "al",Space,Str "som",Space,Str "de",SoftBreak,Str "l'escalina,",LineBreak,Str "'sovegna",Space,Str "vos",Space,Str "a",Space,Str "temps",Space,Str "de",Space,Str "ma",Space,Str "dolor.'",LineBreak,Str "Poi",SoftBreak,Str "s'ascose",Space,Str "nel",Space,Str "foco",Space,Str "che",Space,Str "gli",Space,Str "affina.\""]]]]]
-   ,Div ("wasteland-content.xhtml#ln429",[],[])
-    [Plain [Span ("",[],[("lang","it")]) [SoftBreak,Emph [Str "Quando",Space,Str "fiam",Space,Str "ceu",Space,Str "chelidon"],SoftBreak],Space,Str "-",Space,Str "O",Space,Str "swallow",Space,Str "swallow",Note [Para [Link ("",[],[]) [Str "429."] ("#wasteland-content.xhtml#ln429",""),Space,Str "V.",Space,Str "Pervigilium",Space,Str "Veneris.",Space,Str "Cf.",Space,Str "Philomela",Space,Str "in",Space,Str "Parts",Space,Str "II",Space,Str "and",Space,Str "III."]]]]
-   ,Div ("wasteland-content.xhtml#ln430",[],[("lang","fr")])
-    [Plain [Emph [Str "Le",Space,Str "Prince",Space,Str "d'Aquitaine",Space,Str "a",Space,Str "la",Space,Str "tour",Space,Str "abolie"],SoftBreak,Note [Para [Link ("",[],[]) [Str "430."] ("#wasteland-content.xhtml#ln430",""),Space,Str "V.",Space,Str "Gerard",Space,Str "de",Space,Str "Nerval,",Space,Str "Sonnet",Space,Str "El",Space,Str "Desdichado."]],SoftBreak,Span ("",["lnum"],[]) [Str "430"]]]
-   ,Div ("",[],[])
-    [Plain [Str "These",Space,Str "fragments",Space,Str "I",Space,Str "have",Space,Str "shored",Space,Str "against",Space,Str "my",Space,Str "ruins"]]
-   ,Div ("wasteland-content.xhtml#ln432",[],[])
-    [Plain [Str "Why",Space,Str "then",Space,Str "Ile",Space,Str "fit",Space,Str "you.",Space,Str "Hieronymo's",Space,Str "mad",Space,Str "againe.",Note [Para [Link ("",[],[]) [Str "432."] ("#wasteland-content.xhtml#ln432",""),Space,Str "V.",Space,Str "Kyd's",Space,Str "Spanish",Space,Str "Tragedy."]]]]
-   ,Div ("",[],[("lang","sa")])
-    [Plain [Str "Datta.",Space,Str "Dayadhvam.",Space,Str "Damyata."]]
-   ,Div ("wasteland-content.xhtml#ln434",["linegroup","indent"],[])
-    [Plain [Span ("",[],[("lang","sa")]) [Str "Shantih",Space,Str "shantih",Space,Str "shantih",Note [Para [Link ("",[],[]) [Str "434."] ("#wasteland-content.xhtml#ln434",""),Space,Str "Shantih.",Space,Str "Repeated",Space,Str "as",Space,Str "here,",Space,Str "a",Space,Str "formal",Space,Str "ending",Space,Str "to",Space,Str "an",Space,Str "Upanishad.",Space,Str "'The",SoftBreak,Str "Peace",Space,Str "which",Space,Str "passeth",Space,Str "understanding'",Space,Str "is",Space,Str "a",Space,Str "feeble",Space,Str "translation",Space,Str "of",Space,Str "the",SoftBreak,Str "content",Space,Str "of",Space,Str "this",Space,Str "word."]],SoftBreak]]]]]]
-,Div ("wasteland-content.xhtml#backmatter",["section","backmatter"],[])
- [Div ("wasteland-content.xhtml#rearnotes",["section","rearnotes"],[])
-  [Header 2 ("",[],[]) [Str "NOTES",Space,Str "ON",Space,Str "\"THE",Space,Str "WASTE",Space,Str "LAND\""]
-  ,Para [Str "Not",Space,Str "only",Space,Str "the",Space,Str "title,",Space,Str "but",Space,Str "the",Space,Str "plan",Space,Str "and",Space,Str "a",Space,Str "good",Space,Str "deal",Space,Str "of",Space,Str "the",Space,Str "incidental",Space,Str "symbolism",Space,Str "of",SoftBreak,Str "the",Space,Str "poem",Space,Str "were",Space,Str "suggested",Space,Str "by",Space,Str "Miss",Space,Str "Jessie",Space,Str "L.",Space,Str "Weston's",Space,Str "book",Space,Str "on",Space,Str "the",Space,Str "Grail",Space,Str "legend:",SoftBreak,Str "From",Space,Str "Ritual",Space,Str "to",Space,Str "Romance"]
-  ,Para [Str "Indeed,",Space,Str "so",Space,Str "deeply",Space,Str "am",Space,Str "I",Space,Str "indebted,",Space,Str "Miss",Space,Str "Weston's",Space,Str "book",Space,Str "will",Space,Str "elucidate",Space,Str "the",SoftBreak,Str "difficulties",Space,Str "of",Space,Str "the",Space,Str "poem",Space,Str "much",Space,Str "better",Space,Str "than",Space,Str "my",Space,Str "notes",Space,Str "can",Space,Str "do;",Space,Str "and",Space,Str "I",Space,Str "recommend",Space,Str "it",SoftBreak,Str "(apart",Space,Str "from",Space,Str "the",Space,Str "great",Space,Str "interest",Space,Str "of",Space,Str "the",Space,Str "book",Space,Str "itself)",Space,Str "to",Space,Str "any",Space,Str "who",Space,Str "think",Space,Str "such",SoftBreak,Str "elucidation",Space,Str "of",Space,Str "the",Space,Str "poem",Space,Str "worth",Space,Str "the",Space,Str "trouble.",Space,Str "To",Space,Str "another",Space,Str "work",Space,Str "of",Space,Str "anthropology",Space,Str "I",Space,Str "am",SoftBreak,Str "indebted",Space,Str "in",Space,Str "general,",Space,Str "one",Space,Str "which",Space,Str "has",Space,Str "influenced",Space,Str "our",Space,Str "generation",Space,Str "profoundly;",Space,Str "I",Space,Str "mean",SoftBreak,Str "The",Space,Str "Golden",Space,Str "Bough;",Space,Str "I",Space,Str "have",Space,Str "used",Space,Str "especially",Space,Str "the",Space,Str "two",Space,Str "volumes",Space,Str "Adonis,",Space,Str "Attis,",Space,Str "Osiris.",SoftBreak,Str "Anyone",Space,Str "who",Space,Str "is",Space,Str "acquainted",Space,Str "with",Space,Str "these",Space,Str "works",Space,Str "will",Space,Str "immediately",Space,Str "recognise",Space,Str "in",Space,Str "the",Space,Str "poem",SoftBreak,Str "certain",Space,Str "references",Space,Str "to",Space,Str "vegetation",Space,Str "ceremonies."]
-  ,Div ("",["section"],[])
-   [Header 3 ("",[],[]) [Str "I.",Space,Str "THE",Space,Str "BURIAL",Space,Str "OF",Space,Str "THE",Space,Str "DEAD"]]
-  ,Div ("",["section"],[])
-   [Header 3 ("",[],[]) [Str "II.",Space,Str "A",Space,Str "GAME",Space,Str "OF",Space,Str "CHESS"]]
-  ,Div ("",["section"],[])
-   [Header 3 ("",[],[]) [Str "III.",Space,Str "THE",Space,Str "FIRE",Space,Str "SERMON"]]
-  ,Div ("",["section"],[])
-   [Header 3 ("",[],[]) [Str "V.",Space,Str "WHAT",Space,Str "THE",Space,Str "THUNDER",Space,Str "SAID"]
-   ,Para [Str "In",Space,Str "the",Space,Str "first",Space,Str "part",Space,Str "of",Space,Str "Part",Space,Str "V",Space,Str "three",Space,Str "themes",Space,Str "are",Space,Str "employed:",Space,Str "the",Space,Str "journey",Space,Str "to",Space,Str "Emmaus,",SoftBreak,Str "the",Space,Str "approach",Space,Str "to",Space,Str "the",Space,Str "Chapel",Space,Str "Perilous",Space,Str "(see",Space,Str "Miss",Space,Str "Weston's",Space,Str "book)",Space,Str "and",Space,Str "the",Space,Str "present",SoftBreak,Str "decay",Space,Str "of",Space,Str "eastern",Space,Str "Europe."]]]]]
+[ Para
+  [ Image ( "", [], [] ) [] ( "wasteland-cover.jpg", "" ) ]
+, Para
+  [ Span ( "wasteland-content.xhtml", [], [] ) [] ]
+, Div
+  ( "wasteland-content.xhtml#frontmatter"
+  ,
+    [ "section", "frontmatter" ]
+  , []
+  ) []
+, Div
+  ( "wasteland-content.xhtml#bodymatter"
+  ,
+    [ "section", "bodymatter" ]
+  , []
+  )
+  [ Div
+    ( "wasteland-content.xhtml#ch1", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "I."
+      , Space
+      , Str "THE"
+      , Space
+      , Str "BURIAL"
+      , Space
+      , Str "OF"
+      , Space
+      , Str "THE"
+      , Space
+      , Str "DEAD"
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "April"
+          , Space
+          , Str "is"
+          , Space
+          , Str "the"
+          , Space
+          , Str "cruellest"
+          , Space
+          , Str "month,"
+          , Space
+          , Str "breeding"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Lilacs"
+          , Space
+          , Str "out"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "dead"
+          , Space
+          , Str "land,"
+          , Space
+          , Str "mixing"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Memory"
+          , Space
+          , Str "and"
+          , Space
+          , Str "desire,"
+          , Space
+          , Str "stirring"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Dull"
+          , Space
+          , Str "roots"
+          , Space
+          , Str "with"
+          , Space
+          , Str "spring"
+          , Space
+          , Str "rain."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Winter"
+          , Space
+          , Str "kept"
+          , Space
+          , Str "us"
+          , Space
+          , Str "warm,"
+          , Space
+          , Str "covering"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Earth"
+          , Space
+          , Str "in"
+          , Space
+          , Str "forgetful"
+          , Space
+          , Str "snow,"
+          , Space
+          , Str "feeding"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "A"
+          , Space
+          , Str "little"
+          , Space
+          , Str "life"
+          , Space
+          , Str "with"
+          , Space
+          , Str "dried"
+          , Space
+          , Str "tubers."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Summer"
+          , Space
+          , Str "surprised"
+          , Space
+          , Str "us,"
+          , Space
+          , Str "coming"
+          , Space
+          , Str "over"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Starnbergersee"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "With"
+          , Space
+          , Str "a"
+          , Space
+          , Str "shower"
+          , Space
+          , Str "of"
+          , Space
+          , Str "rain;"
+          , Space
+          , Str "we"
+          , Space
+          , Str "stopped"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "colonnade,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "went"
+          , Space
+          , Str "on"
+          , Space
+          , Str "in"
+          , Space
+          , Str "sunlight,"
+          , Space
+          , Str "into"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Hofgarten,"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "10" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "drank"
+          , Space
+          , Str "coffee,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "talked"
+          , Space
+          , Str "for"
+          , Space
+          , Str "an"
+          , Space
+          , Str "hour."
+          ]
+        ]
+      , Div
+        ( "", [], [ ( "lang", "de" ) ] )
+        [ Plain
+          [ Str "Bin"
+          , Space
+          , Str "gar"
+          , Space
+          , Str "keine"
+          , Space
+          , Str "Russin,"
+          , Space
+          , Str "stamm'"
+          , Space
+          , Str "aus"
+          , Space
+          , Str "Litauen,"
+          , Space
+          , Str "echt"
+          , SoftBreak
+          , Str "deutsch."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "when"
+          , Space
+          , Str "we"
+          , Space
+          , Str "were"
+          , Space
+          , Str "children,"
+          , Space
+          , Str "staying"
+          , Space
+          , Str "at"
+          , Space
+          , Str "the"
+          , Space
+          , Str "archduke's,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "My"
+          , Space
+          , Str "cousin's,"
+          , Space
+          , Str "he"
+          , Space
+          , Str "took"
+          , Space
+          , Str "me"
+          , Space
+          , Str "out"
+          , Space
+          , Str "on"
+          , Space
+          , Str "a"
+          , Space
+          , Str "sled,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "I"
+          , Space
+          , Str "was"
+          , Space
+          , Str "frightened."
+          , Space
+          , Str "He"
+          , Space
+          , Str "said,"
+          , Space
+          , Str "Marie,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Marie,"
+          , Space
+          , Str "hold"
+          , Space
+          , Str "on"
+          , Space
+          , Str "tight."
+          , Space
+          , Str "And"
+          , Space
+          , Str "down"
+          , Space
+          , Str "we"
+          , Space
+          , Str "went."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "In"
+          , Space
+          , Str "the"
+          , Space
+          , Str "mountains,"
+          , Space
+          , Str "there"
+          , Space
+          , Str "you"
+          , Space
+          , Str "feel"
+          , Space
+          , Str "free."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "read,"
+          , Space
+          , Str "much"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "night,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "go"
+          , Space
+          , Str "south"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "winter."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "What"
+          , Space
+          , Str "are"
+          , Space
+          , Str "the"
+          , Space
+          , Str "roots"
+          , Space
+          , Str "that"
+          , Space
+          , Str "clutch,"
+          , Space
+          , Str "what"
+          , Space
+          , Str "branches"
+          , Space
+          , Str "grow"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln20", [], [] )
+        [ Plain
+          [ Str "Out"
+          , Space
+          , Str "of"
+          , Space
+          , Str "this"
+          , Space
+          , Str "stony"
+          , Space
+          , Str "rubbish?"
+          , Space
+          , Str "Son"
+          , Space
+          , Str "of"
+          , Space
+          , Str "man,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "Line", Space, Str "20." ]
+                ( "#wasteland-content.xhtml#ln20", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Ezekiel"
+              , Space
+              , Str "2:1."
+              ]
+            ]
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "20" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "You"
+          , Space
+          , Str "cannot"
+          , Space
+          , Str "say,"
+          , Space
+          , Str "or"
+          , Space
+          , Str "guess,"
+          , Space
+          , Str "for"
+          , Space
+          , Str "you"
+          , Space
+          , Str "know"
+          , Space
+          , Str "only"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "A"
+          , Space
+          , Str "heap"
+          , Space
+          , Str "of"
+          , Space
+          , Str "broken"
+          , Space
+          , Str "images,"
+          , Space
+          , Str "where"
+          , Space
+          , Str "the"
+          , Space
+          , Str "sun"
+          , Space
+          , Str "beats,"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln23", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "the"
+          , Space
+          , Str "dead"
+          , Space
+          , Str "tree"
+          , Space
+          , Str "gives"
+          , Space
+          , Str "no"
+          , Space
+          , Str "shelter,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "cricket"
+          , Space
+          , Str "no"
+          , Space
+          , Str "relief,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "23." ]
+                ( "#wasteland-content.xhtml#ln23", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Ecclesiastes"
+              , Space
+              , Str "12:5."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "the"
+          , Space
+          , Str "dry"
+          , Space
+          , Str "stone"
+          , Space
+          , Str "no"
+          , Space
+          , Str "sound"
+          , Space
+          , Str "of"
+          , Space
+          , Str "water."
+          , Space
+          , Str "Only"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "There"
+          , Space
+          , Str "is"
+          , Space
+          , Str "shadow"
+          , Space
+          , Str "under"
+          , Space
+          , Str "this"
+          , Space
+          , Str "red"
+          , Space
+          , Str "rock,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "(Come"
+          , Space
+          , Str "in"
+          , Space
+          , Str "under"
+          , Space
+          , Str "the"
+          , Space
+          , Str "shadow"
+          , Space
+          , Str "of"
+          , Space
+          , Str "this"
+          , Space
+          , Str "red"
+          , Space
+          , Str "rock),"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "I"
+          , Space
+          , Str "will"
+          , Space
+          , Str "show"
+          , Space
+          , Str "you"
+          , Space
+          , Str "something"
+          , Space
+          , Str "different"
+          , Space
+          , Str "from"
+          , Space
+          , Str "either"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Your"
+          , Space
+          , Str "shadow"
+          , Space
+          , Str "at"
+          , Space
+          , Str "morning"
+          , Space
+          , Str "striding"
+          , Space
+          , Str "behind"
+          , Space
+          , Str "you"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Or"
+          , Space
+          , Str "your"
+          , Space
+          , Str "shadow"
+          , Space
+          , Str "at"
+          , Space
+          , Str "evening"
+          , Space
+          , Str "rising"
+          , Space
+          , Str "to"
+          , Space
+          , Str "meet"
+          , Space
+          , Str "you;"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "will"
+          , Space
+          , Str "show"
+          , Space
+          , Str "you"
+          , Space
+          , Str "fear"
+          , Space
+          , Str "in"
+          , Space
+          , Str "a"
+          , Space
+          , Str "handful"
+          , Space
+          , Str "of"
+          , Space
+          , Str "dust."
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "30" ]
+          ]
+        ]
+      , BlockQuote
+        [ Div
+          ( "", [], [] )
+          [ Div
+            ( "wasteland-content.xhtml#ln31", [], [] )
+            [ Plain
+              [ Str "Frisch"
+              , Space
+              , Str "weht"
+              , Space
+              , Str "der"
+              , Space
+              , Str "Wind"
+              , Note
+                [ Para
+                  [ Link
+                    ( "", [], [] )
+                    [ Str "31." ]
+                    ( "#wasteland-content.xhtml#ln31", "" )
+                  , Space
+                  , Str "V."
+                  , Space
+                  , Str "Tristan"
+                  , Space
+                  , Str "und"
+                  , Space
+                  , Str "Isolde,"
+                  , Space
+                  , Str "i,"
+                  , Space
+                  , Str "verses"
+                  , Space
+                  , Str "5-8."
+                  ]
+                ]
+              ]
+            ]
+          , Div
+            ( "", [], [] )
+            [ Plain
+              [ Str "Der", Space, Str "Heimat", Space, Str "zu" ]
+            ]
+          , Div
+            ( "", [], [] )
+            [ Plain
+              [ Str "Mein", Space, Str "Irisch", Space, Str "Kind," ]
+            ]
+          , Div
+            ( "", [], [] )
+            [ Plain
+              [ Str "Wo", Space, Str "weilest", Space, Str "du?" ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"You"
+          , Space
+          , Str "gave"
+          , Space
+          , Str "me"
+          , Space
+          , Str "hyacinths"
+          , Space
+          , Str "first"
+          , Space
+          , Str "a"
+          , Space
+          , Str "year"
+          , Space
+          , Str "ago;"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"They"
+          , Space
+          , Str "called"
+          , Space
+          , Str "me"
+          , Space
+          , Str "the"
+          , Space
+          , Str "hyacinth"
+          , Space
+          , Str "girl.\""
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\8213Yet"
+          , Space
+          , Str "when"
+          , Space
+          , Str "we"
+          , Space
+          , Str "came"
+          , Space
+          , Str "back,"
+          , Space
+          , Str "late,"
+          , Space
+          , Str "from"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Hyacinth"
+          , SoftBreak
+          , Str "garden,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Your"
+          , Space
+          , Str "arms"
+          , Space
+          , Str "full,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "your"
+          , Space
+          , Str "hair"
+          , Space
+          , Str "wet,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "could"
+          , Space
+          , Str "not"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Speak,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "my"
+          , Space
+          , Str "eyes"
+          , Space
+          , Str "failed,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "was"
+          , Space
+          , Str "neither"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Living"
+          , Space
+          , Str "nor"
+          , Space
+          , Str "dead,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "I"
+          , Space
+          , Str "knew"
+          , Space
+          , Str "nothing,"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "40" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Looking"
+          , Space
+          , Str "into"
+          , Space
+          , Str "the"
+          , Space
+          , Str "heart"
+          , Space
+          , Str "of"
+          , Space
+          , Str "light,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "silence."
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln42", [], [ ( "lang", "de" ) ] )
+        [ Plain
+          [ Emph
+            [ Str "Od'"
+            , Space
+            , Str "und"
+            , Space
+            , Str "leer"
+            , Space
+            , Str "das"
+            , Space
+            , Str "Meer"
+            ]
+          , Str "."
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "42." ]
+                ( "#wasteland-content.xhtml#ln42", "" )
+              , Space
+              , Str "Id."
+              , Space
+              , Str "iii,"
+              , Space
+              , Str "verse"
+              , Space
+              , Str "24."
+              ]
+            ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Madame"
+          , Space
+          , Str "Sosostris,"
+          , Space
+          , Str "famous"
+          , Space
+          , Str "clairvoyante,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Had"
+          , Space
+          , Str "a"
+          , Space
+          , Str "bad"
+          , Space
+          , Str "cold,"
+          , Space
+          , Str "nevertheless"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Is"
+          , Space
+          , Str "known"
+          , Space
+          , Str "to"
+          , Space
+          , Str "be"
+          , Space
+          , Str "the"
+          , Space
+          , Str "wisest"
+          , Space
+          , Str "woman"
+          , Space
+          , Str "in"
+          , Space
+          , Str "Europe,"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln46", [], [] )
+        [ Plain
+          [ Str "With"
+          , Space
+          , Str "a"
+          , Space
+          , Str "wicked"
+          , Space
+          , Str "pack"
+          , Space
+          , Str "of"
+          , Space
+          , Str "cards."
+          , Space
+          , Str "Here,"
+          , Space
+          , Str "said"
+          , Space
+          , Str "she,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "46." ]
+                ( "#wasteland-content.xhtml#ln46", "" )
+              , Space
+              , Str "I"
+              , Space
+              , Str "am"
+              , Space
+              , Str "not"
+              , Space
+              , Str "familiar"
+              , Space
+              , Str "with"
+              , Space
+              , Str "the"
+              , Space
+              , Str "exact"
+              , Space
+              , Str "constitution"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Tarot"
+              , Space
+              , Str "pack"
+              , Space
+              , Str "of"
+              , SoftBreak
+              , Str "cards,"
+              , Space
+              , Str "from"
+              , Space
+              , Str "which"
+              , Space
+              , Str "I"
+              , Space
+              , Str "have"
+              , Space
+              , Str "obviously"
+              , Space
+              , Str "departed"
+              , Space
+              , Str "to"
+              , Space
+              , Str "suit"
+              , Space
+              , Str "my"
+              , Space
+              , Str "own"
+              , Space
+              , Str "convenience."
+              , SoftBreak
+              , Str "The"
+              , Space
+              , Str "Hanged"
+              , Space
+              , Str "Man,"
+              , Space
+              , Str "a"
+              , Space
+              , Str "member"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "traditional"
+              , Space
+              , Str "pack,"
+              , Space
+              , Str "fits"
+              , Space
+              , Str "my"
+              , Space
+              , Str "purpose"
+              , Space
+              , Str "in"
+              , Space
+              , Str "two"
+              , SoftBreak
+              , Str "ways:"
+              , Space
+              , Str "because"
+              , Space
+              , Str "he"
+              , Space
+              , Str "is"
+              , Space
+              , Str "associated"
+              , Space
+              , Str "in"
+              , Space
+              , Str "my"
+              , Space
+              , Str "mind"
+              , Space
+              , Str "with"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Hanged"
+              , Space
+              , Str "God"
+              , Space
+              , Str "of"
+              , Space
+              , Str "Frazer,"
+              , SoftBreak
+              , Str "and"
+              , Space
+              , Str "because"
+              , Space
+              , Str "I"
+              , Space
+              , Str "associate"
+              , Space
+              , Str "him"
+              , Space
+              , Str "with"
+              , Space
+              , Str "the"
+              , Space
+              , Str "hooded"
+              , Space
+              , Str "figure"
+              , Space
+              , Str "in"
+              , Space
+              , Str "the"
+              , Space
+              , Str "passage"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , SoftBreak
+              , Str "disciples"
+              , Space
+              , Str "to"
+              , Space
+              , Str "Emmaus"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Part"
+              , Space
+              , Str "V."
+              , Space
+              , Str "The"
+              , Space
+              , Str "Phoenician"
+              , Space
+              , Str "Sailor"
+              , Space
+              , Str "and"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Merchant"
+              , SoftBreak
+              , Str "appear"
+              , Space
+              , Str "later;"
+              , Space
+              , Str "also"
+              , Space
+              , Str "the"
+              , Space
+              , Str "\"crowds"
+              , Space
+              , Str "of"
+              , Space
+              , Str "people,\""
+              , Space
+              , Str "and"
+              , Space
+              , Str "Death"
+              , Space
+              , Str "by"
+              , Space
+              , Str "Water"
+              , Space
+              , Str "is"
+              , SoftBreak
+              , Str "executed"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Part"
+              , Space
+              , Str "IV."
+              , Space
+              , Str "The"
+              , Space
+              , Str "Man"
+              , Space
+              , Str "with"
+              , Space
+              , Str "Three"
+              , Space
+              , Str "Staves"
+              , Space
+              , Str "(an"
+              , Space
+              , Str "authentic"
+              , Space
+              , Str "member"
+              , Space
+              , Str "of"
+              , SoftBreak
+              , Str "the"
+              , Space
+              , Str "Tarot"
+              , Space
+              , Str "pack)"
+              , Space
+              , Str "I"
+              , Space
+              , Str "associate,"
+              , Space
+              , Str "quite"
+              , Space
+              , Str "arbitrarily,"
+              , Space
+              , Str "with"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Fisher"
+              , Space
+              , Str "King"
+              , SoftBreak
+              , Str "himself."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Is"
+          , Space
+          , Str "your"
+          , Space
+          , Str "card,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "drowned"
+          , Space
+          , Str "Phoenician"
+          , Space
+          , Str "Sailor,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "(Those"
+          , Space
+          , Str "are"
+          , Space
+          , Str "pearls"
+          , Space
+          , Str "that"
+          , Space
+          , Str "were"
+          , Space
+          , Str "his"
+          , Space
+          , Str "eyes."
+          , Space
+          , Str "Look!)"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Here"
+          , Space
+          , Str "is"
+          , Space
+          , Str "Belladonna,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Lady"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Rocks,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "lady"
+          , Space
+          , Str "of"
+          , Space
+          , Str "situations."
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "50" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Here"
+          , Space
+          , Str "is"
+          , Space
+          , Str "the"
+          , Space
+          , Str "man"
+          , Space
+          , Str "with"
+          , Space
+          , Str "three"
+          , Space
+          , Str "staves,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "here"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Wheel,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "here"
+          , Space
+          , Str "is"
+          , Space
+          , Str "the"
+          , Space
+          , Str "one-eyed"
+          , Space
+          , Str "merchant,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "this"
+          , Space
+          , Str "card,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Which"
+          , Space
+          , Str "is"
+          , Space
+          , Str "blank,"
+          , Space
+          , Str "is"
+          , Space
+          , Str "something"
+          , Space
+          , Str "he"
+          , Space
+          , Str "carries"
+          , Space
+          , Str "on"
+          , Space
+          , Str "his"
+          , Space
+          , Str "back,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Which"
+          , Space
+          , Str "I"
+          , Space
+          , Str "am"
+          , Space
+          , Str "forbidden"
+          , Space
+          , Str "to"
+          , Space
+          , Str "see."
+          , Space
+          , Str "I"
+          , Space
+          , Str "do"
+          , Space
+          , Str "not"
+          , Space
+          , Str "find"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "Hanged"
+          , Space
+          , Str "Man."
+          , Space
+          , Str "Fear"
+          , Space
+          , Str "death"
+          , Space
+          , Str "by"
+          , Space
+          , Str "water."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "see"
+          , Space
+          , Str "crowds"
+          , Space
+          , Str "of"
+          , Space
+          , Str "people,"
+          , Space
+          , Str "walking"
+          , Space
+          , Str "round"
+          , Space
+          , Str "in"
+          , Space
+          , Str "a"
+          , Space
+          , Str "ring."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Thank"
+          , Space
+          , Str "you."
+          , Space
+          , Str "If"
+          , Space
+          , Str "you"
+          , Space
+          , Str "see"
+          , Space
+          , Str "dear"
+          , Space
+          , Str "Mrs."
+          , Space
+          , Str "Equitone,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Tell"
+          , Space
+          , Str "her"
+          , Space
+          , Str "I"
+          , Space
+          , Str "bring"
+          , Space
+          , Str "the"
+          , Space
+          , Str "horoscope"
+          , Space
+          , Str "myself:"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "One"
+          , Space
+          , Str "must"
+          , Space
+          , Str "be"
+          , Space
+          , Str "so"
+          , Space
+          , Str "careful"
+          , Space
+          , Str "these"
+          , Space
+          , Str "days."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln60", [], [] )
+        [ Plain
+          [ Str "Unreal"
+          , Space
+          , Str "City,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "60." ]
+                ( "#wasteland-content.xhtml#ln60", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Baudelaire:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"Fourmillante"
+                , Space
+                , Str "cite;,"
+                , Space
+                , Str "cite;"
+                , Space
+                , Str "pleine"
+                , Space
+                , Str "de"
+                , Space
+                , Str "reves,"
+                , LineBreak
+                , Str "Ou"
+                , Space
+                , Str "le"
+                , Space
+                , Str "spectre"
+                , Space
+                , Str "en"
+                , SoftBreak
+                , Str "plein"
+                , Space
+                , Str "jour"
+                , Space
+                , Str "raccroche"
+                , Space
+                , Str "le"
+                , Space
+                , Str "passant.\""
+                ]
+              ]
+            ]
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "60" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Under"
+          , Space
+          , Str "the"
+          , Space
+          , Str "brown"
+          , Space
+          , Str "fog"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "winter"
+          , Space
+          , Str "dawn,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "A"
+          , Space
+          , Str "crowd"
+          , Space
+          , Str "flowed"
+          , Space
+          , Str "over"
+          , Space
+          , Str "London"
+          , Space
+          , Str "Bridge,"
+          , Space
+          , Str "so"
+          , Space
+          , Str "many,"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln63", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "had"
+          , Space
+          , Str "not"
+          , Space
+          , Str "thought"
+          , Space
+          , Str "death"
+          , Space
+          , Str "had"
+          , Space
+          , Str "undone"
+          , Space
+          , Str "so"
+          , Space
+          , Str "many."
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "63." ]
+                ( "#wasteland-content.xhtml#ln63", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Inferno,"
+              , Space
+              , Str "iii."
+              , Space
+              , Str "55-7."
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"si"
+                , Space
+                , Str "lunga"
+                , Space
+                , Str "tratta"
+                , LineBreak
+                , Str "di"
+                , Space
+                , Str "gente,"
+                , Space
+                , Str "ch'io"
+                , Space
+                , Str "non"
+                , Space
+                , Str "avrei"
+                , Space
+                , Str "mai"
+                , Space
+                , Str "creduto"
+                , LineBreak
+                , Str "che"
+                , SoftBreak
+                , Str "morte"
+                , Space
+                , Str "tanta"
+                , Space
+                , Str "n'avesse"
+                , Space
+                , Str "disfatta.\""
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln64", [], [] )
+        [ Plain
+          [ Str "Sighs,"
+          , Space
+          , Str "short"
+          , Space
+          , Str "and"
+          , Space
+          , Str "infrequent,"
+          , Space
+          , Str "were"
+          , Space
+          , Str "exhaled,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "64." ]
+                ( "#wasteland-content.xhtml#ln64", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Inferno,"
+              , Space
+              , Str "iv."
+              , Space
+              , Str "25-7:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"Quivi,"
+                , Space
+                , Str "secondo"
+                , Space
+                , Str "che"
+                , Space
+                , Str "per"
+                , Space
+                , Str "ascoltahre,"
+                , LineBreak
+                , Str "\"non"
+                , Space
+                , Str "avea"
+                , Space
+                , Str "pianto,"
+                , Space
+                , Str "ma'"
+                , Space
+                , Str "che"
+                , Space
+                , Str "di"
+                , SoftBreak
+                , Str "sospiri,"
+                , LineBreak
+                , Str "\"che"
+                , Space
+                , Str "l'aura"
+                , Space
+                , Str "eterna"
+                , Space
+                , Str "facevan"
+                , Space
+                , Str "tremare.\""
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "each"
+          , Space
+          , Str "man"
+          , Space
+          , Str "fixed"
+          , Space
+          , Str "his"
+          , Space
+          , Str "eyes"
+          , Space
+          , Str "before"
+          , Space
+          , Str "his"
+          , Space
+          , Str "feet."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Flowed"
+          , Space
+          , Str "up"
+          , Space
+          , Str "the"
+          , Space
+          , Str "hill"
+          , Space
+          , Str "and"
+          , Space
+          , Str "down"
+          , Space
+          , Str "King"
+          , Space
+          , Str "William"
+          , Space
+          , Str "Street,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "To"
+          , Space
+          , Str "where"
+          , Space
+          , Str "Saint"
+          , Space
+          , Str "Mary"
+          , Space
+          , Str "Woolnoth"
+          , Space
+          , Str "kept"
+          , Space
+          , Str "the"
+          , Space
+          , Str "hours"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln68", [], [] )
+        [ Plain
+          [ Str "With"
+          , Space
+          , Str "a"
+          , Space
+          , Str "dead"
+          , Space
+          , Str "sound"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "final"
+          , Space
+          , Str "stroke"
+          , Space
+          , Str "of"
+          , Space
+          , Str "nine."
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "68." ]
+                ( "#wasteland-content.xhtml#ln68", "" )
+              , Space
+              , Str "A"
+              , Space
+              , Str "phenomenon"
+              , Space
+              , Str "which"
+              , Space
+              , Str "I"
+              , Space
+              , Str "have"
+              , Space
+              , Str "often"
+              , Space
+              , Str "noticed."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "There"
+          , Space
+          , Str "I"
+          , Space
+          , Str "saw"
+          , Space
+          , Str "one"
+          , Space
+          , Str "I"
+          , Space
+          , Str "knew,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "stopped"
+          , Space
+          , Str "him,"
+          , Space
+          , Str "crying"
+          , SoftBreak
+          , Str "\"Stetson!"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"You"
+          , Space
+          , Str "who"
+          , Space
+          , Str "were"
+          , Space
+          , Str "with"
+          , Space
+          , Str "me"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "ships"
+          , Space
+          , Str "at"
+          , Space
+          , Str "Mylae!"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "70" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"That"
+          , Space
+          , Str "corpse"
+          , Space
+          , Str "you"
+          , Space
+          , Str "planted"
+          , Space
+          , Str "last"
+          , Space
+          , Str "year"
+          , Space
+          , Str "in"
+          , Space
+          , Str "your"
+          , Space
+          , Str "garden,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"Has"
+          , Space
+          , Str "it"
+          , Space
+          , Str "begun"
+          , Space
+          , Str "to"
+          , Space
+          , Str "sprout?"
+          , Space
+          , Str "Will"
+          , Space
+          , Str "it"
+          , Space
+          , Str "bloom"
+          , Space
+          , Str "this"
+          , Space
+          , Str "year?"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"Or"
+          , Space
+          , Str "has"
+          , Space
+          , Str "the"
+          , Space
+          , Str "sudden"
+          , Space
+          , Str "frost"
+          , Space
+          , Str "disturbed"
+          , Space
+          , Str "its"
+          , Space
+          , Str "bed?"
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln74", [], [] )
+        [ Plain
+          [ Str "\"Oh"
+          , Space
+          , Str "keep"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Dog"
+          , Space
+          , Str "far"
+          , Space
+          , Str "hence,"
+          , Space
+          , Str "that's"
+          , Space
+          , Str "friend"
+          , Space
+          , Str "to"
+          , Space
+          , Str "men,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "74." ]
+                ( "#wasteland-content.xhtml#ln74", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "the"
+              , Space
+              , Str "Dirge"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Webster's"
+              , Space
+              , Str "White"
+              , Space
+              , Str "Devil"
+              , Space
+              , Str "."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"Or"
+          , Space
+          , Str "with"
+          , Space
+          , Str "his"
+          , Space
+          , Str "nails"
+          , Space
+          , Str "he'll"
+          , Space
+          , Str "dig"
+          , Space
+          , Str "it"
+          , Space
+          , Str "up"
+          , Space
+          , Str "again!"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln76", [], [] )
+        [ Plain
+          [ Str "\"You!"
+          , Space
+          , Span
+            ( "", [], [ ( "lang", "fr" ) ] )
+            [ Str "hypocrite"
+            , Space
+            , Str "lecteur!"
+            , Space
+            , Str "-"
+            , Space
+            , Str "mon"
+            , Space
+            , Str "semblable,"
+            , Space
+            , Str "-"
+            , SoftBreak
+            , Str "mon"
+            , Space
+            , Str "frere"
+            ]
+          , Space
+          , Str "!\""
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "76." ]
+                ( "#wasteland-content.xhtml#ln76", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Baudelaire,"
+              , Space
+              , Str "Preface"
+              , Space
+              , Str "to"
+              , Space
+              , Str "Fleurs"
+              , Space
+              , Str "du"
+              , Space
+              , Str "Mal."
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Div
+    ( "wasteland-content.xhtml#ch2", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "II."
+      , Space
+      , Str "A"
+      , Space
+      , Str "GAME"
+      , Space
+      , Str "OF"
+      , Space
+      , Str "CHESS"
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln77", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "Chair"
+          , Space
+          , Str "she"
+          , Space
+          , Str "sat"
+          , Space
+          , Str "in,"
+          , Space
+          , Str "like"
+          , Space
+          , Str "a"
+          , Space
+          , Str "burnished"
+          , Space
+          , Str "throne,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "77." ]
+                ( "#wasteland-content.xhtml#ln77", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Antony"
+              , Space
+              , Str "and"
+              , Space
+              , Str "Cleopatra,"
+              , Space
+              , Str "II."
+              , Space
+              , Str "ii.,"
+              , Space
+              , Str "l."
+              , Space
+              , Str "190."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Glowed"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "marble,"
+          , Space
+          , Str "where"
+          , Space
+          , Str "the"
+          , Space
+          , Str "glass"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Held"
+          , Space
+          , Str "up"
+          , Space
+          , Str "by"
+          , Space
+          , Str "standards"
+          , Space
+          , Str "wrought"
+          , Space
+          , Str "with"
+          , Space
+          , Str "fruited"
+          , Space
+          , Str "vines"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "From"
+          , Space
+          , Str "which"
+          , Space
+          , Str "a"
+          , Space
+          , Str "golden"
+          , Space
+          , Str "Cupidon"
+          , Space
+          , Str "peeped"
+          , Space
+          , Str "out"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "80" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "(Another"
+          , Space
+          , Str "hid"
+          , Space
+          , Str "his"
+          , Space
+          , Str "eyes"
+          , Space
+          , Str "behind"
+          , Space
+          , Str "his"
+          , Space
+          , Str "wing)"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Doubled"
+          , Space
+          , Str "the"
+          , Space
+          , Str "flames"
+          , Space
+          , Str "of"
+          , Space
+          , Str "sevenbranched"
+          , Space
+          , Str "candelabra"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Reflecting"
+          , Space
+          , Str "light"
+          , Space
+          , Str "upon"
+          , Space
+          , Str "the"
+          , Space
+          , Str "table"
+          , Space
+          , Str "as"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "glitter"
+          , Space
+          , Str "of"
+          , Space
+          , Str "her"
+          , Space
+          , Str "jewels"
+          , Space
+          , Str "rose"
+          , Space
+          , Str "to"
+          , Space
+          , Str "meet"
+          , Space
+          , Str "it,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "From"
+          , Space
+          , Str "satin"
+          , Space
+          , Str "cases"
+          , Space
+          , Str "poured"
+          , Space
+          , Str "in"
+          , Space
+          , Str "rich"
+          , Space
+          , Str "profusion;"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "In"
+          , Space
+          , Str "vials"
+          , Space
+          , Str "of"
+          , Space
+          , Str "ivory"
+          , Space
+          , Str "and"
+          , Space
+          , Str "coloured"
+          , Space
+          , Str "glass"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Unstoppered,"
+          , Space
+          , Str "lurked"
+          , Space
+          , Str "her"
+          , Space
+          , Str "strange"
+          , Space
+          , Str "synthetic"
+          , Space
+          , Str "perfumes,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Unguent,"
+          , Space
+          , Str "powdered,"
+          , Space
+          , Str "or"
+          , Space
+          , Str "liquid"
+          , Space
+          , Str "-"
+          , Space
+          , Str "troubled,"
+          , Space
+          , Str "confused"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "drowned"
+          , Space
+          , Str "the"
+          , Space
+          , Str "sense"
+          , Space
+          , Str "in"
+          , Space
+          , Str "odours;"
+          , Space
+          , Str "stirred"
+          , Space
+          , Str "by"
+          , Space
+          , Str "the"
+          , Space
+          , Str "air"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "That"
+          , Space
+          , Str "freshened"
+          , Space
+          , Str "from"
+          , Space
+          , Str "the"
+          , Space
+          , Str "window,"
+          , Space
+          , Str "these"
+          , Space
+          , Str "ascended"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "90" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "In"
+          , Space
+          , Str "fattening"
+          , Space
+          , Str "the"
+          , Space
+          , Str "prolonged"
+          , Space
+          , Str "candle-flames,"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln92", [], [] )
+        [ Plain
+          [ Str "Flung"
+          , Space
+          , Str "their"
+          , Space
+          , Str "smoke"
+          , Space
+          , Str "into"
+          , Space
+          , Str "the"
+          , Space
+          , Str "laquearia,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "92." ]
+                ( "#wasteland-content.xhtml#ln92", "" )
+              , Space
+              , Str "Laquearia."
+              , Space
+              , Str "V."
+              , Space
+              , Str "Aeneid,"
+              , Space
+              , Str "I."
+              , Space
+              , Str "726:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "dependent"
+                , Space
+                , Str "lychni"
+                , Space
+                , Str "laquearibus"
+                , Space
+                , Str "aureis"
+                , Space
+                , Str "incensi,"
+                , Space
+                , Str "et"
+                , Space
+                , Str "noctem"
+                , SoftBreak
+                , Str "flammis"
+                , LineBreak
+                , Str "funalia"
+                , Space
+                , Str "vincunt."
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Stirring"
+          , Space
+          , Str "the"
+          , Space
+          , Str "pattern"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "coffered"
+          , Space
+          , Str "ceiling."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Huge"
+          , Space
+          , Str "sea-wood"
+          , Space
+          , Str "fed"
+          , Space
+          , Str "with"
+          , Space
+          , Str "copper"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Burned"
+          , Space
+          , Str "green"
+          , Space
+          , Str "and"
+          , Space
+          , Str "orange,"
+          , Space
+          , Str "framed"
+          , Space
+          , Str "by"
+          , Space
+          , Str "the"
+          , Space
+          , Str "coloured"
+          , Space
+          , Str "stone,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "In"
+          , Space
+          , Str "which"
+          , Space
+          , Str "sad"
+          , Space
+          , Str "light"
+          , Space
+          , Str "a"
+          , Space
+          , Str "carved"
+          , Space
+          , Str "dolphin"
+          , Space
+          , Str "swam."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Above"
+          , Space
+          , Str "the"
+          , Space
+          , Str "antique"
+          , Space
+          , Str "mantel"
+          , Space
+          , Str "was"
+          , Space
+          , Str "displayed"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln98", [], [] )
+        [ Plain
+          [ Str "As"
+          , Space
+          , Str "though"
+          , Space
+          , Str "a"
+          , Space
+          , Str "window"
+          , Space
+          , Str "gave"
+          , Space
+          , Str "upon"
+          , Space
+          , Str "the"
+          , Space
+          , Str "sylvan"
+          , Space
+          , Str "scene"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "98." ]
+                ( "#wasteland-content.xhtml#ln98", "" )
+              , Space
+              , Str "Sylvan"
+              , Space
+              , Str "scene."
+              , Space
+              , Str "V."
+              , Space
+              , Str "Milton,"
+              , Space
+              , Str "Paradise"
+              , Space
+              , Str "Lost,"
+              , Space
+              , Str "iv."
+              , Space
+              , Str "140."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln99", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "change"
+          , Space
+          , Str "of"
+          , Space
+          , Str "Philomel,"
+          , Space
+          , Str "by"
+          , Space
+          , Str "the"
+          , Space
+          , Str "barbarous"
+          , Space
+          , Str "king"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "99." ]
+                ( "#wasteland-content.xhtml#ln99", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Ovid,"
+              , Space
+              , Str "Metamorphoses,"
+              , Space
+              , Str "vi,"
+              , Space
+              , Str "Philomela."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln100", [], [] )
+        [ Plain
+          [ Str "So"
+          , Space
+          , Str "rudely"
+          , Space
+          , Str "forced;"
+          , Space
+          , Str "yet"
+          , Space
+          , Str "there"
+          , Space
+          , Str "the"
+          , Space
+          , Str "nightingale"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "100." ]
+                ( "#wasteland-content.xhtml#ln100", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Part"
+              , Space
+              , Str "III,"
+              , Space
+              , Str "l."
+              , Space
+              , Str "204."
+              ]
+            ]
+          , SoftBreak
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "100" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Filled"
+          , Space
+          , Str "all"
+          , Space
+          , Str "the"
+          , Space
+          , Str "desert"
+          , Space
+          , Str "with"
+          , Space
+          , Str "inviolable"
+          , Space
+          , Str "voice"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "still"
+          , Space
+          , Str "she"
+          , Space
+          , Str "cried,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "still"
+          , Space
+          , Str "the"
+          , Space
+          , Str "world"
+          , Space
+          , Str "pursues,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"Jug"
+          , Space
+          , Str "Jug\""
+          , Space
+          , Str "to"
+          , Space
+          , Str "dirty"
+          , Space
+          , Str "ears."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "other"
+          , Space
+          , Str "withered"
+          , Space
+          , Str "stumps"
+          , Space
+          , Str "of"
+          , Space
+          , Str "time"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Were"
+          , Space
+          , Str "told"
+          , Space
+          , Str "upon"
+          , Space
+          , Str "the"
+          , Space
+          , Str "walls;"
+          , Space
+          , Str "staring"
+          , Space
+          , Str "forms"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Leaned"
+          , Space
+          , Str "out,"
+          , Space
+          , Str "leaning,"
+          , Space
+          , Str "hushing"
+          , Space
+          , Str "the"
+          , Space
+          , Str "room"
+          , Space
+          , Str "enclosed."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Footsteps"
+          , Space
+          , Str "shuffled"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "stair."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Under"
+          , Space
+          , Str "the"
+          , Space
+          , Str "firelight,"
+          , Space
+          , Str "under"
+          , Space
+          , Str "the"
+          , Space
+          , Str "brush,"
+          , Space
+          , Str "her"
+          , Space
+          , Str "hair"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Spread"
+          , Space
+          , Str "out"
+          , Space
+          , Str "in"
+          , Space
+          , Str "fiery"
+          , Space
+          , Str "points"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Glowed"
+          , Space
+          , Str "into"
+          , Space
+          , Str "words,"
+          , Space
+          , Str "then"
+          , Space
+          , Str "would"
+          , Space
+          , Str "be"
+          , Space
+          , Str "savagely"
+          , Space
+          , Str "still."
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "110" ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [ "linegroup" ], [] )
+        [ Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "\"My"
+            , Space
+            , Str "nerves"
+            , Space
+            , Str "are"
+            , Space
+            , Str "bad"
+            , Space
+            , Str "to-night."
+            , Space
+            , Str "Yes,"
+            , Space
+            , Str "bad."
+            , Space
+            , Str "Stay"
+            , Space
+            , Str "with"
+            , Space
+            , Str "me."
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "\"Speak"
+            , Space
+            , Str "to"
+            , Space
+            , Str "me."
+            , Space
+            , Str "Why"
+            , Space
+            , Str "do"
+            , Space
+            , Str "you"
+            , Space
+            , Str "never"
+            , Space
+            , Str "speak."
+            , Space
+            , Str "Speak."
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "\"What"
+            , Space
+            , Str "are"
+            , Space
+            , Str "you"
+            , Space
+            , Str "thinking"
+            , Space
+            , Str "of?"
+            , Space
+            , Str "What"
+            , Space
+            , Str "thinking?"
+            , Space
+            , Str "What?"
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "\"I"
+            , Space
+            , Str "never"
+            , Space
+            , Str "know"
+            , Space
+            , Str "what"
+            , Space
+            , Str "you"
+            , Space
+            , Str "are"
+            , Space
+            , Str "thinking."
+            , Space
+            , Str "Think.\""
+            ]
+          ]
+        ]
+      , Div
+        ( "", [ "linegroup" ], [] )
+        [ Div
+          ( "wasteland-content.xhtml#ln115", [], [] )
+          [ Plain
+            [ Str "I"
+            , Space
+            , Str "think"
+            , Space
+            , Str "we"
+            , Space
+            , Str "are"
+            , Space
+            , Str "in"
+            , Space
+            , Str "rats'"
+            , Space
+            , Str "alley"
+            , Note
+              [ Para
+                [ Link
+                  ( "", [], [] )
+                  [ Str "115." ]
+                  ( "#wasteland-content.xhtml#ln115", "" )
+                , Space
+                , Str "Cf."
+                , Space
+                , Str "Part"
+                , Space
+                , Str "III,"
+                , Space
+                , Str "l."
+                , Space
+                , Str "195."
+                ]
+              ]
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "Where"
+            , Space
+            , Str "the"
+            , Space
+            , Str "dead"
+            , Space
+            , Str "men"
+            , Space
+            , Str "lost"
+            , Space
+            , Str "their"
+            , Space
+            , Str "bones."
+            ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"What"
+          , Space
+          , Str "is"
+          , Space
+          , Str "that"
+          , Space
+          , Str "noise?\""
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln118", [ "indent" ], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "wind"
+          , Space
+          , Str "under"
+          , Space
+          , Str "the"
+          , Space
+          , Str "door."
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "118." ]
+                ( "#wasteland-content.xhtml#ln118", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Webster:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"Is"
+                , Space
+                , Str "the"
+                , Space
+                , Str "wind"
+                , Space
+                , Str "in"
+                , Space
+                , Str "that"
+                , Space
+                , Str "door"
+                , Space
+                , Str "still?\""
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"What"
+          , Space
+          , Str "is"
+          , Space
+          , Str "that"
+          , Space
+          , Str "noise"
+          , Space
+          , Str "now?"
+          , Space
+          , Str "What"
+          , Space
+          , Str "is"
+          , Space
+          , Str "the"
+          , Space
+          , Str "wind"
+          , Space
+          , Str "doing?\""
+          ]
+        ]
+      , Div
+        ( "", [ "indent" ], [] )
+        [ Plain
+          [ Str "Nothing"
+          , Space
+          , Str "again"
+          , Space
+          , Str "nothing."
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "120" ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain [ Str "\"Do" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"You"
+          , Space
+          , Str "know"
+          , Space
+          , Str "nothing?"
+          , Space
+          , Str "Do"
+          , Space
+          , Str "you"
+          , Space
+          , Str "see"
+          , Space
+          , Str "nothing?"
+          , Space
+          , Str "Do"
+          , Space
+          , Str "you"
+          , Space
+          , Str "remember"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "\"Nothing?\"" ] ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain [ Str "I", Space, Str "remember" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Those"
+          , Space
+          , Str "are"
+          , Space
+          , Str "pearls"
+          , Space
+          , Str "that"
+          , Space
+          , Str "were"
+          , Space
+          , Str "his"
+          , Space
+          , Str "eyes."
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln126", [], [] )
+        [ Plain
+          [ Str "\"Are"
+          , Space
+          , Str "you"
+          , Space
+          , Str "alive,"
+          , Space
+          , Str "or"
+          , Space
+          , Str "not?"
+          , Space
+          , Str "Is"
+          , Space
+          , Str "there"
+          , Space
+          , Str "nothing"
+          , Space
+          , Str "in"
+          , Space
+          , Str "your"
+          , Space
+          , Str "head?\""
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "126." ]
+                ( "#wasteland-content.xhtml#ln126", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Part"
+              , Space
+              , Str "I,"
+              , Space
+              , Str "l."
+              , Space
+              , Str "37,"
+              , Space
+              , Str "48."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "But" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "O"
+          , Space
+          , Str "O"
+          , Space
+          , Str "O"
+          , Space
+          , Str "O"
+          , Space
+          , Str "that"
+          , Space
+          , Str "Shakespeherian"
+          , Space
+          , Str "Rag\8213"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "It's", Space, Str "so", Space, Str "elegant" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "So"
+          , Space
+          , Str "intelligent"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "130" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"What"
+          , Space
+          , Str "shall"
+          , Space
+          , Str "I"
+          , Space
+          , Str "do"
+          , Space
+          , Str "now?"
+          , Space
+          , Str "What"
+          , Space
+          , Str "shall"
+          , Space
+          , Str "I"
+          , Space
+          , Str "do?\""
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "shall"
+          , Space
+          , Str "rush"
+          , Space
+          , Str "out"
+          , Space
+          , Str "as"
+          , Space
+          , Str "I"
+          , Space
+          , Str "am,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "walk"
+          , Space
+          , Str "the"
+          , Space
+          , Str "street"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"With"
+          , Space
+          , Str "my"
+          , Space
+          , Str "hair"
+          , Space
+          , Str "down,"
+          , Space
+          , Str "so."
+          , Space
+          , Str "What"
+          , Space
+          , Str "shall"
+          , Space
+          , Str "we"
+          , Space
+          , Str "do"
+          , Space
+          , Str "to-morrow?"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"What"
+          , Space
+          , Str "shall"
+          , Space
+          , Str "we"
+          , Space
+          , Str "ever"
+          , Space
+          , Str "do?\""
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "hot"
+          , Space
+          , Str "water"
+          , Space
+          , Str "at"
+          , Space
+          , Str "ten."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "if"
+          , Space
+          , Str "it"
+          , Space
+          , Str "rains,"
+          , Space
+          , Str "a"
+          , Space
+          , Str "closed"
+          , Space
+          , Str "car"
+          , Space
+          , Str "at"
+          , Space
+          , Str "four."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "we"
+          , Space
+          , Str "shall"
+          , Space
+          , Str "play"
+          , Space
+          , Str "a"
+          , Space
+          , Str "game"
+          , Space
+          , Str "of"
+          , Space
+          , Str "chess,"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln138", [], [] )
+        [ Plain
+          [ Str "Pressing"
+          , Space
+          , Str "lidless"
+          , Space
+          , Str "eyes"
+          , Space
+          , Str "and"
+          , Space
+          , Str "waiting"
+          , Space
+          , Str "for"
+          , Space
+          , Str "a"
+          , Space
+          , Str "knock"
+          , Space
+          , Str "upon"
+          , Space
+          , Str "the"
+          , Space
+          , Str "door."
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "138." ]
+                ( "#wasteland-content.xhtml#ln138", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "the"
+              , Space
+              , Str "game"
+              , Space
+              , Str "of"
+              , Space
+              , Str "chess"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Middleton's"
+              , Space
+              , Str "Women"
+              , Space
+              , Str "beware"
+              , Space
+              , Str "Women."
+              ]
+            ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "When"
+          , Space
+          , Str "Lil's"
+          , Space
+          , Str "husband"
+          , Space
+          , Str "got"
+          , Space
+          , Str "demobbed,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "said"
+          , Space
+          , Str "-"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "didn't"
+          , Space
+          , Str "mince"
+          , Space
+          , Str "my"
+          , Space
+          , Str "words,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "said"
+          , Space
+          , Str "to"
+          , Space
+          , Str "her"
+          , Space
+          , Str "myself,"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "140" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "HURRY"
+          , Space
+          , Str "UP"
+          , Space
+          , Str "PLEASE"
+          , Space
+          , Str "ITS"
+          , Space
+          , Str "TIME"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Now"
+          , Space
+          , Str "Albert's"
+          , Space
+          , Str "coming"
+          , Space
+          , Str "back,"
+          , Space
+          , Str "make"
+          , Space
+          , Str "yourself"
+          , Space
+          , Str "a"
+          , Space
+          , Str "bit"
+          , Space
+          , Str "smart."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "He'll"
+          , Space
+          , Str "want"
+          , Space
+          , Str "to"
+          , Space
+          , Str "know"
+          , Space
+          , Str "what"
+          , Space
+          , Str "you"
+          , Space
+          , Str "done"
+          , Space
+          , Str "with"
+          , Space
+          , Str "that"
+          , Space
+          , Str "money"
+          , Space
+          , Str "he"
+          , Space
+          , Str "gave"
+          , SoftBreak
+          , Str "you"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "To"
+          , Space
+          , Str "get"
+          , Space
+          , Str "yourself"
+          , Space
+          , Str "some"
+          , Space
+          , Str "teeth."
+          , Space
+          , Str "He"
+          , Space
+          , Str "did,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "was"
+          , Space
+          , Str "there."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "You"
+          , Space
+          , Str "have"
+          , Space
+          , Str "them"
+          , Space
+          , Str "all"
+          , Space
+          , Str "out,"
+          , Space
+          , Str "Lil,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "get"
+          , Space
+          , Str "a"
+          , Space
+          , Str "nice"
+          , Space
+          , Str "set,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "He"
+          , Space
+          , Str "said,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "swear,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "can't"
+          , Space
+          , Str "bear"
+          , Space
+          , Str "to"
+          , Space
+          , Str "look"
+          , Space
+          , Str "at"
+          , Space
+          , Str "you."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "no"
+          , Space
+          , Str "more"
+          , Space
+          , Str "can't"
+          , Space
+          , Str "I,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "said,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "think"
+          , Space
+          , Str "of"
+          , Space
+          , Str "poor"
+          , Space
+          , Str "Albert,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "He's"
+          , Space
+          , Str "been"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "army"
+          , Space
+          , Str "four"
+          , Space
+          , Str "years,"
+          , Space
+          , Str "he"
+          , Space
+          , Str "wants"
+          , Space
+          , Str "a"
+          , Space
+          , Str "good"
+          , Space
+          , Str "time,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "if"
+          , Space
+          , Str "you"
+          , Space
+          , Str "don't"
+          , Space
+          , Str "give"
+          , Space
+          , Str "it"
+          , Space
+          , Str "him,"
+          , Space
+          , Str "there's"
+          , Space
+          , Str "others"
+          , Space
+          , Str "will,"
+          , Space
+          , Str "I"
+          , SoftBreak
+          , Str "said."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Oh"
+          , Space
+          , Str "is"
+          , Space
+          , Str "there,"
+          , Space
+          , Str "she"
+          , Space
+          , Str "said."
+          , Space
+          , Str "Something"
+          , Space
+          , Str "o'"
+          , Space
+          , Str "that,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "said."
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "150" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Then"
+          , Space
+          , Str "I'll"
+          , Space
+          , Str "know"
+          , Space
+          , Str "who"
+          , Space
+          , Str "to"
+          , Space
+          , Str "thank,"
+          , Space
+          , Str "she"
+          , Space
+          , Str "said,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "give"
+          , Space
+          , Str "me"
+          , Space
+          , Str "a"
+          , Space
+          , Str "straight"
+          , SoftBreak
+          , Str "look."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "HURRY"
+          , Space
+          , Str "UP"
+          , Space
+          , Str "PLEASE"
+          , Space
+          , Str "ITS"
+          , Space
+          , Str "TIME"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "If"
+          , Space
+          , Str "you"
+          , Space
+          , Str "don't"
+          , Space
+          , Str "like"
+          , Space
+          , Str "it"
+          , Space
+          , Str "you"
+          , Space
+          , Str "can"
+          , Space
+          , Str "get"
+          , Space
+          , Str "on"
+          , Space
+          , Str "with"
+          , Space
+          , Str "it,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "said."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Others"
+          , Space
+          , Str "can"
+          , Space
+          , Str "pick"
+          , Space
+          , Str "and"
+          , Space
+          , Str "choose"
+          , Space
+          , Str "if"
+          , Space
+          , Str "you"
+          , Space
+          , Str "can't."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "But"
+          , Space
+          , Str "if"
+          , Space
+          , Str "Albert"
+          , Space
+          , Str "makes"
+          , Space
+          , Str "off,"
+          , Space
+          , Str "it"
+          , Space
+          , Str "won't"
+          , Space
+          , Str "be"
+          , Space
+          , Str "for"
+          , Space
+          , Str "lack"
+          , Space
+          , Str "of"
+          , SoftBreak
+          , Str "telling."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "You"
+          , Space
+          , Str "ought"
+          , Space
+          , Str "to"
+          , Space
+          , Str "be"
+          , Space
+          , Str "ashamed,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "said,"
+          , Space
+          , Str "to"
+          , Space
+          , Str "look"
+          , Space
+          , Str "so"
+          , Space
+          , Str "antique."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "(And"
+          , Space
+          , Str "her"
+          , Space
+          , Str "only"
+          , Space
+          , Str "thirty-one.)"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "can't"
+          , Space
+          , Str "help"
+          , Space
+          , Str "it,"
+          , Space
+          , Str "she"
+          , Space
+          , Str "said,"
+          , Space
+          , Str "pulling"
+          , Space
+          , Str "a"
+          , Space
+          , Str "long"
+          , Space
+          , Str "face,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "It's"
+          , Space
+          , Str "them"
+          , Space
+          , Str "pills"
+          , Space
+          , Str "I"
+          , Space
+          , Str "took,"
+          , Space
+          , Str "to"
+          , Space
+          , Str "bring"
+          , Space
+          , Str "it"
+          , Space
+          , Str "off,"
+          , Space
+          , Str "she"
+          , Space
+          , Str "said."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "(She's"
+          , Space
+          , Str "had"
+          , Space
+          , Str "five"
+          , Space
+          , Str "already,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "nearly"
+          , Space
+          , Str "died"
+          , Space
+          , Str "of"
+          , Space
+          , Str "young"
+          , Space
+          , Str "George.)"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "160" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "chemist"
+          , Space
+          , Str "said"
+          , Space
+          , Str "it"
+          , Space
+          , Str "would"
+          , Space
+          , Str "be"
+          , Space
+          , Str "all"
+          , Space
+          , Str "right,"
+          , Space
+          , Str "but"
+          , Space
+          , Str "I've"
+          , Space
+          , Str "never"
+          , Space
+          , Str "been"
+          , Space
+          , Str "the"
+          , SoftBreak
+          , Str "same."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "You"
+          , Space
+          , Emph
+            [ Str "are" ]
+          , Space
+          , Str "a"
+          , Space
+          , Str "proper"
+          , Space
+          , Str "fool,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "said."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Well,"
+          , Space
+          , Str "if"
+          , Space
+          , Str "Albert"
+          , Space
+          , Str "won't"
+          , Space
+          , Str "leave"
+          , Space
+          , Str "you"
+          , Space
+          , Str "alone,"
+          , Space
+          , Str "there"
+          , Space
+          , Str "it"
+          , Space
+          , Str "is,"
+          , Space
+          , Str "I"
+          , SoftBreak
+          , Str "said,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "What"
+          , Space
+          , Str "you"
+          , Space
+          , Str "get"
+          , Space
+          , Str "married"
+          , Space
+          , Str "for"
+          , Space
+          , Str "if"
+          , Space
+          , Str "you"
+          , Space
+          , Str "don't"
+          , Space
+          , Str "want"
+          , Space
+          , Str "children?"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "HURRY"
+          , Space
+          , Str "UP"
+          , Space
+          , Str "PLEASE"
+          , Space
+          , Str "ITS"
+          , Space
+          , Str "TIME"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Well,"
+          , Space
+          , Str "that"
+          , Space
+          , Str "Sunday"
+          , Space
+          , Str "Albert"
+          , Space
+          , Str "was"
+          , Space
+          , Str "home,"
+          , Space
+          , Str "they"
+          , Space
+          , Str "had"
+          , Space
+          , Str "a"
+          , Space
+          , Str "hot"
+          , SoftBreak
+          , Str "gammon,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "they"
+          , Space
+          , Str "asked"
+          , Space
+          , Str "me"
+          , Space
+          , Str "in"
+          , Space
+          , Str "to"
+          , Space
+          , Str "dinner,"
+          , Space
+          , Str "to"
+          , Space
+          , Str "get"
+          , Space
+          , Str "the"
+          , Space
+          , Str "beauty"
+          , Space
+          , Str "of"
+          , Space
+          , Str "it"
+          , SoftBreak
+          , Str "hot\8213"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "HURRY"
+          , Space
+          , Str "UP"
+          , Space
+          , Str "PLEASE"
+          , Space
+          , Str "ITS"
+          , Space
+          , Str "TIME"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "HURRY"
+          , Space
+          , Str "UP"
+          , Space
+          , Str "PLEASE"
+          , Space
+          , Str "ITS"
+          , Space
+          , Str "TIME"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Goonight"
+          , Space
+          , Str "Bill."
+          , Space
+          , Str "Goonight"
+          , Space
+          , Str "Lou."
+          , Space
+          , Str "Goonight"
+          , Space
+          , Str "May."
+          , Space
+          , Str "Goonight."
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "170" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Ta"
+          , Space
+          , Str "ta."
+          , Space
+          , Str "Goonight."
+          , Space
+          , Str "Goonight."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Good"
+          , Space
+          , Str "night,"
+          , Space
+          , Str "ladies,"
+          , Space
+          , Str "good"
+          , Space
+          , Str "night,"
+          , Space
+          , Str "sweet"
+          , Space
+          , Str "ladies,"
+          , Space
+          , Str "good"
+          , Space
+          , Str "night,"
+          , Space
+          , Str "good"
+          , SoftBreak
+          , Str "night."
+          ]
+        ]
+      ]
+    ]
+  , Div
+    ( "wasteland-content.xhtml#ch3", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "III."
+      , Space
+      , Str "THE"
+      , Space
+      , Str "FIRE"
+      , Space
+      , Str "SERMON"
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "river's"
+          , Space
+          , Str "tent"
+          , Space
+          , Str "is"
+          , Space
+          , Str "broken:"
+          , Space
+          , Str "the"
+          , Space
+          , Str "last"
+          , Space
+          , Str "fingers"
+          , Space
+          , Str "of"
+          , Space
+          , Str "leaf"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Clutch"
+          , Space
+          , Str "and"
+          , Space
+          , Str "sink"
+          , Space
+          , Str "into"
+          , Space
+          , Str "the"
+          , Space
+          , Str "wet"
+          , Space
+          , Str "bank."
+          , Space
+          , Str "The"
+          , Space
+          , Str "wind"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Crosses"
+          , Space
+          , Str "the"
+          , Space
+          , Str "brown"
+          , Space
+          , Str "land,"
+          , Space
+          , Str "unheard."
+          , Space
+          , Str "The"
+          , Space
+          , Str "nymphs"
+          , Space
+          , Str "are"
+          , SoftBreak
+          , Str "departed."
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln176", [], [] )
+        [ Plain
+          [ Str "Sweet"
+          , Space
+          , Str "Thames,"
+          , Space
+          , Str "run"
+          , Space
+          , Str "softly,"
+          , Space
+          , Str "till"
+          , Space
+          , Str "I"
+          , Space
+          , Str "end"
+          , Space
+          , Str "my"
+          , Space
+          , Str "song."
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "176." ]
+                ( "#wasteland-content.xhtml#ln176", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Spenser,"
+              , Space
+              , Str "Prothalamion."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "river"
+          , Space
+          , Str "bears"
+          , Space
+          , Str "no"
+          , Space
+          , Str "empty"
+          , Space
+          , Str "bottles,"
+          , Space
+          , Str "sandwich"
+          , Space
+          , Str "papers,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Silk"
+          , Space
+          , Str "handkerchiefs,"
+          , Space
+          , Str "cardboard"
+          , Space
+          , Str "boxes,"
+          , Space
+          , Str "cigarette"
+          , Space
+          , Str "ends"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Or"
+          , Space
+          , Str "other"
+          , Space
+          , Str "testimony"
+          , Space
+          , Str "of"
+          , Space
+          , Str "summer"
+          , Space
+          , Str "nights."
+          , Space
+          , Str "The"
+          , Space
+          , Str "nymphs"
+          , Space
+          , Str "are"
+          , SoftBreak
+          , Str "departed."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "their"
+          , Space
+          , Str "friends,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "loitering"
+          , Space
+          , Str "heirs"
+          , Space
+          , Str "of"
+          , Space
+          , Str "city"
+          , Space
+          , Str "directors;"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "180" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Departed,"
+          , Space
+          , Str "have"
+          , Space
+          , Str "left"
+          , Space
+          , Str "no"
+          , Space
+          , Str "addresses."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "By"
+          , Space
+          , Str "the"
+          , Space
+          , Str "waters"
+          , Space
+          , Str "of"
+          , Space
+          , Str "Leman"
+          , Space
+          , Str "I"
+          , Space
+          , Str "sat"
+          , Space
+          , Str "down"
+          , Space
+          , Str "and"
+          , Space
+          , Str "wept"
+          , Space
+          , Str "."
+          , Space
+          , Str "."
+          , Space
+          , Str "."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Sweet"
+          , Space
+          , Str "Thames,"
+          , Space
+          , Str "run"
+          , Space
+          , Str "softly"
+          , Space
+          , Str "till"
+          , Space
+          , Str "I"
+          , Space
+          , Str "end"
+          , Space
+          , Str "my"
+          , Space
+          , Str "song,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Sweet"
+          , Space
+          , Str "Thames,"
+          , Space
+          , Str "run"
+          , Space
+          , Str "softly,"
+          , Space
+          , Str "for"
+          , Space
+          , Str "I"
+          , Space
+          , Str "speak"
+          , Space
+          , Str "not"
+          , Space
+          , Str "loud"
+          , Space
+          , Str "or"
+          , Space
+          , Str "long."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "But"
+          , Space
+          , Str "at"
+          , Space
+          , Str "my"
+          , Space
+          , Str "back"
+          , Space
+          , Str "in"
+          , Space
+          , Str "a"
+          , Space
+          , Str "cold"
+          , Space
+          , Str "blast"
+          , Space
+          , Str "I"
+          , Space
+          , Str "hear"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "rattle"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "bones,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "chuckle"
+          , Space
+          , Str "spread"
+          , Space
+          , Str "from"
+          , Space
+          , Str "ear"
+          , Space
+          , Str "to"
+          , SoftBreak
+          , Str "ear."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "A"
+          , Space
+          , Str "rat"
+          , Space
+          , Str "crept"
+          , Space
+          , Str "softly"
+          , Space
+          , Str "through"
+          , Space
+          , Str "the"
+          , Space
+          , Str "vegetation"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Dragging"
+          , Space
+          , Str "its"
+          , Space
+          , Str "slimy"
+          , Space
+          , Str "belly"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "bank"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "While"
+          , Space
+          , Str "I"
+          , Space
+          , Str "was"
+          , Space
+          , Str "fishing"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "dull"
+          , Space
+          , Str "canal"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "On"
+          , Space
+          , Str "a"
+          , Space
+          , Str "winter"
+          , Space
+          , Str "evening"
+          , Space
+          , Str "round"
+          , Space
+          , Str "behind"
+          , Space
+          , Str "the"
+          , Space
+          , Str "gashouse"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "190" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Musing"
+          , Space
+          , Str "upon"
+          , Space
+          , Str "the"
+          , Space
+          , Str "king"
+          , Space
+          , Str "my"
+          , Space
+          , Str "brother's"
+          , Space
+          , Str "wreck"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln192", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "king"
+          , Space
+          , Str "my"
+          , Space
+          , Str "father's"
+          , Space
+          , Str "death"
+          , Space
+          , Str "before"
+          , Space
+          , Str "him."
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "192." ]
+                ( "#wasteland-content.xhtml#ln192", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "The"
+              , Space
+              , Str "Tempest,"
+              , Space
+              , Str "I."
+              , Space
+              , Str "ii."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "White"
+          , Space
+          , Str "bodies"
+          , Space
+          , Str "naked"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "low"
+          , Space
+          , Str "damp"
+          , Space
+          , Str "ground"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "bones"
+          , Space
+          , Str "cast"
+          , Space
+          , Str "in"
+          , Space
+          , Str "a"
+          , Space
+          , Str "little"
+          , Space
+          , Str "low"
+          , Space
+          , Str "dry"
+          , Space
+          , Str "garret,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Rattled"
+          , Space
+          , Str "by"
+          , Space
+          , Str "the"
+          , Space
+          , Str "rat's"
+          , Space
+          , Str "foot"
+          , Space
+          , Str "only,"
+          , Space
+          , Str "year"
+          , Space
+          , Str "to"
+          , Space
+          , Str "year."
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln196", [], [] )
+        [ Plain
+          [ Str "But"
+          , Space
+          , Str "at"
+          , Space
+          , Str "my"
+          , Space
+          , Str "back"
+          , Space
+          , Str "from"
+          , Space
+          , Str "time"
+          , Space
+          , Str "to"
+          , Space
+          , Str "time"
+          , Space
+          , Str "I"
+          , Space
+          , Str "hear"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "196." ]
+                ( "#wasteland-content.xhtml#ln196", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Marvell,"
+              , Space
+              , Str "To"
+              , Space
+              , Str "His"
+              , Space
+              , Str "Coy"
+              , Space
+              , Str "Mistress."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln197", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "sound"
+          , Space
+          , Str "of"
+          , Space
+          , Str "horns"
+          , Space
+          , Str "and"
+          , Space
+          , Str "motors,"
+          , Space
+          , Str "which"
+          , Space
+          , Str "shall"
+          , Space
+          , Str "bring"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "197." ]
+                ( "#wasteland-content.xhtml#ln197", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Day,"
+              , Space
+              , Str "Parliament"
+              , Space
+              , Str "of"
+              , Space
+              , Str "Bees:"
+              ]
+            , BlockQuote
+              [ Div
+                ( "", [], [] )
+                [ Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "\"When"
+                    , Space
+                    , Str "of"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "sudden,"
+                    , Space
+                    , Str "listening,"
+                    , Space
+                    , Str "you"
+                    , Space
+                    , Str "shall"
+                    , SoftBreak
+                    , Str "hear,"
+                    ]
+                  ]
+                , Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "\"A"
+                    , Space
+                    , Str "noise"
+                    , Space
+                    , Str "of"
+                    , Space
+                    , Str "horns"
+                    , Space
+                    , Str "and"
+                    , Space
+                    , Str "hunting,"
+                    , Space
+                    , Str "which"
+                    , Space
+                    , Str "shall"
+                    , SoftBreak
+                    , Str "bring"
+                    ]
+                  ]
+                , Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "\"Actaeon"
+                    , Space
+                    , Str "to"
+                    , Space
+                    , Str "Diana"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "spring,"
+                    ]
+                  ]
+                , Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "\"Where"
+                    , Space
+                    , Str "all"
+                    , Space
+                    , Str "shall"
+                    , Space
+                    , Str "see"
+                    , Space
+                    , Str "her"
+                    , Space
+                    , Str "naked"
+                    , Space
+                    , Str "skin"
+                    , Space
+                    , Str "."
+                    , Space
+                    , Str "."
+                    , Space
+                    , Str ".\""
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Sweeney"
+          , Space
+          , Str "to"
+          , Space
+          , Str "Mrs."
+          , Space
+          , Str "Porter"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "spring."
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln199", [], [] )
+        [ Plain
+          [ Str "O"
+          , Space
+          , Str "the"
+          , Space
+          , Str "moon"
+          , Space
+          , Str "shone"
+          , Space
+          , Str "bright"
+          , Space
+          , Str "on"
+          , Space
+          , Str "Mrs."
+          , Space
+          , Str "Porter"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "199." ]
+                ( "#wasteland-content.xhtml#ln199", "" )
+              , Space
+              , Str "I"
+              , Space
+              , Str "do"
+              , Space
+              , Str "not"
+              , Space
+              , Str "know"
+              , Space
+              , Str "the"
+              , Space
+              , Str "origin"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "ballad"
+              , Space
+              , Str "from"
+              , Space
+              , Str "which"
+              , Space
+              , Str "these"
+              , Space
+              , Str "lines"
+              , Space
+              , Str "are"
+              , SoftBreak
+              , Str "taken:"
+              , Space
+              , Str "it"
+              , Space
+              , Str "was"
+              , Space
+              , Str "reported"
+              , Space
+              , Str "to"
+              , Space
+              , Str "me"
+              , Space
+              , Str "from"
+              , Space
+              , Str "Sydney,"
+              , Space
+              , Str "Australia."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "on"
+          , Space
+          , Str "her"
+          , Space
+          , Str "daughter"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "200" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "They"
+          , Space
+          , Str "wash"
+          , Space
+          , Str "their"
+          , Space
+          , Str "feet"
+          , Space
+          , Str "in"
+          , Space
+          , Str "soda"
+          , Space
+          , Str "water"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln202", [], [ ( "lang", "fr" ) ] )
+        [ Plain
+          [ Emph
+            [ Str "Et"
+            , Space
+            , Str "O"
+            , Space
+            , Str "ces"
+            , Space
+            , Str "voix"
+            , Space
+            , Str "d'enfants,"
+            , Space
+            , Str "chantant"
+            , Space
+            , Str "dans"
+            , Space
+            , Str "la"
+            , Space
+            , Str "coupole"
+            ]
+          , Str "!"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "202." ]
+                ( "#wasteland-content.xhtml#ln202", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Verlaine,"
+              , Space
+              , Str "Parsifal."
+              ]
+            ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain [ Str "Twit", Space, Str "twit", Space, Str "twit" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Jug"
+          , Space
+          , Str "jug"
+          , Space
+          , Str "jug"
+          , Space
+          , Str "jug"
+          , Space
+          , Str "jug"
+          , Space
+          , Str "jug"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "So", Space, Str "rudely", Space, Str "forc'd." ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Tereu" ] ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain [ Str "Unreal", Space, Str "City" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Under"
+          , Space
+          , Str "the"
+          , Space
+          , Str "brown"
+          , Space
+          , Str "fog"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "winter"
+          , Space
+          , Str "noon"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Mr."
+          , Space
+          , Str "Eugenides,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Smyrna"
+          , Space
+          , Str "merchant"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln210", [], [] )
+        [ Plain
+          [ Str "Unshaven,"
+          , Space
+          , Str "with"
+          , Space
+          , Str "a"
+          , Space
+          , Str "pocket"
+          , Space
+          , Str "full"
+          , Space
+          , Str "of"
+          , Space
+          , Str "currants"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "210." ]
+                ( "#wasteland-content.xhtml#ln210", "" )
+              , Space
+              , Str "The"
+              , Space
+              , Str "currants"
+              , Space
+              , Str "were"
+              , Space
+              , Str "quoted"
+              , Space
+              , Str "at"
+              , Space
+              , Str "a"
+              , Space
+              , Str "price"
+              , Space
+              , Str "\"cost"
+              , Space
+              , Str "insurance"
+              , Space
+              , Str "and"
+              , Space
+              , Str "freight"
+              , Space
+              , Str "to"
+              , SoftBreak
+              , Str "London\";"
+              , Space
+              , Str "and"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Bill"
+              , Space
+              , Str "of"
+              , Space
+              , Str "Lading"
+              , Space
+              , Str "etc."
+              , Space
+              , Str "were"
+              , Space
+              , Str "to"
+              , Space
+              , Str "be"
+              , Space
+              , Str "handed"
+              , Space
+              , Str "to"
+              , Space
+              , Str "the"
+              , Space
+              , Str "buyer"
+              , Space
+              , Str "upon"
+              , SoftBreak
+              , Str "payment"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "sight"
+              , Space
+              , Str "draft."
+              ]
+            ]
+          , SoftBreak
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "210" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "C.i.f."
+          , Space
+          , Str "London:"
+          , Space
+          , Str "documents"
+          , Space
+          , Str "at"
+          , Space
+          , Str "sight,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Asked"
+          , Space
+          , Str "me"
+          , Space
+          , Str "in"
+          , Space
+          , Str "demotic"
+          , Space
+          , Str "French"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "To"
+          , Space
+          , Str "luncheon"
+          , Space
+          , Str "at"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Cannon"
+          , Space
+          , Str "Street"
+          , Space
+          , Str "Hotel"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Followed"
+          , Space
+          , Str "by"
+          , Space
+          , Str "a"
+          , Space
+          , Str "weekend"
+          , Space
+          , Str "at"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Metropole."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "At"
+          , Space
+          , Str "the"
+          , Space
+          , Str "violet"
+          , Space
+          , Str "hour,"
+          , Space
+          , Str "when"
+          , Space
+          , Str "the"
+          , Space
+          , Str "eyes"
+          , Space
+          , Str "and"
+          , Space
+          , Str "back"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Turn"
+          , Space
+          , Str "upward"
+          , Space
+          , Str "from"
+          , Space
+          , Str "the"
+          , Space
+          , Str "desk,"
+          , Space
+          , Str "when"
+          , Space
+          , Str "the"
+          , Space
+          , Str "human"
+          , Space
+          , Str "engine"
+          , Space
+          , Str "waits"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Like"
+          , Space
+          , Str "a"
+          , Space
+          , Str "taxi"
+          , Space
+          , Str "throbbing"
+          , Space
+          , Str "waiting,"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln218", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "Tiresias,"
+          , Space
+          , Str "though"
+          , Space
+          , Str "blind,"
+          , Space
+          , Str "throbbing"
+          , Space
+          , Str "between"
+          , Space
+          , Str "two"
+          , Space
+          , Str "lives,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "218." ]
+                ( "#wasteland-content.xhtml#ln218", "" )
+              , Space
+              , Str "Tiresias,"
+              , Space
+              , Str "although"
+              , Space
+              , Str "a"
+              , Space
+              , Str "mere"
+              , Space
+              , Str "spectator"
+              , Space
+              , Str "and"
+              , Space
+              , Str "not"
+              , Space
+              , Str "indeed"
+              , Space
+              , Str "a"
+              , Space
+              , Str "\"character,\""
+              , Space
+              , Str "is"
+              , SoftBreak
+              , Str "yet"
+              , Space
+              , Str "the"
+              , Space
+              , Str "most"
+              , Space
+              , Str "important"
+              , Space
+              , Str "personage"
+              , Space
+              , Str "in"
+              , Space
+              , Str "the"
+              , Space
+              , Str "poem,"
+              , Space
+              , Str "uniting"
+              , Space
+              , Str "all"
+              , Space
+              , Str "the"
+              , Space
+              , Str "rest."
+              , Space
+              , Str "Just"
+              , SoftBreak
+              , Str "as"
+              , Space
+              , Str "the"
+              , Space
+              , Str "one-eyed"
+              , Space
+              , Str "merchant,"
+              , Space
+              , Str "seller"
+              , Space
+              , Str "of"
+              , Space
+              , Str "currants,"
+              , Space
+              , Str "melts"
+              , Space
+              , Str "into"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Phoenician"
+              , SoftBreak
+              , Str "Sailor,"
+              , Space
+              , Str "and"
+              , Space
+              , Str "the"
+              , Space
+              , Str "latter"
+              , Space
+              , Str "is"
+              , Space
+              , Str "not"
+              , Space
+              , Str "wholly"
+              , Space
+              , Str "distinct"
+              , Space
+              , Str "from"
+              , Space
+              , Str "Ferdinand"
+              , Space
+              , Str "Prince"
+              , Space
+              , Str "of"
+              , SoftBreak
+              , Str "Naples,"
+              , Space
+              , Str "so"
+              , Space
+              , Str "all"
+              , Space
+              , Str "the"
+              , Space
+              , Str "women"
+              , Space
+              , Str "are"
+              , Space
+              , Str "one"
+              , Space
+              , Str "woman,"
+              , Space
+              , Str "and"
+              , Space
+              , Str "the"
+              , Space
+              , Str "two"
+              , Space
+              , Str "sexes"
+              , Space
+              , Str "meet"
+              , Space
+              , Str "in"
+              , SoftBreak
+              , Str "Tiresias."
+              , Space
+              , Str "What"
+              , Space
+              , Str "Tiresias"
+              , Space
+              , Str "sees,"
+              , Space
+              , Str "in"
+              , Space
+              , Str "fact,"
+              , Space
+              , Str "is"
+              , Space
+              , Str "the"
+              , Space
+              , Str "substance"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "poem."
+              , Space
+              , Str "The"
+              , SoftBreak
+              , Str "whole"
+              , Space
+              , Str "passage"
+              , Space
+              , Str "from"
+              , Space
+              , Str "Ovid"
+              , Space
+              , Str "is"
+              , Space
+              , Str "of"
+              , Space
+              , Str "great"
+              , Space
+              , Str "anthropological"
+              , Space
+              , Str "interest:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "'."
+                , Space
+                , Str "."
+                , Space
+                , Str "."
+                , Space
+                , Str "Cum"
+                , Space
+                , Str "Iunone"
+                , Space
+                , Str "iocos"
+                , Space
+                , Str "et"
+                , Space
+                , Str "maior"
+                , Space
+                , Str "vestra"
+                , Space
+                , Str "profecto"
+                , Space
+                , Str "est"
+                , LineBreak
+                , Str "Quam,"
+                , Space
+                , Str "quae"
+                , SoftBreak
+                , Str "contingit"
+                , Space
+                , Str "maribus,'"
+                , Space
+                , Str "dixisse,"
+                , Space
+                , Str "'voluptas.'"
+                , LineBreak
+                , Str "Illa"
+                , Space
+                , Str "negat;"
+                , Space
+                , Str "placuit"
+                , SoftBreak
+                , Str "quae"
+                , Space
+                , Str "sit"
+                , Space
+                , Str "sententia"
+                , Space
+                , Str "docti"
+                , LineBreak
+                , Str "Quaerere"
+                , Space
+                , Str "Tiresiae:"
+                , Space
+                , Str "venus"
+                , Space
+                , Str "huic"
+                , Space
+                , Str "erat"
+                , SoftBreak
+                , Str "utraque"
+                , Space
+                , Str "nota."
+                , LineBreak
+                , Str "Nam"
+                , Space
+                , Str "duo"
+                , Space
+                , Str "magnorum"
+                , Space
+                , Str "viridi"
+                , Space
+                , Str "coeuntia"
+                , Space
+                , Str "silva"
+                , LineBreak
+                , Str "Corpora"
+                , Space
+                , Str "serpentum"
+                , Space
+                , Str "baculi"
+                , Space
+                , Str "violaverat"
+                , Space
+                , Str "ictu"
+                , LineBreak
+                , Str "Deque"
+                , Space
+                , Str "viro"
+                , Space
+                , Str "factus,"
+                , SoftBreak
+                , Str "mirabile,"
+                , Space
+                , Str "femina"
+                , Space
+                , Str "septem"
+                , LineBreak
+                , Str "Egerat"
+                , Space
+                , Str "autumnos;"
+                , Space
+                , Str "octavo"
+                , Space
+                , Str "rursus"
+                , SoftBreak
+                , Str "eosdem"
+                , LineBreak
+                , Str "Vidit"
+                , Space
+                , Str "et"
+                , Space
+                , Str "'est"
+                , Space
+                , Str "vestrae"
+                , Space
+                , Str "si"
+                , Space
+                , Str "tanta"
+                , Space
+                , Str "potentia"
+                , Space
+                , Str "plagae,'"
+                , LineBreak
+                , Str "Dixit"
+                , Space
+                , Str "'ut"
+                , Space
+                , Str "auctoris"
+                , Space
+                , Str "sortem"
+                , Space
+                , Str "in"
+                , Space
+                , Str "contraria"
+                , Space
+                , Str "mutet,"
+                , LineBreak
+                , Str "Nunc"
+                , Space
+                , Str "quoque"
+                , Space
+                , Str "vos"
+                , SoftBreak
+                , Str "feriam!'"
+                , Space
+                , Str "percussis"
+                , Space
+                , Str "anguibus"
+                , Space
+                , Str "isdem"
+                , LineBreak
+                , Str "Forma"
+                , Space
+                , Str "prior"
+                , Space
+                , Str "rediit"
+                , SoftBreak
+                , Str "genetivaque"
+                , Space
+                , Str "venit"
+                , Space
+                , Str "imago."
+                , LineBreak
+                , Str "Arbiter"
+                , Space
+                , Str "hic"
+                , Space
+                , Str "igitur"
+                , Space
+                , Str "sumptus"
+                , Space
+                , Str "de"
+                , Space
+                , Str "lite"
+                , SoftBreak
+                , Str "iocosa"
+                , LineBreak
+                , Str "Dicta"
+                , Space
+                , Str "Iovis"
+                , Space
+                , Str "firmat;"
+                , Space
+                , Str "gravius"
+                , Space
+                , Str "Saturnia"
+                , Space
+                , Str "iusto"
+                , LineBreak
+                , Str "Nec"
+                , SoftBreak
+                , Str "pro"
+                , Space
+                , Str "materia"
+                , Space
+                , Str "fertur"
+                , Space
+                , Str "doluisse"
+                , Space
+                , Str "suique"
+                , LineBreak
+                , Str "Iudicis"
+                , Space
+                , Str "aeterna"
+                , Space
+                , Str "damnavit"
+                , SoftBreak
+                , Str "lumina"
+                , Space
+                , Str "nocte,"
+                , LineBreak
+                , Str "At"
+                , Space
+                , Str "pater"
+                , Space
+                , Str "omnipotens"
+                , Space
+                , Str "(neque"
+                , Space
+                , Str "enim"
+                , Space
+                , Str "licet"
+                , Space
+                , Str "inrita"
+                , SoftBreak
+                , Str "cuiquam"
+                , LineBreak
+                , Str "Facta"
+                , Space
+                , Str "dei"
+                , Space
+                , Str "fecisse"
+                , Space
+                , Str "deo)"
+                , Space
+                , Str "pro"
+                , Space
+                , Str "lumine"
+                , Space
+                , Str "adempto"
+                , LineBreak
+                , Str "Scire"
+                , SoftBreak
+                , Str "futura"
+                , Space
+                , Str "dedit"
+                , Space
+                , Str "poenamque"
+                , Space
+                , Str "levavit"
+                , Space
+                , Str "honore."
+                , LineBreak
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Old"
+          , Space
+          , Str "man"
+          , Space
+          , Str "with"
+          , Space
+          , Str "wrinkled"
+          , Space
+          , Str "female"
+          , Space
+          , Str "breasts,"
+          , Space
+          , Str "can"
+          , Space
+          , Str "see"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "At"
+          , Space
+          , Str "the"
+          , Space
+          , Str "violet"
+          , Space
+          , Str "hour,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "evening"
+          , Space
+          , Str "hour"
+          , Space
+          , Str "that"
+          , Space
+          , Str "strives"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "220" ]
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln221", [], [] )
+        [ Plain
+          [ Str "Homeward,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "brings"
+          , Space
+          , Str "the"
+          , Space
+          , Str "sailor"
+          , Space
+          , Str "home"
+          , Space
+          , Str "from"
+          , Space
+          , Str "sea,"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "221." ]
+                ( "#wasteland-content.xhtml#ln221", "" )
+              , Space
+              , Str "This"
+              , Space
+              , Str "may"
+              , Space
+              , Str "not"
+              , Space
+              , Str "appear"
+              , Space
+              , Str "as"
+              , Space
+              , Str "exact"
+              , Space
+              , Str "as"
+              , Space
+              , Str "Sappho's"
+              , Space
+              , Str "lines,"
+              , Space
+              , Str "but"
+              , Space
+              , Str "I"
+              , Space
+              , Str "had"
+              , Space
+              , Str "in"
+              , Space
+              , Str "mind"
+              , SoftBreak
+              , Str "the"
+              , Space
+              , Str "\"longshore\""
+              , Space
+              , Str "or"
+              , Space
+              , Str "\"dory\""
+              , Space
+              , Str "fisherman,"
+              , Space
+              , Str "who"
+              , Space
+              , Str "returns"
+              , Space
+              , Str "at"
+              , Space
+              , Str "nightfall."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "typist"
+          , Space
+          , Str "home"
+          , Space
+          , Str "at"
+          , Space
+          , Str "teatime,"
+          , Space
+          , Str "clears"
+          , Space
+          , Str "her"
+          , Space
+          , Str "breakfast,"
+          , Space
+          , Str "lights"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Her"
+          , Space
+          , Str "stove,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "lays"
+          , Space
+          , Str "out"
+          , Space
+          , Str "food"
+          , Space
+          , Str "in"
+          , Space
+          , Str "tins."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Out"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "window"
+          , Space
+          , Str "perilously"
+          , Space
+          , Str "spread"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Her"
+          , Space
+          , Str "drying"
+          , Space
+          , Str "combinations"
+          , Space
+          , Str "touched"
+          , Space
+          , Str "by"
+          , Space
+          , Str "the"
+          , Space
+          , Str "sun's"
+          , Space
+          , Str "last"
+          , Space
+          , Str "rays,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "On"
+          , Space
+          , Str "the"
+          , Space
+          , Str "divan"
+          , Space
+          , Str "are"
+          , Space
+          , Str "piled"
+          , Space
+          , Str "(at"
+          , Space
+          , Str "night"
+          , Space
+          , Str "her"
+          , Space
+          , Str "bed)"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Stockings,"
+          , Space
+          , Str "slippers,"
+          , Space
+          , Str "camisoles,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "stays."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "Tiresias,"
+          , Space
+          , Str "old"
+          , Space
+          , Str "man"
+          , Space
+          , Str "with"
+          , Space
+          , Str "wrinkled"
+          , Space
+          , Str "dugs"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Perceived"
+          , Space
+          , Str "the"
+          , Space
+          , Str "scene,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "foretold"
+          , Space
+          , Str "the"
+          , Space
+          , Str "rest"
+          , Space
+          , Str "-"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "too"
+          , Space
+          , Str "awaited"
+          , Space
+          , Str "the"
+          , Space
+          , Str "expected"
+          , Space
+          , Str "guest."
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "230" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "He,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "young"
+          , Space
+          , Str "man"
+          , Space
+          , Str "carbuncular,"
+          , Space
+          , Str "arrives,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "A"
+          , Space
+          , Str "small"
+          , Space
+          , Str "house"
+          , Space
+          , Str "agent's"
+          , Space
+          , Str "clerk,"
+          , Space
+          , Str "with"
+          , Space
+          , Str "one"
+          , Space
+          , Str "bold"
+          , Space
+          , Str "stare,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "One"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "low"
+          , Space
+          , Str "on"
+          , Space
+          , Str "whom"
+          , Space
+          , Str "assurance"
+          , Space
+          , Str "sits"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "As"
+          , Space
+          , Str "a"
+          , Space
+          , Str "silk"
+          , Space
+          , Str "hat"
+          , Space
+          , Str "on"
+          , Space
+          , Str "a"
+          , Space
+          , Str "Bradford"
+          , Space
+          , Str "millionaire."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "time"
+          , Space
+          , Str "is"
+          , Space
+          , Str "now"
+          , Space
+          , Str "propitious,"
+          , Space
+          , Str "as"
+          , Space
+          , Str "he"
+          , Space
+          , Str "guesses,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "meal"
+          , Space
+          , Str "is"
+          , Space
+          , Str "ended,"
+          , Space
+          , Str "she"
+          , Space
+          , Str "is"
+          , Space
+          , Str "bored"
+          , Space
+          , Str "and"
+          , Space
+          , Str "tired,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Endeavours"
+          , Space
+          , Str "to"
+          , Space
+          , Str "engage"
+          , Space
+          , Str "her"
+          , Space
+          , Str "in"
+          , Space
+          , Str "caresses"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Which"
+          , Space
+          , Str "still"
+          , Space
+          , Str "are"
+          , Space
+          , Str "unreproved,"
+          , Space
+          , Str "if"
+          , Space
+          , Str "undesired."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Flushed"
+          , Space
+          , Str "and"
+          , Space
+          , Str "decided,"
+          , Space
+          , Str "he"
+          , Space
+          , Str "assaults"
+          , Space
+          , Str "at"
+          , Space
+          , Str "once;"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Exploring"
+          , Space
+          , Str "hands"
+          , Space
+          , Str "encounter"
+          , Space
+          , Str "no"
+          , Space
+          , Str "defence;"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "240" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "His"
+          , Space
+          , Str "vanity"
+          , Space
+          , Str "requires"
+          , Space
+          , Str "no"
+          , Space
+          , Str "response,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "makes"
+          , Space
+          , Str "a"
+          , Space
+          , Str "welcome"
+          , Space
+          , Str "of"
+          , Space
+          , Str "indifference."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "(And"
+          , Space
+          , Str "I"
+          , Space
+          , Str "Tiresias"
+          , Space
+          , Str "have"
+          , Space
+          , Str "foresuffered"
+          , Space
+          , Str "all"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Enacted"
+          , Space
+          , Str "on"
+          , Space
+          , Str "this"
+          , Space
+          , Str "same"
+          , Space
+          , Str "divan"
+          , Space
+          , Str "or"
+          , Space
+          , Str "bed;"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "who"
+          , Space
+          , Str "have"
+          , Space
+          , Str "sat"
+          , Space
+          , Str "by"
+          , Space
+          , Str "Thebes"
+          , Space
+          , Str "below"
+          , Space
+          , Str "the"
+          , Space
+          , Str "wall"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "walked"
+          , Space
+          , Str "among"
+          , Space
+          , Str "the"
+          , Space
+          , Str "lowest"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "dead.)"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Bestows"
+          , Space
+          , Str "one"
+          , Space
+          , Str "final"
+          , Space
+          , Str "patronising"
+          , Space
+          , Str "kiss,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "gropes"
+          , Space
+          , Str "his"
+          , Space
+          , Str "way,"
+          , Space
+          , Str "finding"
+          , Space
+          , Str "the"
+          , Space
+          , Str "stairs"
+          , Space
+          , Str "unlit"
+          , Space
+          , Str "."
+          , Space
+          , Str "."
+          , Space
+          , Str "."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "She"
+          , Space
+          , Str "turns"
+          , Space
+          , Str "and"
+          , Space
+          , Str "looks"
+          , Space
+          , Str "a"
+          , Space
+          , Str "moment"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "glass,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Hardly"
+          , Space
+          , Str "aware"
+          , Space
+          , Str "of"
+          , Space
+          , Str "her"
+          , Space
+          , Str "departed"
+          , Space
+          , Str "lover;"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "250" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Her"
+          , Space
+          , Str "brain"
+          , Space
+          , Str "allows"
+          , Space
+          , Str "one"
+          , Space
+          , Str "half-formed"
+          , Space
+          , Str "thought"
+          , Space
+          , Str "to"
+          , Space
+          , Str "pass:"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"Well"
+          , Space
+          , Str "now"
+          , Space
+          , Str "that's"
+          , Space
+          , Str "done:"
+          , Space
+          , Str "and"
+          , Space
+          , Str "I'm"
+          , Space
+          , Str "glad"
+          , Space
+          , Str "it's"
+          , Space
+          , Str "over.\""
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln253", [], [] )
+        [ Plain
+          [ Str "When"
+          , Space
+          , Str "lovely"
+          , Space
+          , Str "woman"
+          , Space
+          , Str "stoops"
+          , Space
+          , Str "to"
+          , Space
+          , Str "folly"
+          , Space
+          , Str "and"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "253." ]
+                ( "#wasteland-content.xhtml#ln253", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Goldsmith,"
+              , Space
+              , Str "the"
+              , Space
+              , Str "song"
+              , Space
+              , Str "in"
+              , Space
+              , Str "The"
+              , Space
+              , Str "Vicar"
+              , Space
+              , Str "of"
+              , Space
+              , Str "Wakefield."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Paces"
+          , Space
+          , Str "about"
+          , Space
+          , Str "her"
+          , Space
+          , Str "room"
+          , Space
+          , Str "again,"
+          , Space
+          , Str "alone,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "She"
+          , Space
+          , Str "smoothes"
+          , Space
+          , Str "her"
+          , Space
+          , Str "hair"
+          , Space
+          , Str "with"
+          , Space
+          , Str "automatic"
+          , Space
+          , Str "hand,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "puts"
+          , Space
+          , Str "a"
+          , Space
+          , Str "record"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "gramophone."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln257", [], [] )
+        [ Plain
+          [ Str "\"This"
+          , Space
+          , Str "music"
+          , Space
+          , Str "crept"
+          , Space
+          , Str "by"
+          , Space
+          , Str "me"
+          , Space
+          , Str "upon"
+          , Space
+          , Str "the"
+          , Space
+          , Str "waters\""
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "257." ]
+                ( "#wasteland-content.xhtml#ln257", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "The"
+              , Space
+              , Str "Tempest,"
+              , Space
+              , Str "as"
+              , Space
+              , Str "above."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "along"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Strand,"
+          , Space
+          , Str "up"
+          , Space
+          , Str "Queen"
+          , Space
+          , Str "Victoria"
+          , Space
+          , Str "Street."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "O"
+          , Space
+          , Str "City"
+          , Space
+          , Str "city,"
+          , Space
+          , Str "I"
+          , Space
+          , Str "can"
+          , Space
+          , Str "sometimes"
+          , Space
+          , Str "hear"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Beside"
+          , Space
+          , Str "a"
+          , Space
+          , Str "public"
+          , Space
+          , Str "bar"
+          , Space
+          , Str "in"
+          , Space
+          , Str "Lower"
+          , Space
+          , Str "Thames"
+          , Space
+          , Str "Street,"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "260" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "pleasant"
+          , Space
+          , Str "whining"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "mandoline"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "a"
+          , Space
+          , Str "clatter"
+          , Space
+          , Str "and"
+          , Space
+          , Str "a"
+          , Space
+          , Str "chatter"
+          , Space
+          , Str "from"
+          , Space
+          , Str "within"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Where"
+          , Space
+          , Str "fishmen"
+          , Space
+          , Str "lounge"
+          , Space
+          , Str "at"
+          , Space
+          , Str "noon:"
+          , Space
+          , Str "where"
+          , Space
+          , Str "the"
+          , Space
+          , Str "walls"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln264", [], [] )
+        [ Plain
+          [ Str "Of"
+          , Space
+          , Str "Magnus"
+          , Space
+          , Str "Martyr"
+          , Space
+          , Str "hold"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "264." ]
+                ( "#wasteland-content.xhtml#ln264", "" )
+              , Space
+              , Str "The"
+              , Space
+              , Str "interior"
+              , Space
+              , Str "of"
+              , Space
+              , Str "St."
+              , Space
+              , Str "Magnus"
+              , Space
+              , Str "Martyr"
+              , Space
+              , Str "is"
+              , Space
+              , Str "to"
+              , Space
+              , Str "my"
+              , Space
+              , Str "mind"
+              , Space
+              , Str "one"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "finest"
+              , SoftBreak
+              , Str "among"
+              , Space
+              , Str "Wren's"
+              , Space
+              , Str "interiors."
+              , Space
+              , Str "See"
+              , Space
+              , Str "The"
+              , Space
+              , Str "Proposed"
+              , Space
+              , Str "Demolition"
+              , Space
+              , Str "of"
+              , Space
+              , Str "Nineteen"
+              , Space
+              , Str "City"
+              , SoftBreak
+              , Str "Churches"
+              , Space
+              , Str "(P."
+              , Space
+              , Str "S."
+              , Space
+              , Str "King"
+              , Space
+              , Str "&"
+              , Space
+              , Str "Son,"
+              , Space
+              , Str "Ltd.)."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Inexplicable"
+          , Space
+          , Str "splendour"
+          , Space
+          , Str "of"
+          , Space
+          , Str "Ionian"
+          , Space
+          , Str "white"
+          , Space
+          , Str "and"
+          , Space
+          , Str "gold."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup", "indent" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln266", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "river"
+          , Space
+          , Str "sweats"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "266." ]
+                ( "#wasteland-content.xhtml#ln266", "" )
+              , Space
+              , Str "The"
+              , Space
+              , Str "Song"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "(three)"
+              , Space
+              , Str "Thames-daughters"
+              , Space
+              , Str "begins"
+              , Space
+              , Str "here."
+              , Space
+              , Str "From"
+              , Space
+              , Str "line"
+              , Space
+              , Str "292"
+              , SoftBreak
+              , Str "to"
+              , Space
+              , Str "306"
+              , Space
+              , Str "inclusive"
+              , Space
+              , Str "they"
+              , Space
+              , Str "speak"
+              , Space
+              , Str "in"
+              , Space
+              , Str "turn."
+              , Space
+              , Str "V."
+              , Space
+              , Str "Gutterdsammerung,"
+              , Space
+              , Str "III."
+              , Space
+              , Str "i:"
+              , Space
+              , Str "the"
+              , SoftBreak
+              , Str "Rhine-daughters."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Oil", Space, Str "and", Space, Str "tar" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "The", Space, Str "barges", Space, Str "drift" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "With"
+          , Space
+          , Str "the"
+          , Space
+          , Str "turning"
+          , Space
+          , Str "tide"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Red"
+          , Space
+          , Str "sails"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "270" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Wide" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "To"
+          , Space
+          , Str "leeward,"
+          , Space
+          , Str "swing"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "heavy"
+          , Space
+          , Str "spar."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "The", Space, Str "barges", Space, Str "wash" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Drifting", Space, Str "logs" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Down", Space, Str "Greenwich", Space, Str "reach" ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Past"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Isle"
+          , Space
+          , Str "of"
+          , Space
+          , Str "Dogs."
+          ]
+        ]
+      , Div
+        ( "", [ "indent" ], [] )
+        [ Plain [ Str "Weialala", Space, Str "leia" ] ]
+      , Div
+        ( "", [ "indent" ], [] )
+        [ Plain [ Str "Wallala", Space, Str "leialala" ] ]
+      ]
+    , Div
+      ( "", [ "linegroup", "indent" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln279", [], [] )
+        [ Plain
+          [ Str "Elizabeth"
+          , Space
+          , Str "and"
+          , Space
+          , Str "Leicester"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "279." ]
+                ( "#wasteland-content.xhtml#ln279", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Froude,"
+              , Space
+              , Str "Elizabeth,"
+              , Space
+              , Str "Vol."
+              , Space
+              , Str "I,"
+              , Space
+              , Str "ch."
+              , Space
+              , Str "iv,"
+              , Space
+              , Str "letter"
+              , Space
+              , Str "of"
+              , Space
+              , Str "De"
+              , Space
+              , Str "Quadra"
+              , Space
+              , Str "to"
+              , Space
+              , Str "Philip"
+              , SoftBreak
+              , Str "of"
+              , Space
+              , Str "Spain:"
+              ]
+            , BlockQuote
+              [ Div
+                ( "", [], [] )
+                [ Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "\"In"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "afternoon"
+                    , Space
+                    , Str "we"
+                    , Space
+                    , Str "were"
+                    , Space
+                    , Str "in"
+                    , Space
+                    , Str "a"
+                    , Space
+                    , Str "barge,"
+                    , Space
+                    , Str "watching"
+                    , Space
+                    , Str "the"
+                    , SoftBreak
+                    , Str "games"
+                    , Space
+                    , Str "on"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "river."
+                    ]
+                  ]
+                , Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "(The"
+                    , Space
+                    , Str "queen)"
+                    , Space
+                    , Str "was"
+                    , Space
+                    , Str "alone"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "Lord"
+                    , Space
+                    , Str "Robert"
+                    , Space
+                    , Str "and"
+                    , Space
+                    , Str "myself"
+                    , SoftBreak
+                    , Str "on"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "poop,"
+                    ]
+                  ]
+                , Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "when"
+                    , Space
+                    , Str "they"
+                    , Space
+                    , Str "began"
+                    , Space
+                    , Str "to"
+                    , Space
+                    , Str "talk"
+                    , Space
+                    , Str "nonsense,"
+                    , Space
+                    , Str "and"
+                    , Space
+                    , Str "went"
+                    , Space
+                    , Str "so"
+                    , Space
+                    , Str "far"
+                    , SoftBreak
+                    , Str "that"
+                    , Space
+                    , Str "Lord"
+                    , Space
+                    , Str "Robert"
+                    ]
+                  ]
+                , Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "at"
+                    , Space
+                    , Str "last"
+                    , Space
+                    , Str "said,"
+                    , Space
+                    , Str "as"
+                    , Space
+                    , Str "I"
+                    , Space
+                    , Str "was"
+                    , Space
+                    , Str "on"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "spot"
+                    , Space
+                    , Str "there"
+                    , Space
+                    , Str "was"
+                    , Space
+                    , Str "no"
+                    , SoftBreak
+                    , Str "reason"
+                    , Space
+                    , Str "why"
+                    , Space
+                    , Str "they"
+                    ]
+                  ]
+                , Div
+                  ( "", [], [] )
+                  [ Plain
+                    [ Str "should"
+                    , Space
+                    , Str "not"
+                    , Space
+                    , Str "be"
+                    , Space
+                    , Str "married"
+                    , Space
+                    , Str "if"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "queen"
+                    , Space
+                    , Str "pleased.\""
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Beating"
+          , Space
+          , Str "oars"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "280" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "stern"
+          , Space
+          , Str "was"
+          , Space
+          , Str "formed"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "A", Space, Str "gilded", Space, Str "shell" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Red", Space, Str "and", Space, Str "gold" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "The", Space, Str "brisk", Space, Str "swell" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Rippled", Space, Str "both", Space, Str "shores" ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Southwest", Space, Str "wind" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Carried", Space, Str "down", Space, Str "stream" ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "peal"
+          , Space
+          , Str "of"
+          , Space
+          , Str "bells"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "White", Space, Str "towers" ] ]
+      , Div
+        ( "", [ "indent" ], [] )
+        [ Plain
+          [ Str "Weialala"
+          , Space
+          , Str "leia"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "290" ]
+          ]
+        ]
+      , Div
+        ( "", [ "indent" ], [] )
+        [ Plain [ Str "Wallala", Space, Str "leialala" ] ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"Trams"
+          , Space
+          , Str "and"
+          , Space
+          , Str "dusty"
+          , Space
+          , Str "trees."
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln293", [], [] )
+        [ Plain
+          [ Str "Highbury"
+          , Space
+          , Str "bore"
+          , Space
+          , Str "me."
+          , Space
+          , Str "Richmond"
+          , Space
+          , Str "and"
+          , Space
+          , Str "Kew"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "293." ]
+                ( "#wasteland-content.xhtml#ln293", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Purgatorio,"
+              , Space
+              , Str "v."
+              , Space
+              , Str "133:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"Ricorditi"
+                , Space
+                , Str "di"
+                , Space
+                , Str "me,"
+                , Space
+                , Str "che"
+                , Space
+                , Str "son"
+                , Space
+                , Str "la"
+                , Space
+                , Str "Pia;"
+                , LineBreak
+                , Str "Siena"
+                , Space
+                , Str "mi"
+                , Space
+                , Str "fe',"
+                , Space
+                , Str "disfecemi"
+                , SoftBreak
+                , Str "Maremma.\""
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Undid"
+          , Space
+          , Str "me."
+          , Space
+          , Str "By"
+          , Space
+          , Str "Richmond"
+          , Space
+          , Str "I"
+          , Space
+          , Str "raised"
+          , Space
+          , Str "my"
+          , Space
+          , Str "knees"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Supine"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "floor"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "narrow"
+          , Space
+          , Str "canoe.\""
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"My"
+          , Space
+          , Str "feet"
+          , Space
+          , Str "are"
+          , Space
+          , Str "at"
+          , Space
+          , Str "Moorgate,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "my"
+          , Space
+          , Str "heart"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Under"
+          , Space
+          , Str "my"
+          , Space
+          , Str "feet."
+          , Space
+          , Str "After"
+          , Space
+          , Str "the"
+          , Space
+          , Str "event"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "He"
+          , Space
+          , Str "wept."
+          , Space
+          , Str "He"
+          , Space
+          , Str "promised"
+          , Space
+          , Str "'a"
+          , Space
+          , Str "new"
+          , Space
+          , Str "start'."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "made"
+          , Space
+          , Str "no"
+          , Space
+          , Str "comment."
+          , Space
+          , Str "What"
+          , Space
+          , Str "should"
+          , Space
+          , Str "I"
+          , Space
+          , Str "resent?\""
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "\"On"
+          , Space
+          , Str "Margate"
+          , Space
+          , Str "Sands."
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "300" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "I", Space, Str "can", Space, Str "connect" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Nothing", Space, Str "with", Space, Str "nothing." ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "broken"
+          , Space
+          , Str "fingernails"
+          , Space
+          , Str "of"
+          , Space
+          , Str "dirty"
+          , Space
+          , Str "hands."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "My"
+          , Space
+          , Str "people"
+          , Space
+          , Str "humble"
+          , Space
+          , Str "people"
+          , Space
+          , Str "who"
+          , Space
+          , Str "expect"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Nothing.\"" ] ]
+      , Div
+        ( "", [ "indent" ], [] )
+        [ Plain [ Str "la", Space, Str "la" ] ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln307", [], [] )
+        [ Plain
+          [ Str "To"
+          , Space
+          , Str "Carthage"
+          , Space
+          , Str "then"
+          , Space
+          , Str "I"
+          , Space
+          , Str "came"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "307." ]
+                ( "#wasteland-content.xhtml#ln307", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "St."
+              , Space
+              , Str "Augustine's"
+              , Space
+              , Str "Confessions:"
+              , Space
+              , Str "\"to"
+              , Space
+              , Str "Carthage"
+              , Space
+              , Str "then"
+              , Space
+              , Str "I"
+              , Space
+              , Str "came,"
+              , Space
+              , Str "where"
+              , Space
+              , Str "a"
+              , SoftBreak
+              , Str "cauldron"
+              , Space
+              , Str "of"
+              , Space
+              , Str "unholy"
+              , Space
+              , Str "loves"
+              , Space
+              , Str "sang"
+              , Space
+              , Str "all"
+              , Space
+              , Str "about"
+              , Space
+              , Str "mine"
+              , Space
+              , Str "ears.\""
+              ]
+            ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln308", [], [] )
+        [ Plain
+          [ Str "Burning"
+          , Space
+          , Str "burning"
+          , Space
+          , Str "burning"
+          , Space
+          , Str "burning"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "308." ]
+                ( "#wasteland-content.xhtml#ln308", "" )
+              , Space
+              , Str "The"
+              , Space
+              , Str "complete"
+              , Space
+              , Str "text"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Buddha's"
+              , Space
+              , Str "Fire"
+              , Space
+              , Str "Sermon"
+              , Space
+              , Str "(which"
+              , Space
+              , Str "corresponds"
+              , Space
+              , Str "in"
+              , SoftBreak
+              , Str "importance"
+              , Space
+              , Str "to"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Sermon"
+              , Space
+              , Str "on"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Mount)"
+              , Space
+              , Str "from"
+              , Space
+              , Str "which"
+              , Space
+              , Str "these"
+              , Space
+              , Str "words"
+              , Space
+              , Str "are"
+              , Space
+              , Str "taken,"
+              , SoftBreak
+              , Str "will"
+              , Space
+              , Str "be"
+              , Space
+              , Str "found"
+              , Space
+              , Str "translated"
+              , Space
+              , Str "in"
+              , Space
+              , Str "the"
+              , Space
+              , Str "late"
+              , Space
+              , Str "Henry"
+              , Space
+              , Str "Clarke"
+              , Space
+              , Str "Warren's"
+              , Space
+              , Str "Buddhism"
+              , Space
+              , Str "in"
+              , SoftBreak
+              , Str "Translation"
+              , Space
+              , Str "(Harvard"
+              , Space
+              , Str "Oriental"
+              , Space
+              , Str "Series)."
+              , Space
+              , Str "Mr."
+              , Space
+              , Str "Warren"
+              , Space
+              , Str "was"
+              , Space
+              , Str "one"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "great"
+              , SoftBreak
+              , Str "pioneers"
+              , Space
+              , Str "of"
+              , Space
+              , Str "Buddhist"
+              , Space
+              , Str "studies"
+              , Space
+              , Str "in"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Occident."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln309", [], [] )
+        [ Plain
+          [ Str "O"
+          , Space
+          , Str "Lord"
+          , Space
+          , Str "Thou"
+          , Space
+          , Str "pluckest"
+          , Space
+          , Str "me"
+          , Space
+          , Str "out"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "309." ]
+                ( "#wasteland-content.xhtml#ln309", "" )
+              , Space
+              , Str "From"
+              , Space
+              , Str "St."
+              , Space
+              , Str "Augustine's"
+              , Space
+              , Str "Confessions"
+              , Space
+              , Str "again."
+              , Space
+              , Str "The"
+              , Space
+              , Str "collocation"
+              , Space
+              , Str "of"
+              , Space
+              , Str "these"
+              , Space
+              , Str "two"
+              , SoftBreak
+              , Str "representatives"
+              , Space
+              , Str "of"
+              , Space
+              , Str "eastern"
+              , Space
+              , Str "and"
+              , Space
+              , Str "western"
+              , Space
+              , Str "asceticism,"
+              , Space
+              , Str "as"
+              , Space
+              , Str "the"
+              , Space
+              , Str "culmination"
+              , Space
+              , Str "of"
+              , SoftBreak
+              , Str "this"
+              , Space
+              , Str "part"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "poem,"
+              , Space
+              , Str "is"
+              , Space
+              , Str "not"
+              , Space
+              , Str "an"
+              , Space
+              , Str "accident."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "O"
+          , Space
+          , Str "Lord"
+          , Space
+          , Str "Thou"
+          , Space
+          , Str "pluckest"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "310" ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div ( "", [], [] ) [ Plain [ Str "burning" ] ] ]
+    ]
+  , Div
+    ( "wasteland-content.xhtml#ch4", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "IV."
+      , Space
+      , Str "DEATH"
+      , Space
+      , Str "BY"
+      , Space
+      , Str "WATER"
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Phlebas"
+          , Space
+          , Str "the"
+          , Space
+          , Str "Phoenician,"
+          , Space
+          , Str "a"
+          , Space
+          , Str "fortnight"
+          , Space
+          , Str "dead,"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Forgot"
+          , Space
+          , Str "the"
+          , Space
+          , Str "cry"
+          , Space
+          , Str "of"
+          , Space
+          , Str "gulls,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "the"
+          , Space
+          , Str "deep"
+          , Space
+          , Str "sea"
+          , Space
+          , Str "swell"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "the"
+          , Space
+          , Str "profit"
+          , Space
+          , Str "and"
+          , Space
+          , Str "loss."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [ "indent2" ], [] )
+        [ Plain
+          [ Str "A"
+          , Space
+          , Str "current"
+          , Space
+          , Str "under"
+          , Space
+          , Str "sea"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Picked"
+          , Space
+          , Str "his"
+          , Space
+          , Str "bones"
+          , Space
+          , Str "in"
+          , Space
+          , Str "whispers."
+          , Space
+          , Str "As"
+          , Space
+          , Str "he"
+          , Space
+          , Str "rose"
+          , Space
+          , Str "and"
+          , Space
+          , Str "fell"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "He"
+          , Space
+          , Str "passed"
+          , Space
+          , Str "the"
+          , Space
+          , Str "stages"
+          , Space
+          , Str "of"
+          , Space
+          , Str "his"
+          , Space
+          , Str "age"
+          , Space
+          , Str "and"
+          , Space
+          , Str "youth"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Entering", Space, Str "the", Space, Str "whirlpool." ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [ "indent2" ], [] )
+        [ Plain [ Str "Gentile", Space, Str "or", Space, Str "Jew" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "O"
+          , Space
+          , Str "you"
+          , Space
+          , Str "who"
+          , Space
+          , Str "turn"
+          , Space
+          , Str "the"
+          , Space
+          , Str "wheel"
+          , Space
+          , Str "and"
+          , Space
+          , Str "look"
+          , Space
+          , Str "to"
+          , Space
+          , Str "windward,"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "320" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Consider"
+          , Space
+          , Str "Phlebas,"
+          , Space
+          , Str "who"
+          , Space
+          , Str "was"
+          , Space
+          , Str "once"
+          , Space
+          , Str "handsome"
+          , Space
+          , Str "and"
+          , Space
+          , Str "tall"
+          , Space
+          , Str "as"
+          , Space
+          , Str "you."
+          ]
+        ]
+      ]
+    ]
+  , Div
+    ( "wasteland-content.xhtml#ch5", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "V."
+      , Space
+      , Str "WHAT"
+      , Space
+      , Str "THE"
+      , Space
+      , Str "THUNDER"
+      , Space
+      , Str "SAID"
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "After"
+          , Space
+          , Str "the"
+          , Space
+          , Str "torchlight"
+          , Space
+          , Str "red"
+          , Space
+          , Str "on"
+          , Space
+          , Str "sweaty"
+          , Space
+          , Str "faces"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "After"
+          , Space
+          , Str "the"
+          , Space
+          , Str "frosty"
+          , Space
+          , Str "silence"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "gardens"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "After"
+          , Space
+          , Str "the"
+          , Space
+          , Str "agony"
+          , Space
+          , Str "in"
+          , Space
+          , Str "stony"
+          , Space
+          , Str "places"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "shouting"
+          , Space
+          , Str "and"
+          , Space
+          , Str "the"
+          , Space
+          , Str "crying"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Prison"
+          , Space
+          , Str "and"
+          , Space
+          , Str "palace"
+          , Space
+          , Str "and"
+          , Space
+          , Str "reverberation"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Of"
+          , Space
+          , Str "thunder"
+          , Space
+          , Str "of"
+          , Space
+          , Str "spring"
+          , Space
+          , Str "over"
+          , Space
+          , Str "distant"
+          , Space
+          , Str "mountains"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "He"
+          , Space
+          , Str "who"
+          , Space
+          , Str "was"
+          , Space
+          , Str "living"
+          , Space
+          , Str "is"
+          , Space
+          , Str "now"
+          , Space
+          , Str "dead"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "We"
+          , Space
+          , Str "who"
+          , Space
+          , Str "were"
+          , Space
+          , Str "living"
+          , Space
+          , Str "are"
+          , Space
+          , Str "now"
+          , Space
+          , Str "dying"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "With"
+          , Space
+          , Str "a"
+          , Space
+          , Str "little"
+          , Space
+          , Str "patience"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "330" ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Here"
+          , Space
+          , Str "is"
+          , Space
+          , Str "no"
+          , Space
+          , Str "water"
+          , Space
+          , Str "but"
+          , Space
+          , Str "only"
+          , Space
+          , Str "rock"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Rock"
+          , Space
+          , Str "and"
+          , Space
+          , Str "no"
+          , Space
+          , Str "water"
+          , Space
+          , Str "and"
+          , Space
+          , Str "the"
+          , Space
+          , Str "sandy"
+          , Space
+          , Str "road"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "road"
+          , Space
+          , Str "winding"
+          , Space
+          , Str "above"
+          , Space
+          , Str "among"
+          , Space
+          , Str "the"
+          , Space
+          , Str "mountains"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Which"
+          , Space
+          , Str "are"
+          , Space
+          , Str "mountains"
+          , Space
+          , Str "of"
+          , Space
+          , Str "rock"
+          , Space
+          , Str "without"
+          , Space
+          , Str "water"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "If"
+          , Space
+          , Str "there"
+          , Space
+          , Str "were"
+          , Space
+          , Str "water"
+          , Space
+          , Str "we"
+          , Space
+          , Str "should"
+          , Space
+          , Str "stop"
+          , Space
+          , Str "and"
+          , Space
+          , Str "drink"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Amongst"
+          , Space
+          , Str "the"
+          , Space
+          , Str "rock"
+          , Space
+          , Str "one"
+          , Space
+          , Str "cannot"
+          , Space
+          , Str "stop"
+          , Space
+          , Str "or"
+          , Space
+          , Str "think"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Sweat"
+          , Space
+          , Str "is"
+          , Space
+          , Str "dry"
+          , Space
+          , Str "and"
+          , Space
+          , Str "feet"
+          , Space
+          , Str "are"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "sand"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "If"
+          , Space
+          , Str "there"
+          , Space
+          , Str "were"
+          , Space
+          , Str "only"
+          , Space
+          , Str "water"
+          , Space
+          , Str "amongst"
+          , Space
+          , Str "the"
+          , Space
+          , Str "rock"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Dead"
+          , Space
+          , Str "mountain"
+          , Space
+          , Str "mouth"
+          , Space
+          , Str "of"
+          , Space
+          , Str "carious"
+          , Space
+          , Str "teeth"
+          , Space
+          , Str "that"
+          , Space
+          , Str "cannot"
+          , Space
+          , Str "spit"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Here"
+          , Space
+          , Str "one"
+          , Space
+          , Str "can"
+          , Space
+          , Str "neither"
+          , Space
+          , Str "stand"
+          , Space
+          , Str "nor"
+          , Space
+          , Str "lie"
+          , Space
+          , Str "nor"
+          , Space
+          , Str "sit"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "340" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "There"
+          , Space
+          , Str "is"
+          , Space
+          , Str "not"
+          , Space
+          , Str "even"
+          , Space
+          , Str "silence"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "mountains"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "But"
+          , Space
+          , Str "dry"
+          , Space
+          , Str "sterile"
+          , Space
+          , Str "thunder"
+          , Space
+          , Str "without"
+          , Space
+          , Str "rain"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "There"
+          , Space
+          , Str "is"
+          , Space
+          , Str "not"
+          , Space
+          , Str "even"
+          , Space
+          , Str "solitude"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "mountains"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "But"
+          , Space
+          , Str "red"
+          , Space
+          , Str "sullen"
+          , Space
+          , Str "faces"
+          , Space
+          , Str "sneer"
+          , Space
+          , Str "and"
+          , Space
+          , Str "snarl"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "From"
+          , Space
+          , Str "doors"
+          , Space
+          , Str "of"
+          , Space
+          , Str "mudcracked"
+          , Space
+          , Str "houses"
+          ]
+        ]
+      , Div
+        ( "", [ "linegroup" ], [] )
+        [ Div
+          ( "", [ "indent2" ], [] )
+          [ Plain
+            [ Str "If"
+            , Space
+            , Str "there"
+            , Space
+            , Str "were"
+            , Space
+            , Str "water"
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain [ Str "And", Space, Str "no", Space, Str "rock" ] ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "If"
+            , Space
+            , Str "there"
+            , Space
+            , Str "were"
+            , Space
+            , Str "rock"
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain [ Str "And", Space, Str "also", Space, Str "water" ] ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "And"
+            , Space
+            , Str "water"
+            , Span
+              ( "", [ "lnum" ], [] )
+              [ Str "350" ]
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain [ Str "A", Space, Str "spring" ] ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "A"
+            , Space
+            , Str "pool"
+            , Space
+            , Str "among"
+            , Space
+            , Str "the"
+            , Space
+            , Str "rock"
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "If"
+            , Space
+            , Str "there"
+            , Space
+            , Str "were"
+            , Space
+            , Str "the"
+            , Space
+            , Str "sound"
+            , Space
+            , Str "of"
+            , Space
+            , Str "water"
+            , Space
+            , Str "only"
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain [ Str "Not", Space, Str "the", Space, Str "cicada" ] ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "And"
+            , Space
+            , Str "dry"
+            , Space
+            , Str "grass"
+            , Space
+            , Str "singing"
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "But"
+            , Space
+            , Str "sound"
+            , Space
+            , Str "of"
+            , Space
+            , Str "water"
+            , Space
+            , Str "over"
+            , Space
+            , Str "a"
+            , Space
+            , Str "rock"
+            ]
+          ]
+        , Div
+          ( "wasteland-content.xhtml#ln357", [], [] )
+          [ Plain
+            [ Str "Where"
+            , Space
+            , Str "the"
+            , Space
+            , Str "hermit-thrush"
+            , Space
+            , Str "sings"
+            , Space
+            , Str "in"
+            , Space
+            , Str "the"
+            , Space
+            , Str "pine"
+            , Space
+            , Str "trees"
+            , Note
+              [ Para
+                [ Link
+                  ( "", [], [] )
+                  [ Str "357." ]
+                  ( "#wasteland-content.xhtml#ln357", "" )
+                , Space
+                , Str "This"
+                , Space
+                , Str "is"
+                , Space
+                , Str "Turdus"
+                , Space
+                , Str "aonalaschkae"
+                , Space
+                , Str "pallasii,"
+                , Space
+                , Str "the"
+                , Space
+                , Str "hermit-thrush"
+                , Space
+                , Str "which"
+                , Space
+                , Str "I"
+                , Space
+                , Str "have"
+                , SoftBreak
+                , Str "heard"
+                , Space
+                , Str "in"
+                , Space
+                , Str "Quebec"
+                , Space
+                , Str "County."
+                , Space
+                , Str "Chapman"
+                , Space
+                , Str "says"
+                , Space
+                , Str "(Handbook"
+                , Space
+                , Str "of"
+                , Space
+                , Str "Birds"
+                , Space
+                , Str "of"
+                , Space
+                , Str "Eastern"
+                , Space
+                , Str "North"
+                , SoftBreak
+                , Str "America)"
+                , Space
+                , Str "\"it"
+                , Space
+                , Str "is"
+                , Space
+                , Str "most"
+                , Space
+                , Str "at"
+                , Space
+                , Str "home"
+                , Space
+                , Str "in"
+                , Space
+                , Str "secluded"
+                , Space
+                , Str "woodland"
+                , Space
+                , Str "and"
+                , Space
+                , Str "thickety"
+                , Space
+                , Str "retreats."
+                , SoftBreak
+                , Str "."
+                , Space
+                , Str "."
+                , Space
+                , Str "."
+                , Space
+                , Str "Its"
+                , Space
+                , Str "notes"
+                , Space
+                , Str "are"
+                , Space
+                , Str "not"
+                , Space
+                , Str "remarkable"
+                , Space
+                , Str "for"
+                , Space
+                , Str "variety"
+                , Space
+                , Str "or"
+                , Space
+                , Str "volume,"
+                , Space
+                , Str "but"
+                , Space
+                , Str "in"
+                , Space
+                , Str "purity"
+                , SoftBreak
+                , Str "and"
+                , Space
+                , Str "sweetness"
+                , Space
+                , Str "of"
+                , Space
+                , Str "tone"
+                , Space
+                , Str "and"
+                , Space
+                , Str "exquisite"
+                , Space
+                , Str "modulation"
+                , Space
+                , Str "they"
+                , Space
+                , Str "are"
+                , Space
+                , Str "unequalled.\""
+                , Space
+                , Str "Its"
+                , SoftBreak
+                , Str "\"water-dripping"
+                , Space
+                , Str "song\""
+                , Space
+                , Str "is"
+                , Space
+                , Str "justly"
+                , Space
+                , Str "celebrated."
+                ]
+              ]
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "Drip"
+            , Space
+            , Str "drop"
+            , Space
+            , Str "drip"
+            , Space
+            , Str "drop"
+            , Space
+            , Str "drop"
+            , Space
+            , Str "drop"
+            , Space
+            , Str "drop"
+            ]
+          ]
+        , Div
+          ( "", [], [] )
+          [ Plain
+            [ Str "But"
+            , Space
+            , Str "there"
+            , Space
+            , Str "is"
+            , Space
+            , Str "no"
+            , Space
+            , Str "water"
+            ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "wasteland-content.xhtml#ln360", [], [] )
+        [ Plain
+          [ Str "Who"
+          , Space
+          , Str "is"
+          , Space
+          , Str "the"
+          , Space
+          , Str "third"
+          , Space
+          , Str "who"
+          , Space
+          , Str "walks"
+          , Space
+          , Str "always"
+          , Space
+          , Str "beside"
+          , Space
+          , Str "you?"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "360." ]
+                ( "#wasteland-content.xhtml#ln360", "" )
+              , Space
+              , Str "The"
+              , Space
+              , Str "following"
+              , Space
+              , Str "lines"
+              , Space
+              , Str "were"
+              , Space
+              , Str "stimulated"
+              , Space
+              , Str "by"
+              , Space
+              , Str "the"
+              , Space
+              , Str "account"
+              , Space
+              , Str "of"
+              , Space
+              , Str "one"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , SoftBreak
+              , Str "Antarctic"
+              , Space
+              , Str "expeditions"
+              , Space
+              , Str "(I"
+              , Space
+              , Str "forget"
+              , Space
+              , Str "which,"
+              , Space
+              , Str "but"
+              , Space
+              , Str "I"
+              , Space
+              , Str "think"
+              , Space
+              , Str "one"
+              , Space
+              , Str "of"
+              , Space
+              , Str "Shackleton's):"
+              , SoftBreak
+              , Str "it"
+              , Space
+              , Str "was"
+              , Space
+              , Str "related"
+              , Space
+              , Str "that"
+              , Space
+              , Str "the"
+              , Space
+              , Str "party"
+              , Space
+              , Str "of"
+              , Space
+              , Str "explorers,"
+              , Space
+              , Str "at"
+              , Space
+              , Str "the"
+              , Space
+              , Str "extremity"
+              , Space
+              , Str "of"
+              , Space
+              , Str "their"
+              , SoftBreak
+              , Str "strength,"
+              , Space
+              , Str "had"
+              , Space
+              , Str "the"
+              , Space
+              , Str "constant"
+              , Space
+              , Str "delusion"
+              , Space
+              , Str "that"
+              , Space
+              , Str "there"
+              , Space
+              , Str "was"
+              , Space
+              , Str "one"
+              , Space
+              , Str "more"
+              , Space
+              , Str "member"
+              , Space
+              , Str "than"
+              , SoftBreak
+              , Str "could"
+              , Space
+              , Str "actually"
+              , Space
+              , Str "be"
+              , Space
+              , Str "counted."
+              ]
+            ]
+          , SoftBreak
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "360" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "When"
+          , Space
+          , Str "I"
+          , Space
+          , Str "count,"
+          , Space
+          , Str "there"
+          , Space
+          , Str "are"
+          , Space
+          , Str "only"
+          , Space
+          , Str "you"
+          , Space
+          , Str "and"
+          , Space
+          , Str "I"
+          , Space
+          , Str "together"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "But"
+          , Space
+          , Str "when"
+          , Space
+          , Str "I"
+          , Space
+          , Str "look"
+          , Space
+          , Str "ahead"
+          , Space
+          , Str "up"
+          , Space
+          , Str "the"
+          , Space
+          , Str "white"
+          , Space
+          , Str "road"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "There"
+          , Space
+          , Str "is"
+          , Space
+          , Str "always"
+          , Space
+          , Str "another"
+          , Space
+          , Str "one"
+          , Space
+          , Str "walking"
+          , Space
+          , Str "beside"
+          , Space
+          , Str "you"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Gliding"
+          , Space
+          , Str "wrapt"
+          , Space
+          , Str "in"
+          , Space
+          , Str "a"
+          , Space
+          , Str "brown"
+          , Space
+          , Str "mantle,"
+          , Space
+          , Str "hooded"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "do"
+          , Space
+          , Str "not"
+          , Space
+          , Str "know"
+          , Space
+          , Str "whether"
+          , Space
+          , Str "a"
+          , Space
+          , Str "man"
+          , Space
+          , Str "or"
+          , Space
+          , Str "a"
+          , Space
+          , Str "woman"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln367", [], [] )
+        [ Plain
+          [ Str "\8213But"
+          , Space
+          , Str "who"
+          , Space
+          , Str "is"
+          , Space
+          , Str "that"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "other"
+          , Space
+          , Str "side"
+          , Space
+          , Str "of"
+          , Space
+          , Str "you?"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "367-77." ]
+                ( "#wasteland-content.xhtml#ln367", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Hermann"
+              , Space
+              , Str "Hesse,"
+              , Space
+              , Str "Blick"
+              , Space
+              , Str "ins"
+              , Space
+              , Str "Chaos:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"Schon"
+                , Space
+                , Str "ist"
+                , Space
+                , Str "halb"
+                , Space
+                , Str "Europa,"
+                , Space
+                , Str "schon"
+                , Space
+                , Str "ist"
+                , Space
+                , Str "zumindest"
+                , Space
+                , Str "der"
+                , Space
+                , Str "halbe"
+                , Space
+                , Str "Osten"
+                , Space
+                , Str "Europas"
+                , SoftBreak
+                , Str "auf"
+                , Space
+                , Str "dem"
+                , LineBreak
+                , Str "Wege"
+                , Space
+                , Str "zum"
+                , Space
+                , Str "Chaos,"
+                , Space
+                , Str "fhrt"
+                , Space
+                , Str "betrunken"
+                , Space
+                , Str "im"
+                , Space
+                , Str "heiligem"
+                , Space
+                , Str "Wahn"
+                , Space
+                , Str "am"
+                , SoftBreak
+                , Str "Abgrund"
+                , Space
+                , Str "entlang"
+                , LineBreak
+                , Str "und"
+                , Space
+                , Str "singt"
+                , Space
+                , Str "dazu,"
+                , Space
+                , Str "singt"
+                , Space
+                , Str "betrunken"
+                , Space
+                , Str "und"
+                , Space
+                , Str "hymnisch"
+                , SoftBreak
+                , Str "wie"
+                , Space
+                , Str "Dmitri"
+                , Space
+                , Str "Karamasoff"
+                , Space
+                , Str "sang."
+                , LineBreak
+                , Str "Ueber"
+                , Space
+                , Str "diese"
+                , Space
+                , Str "Lieder"
+                , Space
+                , Str "lacht"
+                , Space
+                , Str "der"
+                , SoftBreak
+                , Str "Bsrger"
+                , Space
+                , Str "beleidigt,"
+                , Space
+                , Str "der"
+                , Space
+                , Str "Heilige"
+                , LineBreak
+                , Str "und"
+                , Space
+                , Str "Seher"
+                , Space
+                , Str "hrt"
+                , Space
+                , Str "sie"
+                , Space
+                , Str "mit"
+                , SoftBreak
+                , Str "Trvnen.\""
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "What"
+          , Space
+          , Str "is"
+          , Space
+          , Str "that"
+          , Space
+          , Str "sound"
+          , Space
+          , Str "high"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "air"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Murmur"
+          , Space
+          , Str "of"
+          , Space
+          , Str "maternal"
+          , Space
+          , Str "lamentation"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Who"
+          , Space
+          , Str "are"
+          , Space
+          , Str "those"
+          , Space
+          , Str "hooded"
+          , Space
+          , Str "hordes"
+          , Space
+          , Str "swarming"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Over"
+          , Space
+          , Str "endless"
+          , Space
+          , Str "plains,"
+          , Space
+          , Str "stumbling"
+          , Space
+          , Str "in"
+          , Space
+          , Str "cracked"
+          , Space
+          , Str "earth"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "370" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Ringed"
+          , Space
+          , Str "by"
+          , Space
+          , Str "the"
+          , Space
+          , Str "flat"
+          , Space
+          , Str "horizon"
+          , Space
+          , Str "only"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "What"
+          , Space
+          , Str "is"
+          , Space
+          , Str "the"
+          , Space
+          , Str "city"
+          , Space
+          , Str "over"
+          , Space
+          , Str "the"
+          , Space
+          , Str "mountains"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Cracks"
+          , Space
+          , Str "and"
+          , Space
+          , Str "reforms"
+          , Space
+          , Str "and"
+          , Space
+          , Str "bursts"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "violet"
+          , Space
+          , Str "air"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Falling", Space, Str "towers" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Jerusalem"
+          , Space
+          , Str "Athens"
+          , Space
+          , Str "Alexandria"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Vienna", Space, Str "London" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Unreal" ] ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "A"
+          , Space
+          , Str "woman"
+          , Space
+          , Str "drew"
+          , Space
+          , Str "her"
+          , Space
+          , Str "long"
+          , Space
+          , Str "black"
+          , Space
+          , Str "hair"
+          , Space
+          , Str "out"
+          , Space
+          , Str "tight"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "fiddled"
+          , Space
+          , Str "whisper"
+          , Space
+          , Str "music"
+          , Space
+          , Str "on"
+          , Space
+          , Str "those"
+          , Space
+          , Str "strings"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "bats"
+          , Space
+          , Str "with"
+          , Space
+          , Str "baby"
+          , Space
+          , Str "faces"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "violet"
+          , Space
+          , Str "light"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "380" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Whistled,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "beat"
+          , Space
+          , Str "their"
+          , Space
+          , Str "wings"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "crawled"
+          , Space
+          , Str "head"
+          , Space
+          , Str "downward"
+          , Space
+          , Str "down"
+          , Space
+          , Str "a"
+          , Space
+          , Str "blackened"
+          , Space
+          , Str "wall"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "upside"
+          , Space
+          , Str "down"
+          , Space
+          , Str "in"
+          , Space
+          , Str "air"
+          , Space
+          , Str "were"
+          , Space
+          , Str "towers"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Tolling"
+          , Space
+          , Str "reminiscent"
+          , Space
+          , Str "bells,"
+          , Space
+          , Str "that"
+          , Space
+          , Str "kept"
+          , Space
+          , Str "the"
+          , Space
+          , Str "hours"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "And"
+          , Space
+          , Str "voices"
+          , Space
+          , Str "singing"
+          , Space
+          , Str "out"
+          , Space
+          , Str "of"
+          , Space
+          , Str "empty"
+          , Space
+          , Str "cisterns"
+          , Space
+          , Str "and"
+          , Space
+          , Str "exhausted"
+          , SoftBreak
+          , Str "wells."
+          ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "In"
+          , Space
+          , Str "this"
+          , Space
+          , Str "decayed"
+          , Space
+          , Str "hole"
+          , Space
+          , Str "among"
+          , Space
+          , Str "the"
+          , Space
+          , Str "mountains"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "In"
+          , Space
+          , Str "the"
+          , Space
+          , Str "faint"
+          , Space
+          , Str "moonlight,"
+          , Space
+          , Str "the"
+          , Space
+          , Str "grass"
+          , Space
+          , Str "is"
+          , Space
+          , Str "singing"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Over"
+          , Space
+          , Str "the"
+          , Space
+          , Str "tumbled"
+          , Space
+          , Str "graves,"
+          , Space
+          , Str "about"
+          , Space
+          , Str "the"
+          , Space
+          , Str "chapel"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "There"
+          , Space
+          , Str "is"
+          , Space
+          , Str "the"
+          , Space
+          , Str "empty"
+          , Space
+          , Str "chapel,"
+          , Space
+          , Str "only"
+          , Space
+          , Str "the"
+          , Space
+          , Str "wind's"
+          , Space
+          , Str "home."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "It"
+          , Space
+          , Str "has"
+          , Space
+          , Str "no"
+          , Space
+          , Str "windows,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "the"
+          , Space
+          , Str "door"
+          , Space
+          , Str "swings,"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "390" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Dry"
+          , Space
+          , Str "bones"
+          , Space
+          , Str "can"
+          , Space
+          , Str "harm"
+          , Space
+          , Str "no"
+          , Space
+          , Str "one."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Only"
+          , Space
+          , Str "a"
+          , Space
+          , Str "cock"
+          , Space
+          , Str "stood"
+          , Space
+          , Str "on"
+          , Space
+          , Str "the"
+          , Space
+          , Str "rooftree"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Co"
+          , Space
+          , Str "co"
+          , Space
+          , Str "rico"
+          , Space
+          , Str "co"
+          , Space
+          , Str "co"
+          , Space
+          , Str "rico"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "In"
+          , Space
+          , Str "a"
+          , Space
+          , Str "flash"
+          , Space
+          , Str "of"
+          , Space
+          , Str "lightning."
+          , Space
+          , Str "Then"
+          , Space
+          , Str "a"
+          , Space
+          , Str "damp"
+          , Space
+          , Str "gust"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "Bringing", Space, Str "rain" ] ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Ganga"
+          , Space
+          , Str "was"
+          , Space
+          , Str "sunken,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "the"
+          , Space
+          , Str "limp"
+          , Space
+          , Str "leaves"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Waited"
+          , Space
+          , Str "for"
+          , Space
+          , Str "rain,"
+          , Space
+          , Str "while"
+          , Space
+          , Str "the"
+          , Space
+          , Str "black"
+          , Space
+          , Str "clouds"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Gathered"
+          , Space
+          , Str "far"
+          , Space
+          , Str "distant,"
+          , Space
+          , Str "over"
+          , Space
+          , Str "Himavant."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "jungle"
+          , Space
+          , Str "crouched,"
+          , Space
+          , Str "humped"
+          , Space
+          , Str "in"
+          , Space
+          , Str "silence."
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Then"
+          , Space
+          , Str "spoke"
+          , Space
+          , Str "the"
+          , Space
+          , Str "thunder"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "400" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "DA" ] ]
+      , Div
+        ( "wasteland-content.xhtml#ln402", [], [] )
+        [ Plain
+          [ Span
+            ( "", [], [ ( "lang", "sa" ) ] )
+            [ Str "Datta" ]
+          , Str ":"
+          , Space
+          , Str "what"
+          , Space
+          , Str "have"
+          , Space
+          , Str "we"
+          , Space
+          , Str "given?"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "402." ]
+                ( "#wasteland-content.xhtml#ln402", "" )
+              , Space
+              , Quoted DoubleQuote
+                [ Str "\"Datta,"
+                , Space
+                , Str "dayadhvam,"
+                , Space
+                , Str "damyata\""
+                ]
+              , Space
+              , Str "(Give,"
+              , Space
+              , Str "sympathize,"
+              , SoftBreak
+              , Str "control)."
+              , Space
+              , Str "The"
+              , Space
+              , Str "fable"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "meaning"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Thunder"
+              , Space
+              , Str "is"
+              , Space
+              , Str "found"
+              , Space
+              , Str "in"
+              , Space
+              , Str "the"
+              , SoftBreak
+              , Str "Brihadaranyaka-Upanishad,"
+              , Space
+              , Str "5,"
+              , Space
+              , Str "1."
+              , Space
+              , Str "A"
+              , Space
+              , Str "translation"
+              , Space
+              , Str "is"
+              , Space
+              , Str "found"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Deussen's"
+              , SoftBreak
+              , Str "Sechzig"
+              , Space
+              , Str "Upanishads"
+              , Space
+              , Str "des"
+              , Space
+              , Str "Veda,"
+              , Space
+              , Str "p."
+              , Space
+              , Str "489."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "My"
+          , Space
+          , Str "friend,"
+          , Space
+          , Str "blood"
+          , Space
+          , Str "shaking"
+          , Space
+          , Str "my"
+          , Space
+          , Str "heart"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "awful"
+          , Space
+          , Str "daring"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "moment's"
+          , Space
+          , Str "surrender"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Which"
+          , Space
+          , Str "an"
+          , Space
+          , Str "age"
+          , Space
+          , Str "of"
+          , Space
+          , Str "prudence"
+          , Space
+          , Str "can"
+          , Space
+          , Str "never"
+          , Space
+          , Str "retract"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "By"
+          , Space
+          , Str "this,"
+          , Space
+          , Str "and"
+          , Space
+          , Str "this"
+          , Space
+          , Str "only,"
+          , Space
+          , Str "we"
+          , Space
+          , Str "have"
+          , Space
+          , Str "existed"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Which"
+          , Space
+          , Str "is"
+          , Space
+          , Str "not"
+          , Space
+          , Str "to"
+          , Space
+          , Str "be"
+          , Space
+          , Str "found"
+          , Space
+          , Str "in"
+          , Space
+          , Str "our"
+          , Space
+          , Str "obituaries"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln408", [], [] )
+        [ Plain
+          [ Str "Or"
+          , Space
+          , Str "in"
+          , Space
+          , Str "memories"
+          , Space
+          , Str "draped"
+          , Space
+          , Str "by"
+          , Space
+          , Str "the"
+          , Space
+          , Str "beneficent"
+          , Space
+          , Str "spider"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "408." ]
+                ( "#wasteland-content.xhtml#ln408", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Webster,"
+              , Space
+              , Str "The"
+              , Space
+              , Str "White"
+              , Space
+              , Str "Devil,"
+              , Space
+              , Str "v."
+              , Space
+              , Str "vi:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"."
+                , Space
+                , Str "."
+                , Space
+                , Str "."
+                , Space
+                , Str "they'll"
+                , Space
+                , Str "remarry"
+                , LineBreak
+                , Str "Ere"
+                , Space
+                , Str "the"
+                , Space
+                , Str "worm"
+                , Space
+                , Str "pierce"
+                , Space
+                , Str "your"
+                , Space
+                , Str "winding-sheet,"
+                , SoftBreak
+                , Str "ere"
+                , Space
+                , Str "the"
+                , Space
+                , Str "spider"
+                , LineBreak
+                , Str "Make"
+                , Space
+                , Str "a"
+                , Space
+                , Str "thin"
+                , Space
+                , Str "curtain"
+                , Space
+                , Str "for"
+                , Space
+                , Str "your"
+                , Space
+                , Str "epitaphs.\""
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Or"
+          , Space
+          , Str "under"
+          , Space
+          , Str "seals"
+          , Space
+          , Str "broken"
+          , Space
+          , Str "by"
+          , Space
+          , Str "the"
+          , Space
+          , Str "lean"
+          , Space
+          , Str "solicitor"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "In"
+          , Space
+          , Str "our"
+          , Space
+          , Str "empty"
+          , Space
+          , Str "rooms"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "410" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "DA" ] ]
+      , Div
+        ( "wasteland-content.xhtml#ln412", [], [] )
+        [ Plain
+          [ Span
+            ( "", [], [ ( "lang", "sa" ) ] )
+            [ Str "Dayadhvam" ]
+          , Str ":"
+          , Space
+          , Str "I"
+          , Space
+          , Str "have"
+          , Space
+          , Str "heard"
+          , Space
+          , Str "the"
+          , Space
+          , Str "key"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "412." ]
+                ( "#wasteland-content.xhtml#ln412", "" )
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Inferno,"
+              , Space
+              , Str "xxxiii."
+              , Space
+              , Str "46:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"ed"
+                , Space
+                , Str "io"
+                , Space
+                , Str "sentii"
+                , Space
+                , Str "chiavar"
+                , Space
+                , Str "l'uscio"
+                , Space
+                , Str "di"
+                , Space
+                , Str "sotto"
+                , LineBreak
+                , Str "all'orribile"
+                , Space
+                , Str "torre.\""
+                ]
+              ]
+            , Para
+              [ Str "Also"
+              , Space
+              , Str "F."
+              , Space
+              , Str "H."
+              , Space
+              , Str "Bradley,"
+              , Space
+              , Str "Appearance"
+              , Space
+              , Str "and"
+              , Space
+              , Str "Reality,"
+              , Space
+              , Str "p."
+              , Space
+              , Str "346:"
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"My"
+                , Space
+                , Str "external"
+                , Space
+                , Str "sensations"
+                , Space
+                , Str "are"
+                , Space
+                , Str "no"
+                , Space
+                , Str "less"
+                , Space
+                , Str "private"
+                , Space
+                , Str "to"
+                , Space
+                , Str "myself"
+                , Space
+                , Str "than"
+                , Space
+                , Str "are"
+                , Space
+                , Str "my"
+                , SoftBreak
+                , Str "thoughts"
+                , Space
+                , Str "or"
+                , Space
+                , Str "my"
+                , Space
+                , Str "feelings."
+                , Space
+                , Str "In"
+                , Space
+                , Str "either"
+                , Space
+                , Str "case"
+                , Space
+                , Str "my"
+                , Space
+                , Str "experience"
+                , Space
+                , Str "falls"
+                , Space
+                , Str "within"
+                , SoftBreak
+                , Str "my"
+                , Space
+                , Str "own"
+                , Space
+                , Str "circle,"
+                , Space
+                , Str "a"
+                , Space
+                , Str "circle"
+                , Space
+                , Str "closed"
+                , Space
+                , Str "on"
+                , Space
+                , Str "the"
+                , Space
+                , Str "outside;"
+                , Space
+                , Str "and,"
+                , Space
+                , Str "with"
+                , Space
+                , Str "all"
+                , Space
+                , Str "its"
+                , SoftBreak
+                , Str "elements"
+                , Space
+                , Str "alike,"
+                , Space
+                , Str "every"
+                , Space
+                , Str "sphere"
+                , Space
+                , Str "is"
+                , Space
+                , Str "opaque"
+                , Space
+                , Str "to"
+                , Space
+                , Str "the"
+                , Space
+                , Str "others"
+                , Space
+                , Str "which"
+                , Space
+                , Str "surround"
+                , SoftBreak
+                , Str "it."
+                , Space
+                , Str "."
+                , Space
+                , Str "."
+                , Space
+                , Str "."
+                , Space
+                , Str "In"
+                , Space
+                , Str "brief,"
+                , Space
+                , Str "regarded"
+                , Space
+                , Str "as"
+                , Space
+                , Str "an"
+                , Space
+                , Str "existence"
+                , Space
+                , Str "which"
+                , Space
+                , Str "appears"
+                , Space
+                , Str "in"
+                , Space
+                , Str "a"
+                , SoftBreak
+                , Str "soul,"
+                , Space
+                , Str "the"
+                , Space
+                , Str "whole"
+                , Space
+                , Str "world"
+                , Space
+                , Str "for"
+                , Space
+                , Str "each"
+                , Space
+                , Str "is"
+                , Space
+                , Str "peculiar"
+                , Space
+                , Str "and"
+                , Space
+                , Str "private"
+                , Space
+                , Str "to"
+                , Space
+                , Str "that"
+                , SoftBreak
+                , Str "soul.\""
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Turn"
+          , Space
+          , Str "in"
+          , Space
+          , Str "the"
+          , Space
+          , Str "door"
+          , Space
+          , Str "once"
+          , Space
+          , Str "and"
+          , Space
+          , Str "turn"
+          , Space
+          , Str "once"
+          , Space
+          , Str "only"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "We"
+          , Space
+          , Str "think"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "key,"
+          , Space
+          , Str "each"
+          , Space
+          , Str "in"
+          , Space
+          , Str "his"
+          , Space
+          , Str "prison"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Thinking"
+          , Space
+          , Str "of"
+          , Space
+          , Str "the"
+          , Space
+          , Str "key,"
+          , Space
+          , Str "each"
+          , Space
+          , Str "confirms"
+          , Space
+          , Str "a"
+          , Space
+          , Str "prison"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Only"
+          , Space
+          , Str "at"
+          , Space
+          , Str "nightfall,"
+          , Space
+          , Str "aetherial"
+          , Space
+          , Str "rumours"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Revive"
+          , Space
+          , Str "for"
+          , Space
+          , Str "a"
+          , Space
+          , Str "moment"
+          , Space
+          , Str "a"
+          , Space
+          , Str "broken"
+          , Space
+          , Str "Coriolanus"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain [ Str "DA" ] ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Span
+            ( "", [], [ ( "lang", "sa" ) ] )
+            [ Str "Damyata" ]
+          , Str ":"
+          , Space
+          , Str "The"
+          , Space
+          , Str "boat"
+          , Space
+          , Str "responded"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Gaily,"
+          , Space
+          , Str "to"
+          , Space
+          , Str "the"
+          , Space
+          , Str "hand"
+          , Space
+          , Str "expert"
+          , Space
+          , Str "with"
+          , Space
+          , Str "sail"
+          , Space
+          , Str "and"
+          , Space
+          , Str "oar"
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "420" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "The"
+          , Space
+          , Str "sea"
+          , Space
+          , Str "was"
+          , Space
+          , Str "calm,"
+          , Space
+          , Str "your"
+          , Space
+          , Str "heart"
+          , Space
+          , Str "would"
+          , Space
+          , Str "have"
+          , Space
+          , Str "responded"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Gaily,"
+          , Space
+          , Str "when"
+          , Space
+          , Str "invited,"
+          , Space
+          , Str "beating"
+          , Space
+          , Str "obedient"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "To", Space, Str "controlling", Space, Str "hands" ]
+        ]
+      ]
+    , Div
+      ( "", [ "linegroup" ], [] )
+      [ Div
+        ( "", [ "indent" ], [] )
+        [ Plain
+          [ Str "I"
+          , Space
+          , Str "sat"
+          , Space
+          , Str "upon"
+          , Space
+          , Str "the"
+          , Space
+          , Str "shore"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln425", [], [] )
+        [ Plain
+          [ Str "Fishing,"
+          , Space
+          , Str "with"
+          , Space
+          , Str "the"
+          , Space
+          , Str "arid"
+          , Space
+          , Str "plain"
+          , Space
+          , Str "behind"
+          , Space
+          , Str "me"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "425." ]
+                ( "#wasteland-content.xhtml#ln425", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Weston,"
+              , Space
+              , Str "From"
+              , Space
+              , Str "Ritual"
+              , Space
+              , Str "to"
+              , Space
+              , Str "Romance;"
+              , Space
+              , Str "chapter"
+              , Space
+              , Str "on"
+              , Space
+              , Str "the"
+              , Space
+              , Str "Fisher"
+              , Space
+              , Str "King."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "Shall"
+          , Space
+          , Str "I"
+          , Space
+          , Str "at"
+          , Space
+          , Str "least"
+          , Space
+          , Str "set"
+          , Space
+          , Str "my"
+          , Space
+          , Str "lands"
+          , Space
+          , Str "in"
+          , Space
+          , Str "order?"
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "London"
+          , Space
+          , Str "Bridge"
+          , Space
+          , Str "is"
+          , Space
+          , Str "falling"
+          , Space
+          , Str "down"
+          , Space
+          , Str "falling"
+          , Space
+          , Str "down"
+          , Space
+          , Str "falling"
+          , Space
+          , Str "down"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln428", [], [ ( "lang", "it" ) ] )
+        [ Plain
+          [ Emph
+            [ Str "Poi"
+            , Space
+            , Str "s'ascose"
+            , Space
+            , Str "nel"
+            , Space
+            , Str "foco"
+            , Space
+            , Str "che"
+            , Space
+            , Str "gli"
+            , Space
+            , Str "affina"
+            ]
+          , SoftBreak
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "428." ]
+                ( "#wasteland-content.xhtml#ln428", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Purgatorio,"
+              , Space
+              , Str "xxvi."
+              , Space
+              , Str "148."
+              ]
+            , BlockQuote
+              [ Para
+                [ Str "\"'Ara"
+                , Space
+                , Str "vos"
+                , Space
+                , Str "prec"
+                , Space
+                , Str "per"
+                , Space
+                , Str "aquella"
+                , Space
+                , Str "valor"
+                , LineBreak
+                , Str "'que"
+                , Space
+                , Str "vos"
+                , Space
+                , Str "guida"
+                , Space
+                , Str "al"
+                , Space
+                , Str "som"
+                , Space
+                , Str "de"
+                , SoftBreak
+                , Str "l'escalina,"
+                , LineBreak
+                , Str "'sovegna"
+                , Space
+                , Str "vos"
+                , Space
+                , Str "a"
+                , Space
+                , Str "temps"
+                , Space
+                , Str "de"
+                , Space
+                , Str "ma"
+                , Space
+                , Str "dolor.'"
+                , LineBreak
+                , Str "Poi"
+                , SoftBreak
+                , Str "s'ascose"
+                , Space
+                , Str "nel"
+                , Space
+                , Str "foco"
+                , Space
+                , Str "che"
+                , Space
+                , Str "gli"
+                , Space
+                , Str "affina.\""
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln429", [], [] )
+        [ Plain
+          [ Span
+            ( "", [], [ ( "lang", "it" ) ] )
+            [ SoftBreak
+            , Emph
+              [ Str "Quando"
+              , Space
+              , Str "fiam"
+              , Space
+              , Str "ceu"
+              , Space
+              , Str "chelidon"
+              ]
+            , SoftBreak
+            ]
+          , Space
+          , Str "-"
+          , Space
+          , Str "O"
+          , Space
+          , Str "swallow"
+          , Space
+          , Str "swallow"
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "429." ]
+                ( "#wasteland-content.xhtml#ln429", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Pervigilium"
+              , Space
+              , Str "Veneris."
+              , Space
+              , Str "Cf."
+              , Space
+              , Str "Philomela"
+              , Space
+              , Str "in"
+              , Space
+              , Str "Parts"
+              , Space
+              , Str "II"
+              , Space
+              , Str "and"
+              , Space
+              , Str "III."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln430", [], [ ( "lang", "fr" ) ] )
+        [ Plain
+          [ Emph
+            [ Str "Le"
+            , Space
+            , Str "Prince"
+            , Space
+            , Str "d'Aquitaine"
+            , Space
+            , Str "a"
+            , Space
+            , Str "la"
+            , Space
+            , Str "tour"
+            , Space
+            , Str "abolie"
+            ]
+          , SoftBreak
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "430." ]
+                ( "#wasteland-content.xhtml#ln430", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Gerard"
+              , Space
+              , Str "de"
+              , Space
+              , Str "Nerval,"
+              , Space
+              , Str "Sonnet"
+              , Space
+              , Str "El"
+              , Space
+              , Str "Desdichado."
+              ]
+            ]
+          , SoftBreak
+          , Span
+            ( "", [ "lnum" ], [] )
+            [ Str "430" ]
+          ]
+        ]
+      , Div
+        ( "", [], [] )
+        [ Plain
+          [ Str "These"
+          , Space
+          , Str "fragments"
+          , Space
+          , Str "I"
+          , Space
+          , Str "have"
+          , Space
+          , Str "shored"
+          , Space
+          , Str "against"
+          , Space
+          , Str "my"
+          , Space
+          , Str "ruins"
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln432", [], [] )
+        [ Plain
+          [ Str "Why"
+          , Space
+          , Str "then"
+          , Space
+          , Str "Ile"
+          , Space
+          , Str "fit"
+          , Space
+          , Str "you."
+          , Space
+          , Str "Hieronymo's"
+          , Space
+          , Str "mad"
+          , Space
+          , Str "againe."
+          , Note
+            [ Para
+              [ Link
+                ( "", [], [] )
+                [ Str "432." ]
+                ( "#wasteland-content.xhtml#ln432", "" )
+              , Space
+              , Str "V."
+              , Space
+              , Str "Kyd's"
+              , Space
+              , Str "Spanish"
+              , Space
+              , Str "Tragedy."
+              ]
+            ]
+          ]
+        ]
+      , Div
+        ( "", [], [ ( "lang", "sa" ) ] )
+        [ Plain
+          [ Str "Datta."
+          , Space
+          , Str "Dayadhvam."
+          , Space
+          , Str "Damyata."
+          ]
+        ]
+      , Div
+        ( "wasteland-content.xhtml#ln434"
+        ,
+          [ "linegroup", "indent" ]
+        , []
+        )
+        [ Plain
+          [ Span
+            ( "", [], [ ( "lang", "sa" ) ] )
+            [ Str "Shantih"
+            , Space
+            , Str "shantih"
+            , Space
+            , Str "shantih"
+            , Note
+              [ Para
+                [ Link
+                  ( "", [], [] )
+                  [ Str "434." ]
+                  ( "#wasteland-content.xhtml#ln434", "" )
+                , Space
+                , Str "Shantih."
+                , Space
+                , Str "Repeated"
+                , Space
+                , Str "as"
+                , Space
+                , Str "here,"
+                , Space
+                , Str "a"
+                , Space
+                , Str "formal"
+                , Space
+                , Str "ending"
+                , Space
+                , Str "to"
+                , Space
+                , Str "an"
+                , Space
+                , Str "Upanishad."
+                , Space
+                , Str "'The"
+                , SoftBreak
+                , Str "Peace"
+                , Space
+                , Str "which"
+                , Space
+                , Str "passeth"
+                , Space
+                , Str "understanding'"
+                , Space
+                , Str "is"
+                , Space
+                , Str "a"
+                , Space
+                , Str "feeble"
+                , Space
+                , Str "translation"
+                , Space
+                , Str "of"
+                , Space
+                , Str "the"
+                , SoftBreak
+                , Str "content"
+                , Space
+                , Str "of"
+                , Space
+                , Str "this"
+                , Space
+                , Str "word."
+                ]
+              ]
+            , SoftBreak
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+, Div
+  ( "wasteland-content.xhtml#backmatter"
+  ,
+    [ "section", "backmatter" ]
+  , []
+  )
+  [ Div
+    ( "wasteland-content.xhtml#rearnotes"
+    ,
+      [ "section", "rearnotes" ]
+    , []
+    )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "NOTES"
+      , Space
+      , Str "ON"
+      , Space
+      , Str "\"THE"
+      , Space
+      , Str "WASTE"
+      , Space
+      , Str "LAND\""
+      ]
+    , Para
+      [ Str "Not"
+      , Space
+      , Str "only"
+      , Space
+      , Str "the"
+      , Space
+      , Str "title,"
+      , Space
+      , Str "but"
+      , Space
+      , Str "the"
+      , Space
+      , Str "plan"
+      , Space
+      , Str "and"
+      , Space
+      , Str "a"
+      , Space
+      , Str "good"
+      , Space
+      , Str "deal"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "incidental"
+      , Space
+      , Str "symbolism"
+      , Space
+      , Str "of"
+      , SoftBreak
+      , Str "the"
+      , Space
+      , Str "poem"
+      , Space
+      , Str "were"
+      , Space
+      , Str "suggested"
+      , Space
+      , Str "by"
+      , Space
+      , Str "Miss"
+      , Space
+      , Str "Jessie"
+      , Space
+      , Str "L."
+      , Space
+      , Str "Weston's"
+      , Space
+      , Str "book"
+      , Space
+      , Str "on"
+      , Space
+      , Str "the"
+      , Space
+      , Str "Grail"
+      , Space
+      , Str "legend:"
+      , SoftBreak
+      , Str "From"
+      , Space
+      , Str "Ritual"
+      , Space
+      , Str "to"
+      , Space
+      , Str "Romance"
+      ]
+    , Para
+      [ Str "Indeed,"
+      , Space
+      , Str "so"
+      , Space
+      , Str "deeply"
+      , Space
+      , Str "am"
+      , Space
+      , Str "I"
+      , Space
+      , Str "indebted,"
+      , Space
+      , Str "Miss"
+      , Space
+      , Str "Weston's"
+      , Space
+      , Str "book"
+      , Space
+      , Str "will"
+      , Space
+      , Str "elucidate"
+      , Space
+      , Str "the"
+      , SoftBreak
+      , Str "difficulties"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "poem"
+      , Space
+      , Str "much"
+      , Space
+      , Str "better"
+      , Space
+      , Str "than"
+      , Space
+      , Str "my"
+      , Space
+      , Str "notes"
+      , Space
+      , Str "can"
+      , Space
+      , Str "do;"
+      , Space
+      , Str "and"
+      , Space
+      , Str "I"
+      , Space
+      , Str "recommend"
+      , Space
+      , Str "it"
+      , SoftBreak
+      , Str "(apart"
+      , Space
+      , Str "from"
+      , Space
+      , Str "the"
+      , Space
+      , Str "great"
+      , Space
+      , Str "interest"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "book"
+      , Space
+      , Str "itself)"
+      , Space
+      , Str "to"
+      , Space
+      , Str "any"
+      , Space
+      , Str "who"
+      , Space
+      , Str "think"
+      , Space
+      , Str "such"
+      , SoftBreak
+      , Str "elucidation"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "poem"
+      , Space
+      , Str "worth"
+      , Space
+      , Str "the"
+      , Space
+      , Str "trouble."
+      , Space
+      , Str "To"
+      , Space
+      , Str "another"
+      , Space
+      , Str "work"
+      , Space
+      , Str "of"
+      , Space
+      , Str "anthropology"
+      , Space
+      , Str "I"
+      , Space
+      , Str "am"
+      , SoftBreak
+      , Str "indebted"
+      , Space
+      , Str "in"
+      , Space
+      , Str "general,"
+      , Space
+      , Str "one"
+      , Space
+      , Str "which"
+      , Space
+      , Str "has"
+      , Space
+      , Str "influenced"
+      , Space
+      , Str "our"
+      , Space
+      , Str "generation"
+      , Space
+      , Str "profoundly;"
+      , Space
+      , Str "I"
+      , Space
+      , Str "mean"
+      , SoftBreak
+      , Str "The"
+      , Space
+      , Str "Golden"
+      , Space
+      , Str "Bough;"
+      , Space
+      , Str "I"
+      , Space
+      , Str "have"
+      , Space
+      , Str "used"
+      , Space
+      , Str "especially"
+      , Space
+      , Str "the"
+      , Space
+      , Str "two"
+      , Space
+      , Str "volumes"
+      , Space
+      , Str "Adonis,"
+      , Space
+      , Str "Attis,"
+      , Space
+      , Str "Osiris."
+      , SoftBreak
+      , Str "Anyone"
+      , Space
+      , Str "who"
+      , Space
+      , Str "is"
+      , Space
+      , Str "acquainted"
+      , Space
+      , Str "with"
+      , Space
+      , Str "these"
+      , Space
+      , Str "works"
+      , Space
+      , Str "will"
+      , Space
+      , Str "immediately"
+      , Space
+      , Str "recognise"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "poem"
+      , SoftBreak
+      , Str "certain"
+      , Space
+      , Str "references"
+      , Space
+      , Str "to"
+      , Space
+      , Str "vegetation"
+      , Space
+      , Str "ceremonies."
+      ]
+    , Div
+      ( "", [ "section" ], [] )
+      [ Header 3
+        ( "", [], [] )
+        [ Str "I."
+        , Space
+        , Str "THE"
+        , Space
+        , Str "BURIAL"
+        , Space
+        , Str "OF"
+        , Space
+        , Str "THE"
+        , Space
+        , Str "DEAD"
+        ]
+      ]
+    , Div
+      ( "", [ "section" ], [] )
+      [ Header 3
+        ( "", [], [] )
+        [ Str "II."
+        , Space
+        , Str "A"
+        , Space
+        , Str "GAME"
+        , Space
+        , Str "OF"
+        , Space
+        , Str "CHESS"
+        ]
+      ]
+    , Div
+      ( "", [ "section" ], [] )
+      [ Header 3
+        ( "", [], [] )
+        [ Str "III."
+        , Space
+        , Str "THE"
+        , Space
+        , Str "FIRE"
+        , Space
+        , Str "SERMON"
+        ]
+      ]
+    , Div
+      ( "", [ "section" ], [] )
+      [ Header 3
+        ( "", [], [] )
+        [ Str "V."
+        , Space
+        , Str "WHAT"
+        , Space
+        , Str "THE"
+        , Space
+        , Str "THUNDER"
+        , Space
+        , Str "SAID"
+        ]
+      , Para
+        [ Str "In"
+        , Space
+        , Str "the"
+        , Space
+        , Str "first"
+        , Space
+        , Str "part"
+        , Space
+        , Str "of"
+        , Space
+        , Str "Part"
+        , Space
+        , Str "V"
+        , Space
+        , Str "three"
+        , Space
+        , Str "themes"
+        , Space
+        , Str "are"
+        , Space
+        , Str "employed:"
+        , Space
+        , Str "the"
+        , Space
+        , Str "journey"
+        , Space
+        , Str "to"
+        , Space
+        , Str "Emmaus,"
+        , SoftBreak
+        , Str "the"
+        , Space
+        , Str "approach"
+        , Space
+        , Str "to"
+        , Space
+        , Str "the"
+        , Space
+        , Str "Chapel"
+        , Space
+        , Str "Perilous"
+        , Space
+        , Str "(see"
+        , Space
+        , Str "Miss"
+        , Space
+        , Str "Weston's"
+        , Space
+        , Str "book)"
+        , Space
+        , Str "and"
+        , Space
+        , Str "the"
+        , Space
+        , Str "present"
+        , SoftBreak
+        , Str "decay"
+        , Space
+        , Str "of"
+        , Space
+        , Str "eastern"
+        , Space
+        , Str "Europe."
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/fb2/reader/emphasis.native
+++ b/test/fb2/reader/emphasis.native
@@ -1,6 +1,38 @@
-Pandoc (Meta {unMeta = fromList []})
-[Div ("",["section"],[])
- [Para [Str "Plain,",Space,Strong [Str "strong"],Str ",",Space,Emph [Str "emphasis"],Str ",",Space,Strong [Emph [Str "strong",Space,Str "emphasis"]],Str ",",Space,Emph [Strong [Str "emphasized",Space,Str "strong"]],Str "."]
- ,Para [Str "Strikethrough:",Space,Strikeout [Str "deleted"]]
- ,Para [Subscript [Str "Subscript"],Space,Str "and",Space,Superscript [Str "superscript"]]
- ,Para [Str "Some",Space,Code ("",[],[]) "code"]]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Div
+    ( "", [ "section" ], [] )
+    [ Para
+      [ Str "Plain,"
+      , Space
+      , Strong
+        [ Str "strong" ]
+      , Str ","
+      , Space
+      , Emph
+        [ Str "emphasis" ]
+      , Str ","
+      , Space
+      , Strong
+        [ Emph [ Str "strong", Space, Str "emphasis" ] ]
+      , Str ","
+      , Space
+      , Emph
+        [ Strong [ Str "emphasized", Space, Str "strong" ] ]
+      , Str "."
+      ]
+    , Para
+      [ Str "Strikethrough:", Space, Strikeout [ Str "deleted" ] ]
+    , Para
+      [ Subscript
+        [ Str "Subscript" ]
+      , Space
+      , Str "and"
+      , Space
+      , Superscript
+        [ Str "superscript" ]
+      ]
+    , Para
+      [ Str "Some", Space, Code ( "", [], [] ) "code" ]
+    ]
+  ]

--- a/test/fb2/reader/epigraph.native
+++ b/test/fb2/reader/epigraph.native
@@ -1,9 +1,18 @@
-Pandoc (Meta {unMeta = fromList []})
-[Div ("",["epigraph"],[])
- [Para [Str "Body",Space,Str "epigraph"]]
-,Div ("",["section"],[])
- [Div ("",["epigraph"],[])
-  [Para [Str "Section",Space,Str "epigraph"]]
- ,Div ("",["section"],[])
-  [Div ("",["epigraph"],[])
-   [Para [Str "Subsection",Space,Str "epigraph"]]]]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Div
+    ( "", [ "epigraph" ], [] )
+    [ Para [ Str "Body", Space, Str "epigraph" ] ]
+  , Div
+    ( "", [ "section" ], [] )
+    [ Div
+      ( "", [ "epigraph" ], [] )
+      [ Para [ Str "Section", Space, Str "epigraph" ] ]
+    , Div
+      ( "", [ "section" ], [] )
+      [ Div
+        ( "", [ "epigraph" ], [] )
+        [ Para [ Str "Subsection", Space, Str "epigraph" ] ]
+      ]
+    ]
+  ]

--- a/test/fb2/reader/meta.native
+++ b/test/fb2/reader/meta.native
@@ -1,2 +1,43 @@
-Pandoc (Meta {unMeta = fromList [("abstract",MetaBlocks [Para [Str "Book",Space,Str "annotation"],Para [Str "Second",Space,Str "paragraph",Space,Str "of",Space,Str "book",Space,Str "annotation"]]),("author",MetaList [MetaInlines [Str "First",Space,Str "Middle",Space,Str "Last"],MetaInlines [Str "Another",Space,Str "Author"]]),("date",MetaInlines [Str "2018"]),("keywords",MetaList [MetaString "foo",MetaString "bar",MetaString "baz"]),("title",MetaInlines [Str "Book",Space,Str "title"])]})
-[Header 1 ("",[],[]) [Str "Body",Space,Str "title"]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "abstract"
+        , MetaBlocks
+          [ Para
+            [ Str "Book", Space, Str "annotation" ]
+          , Para
+            [ Str "Second"
+            , Space
+            , Str "paragraph"
+            , Space
+            , Str "of"
+            , Space
+            , Str "book"
+            , Space
+            , Str "annotation"
+            ]
+          ]
+        )
+      ,
+        ( "author"
+        , MetaList
+          [ MetaInlines
+            [ Str "First", Space, Str "Middle", Space, Str "Last" ]
+          , MetaInlines
+            [ Str "Another", Space, Str "Author" ]
+          ]
+        )
+      ,
+        ( "date", MetaInlines [ Str "2018" ] )
+      ,
+        ( "keywords"
+        , MetaList
+          [ MetaString "foo", MetaString "bar", MetaString "baz" ]
+        )
+      ,
+        ( "title", MetaInlines [ Str "Book", Space, Str "title" ] )
+      ]
+    }
+  )
+  [ Header 1 ( "", [], [] ) [ Str "Body", Space, Str "title" ] ]

--- a/test/fb2/reader/notes.native
+++ b/test/fb2/reader/notes.native
@@ -1,4 +1,24 @@
-Pandoc (Meta {unMeta = fromList []})
-[Div ("",["section"],[])
- [Para [Str "Note",Space,Note [Para [Str "Note",Space,Str "contents"]],Str "."]
- ,Para [Str "Second",Space,Str "note",Space,Note [Para [Str "Second",Space,Str "note",Space,Str "contents."]],Str "."]]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Div
+    ( "", [ "section" ], [] )
+    [ Para
+      [ Str "Note"
+      , Space
+      , Note
+        [ Para [ Str "Note", Space, Str "contents" ] ]
+      , Str "."
+      ]
+    , Para
+      [ Str "Second"
+      , Space
+      , Str "note"
+      , Space
+      , Note
+        [ Para
+          [ Str "Second", Space, Str "note", Space, Str "contents." ]
+        ]
+      , Str "."
+      ]
+    ]
+  ]

--- a/test/fb2/reader/poem.native
+++ b/test/fb2/reader/poem.native
@@ -1,14 +1,26 @@
-Pandoc (Meta {unMeta = fromList []})
-[Div ("",["section"],[])
- [Header 2 ("",[],[]) [Str "Poem",Space,Str "title"]
- ,Div ("",["epigraph"],[])
-  [Para [Str "Poem",Space,Str "epigraph"]]
- ,Header 2 ("",["unnumbered"],[]) [Str "Subtitle"]
- ,Header 2 ("",[],[]) [Str "First",Space,Str "stanza",Space,Str "title"]
- ,LineBlock
-  [[Str "Verse"]
-  ,[Emph [Str "More"],Space,Str "verse"]]
- ,LineBlock
-  [[Str "One",Space,Str "more",Space,Str "stanza"]]
- ,Para [Str "Author"]
- ,Para [Str "April",Space,Str "2018"]]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Div
+    ( "", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "Poem", Space, Str "title" ]
+    , Div
+      ( "", [ "epigraph" ], [] )
+      [ Para [ Str "Poem", Space, Str "epigraph" ] ]
+    , Header 2
+      ( "", [ "unnumbered" ], [] )
+      [ Str "Subtitle" ]
+    , Header 2
+      ( "", [], [] )
+      [ Str "First", Space, Str "stanza", Space, Str "title" ]
+    , LineBlock
+      [ [ Str "Verse" ], [ Emph [ Str "More" ], Space, Str "verse" ] ]
+    , LineBlock
+      [ [ Str "One", Space, Str "more", Space, Str "stanza" ] ]
+    , Para
+      [ Str "Author" ]
+    , Para
+      [ Str "April", Space, Str "2018" ]
+    ]
+  ]

--- a/test/fb2/reader/titles.native
+++ b/test/fb2/reader/titles.native
@@ -1,8 +1,33 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("",[],[]) [Str "Body",Space,Str "title"]
-,Div ("",["section"],[])
- [Header 2 ("",[],[]) [Str "Section",Space,Str "title"]
- ,Div ("",["section"],[])
-  [Header 3 ("",[],[]) [Str "Subsection",Space,Str "title",LineBreak,Str "with",Space,Str "multiple",Space,Str "paragraphs"]]
- ,Div ("",["section"],[])
-  [Header 3 ("",[],[]) [Str "Another",Space,Str "subsection",Space,Str "title"]]]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "", [], [] )
+    [ Str "Body", Space, Str "title" ]
+  , Div
+    ( "", [ "section" ], [] )
+    [ Header 2
+      ( "", [], [] )
+      [ Str "Section", Space, Str "title" ]
+    , Div
+      ( "", [ "section" ], [] )
+      [ Header 3
+        ( "", [], [] )
+        [ Str "Subsection"
+        , Space
+        , Str "title"
+        , LineBreak
+        , Str "with"
+        , Space
+        , Str "multiple"
+        , Space
+        , Str "paragraphs"
+        ]
+      ]
+    , Div
+      ( "", [ "section" ], [] )
+      [ Header 3
+        ( "", [], [] )
+        [ Str "Another", Space, Str "subsection", Space, Str "title" ]
+      ]
+    ]
+  ]

--- a/test/haddock-reader.native
+++ b/test/haddock-reader.native
@@ -1,31 +1,432 @@
-Pandoc (Meta {unMeta = fromList []})
-[Para [Str "This",Space,Str "file",Space,Str "tests",Space,Str "the",Space,Str "Pandoc",Space,Str "reader",Space,Str "for",Space,Str "Haddock.",SoftBreak,Str "We've",Space,Str "borrowed",Space,Str "examples",Space,Str "from",Space,Str "Haddock's",Space,Str "documentation:",Space,Link ("",[],[]) [Str "http://www.haskell.org/haddock/doc/html/ch03s08.html"] ("http://www.haskell.org/haddock/doc/html/ch03s08.html","http://www.haskell.org/haddock/doc/html/ch03s08.html"),Str "."]
-,Para [Str "The",Space,Str "following",Space,Str "characters",Space,Str "have",Space,Str "special",Space,Str "meanings",Space,Str "in",Space,Str "Haddock,",Space,Str "/,",Space,Str "',",Space,Str "`,",Space,Str "\",",Space,Str "@,",Space,Str "<,",Space,Str "so",Space,Str "they",Space,Str "must",Space,Str "be",Space,Str "escaped."]
-,Para [Str "*",Space,Str "This",Space,Str "is",Space,Str "a",Space,Str "paragraph,",Space,Str "not",Space,Str "a",Space,Str "list",Space,Str "item.",SoftBreak,Str ">",Space,Str "This",Space,Str "sentence",Space,Str "is",Space,Str "not",Space,Str "code.",SoftBreak,Str ">>>",Space,Str "This",Space,Str "is",Space,Str "not",Space,Str "an",Space,Str "example."]
-,Para [Str "The",Space,Str "references",Space,Str "\955,",Space,Str "\955",Space,Str "and",Space,Str "\955",Space,Str "all",Space,Str "represent",Space,Str "the",Space,Str "lower-case",Space,Str "letter",Space,Str "lambda."]
-,Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "code",Space,Str "block:"]
-,CodeBlock ("",[],[]) "map :: (a -> b) -> [a] -> [b]\nmap _ []     = []\nmap f (x:xs) = f x : map f xs"
-,Para [Str "This",Space,Str "is",Space,Str "another",Space,Str "code",Space,Str "block:"]
-,Para [Code ("",[],[]) "f x = x + x.",LineBreak,Code ("",[],[]) "The @...@ code block ",Emph [Code ("",[],[]) "interprets markup normally"],Code ("",[],[]) ".",Code ("",["haskell","module"],[]) "Module.Foo",Code ("",[],[]) "",LineBreak,Code ("",[],[]) "\"Hello World\""]
-,Para [Str "Haddock",Space,Str "supports",Space,Str "REPL",Space,Str "examples:"]
-,Para [Code ("",["prompt"],[]) ">>>",Space,Code ("",["haskell","expr"],[]) "fib 10",LineBreak,Code ("",["result"],[]) "55"]
-,Para [Code ("",["prompt"],[]) ">>>",Space,Code ("",["haskell","expr"],[]) "putStrLn \"foo\\nbar\"",LineBreak,Code ("",["result"],[]) "foo",LineBreak,Code ("",["result"],[]) "bar"]
-,Para [Str "That",Space,Str "was",Space,Emph [Str "really",Space,Str "cool"],Str "!",SoftBreak,Str "I",Space,Str "had",Space,Str "no",Space,Str "idea",Space,Code ("",[],[]) "fib 10 = 55",Str "."]
-,Para [Str "This",Space,Str "module",Space,Str "defines",Space,Str "the",Space,Str "type",Space,Code ("",["haskell","identifier"],[]) "T",Str ".",SoftBreak,Str "The",Space,Str "identifier",Space,Code ("",["haskell","identifier"],[]) "M.T",Space,Str "is",Space,Str "not",Space,Str "in",Space,Str "scope",SoftBreak,Str "I",Space,Str "don't",Space,Str "have",Space,Str "to",Space,Str "escape",Space,Str "my",Space,Str "apostrophes;",Space,Str "great,",Space,Str "isn't",Space,Str "it?",SoftBreak,Str "This",Space,Str "is",Space,Str "a",Space,Str "reference",Space,Str "to",Space,Str "the",Space,Code ("",["haskell","module"],[]) "Foo",Space,Str "module."]
-,Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "bulleted",Space,Str "list:"]
-,BulletList
- [[Para [Str "first",Space,Str "item"]]
- ,[Para [Str "second",Space,Str "item"]]]
-,Para [Str "This",Space,Str "is",Space,Str "an",Space,Str "enumerated",Space,Str "list:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "first",Space,Str "item"]]
- ,[Para [Str "second",Space,Str "item"]]]
-,Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "definition",Space,Str "list:"]
-,DefinitionList
- [([Code ("",[],[]) "foo"],
-   [[Para [Str "The",Space,Str "description",Space,Str "of",Space,Code ("",[],[]) "foo",Str "."]]])
- ,([Code ("",[],[]) "bar"],
-   [[Para [Str "The",Space,Str "description",Space,Str "of",Space,Code ("",[],[]) "bar",Str "."]]])]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "link:",Space,Link ("",[],[]) [Str "http://haskell.org"] ("http://haskell.org","http://haskell.org")]
-,Para [Link ("",[],[]) [Str "Haskell"] ("http://haskell.org","http://haskell.org"),Space,Str "is",Space,Str "a",Space,Str "fun",Space,Str "language!"]
-,Para [Link ("",[],[]) [Str "Click",Space,Str "Here!"] ("http://example.com","http://example.com")]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "file"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "the"
+    , Space
+    , Str "Pandoc"
+    , Space
+    , Str "reader"
+    , Space
+    , Str "for"
+    , Space
+    , Str "Haddock."
+    , SoftBreak
+    , Str "We've"
+    , Space
+    , Str "borrowed"
+    , Space
+    , Str "examples"
+    , Space
+    , Str "from"
+    , Space
+    , Str "Haddock's"
+    , Space
+    , Str "documentation:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.haskell.org/haddock/doc/html/ch03s08.html" ]
+      ( "http://www.haskell.org/haddock/doc/html/ch03s08.html"
+      , "http://www.haskell.org/haddock/doc/html/ch03s08.html"
+      )
+    , Str "."
+    ]
+  , Para
+    [ Str "The"
+    , Space
+    , Str "following"
+    , Space
+    , Str "characters"
+    , Space
+    , Str "have"
+    , Space
+    , Str "special"
+    , Space
+    , Str "meanings"
+    , Space
+    , Str "in"
+    , Space
+    , Str "Haddock,"
+    , Space
+    , Str "/,"
+    , Space
+    , Str "',"
+    , Space
+    , Str "`,"
+    , Space
+    , Str "\","
+    , Space
+    , Str "@,"
+    , Space
+    , Str "<,"
+    , Space
+    , Str "so"
+    , Space
+    , Str "they"
+    , Space
+    , Str "must"
+    , Space
+    , Str "be"
+    , Space
+    , Str "escaped."
+    ]
+  , Para
+    [ Str "*"
+    , Space
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph,"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    , SoftBreak
+    , Str ">"
+    , Space
+    , Str "This"
+    , Space
+    , Str "sentence"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "code."
+    , SoftBreak
+    , Str ">>>"
+    , Space
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "an"
+    , Space
+    , Str "example."
+    ]
+  , Para
+    [ Str "The"
+    , Space
+    , Str "references"
+    , Space
+    , Str "\955,"
+    , Space
+    , Str "\955"
+    , Space
+    , Str "and"
+    , Space
+    , Str "\955"
+    , Space
+    , Str "all"
+    , Space
+    , Str "represent"
+    , Space
+    , Str "the"
+    , Space
+    , Str "lower-case"
+    , Space
+    , Str "letter"
+    , Space
+    , Str "lambda."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "code"
+    , Space
+    , Str "block:"
+    ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "map :: (a -> b) -> [a] -> [b]\nmap _ []     = []\nmap f (x:xs) = f x : map f xs"
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "another"
+    , Space
+    , Str "code"
+    , Space
+    , Str "block:"
+    ]
+  , Para
+    [ Code
+      ( "", [], [] ) "f x = x + x."
+    , LineBreak
+    , Code
+      ( "", [], [] ) "The @...@ code block "
+    , Emph
+      [ Code ( "", [], [] ) "interprets markup normally" ]
+    , Code
+      ( "", [], [] ) "."
+    , Code
+      ( "", [ "haskell", "module" ], [] ) "Module.Foo"
+    , Code
+      ( "", [], [] ) ""
+    , LineBreak
+    , Code
+      ( "", [], [] ) "\"Hello World\""
+    ]
+  , Para
+    [ Str "Haddock"
+    , Space
+    , Str "supports"
+    , Space
+    , Str "REPL"
+    , Space
+    , Str "examples:"
+    ]
+  , Para
+    [ Code
+      ( "", [ "prompt" ], [] ) ">>>"
+    , Space
+    , Code
+      ( "", [ "haskell", "expr" ], [] ) "fib 10"
+    , LineBreak
+    , Code
+      ( "", [ "result" ], [] ) "55"
+    ]
+  , Para
+    [ Code
+      ( "", [ "prompt" ], [] ) ">>>"
+    , Space
+    , Code
+      ( "", [ "haskell", "expr" ], [] ) "putStrLn \"foo\\nbar\""
+    , LineBreak
+    , Code
+      ( "", [ "result" ], [] ) "foo"
+    , LineBreak
+    , Code
+      ( "", [ "result" ], [] ) "bar"
+    ]
+  , Para
+    [ Str "That"
+    , Space
+    , Str "was"
+    , Space
+    , Emph
+      [ Str "really", Space, Str "cool" ]
+    , Str "!"
+    , SoftBreak
+    , Str "I"
+    , Space
+    , Str "had"
+    , Space
+    , Str "no"
+    , Space
+    , Str "idea"
+    , Space
+    , Code
+      ( "", [], [] ) "fib 10 = 55"
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "module"
+    , Space
+    , Str "defines"
+    , Space
+    , Str "the"
+    , Space
+    , Str "type"
+    , Space
+    , Code
+      ( "", [ "haskell", "identifier" ], [] ) "T"
+    , Str "."
+    , SoftBreak
+    , Str "The"
+    , Space
+    , Str "identifier"
+    , Space
+    , Code
+      ( "", [ "haskell", "identifier" ], [] ) "M.T"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "in"
+    , Space
+    , Str "scope"
+    , SoftBreak
+    , Str "I"
+    , Space
+    , Str "don't"
+    , Space
+    , Str "have"
+    , Space
+    , Str "to"
+    , Space
+    , Str "escape"
+    , Space
+    , Str "my"
+    , Space
+    , Str "apostrophes;"
+    , Space
+    , Str "great,"
+    , Space
+    , Str "isn't"
+    , Space
+    , Str "it?"
+    , SoftBreak
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "reference"
+    , Space
+    , Str "to"
+    , Space
+    , Str "the"
+    , Space
+    , Code
+      ( "", [ "haskell", "module" ], [] ) "Foo"
+    , Space
+    , Str "module."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bulleted"
+    , Space
+    , Str "list:"
+    ]
+  , BulletList
+    [
+      [ Para [ Str "first", Space, Str "item" ] ]
+    ,
+      [ Para [ Str "second", Space, Str "item" ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "an"
+    , Space
+    , Str "enumerated"
+    , Space
+    , Str "list:"
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "first", Space, Str "item" ] ]
+    ,
+      [ Para [ Str "second", Space, Str "item" ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "definition"
+    , Space
+    , Str "list:"
+    ]
+  , DefinitionList
+    [
+      (
+        [ Code ( "", [], [] ) "foo" ]
+      ,
+        [
+          [ Para
+            [ Str "The"
+            , Space
+            , Str "description"
+            , Space
+            , Str "of"
+            , Space
+            , Code
+              ( "", [], [] ) "foo"
+            , Str "."
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Code ( "", [], [] ) "bar" ]
+      ,
+        [
+          [ Para
+            [ Str "The"
+            , Space
+            , Str "description"
+            , Space
+            , Str "of"
+            , Space
+            , Code
+              ( "", [], [] ) "bar"
+            , Str "."
+            ]
+          ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://haskell.org" ]
+      ( "http://haskell.org", "http://haskell.org" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Haskell" ]
+      ( "http://haskell.org", "http://haskell.org" )
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "fun"
+    , Space
+    , Str "language!"
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Click", Space, Str "Here!" ]
+      ( "http://example.com", "http://example.com" )
+    ]
+  ]

--- a/test/html-reader.native
+++ b/test/html-reader.native
@@ -1,837 +1,3365 @@
-Pandoc (Meta {unMeta = fromList [("generator",MetaInlines [Str "pandoc"]),("title",MetaInlines [Str "Pandoc",Space,Str "Test",Space,Str "Suite"])]})
-[Header 1 ("pandoc-test-suite",["title"],[]) [Str "Pandoc",Space,Str "Test",Space,Str "Suite"]
-,Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc.",Space,Str "Most",Space,Str "of",Space,Str "them",Space,Str "are",Space,Str "adapted",Space,Str "from",Space,Str "John",Space,Str "Gruber's",Space,Str "markdown",Space,Str "test",Space,Str "suite."]
-,HorizontalRule
-,Header 1 ("headers",[],[]) [Str "Headers"]
-,Header 2 ("level-2-with-an-embedded-link",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Str "an",Space,Link ("",[],[]) [Str "embedded",Space,Str "link"] ("/url","")]
-,Header 3 ("level-3-with-emphasis",[],[]) [Str "Level",Space,Str "3",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 4 ("level-4",[],[]) [Str "Level",Space,Str "4"]
-,Header 5 ("level-5",[],[]) [Str "Level",Space,Str "5"]
-,Header 1 ("level-1",[],[]) [Str "Level",Space,Str "1"]
-,Header 2 ("level-2-with-emphasis",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 3 ("level-3",[],[]) [Str "Level",Space,Str "3"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Header 2 ("level-2",[],[]) [Str "Level",Space,Str "2"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,HorizontalRule
-,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]
-,Para [Str "Here's",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "In",Space,Str "Markdown",Space,Str "1.0.0",Space,Str "and",Space,Str "earlier.",Space,Str "Version",Space,Str "8.",Space,Str "This",Space,Str "line",Space,Str "turns",Space,Str "into",Space,Str "a",Space,Str "list",Space,Str "item.",Space,Str "Because",Space,Str "a",Space,Str "hard-wrapped",Space,Str "line",Space,Str "in",Space,Str "the",Space,Str "middle",Space,Str "of",Space,Str "a",Space,Str "paragraph",Space,Str "looked",Space,Str "like",Space,Str "a",Space,Str "list",Space,Str "item."]
-,Para [Str "Here's",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet.",Space,Str "*",Space,Str "criminey."]
-,Para [Str "There",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "hard",Space,Str "line",Space,Str "break",LineBreak,Str "here."]
-,HorizontalRule
-,Header 1 ("block-quotes",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "E-mail",Space,Str "style:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",Space,Str "It",Space,Str "is",Space,Str "pretty",Space,Str "short."]]
-,BlockQuote
- [Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"
- ,Para [Str "A",Space,Str "list:"]
- ,OrderedList (1,DefaultStyle,DefaultDelim)
-  [[Plain [Str "item",Space,Str "one"]]
-  ,[Plain [Str "item",Space,Str "two"]]]
- ,Para [Str "Nested",Space,Str "block",Space,Str "quotes:"]
- ,BlockQuote
-  [Para [Str "nested"]]
- ,BlockQuote
-  [Para [Str "nested"]]]
-,Para [Str "This",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "block",Space,Str "quote:",Space,Str "2",Space,Str ">",Space,Str "1."]
-,Para [Str "Box-style:"]
-,BlockQuote
- [Para [Str "Example:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"]
-,BlockQuote
- [OrderedList (1,DefaultStyle,DefaultDelim)
-  [[Plain [Str "do",Space,Str "laundry"]]
-  ,[Plain [Str "take",Space,Str "out",Space,Str "the",Space,Str "trash"]]]]
-,Para [Str "Here's",Space,Str "a",Space,Str "nested",Space,Str "one:"]
-,BlockQuote
- [Para [Str "Joe",Space,Str "said:"]
- ,BlockQuote
-  [Para [Str "Don't",Space,Str "quote",Space,Str "me."]]]
-,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
-,HorizontalRule
-,Header 1 ("inline-quotes",[],[]) [Str "Inline",Space,Str "quotes"]
-,Para [Str "Normal",Space,Str "text",Space,Str "but",Space,Str "then",Space,Str "a",Space,Quoted DoubleQuote [Span ("",[],[("cite","https://www.imdb.com/title/tt0062622/quotes/qt0396921")]) [Str "inline",Space,Str "quote"]],Str "."]
-,Para [Quoted DoubleQuote [Str "Missing",Space,Str "a",Space,Str "cite",Space,Str "attribute",Space,Str "means",Space,Str "its",Space,Str "just",Space,Str "normal",Space,Str "text"]]
-,HorizontalRule
-,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
-,HorizontalRule
-,Header 1 ("lists",[],[]) [Str "Lists"]
-,Header 2 ("unordered",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "asterisk",Space,Str "1"]]
- ,[Plain [Str "asterisk",Space,Str "2"]]
- ,[Plain [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Asterisks",Space,Str "loose:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "Plus",Space,Str "1"]]
- ,[Plain [Str "Plus",Space,Str "2"]]
- ,[Plain [Str "Plus",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Plus",Space,Str "1"]]
- ,[Para [Str "Plus",Space,Str "2"]]
- ,[Para [Str "Plus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "Minus",Space,Str "1"]]
- ,[Plain [Str "Minus",Space,Str "2"]]
- ,[Plain [Str "Minus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Header 2 ("ordered",[],[]) [Str "Ordered"]
-,Para [Str "Tight:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second"]]
- ,[Plain [Str "Third"]]]
-,Para [Str "and:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "One"]]
- ,[Plain [Str "Two"]]
- ,[Plain [Str "Three"]]]
-,Para [Str "Loose",Space,Str "using",Space,Str "tabs:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "and",Space,Str "using",Space,Str "spaces:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]]
- ,[Para [Str "Three"]]]
-,Para [Str "Multiple",Space,Str "paragraphs:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "Item",Space,Str "1,",Space,Str "graf",Space,Str "one."]
-  ,Para [Str "Item",Space,Str "1.",Space,Str "graf",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",Space,Str "dog's",Space,Str "back."]]
- ,[Para [Str "Item",Space,Str "2."]]
- ,[Para [Str "Item",Space,Str "3."]]]
-,Para [Str "List",Space,Str "styles:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- []
-,OrderedList (1,LowerRoman,DefaultDelim)
- []
-,OrderedList (1,LowerRoman,DefaultDelim)
- []
-,OrderedList (1,DefaultStyle,DefaultDelim)
- []
-,OrderedList (1,LowerRoman,DefaultDelim)
- []
-,OrderedList (1,LowerRoman,DefaultDelim)
- []
-,Header 2 ("nested",[],[]) [Str "Nested"]
-,BulletList
- [[Plain [Str "Tab"]
-  ,BulletList
-   [[Plain [Str "Tab"]
-    ,BulletList
-     [[Plain [Str "Tab"]]]]]]]
-,Para [Str "Here's",Space,Str "another:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second:"]
-  ,BulletList
-   [[Plain [Str "Fee"]]
-   ,[Plain [Str "Fie"]]
-   ,[Plain [Str "Foe"]]]]
- ,[Plain [Str "Third"]]]
-,Para [Str "Same",Space,Str "thing",Space,Str "but",Space,Str "with",Space,Str "paragraphs:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Plain [Str "Fee"]]
-   ,[Plain [Str "Fie"]]
-   ,[Plain [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Header 2 ("tabs-and-spaces",[],[]) [Str "Tabs",Space,Str "and",Space,Str "spaces"]
-,BulletList
- [[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "tabs"]]
- ,[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "spaces"]
-  ,BulletList
-   [[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "tabs"]]
-   ,[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "spaces"]]]]]
-,Header 2 ("fancy-list-markers",[],[]) [Str "Fancy",Space,Str "list",Space,Str "markers"]
-,OrderedList (2,Decimal,DefaultDelim)
- [[Plain [Str "begins",Space,Str "with",Space,Str "2"]]
- ,[Para [Str "and",Space,Str "now",Space,Str "3"]
-  ,Para [Str "with",Space,Str "a",Space,Str "continuation"]
-  ,OrderedList (4,LowerRoman,DefaultDelim)
-   [[Plain [Str "sublist",Space,Str "with",Space,Str "roman",Space,Str "numerals,",Space,Str "starting",Space,Str "with",Space,Str "4"]]
-   ,[Plain [Str "more",Space,Str "items"]
-    ,OrderedList (1,UpperAlpha,DefaultDelim)
-     [[Plain [Str "a",Space,Str "subsublist"]]
-     ,[Plain [Str "a",Space,Str "subsublist"]]]]]]]
-,Para [Str "Nesting:"]
-,OrderedList (1,UpperAlpha,DefaultDelim)
- [[Plain [Str "Upper",Space,Str "Alpha"]
-  ,OrderedList (1,UpperRoman,DefaultDelim)
-   [[Plain [Str "Upper",Space,Str "Roman."]
-    ,OrderedList (6,Decimal,DefaultDelim)
-     [[Plain [Str "Decimal",Space,Str "start",Space,Str "with",Space,Str "6"]
-      ,OrderedList (3,LowerAlpha,DefaultDelim)
-       [[Plain [Str "Lower",Space,Str "alpha",Space,Str "with",Space,Str "paren"]]]]]]]]]
-,Para [Str "Autonumbering:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Autonumber."]]
- ,[Plain [Str "More."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "Nested."]]]]]
-,HorizontalRule
-,Header 2 ("definition",[],[]) [Str "Definition"]
-,DefinitionList
- [([Str "Violin"],
-   [[Plain [Str "Stringed",Space,Str "musical",Space,Str "instrument."]]
-   ,[Plain [Str "Torture",Space,Str "device."]]])
- ,([Str "Cello",LineBreak,Str "Violoncello"],
-   [[Plain [Str "Low-voiced",Space,Str "stringed",Space,Str "instrument."]]])]
-,HorizontalRule
-,Header 1 ("inline-markup",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ",",Space,Str "and",Space,Str "so",Space,Emph [Str "is",Space,Str "this"],Str "."]
-,Para [Str "This",Space,Str "is",Space,Strong [Str "strong"],Str ",",Space,Str "and",Space,Str "so",Space,Strong [Str "is",Space,Str "this"],Str "."]
-,Para [Str "Empty",Space,Strong [],Space,Str "and",Space,Emph [],Str "."]
-,Para [Str "An",Space,Emph [Link ("",[],[]) [Str "emphasized",Space,Str "link"] ("/url","")],Str "."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Str "This",Space,Str "is",Space,Str "code:",Space,Code ("",[],[]) ">",Str ",",Space,Code ("",[],[]) "$",Str ",",Space,Code ("",[],[]) "\\",Str ",",Space,Code ("",[],[]) "\\$",Str ",",Space,Code ("",[],[]) "<html>",Str "."]
-,Para [Str "This",Space,Str "is",Space,SmallCaps [Str "small",Space,Str "caps"],Str "."]
-,Para [Str "These",Space,Str "are",Space,Str "all",Space,Str "underlined:",Space,Underline [Str "foo"],Space,Str "and",Space,Underline [Str "bar"],Str "."]
-,Para [Str "These",Space,Str "are",Space,Str "all",Space,Str "strikethrough:",Space,Strikeout [Str "foo"],Str ",",Space,Strikeout [Str "bar"],Str ",",Space,Str "and",Space,Strikeout [Str "baz"],Str "."]
-,HorizontalRule
-,Header 1 ("smart-quotes-ellipses-dashes",[],[]) [Str "Smart",Space,Str "quotes,",Space,Str "ellipses,",Space,Str "dashes"]
-,Para [Str "\"Hello,\"",Space,Str "said",Space,Str "the",Space,Str "spider.",Space,Str "\"'Shelob'",Space,Str "is",Space,Str "my",Space,Str "name.\""]
-,Para [Str "'A',",Space,Str "'B',",Space,Str "and",Space,Str "'C'",Space,Str "are",Space,Str "letters."]
-,Para [Str "'Oak,'",Space,Str "'elm,'",Space,Str "and",Space,Str "'beech'",Space,Str "are",Space,Str "names",Space,Str "of",Space,Str "trees.",Space,Str "So",Space,Str "is",Space,Str "'pine.'"]
-,Para [Str "'He",Space,Str "said,",Space,Str "\"I",Space,Str "want",Space,Str "to",Space,Str "go.\"'",Space,Str "Were",Space,Str "you",Space,Str "alive",Space,Str "in",Space,Str "the",Space,Str "70's?"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "quoted",Space,Str "'",Code ("",[],[]) "code",Str "'",Space,Str "and",Space,Str "a",Space,Str "\"",Link ("",[],[]) [Str "quoted",Space,Str "link"] ("http://example.com/?foo=1&bar=2",""),Str "\"."]
-,Para [Str "Some",Space,Str "dashes:",Space,Str "one---two",Space,Str "---",Space,Str "three--four",Space,Str "--",Space,Str "five."]
-,Para [Str "Dashes",Space,Str "between",Space,Str "numbers:",Space,Str "5-7,",Space,Str "255-66,",Space,Str "1987-1999."]
-,Para [Str "Ellipses...and.",Space,Str ".",Space,Str ".and",Space,Str ".",Space,Str ".",Space,Str ".",Space,Str "."]
-,HorizontalRule
-,Header 1 ("latex",[],[]) [Str "LaTeX"]
-,BulletList
- [[Plain [Str "\\cite[22-23]{smith.1899}"]]
- ,[Plain [Str "\\doublespacing"]]
- ,[Plain [Str "$2+2=4$"]]
- ,[Plain [Str "$x",Space,Str "\\in",Space,Str "y$"]]
- ,[Plain [Str "$\\alpha",Space,Str "\\wedge",Space,Str "\\omega$"]]
- ,[Plain [Str "$223$"]]
- ,[Plain [Str "$p$-Tree"]]
- ,[Plain [Str "$\\frac{d}{dx}f(x)=\\lim_{h\\to",Space,Str "0}\\frac{f(x+h)-f(x)}{h}$"]]
- ,[Plain [Str "Here's",Space,Str "one",Space,Str "that",Space,Str "has",Space,Str "a",Space,Str "line",Space,Str "break",Space,Str "in",Space,Str "it:",Space,Str "$\\alpha",Space,Str "+",Space,Str "\\omega",Space,Str "\\times",Space,Str "x^2$."]]]
-,Para [Str "These",Space,Str "shouldn't",Space,Str "be",Space,Str "math:"]
-,BulletList
- [[Plain [Str "To",Space,Str "get",Space,Str "the",Space,Str "famous",Space,Str "equation,",Space,Str "write",Space,Code ("",[],[]) "$e = mc^2$",Str "."]]
- ,[Plain [Str "$22,000",Space,Str "is",Space,Str "a",Space,Emph [Str "lot"],Space,Str "of",Space,Str "money.",Space,Str "So",Space,Str "is",Space,Str "$34,000.",Space,Str "(It",Space,Str "worked",Space,Str "if",Space,Str "\"lot\"",Space,Str "is",Space,Str "emphasized.)"]]
- ,[Plain [Str "Escaped",Space,Code ("",[],[]) "$",Str ":",Space,Str "$73",Space,Emph [Str "this",Space,Str "should",Space,Str "be",Space,Str "emphasized"],Space,Str "23$."]]]
-,Para [Str "Here's",Space,Str "a",Space,Str "LaTeX",Space,Str "table:"]
-,Para [Str "\\begin{tabular}{|l|l|}\\hline",Space,Str "Animal",Space,Str "&",Space,Str "Number",Space,Str "\\\\",Space,Str "\\hline",Space,Str "Dog",Space,Str "&",Space,Str "2",Space,Str "\\\\",Space,Str "Cat",Space,Str "&",Space,Str "1",Space,Str "\\\\",Space,Str "\\hline",Space,Str "\\end{tabular}"]
-,HorizontalRule
-,Header 1 ("special-characters",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "unicode:"]
-,BulletList
- [[Plain [Str "I",Space,Str "hat:",Space,Str "\206"]]
- ,[Plain [Str "o",Space,Str "umlaut:",Space,Str "\246"]]
- ,[Plain [Str "section:",Space,Str "\167"]]
- ,[Plain [Str "set",Space,Str "membership:",Space,Str "\8712"]]
- ,[Plain [Str "copyright:",Space,Str "\169"]]]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "AT&T",Space,Str "is",Space,Str "another",Space,Str "way",Space,Str "to",Space,Str "write",Space,Str "it."]
-,Para [Str "This",Space,Str "&",Space,Str "that."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "`"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,HorizontalRule
-,Header 1 ("links",[],[]) [Str "Links"]
-,Header 2 ("explicit",[],[]) [Str "Explicit"]
-,Para [Str "Just",Space,Str "a",Space,Link ("",[],[]) [Str "URL"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title preceded by two spaces"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title preceded by a tab"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title with \"quotes\" in it")]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title with single quotes")]
-,Para [Str "Email",Space,Str "link",Space,Str "(nobody",Space,Str "[at]",Space,Str "nowhere.net)"]
-,Para [Link ("",[],[]) [Str "Empty"] ("",""),Str "."]
-,Header 2 ("reference",[],[]) [Str "Reference"]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "With",Space,Link ("",[],[]) [Str "embedded",Space,Str "[brackets]"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "b"] ("/url/",""),Space,Str "by",Space,Str "itself",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "link."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "once"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "twice"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "thrice"] ("/url",""),Str "."]
-,Para [Str "This",Space,Str "should",Space,Str "[not]",Space,Str "be",Space,Str "a",Space,Str "link."]
-,CodeBlock ("",[],[]) "[not]: /url"
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/","Title with \"quotes\" inside"),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "biz"] ("/url/","Title with \"quote\" inside"),Str "."]
-,Header 2 ("with-ampersands",[],[]) [Str "With",Space,Str "ampersands"]
-,Para [Str "Here's",Space,Str "a",Space,Link ("",[],[]) [Str "link",Space,Str "with",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "URL"] ("http://example.com/?foo=1&bar=2",""),Str "."]
-,Para [Str "Here's",Space,Str "a",Space,Str "link",Space,Str "with",Space,Str "an",Space,Str "amersand",Space,Str "in",Space,Str "the",Space,Str "link",Space,Str "text:",Space,Link ("",[],[]) [Str "AT&T"] ("http://att.com/","AT&T"),Str "."]
-,Para [Str "Here's",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link"] ("/script?foo=1&bar=2",""),Str "."]
-,Para [Str "Here's",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link",Space,Str "in",Space,Str "pointy",Space,Str "braces"] ("/script?foo=1&bar=2",""),Str "."]
-,Header 2 ("autolinks",[],[]) [Str "Autolinks"]
-,Para [Str "With",Space,Str "an",Space,Str "ampersand:",Space,Link ("",[],[]) [Str "http://example.com/?foo=1&bar=2"] ("http://example.com/?foo=1&bar=2","")]
-,BulletList
- [[Plain [Str "In",Space,Str "a",Space,Str "list?"]]
- ,[Plain [Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
- ,[Plain [Str "It",Space,Str "should."]]]
-,Para [Str "An",Space,Str "e-mail",Space,Str "address:",Space,Str "nobody",Space,Str "[at]",Space,Str "nowhere.net"]
-,BlockQuote
- [Para [Str "Blockquoted:",Space,Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
-,Para [Str "Auto-links",Space,Str "should",Space,Str "not",Space,Str "occur",Space,Str "here:",Space,Code ("",[],[]) "<http://example.com/>"]
-,CodeBlock ("",[],[]) "or here: <http://example.com/>"
-,HorizontalRule
-,Header 1 ("images",[],[]) [Str "Images"]
-,Para [Str "From",Space,Str "\"Voyage",Space,Str "dans",Space,Str "la",Space,Str "Lune\"",Space,Str "by",Space,Str "Georges",Space,Str "Melies",Space,Str "(1902):"]
-,Para [Image ("",[],[]) [Str "lalune"] ("lalune.jpg","Voyage dans la Lune")]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "movie",Space,Image ("",[],[]) [Str "movie"] ("movie.jpg",""),Space,Str "icon."]
-,HorizontalRule
-,Header 1 ("footnotes",[],[]) [Str "Footnotes"]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "footnote",Space,Str "reference",Link ("",[],[]) [Str "(1)"] ("#note_1",""),Str ",",Space,Str "and",Space,Str "another",Link ("",[],[]) [Str "(longnote)"] ("#note_longnote",""),Str ".",Space,Str "This",Space,Str "should",Space,Emph [Str "not"],Space,Str "be",Space,Str "a",Space,Str "footnote",Space,Str "reference,",Space,Str "because",Space,Str "it",Space,Str "contains",Space,Str "a",Space,Str "space^(my",Space,Str "note)."]
-,Para [Link ("",[],[]) [Str "(1)"] ("#ref_1",""),Space,Str "Here",Space,Str "is",Space,Str "the",Space,Str "footnote.",Space,Str "It",Space,Str "can",Space,Str "go",Space,Str "anywhere",Space,Str "in",Space,Str "the",Space,Str "document,",Space,Str "not",Space,Str "just",Space,Str "at",Space,Str "the",Space,Str "end."]
-,Para [Link ("",[],[]) [Str "(longnote)"] ("#ref_longnote",""),Space,Str "Here's",Space,Str "the",Space,Str "other",Space,Str "note.",Space,Str "This",Space,Str "one",Space,Str "contains",Space,Str "multiple",Space,Str "blocks."]
-,Para [Str "Caret",Space,Str "characters",Space,Str "are",Space,Str "used",Space,Str "to",Space,Str "indicate",Space,Str "that",Space,Str "the",Space,Str "blocks",Space,Str "all",Space,Str "belong",Space,Str "to",Space,Str "a",Space,Str "single",Space,Str "footnote",Space,Str "(as",Space,Str "with",Space,Str "block",Space,Str "quotes)."]
-,CodeBlock ("",[],[]) "  { <code> }"
-,Para [Str "If",Space,Str "you",Space,Str "want,",Space,Str "you",Space,Str "can",Space,Str "use",Space,Str "a",Space,Str "caret",Space,Str "at",Space,Str "the",Space,Str "beginning",Space,Str "of",Space,Str "every",Space,Str "line,",Space,Str "as",Space,Str "with",Space,Str "blockquotes,",Space,Str "but",Space,Str "all",Space,Str "that",Space,Str "you",Space,Str "need",Space,Str "is",Space,Str "a",Space,Str "caret",Space,Str "at",Space,Str "the",Space,Str "beginning",Space,Str "of",Space,Str "the",Space,Str "first",Space,Str "line",Space,Str "of",Space,Str "the",Space,Str "block",Space,Str "and",Space,Str "any",Space,Str "preceding",Space,Str "blank",Space,Str "lines."]
-,Para [Str "text",Space,Emph [Str "Leading",Space,Str "space"]]
-,Para [Emph [Str "Trailing",Space,Str "space"],Space,Str "text"]
-,Para [Str "text",Space,Emph [Str "Leading",Space,Str "spaces"]]
-,Para [Emph [Str "Trailing",Space,Str "spaces"],Space,Str "text"]
-,Header 1 ("tables",[],[]) [Str "Tables"]
-,Header 2 ("tables-with-headers",[],[]) [Str "Tables",Space,Str "with",Space,Str "Headers"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Para [Str "Row",Space,Str "headers"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 1)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 1)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]])]
- (TableFoot ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "4"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "5"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "6"]]]])
-,HorizontalRule
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]]
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "X"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Y"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Z"]]]]
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "X"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Y"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Z"]]]]
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]])
- ,(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]])
- ,(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 2 ("tables-without-headers",[],[]) [Str "Tables",Space,Str "without",Space,Str "Headers"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Para [Str "tbody",Space,Str "tags",Space,Str "omitted"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Para [Str "empty",Space,Str "head"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Para [Str "explicit",Space,Str "body",Space,Str "and",Space,Str "foot"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]])]
- (TableFoot ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "4"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "5"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "6"]]]])
-,Header 2 ("colspans-and-rowspans",[],[]) [Str "Colspans",Space,Str "and",Space,Str "Rowspans"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 2)
-    [Plain [Str "1",Space,Str "and",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 3)
-    [Plain [Str "4,",Space,Str "5,",Space,Str "and",Space,Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,HorizontalRule
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 3)
-   [Plain [Str "Numbers"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 2) (ColSpan 1)
-    [Plain [Str "1",Space,Str "and",Space,Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 2 ("attributes",[],[]) [Str "Attributes"]
-,Table ("attrib-test-table",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",["table-head"],[])
- [Row ("",["table-head-row"],[])
-  [Cell ("",[],[("abbr","x")]) AlignDefault (RowSpan 1) (ColSpan 3)
-   [Plain [Str "Cat",Space,Str "X"]]]])
- [(TableBody ("",["main"],[("part","body")]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[("part","row")])
-   [Cell ("",[],[("part","cell")]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[("valign","bottom")]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[("style","color: #151950")]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]])]
- (TableFoot ("",["summary"],[])
- [Row ("",[],[("bgcolor","#ccc")])
-  [Cell ("",[],[("square","true")]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "4"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "5"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "6"]]]])
-,Header 2 ("tag-omission",[],[]) [Str "Tag",Space,Str "omission"]
-,Para [Str "thead,",Space,Str "tbody,",Space,Str "and",Space,Str "tfoot"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]]])]
- (TableFoot ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "4"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "5"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "6"]]]])
-,Header 2 ("empty-tables",[],[]) [Str "Empty",Space,Str "Tables"]
-,Para [Str "This",Space,Str "section",Space,Str "should",Space,Str "be",Space,Str "empty."]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "generator", MetaInlines [ Str "pandoc" ] )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Pandoc", Space, Str "Test", Space, Str "Suite" ]
+        )
+      ]
+    }
+  )
+  [ Header 1
+    ( "pandoc-test-suite", [ "title" ], [] )
+    [ Str "Pandoc", Space, Str "Test", Space, Str "Suite" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc."
+    , Space
+    , Str "Most"
+    , Space
+    , Str "of"
+    , Space
+    , Str "them"
+    , Space
+    , Str "are"
+    , Space
+    , Str "adapted"
+    , Space
+    , Str "from"
+    , Space
+    , Str "John"
+    , Space
+    , Str "Gruber's"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "test"
+    , Space
+    , Str "suite."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "headers", [], [] )
+    [ Str "Headers" ]
+  , Header 2
+    ( "level-2-with-an-embedded-link", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "link" ]
+      ( "/url", "" )
+    ]
+  , Header 3
+    ( "level-3-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "3"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 4
+    ( "level-4", [], [] )
+    [ Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "level-5", [], [] )
+    [ Str "Level", Space, Str "5" ]
+  , Header 1
+    ( "level-1", [], [] )
+    [ Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "level-2-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 3
+    ( "level-3", [], [] )
+    [ Str "Level", Space, Str "3" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , Header 2
+    ( "level-2", [], [] )
+    [ Str "Level", Space, Str "2" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "paragraphs", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "In"
+    , Space
+    , Str "Markdown"
+    , Space
+    , Str "1.0.0"
+    , Space
+    , Str "and"
+    , Space
+    , Str "earlier."
+    , Space
+    , Str "Version"
+    , Space
+    , Str "8."
+    , Space
+    , Str "This"
+    , Space
+    , Str "line"
+    , Space
+    , Str "turns"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    , Space
+    , Str "Because"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard-wrapped"
+    , Space
+    , Str "line"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "middle"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "looked"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    , Space
+    , Str "*"
+    , Space
+    , Str "criminey."
+    ]
+  , Para
+    [ Str "There"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard"
+    , Space
+    , Str "line"
+    , Space
+    , Str "break"
+    , LineBreak
+    , Str "here."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "E-mail", Space, Str "style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , Space
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "pretty"
+      , Space
+      , Str "short."
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Code"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    , Para
+      [ Str "A", Space, Str "list:" ]
+    , OrderedList
+      ( 1, DefaultStyle, DefaultDelim )
+      [
+        [ Plain [ Str "item", Space, Str "one" ] ]
+      ,
+        [ Plain [ Str "item", Space, Str "two" ] ]
+      ]
+    , Para
+      [ Str "Nested", Space, Str "block", Space, Str "quotes:" ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote:"
+    , Space
+    , Str "2"
+    , Space
+    , Str ">"
+    , Space
+    , Str "1."
+    ]
+  , Para
+    [ Str "Box-style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "Example:" ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    ]
+  , BlockQuote
+    [ OrderedList
+      ( 1, DefaultStyle, DefaultDelim )
+      [
+        [ Plain [ Str "do", Space, Str "laundry" ] ]
+      ,
+        [ Plain
+          [ Str "take"
+          , Space
+          , Str "out"
+          , Space
+          , Str "the"
+          , Space
+          , Str "trash"
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "nested"
+    , Space
+    , Str "one:"
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Joe", Space, Str "said:" ]
+    , BlockQuote
+      [ Para [ Str "Don't", Space, Str "quote", Space, Str "me." ] ]
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "a"
+    , Space
+    , Str "following"
+    , Space
+    , Str "paragraph."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "inline-quotes", [], [] )
+    [ Str "Inline", Space, Str "quotes" ]
+  , Para
+    [ Str "Normal"
+    , Space
+    , Str "text"
+    , Space
+    , Str "but"
+    , Space
+    , Str "then"
+    , Space
+    , Str "a"
+    , Space
+    , Quoted DoubleQuote
+      [ Span
+        ( ""
+        , []
+        ,
+          [
+            ( "cite"
+            , "https://www.imdb.com/title/tt0062622/quotes/qt0396921"
+            )
+          ]
+        )
+        [ Str "inline", Space, Str "quote" ]
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Quoted DoubleQuote
+      [ Str "Missing"
+      , Space
+      , Str "a"
+      , Space
+      , Str "cite"
+      , Space
+      , Str "attribute"
+      , Space
+      , Str "means"
+      , Space
+      , Str "its"
+      , Space
+      , Str "just"
+      , Space
+      , Str "normal"
+      , Space
+      , Str "text"
+      ]
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
+  , HorizontalRule
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "unordered", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Asterisks", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "ordered", [], [] )
+    [ Str "Ordered" ]
+  , Para
+    [ Str "Tight:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain [ Str "Second" ] ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "One" ] ]
+    ,
+      [ Plain [ Str "Two" ] ]
+    ,
+      [ Plain [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Loose", Space, Str "using", Space, Str "tabs:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and", Space, Str "using", Space, Str "spaces:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "One" ] ]
+    ,
+      [ Para [ Str "Two" ] ]
+    ,
+      [ Para [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "paragraphs:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para
+        [ Str "Item"
+        , Space
+        , Str "1,"
+        , Space
+        , Str "graf"
+        , Space
+        , Str "one."
+        ]
+      , Para
+        [ Str "Item"
+        , Space
+        , Str "1."
+        , Space
+        , Str "graf"
+        , Space
+        , Str "two."
+        , Space
+        , Str "The"
+        , Space
+        , Str "quick"
+        , Space
+        , Str "brown"
+        , Space
+        , Str "fox"
+        , Space
+        , Str "jumped"
+        , Space
+        , Str "over"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lazy"
+        , Space
+        , Str "dog's"
+        , Space
+        , Str "back."
+        ]
+      ]
+    ,
+      [ Para [ Str "Item", Space, Str "2." ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "3." ] ]
+    ]
+  , Para
+    [ Str "List", Space, Str "styles:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim ) []
+  , OrderedList
+    ( 1, LowerRoman, DefaultDelim ) []
+  , OrderedList
+    ( 1, LowerRoman, DefaultDelim ) []
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim ) []
+  , OrderedList
+    ( 1, LowerRoman, DefaultDelim ) []
+  , OrderedList
+    ( 1, LowerRoman, DefaultDelim ) []
+  , Header 2
+    ( "nested", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Tab" ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "Tab" ]
+          , BulletList
+            [ [ Plain [ Str "Tab" ] ] ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here's", Space, Str "another:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Plain [ Str "Fee" ] ]
+        ,
+          [ Plain [ Str "Fie" ] ]
+        ,
+          [ Plain [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Same"
+    , Space
+    , Str "thing"
+    , Space
+    , Str "but"
+    , Space
+    , Str "with"
+    , Space
+    , Str "paragraphs:"
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Plain [ Str "Fee" ] ]
+        ,
+          [ Plain [ Str "Fie" ] ]
+        ,
+          [ Plain [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "tabs-and-spaces", [], [] )
+    [ Str "Tabs", Space, Str "and", Space, Str "spaces" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "tabs"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "spaces"
+        ]
+      , BulletList
+        [
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "tabs"
+            ]
+          ]
+        ,
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "spaces"
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "fancy-list-markers", [], [] )
+    [ Str "Fancy", Space, Str "list", Space, Str "markers" ]
+  , OrderedList
+    ( 2, Decimal, DefaultDelim )
+    [
+      [ Plain [ Str "begins", Space, Str "with", Space, Str "2" ] ]
+    ,
+      [ Para
+        [ Str "and", Space, Str "now", Space, Str "3" ]
+      , Para
+        [ Str "with", Space, Str "a", Space, Str "continuation" ]
+      , OrderedList
+        ( 4, LowerRoman, DefaultDelim )
+        [
+          [ Plain
+            [ Str "sublist"
+            , Space
+            , Str "with"
+            , Space
+            , Str "roman"
+            , Space
+            , Str "numerals,"
+            , Space
+            , Str "starting"
+            , Space
+            , Str "with"
+            , Space
+            , Str "4"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "more", Space, Str "items" ]
+          , OrderedList
+            ( 1, UpperAlpha, DefaultDelim )
+            [
+              [ Plain [ Str "a", Space, Str "subsublist" ] ]
+            ,
+              [ Plain [ Str "a", Space, Str "subsublist" ] ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Nesting:" ]
+  , OrderedList
+    ( 1, UpperAlpha, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Upper", Space, Str "Alpha" ]
+      , OrderedList
+        ( 1, UpperRoman, DefaultDelim )
+        [
+          [ Plain
+            [ Str "Upper", Space, Str "Roman." ]
+          , OrderedList
+            ( 6, Decimal, DefaultDelim )
+            [
+              [ Plain
+                [ Str "Decimal"
+                , Space
+                , Str "start"
+                , Space
+                , Str "with"
+                , Space
+                , Str "6"
+                ]
+              , OrderedList
+                ( 3, LowerAlpha, DefaultDelim )
+                [
+                  [ Plain
+                    [ Str "Lower"
+                    , Space
+                    , Str "alpha"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "paren"
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Autonumbering:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "Autonumber." ] ]
+    ,
+      [ Plain
+        [ Str "More." ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [ [ Plain [ Str "Nested." ] ] ]
+      ]
+    ]
+  , HorizontalRule
+  , Header 2
+    ( "definition", [], [] )
+    [ Str "Definition" ]
+  , DefinitionList
+    [
+      (
+        [ Str "Violin" ]
+      ,
+        [
+          [ Plain
+            [ Str "Stringed"
+            , Space
+            , Str "musical"
+            , Space
+            , Str "instrument."
+            ]
+          ]
+        ,
+          [ Plain [ Str "Torture", Space, Str "device." ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "Cello", LineBreak, Str "Violoncello" ]
+      ,
+        [
+          [ Plain
+            [ Str "Low-voiced"
+            , Space
+            , Str "stringed"
+            , Space
+            , Str "instrument."
+            ]
+          ]
+        ]
+      )
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "inline-markup", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Emph
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Strong
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Empty"
+    , Space
+    , Strong []
+    , Space
+    , Str "and"
+    , Space
+    , Emph []
+    , Str "."
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Emph
+      [ Link
+        ( "", [], [] )
+        [ Str "emphasized", Space, Str "link" ]
+        ( "/url", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) ">"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "<html>"
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , SmallCaps
+      [ Str "small", Space, Str "caps" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "are"
+    , Space
+    , Str "all"
+    , Space
+    , Str "underlined:"
+    , Space
+    , Underline
+      [ Str "foo" ]
+    , Space
+    , Str "and"
+    , Space
+    , Underline
+      [ Str "bar" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "are"
+    , Space
+    , Str "all"
+    , Space
+    , Str "strikethrough:"
+    , Space
+    , Strikeout
+      [ Str "foo" ]
+    , Str ","
+    , Space
+    , Strikeout
+      [ Str "bar" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Strikeout
+      [ Str "baz" ]
+    , Str "."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "smart-quotes-ellipses-dashes", [], [] )
+    [ Str "Smart"
+    , Space
+    , Str "quotes,"
+    , Space
+    , Str "ellipses,"
+    , Space
+    , Str "dashes"
+    ]
+  , Para
+    [ Str "\"Hello,\""
+    , Space
+    , Str "said"
+    , Space
+    , Str "the"
+    , Space
+    , Str "spider."
+    , Space
+    , Str "\"'Shelob'"
+    , Space
+    , Str "is"
+    , Space
+    , Str "my"
+    , Space
+    , Str "name.\""
+    ]
+  , Para
+    [ Str "'A',"
+    , Space
+    , Str "'B',"
+    , Space
+    , Str "and"
+    , Space
+    , Str "'C'"
+    , Space
+    , Str "are"
+    , Space
+    , Str "letters."
+    ]
+  , Para
+    [ Str "'Oak,'"
+    , Space
+    , Str "'elm,'"
+    , Space
+    , Str "and"
+    , Space
+    , Str "'beech'"
+    , Space
+    , Str "are"
+    , Space
+    , Str "names"
+    , Space
+    , Str "of"
+    , Space
+    , Str "trees."
+    , Space
+    , Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Str "'pine.'"
+    ]
+  , Para
+    [ Str "'He"
+    , Space
+    , Str "said,"
+    , Space
+    , Str "\"I"
+    , Space
+    , Str "want"
+    , Space
+    , Str "to"
+    , Space
+    , Str "go.\"'"
+    , Space
+    , Str "Were"
+    , Space
+    , Str "you"
+    , Space
+    , Str "alive"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "70's?"
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "quoted"
+    , Space
+    , Str "'"
+    , Code
+      ( "", [], [] ) "code"
+    , Str "'"
+    , Space
+    , Str "and"
+    , Space
+    , Str "a"
+    , Space
+    , Str "\""
+    , Link
+      ( "", [], [] )
+      [ Str "quoted", Space, Str "link" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "\"."
+    ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Str "dashes:"
+    , Space
+    , Str "one---two"
+    , Space
+    , Str "---"
+    , Space
+    , Str "three--four"
+    , Space
+    , Str "--"
+    , Space
+    , Str "five."
+    ]
+  , Para
+    [ Str "Dashes"
+    , Space
+    , Str "between"
+    , Space
+    , Str "numbers:"
+    , Space
+    , Str "5-7,"
+    , Space
+    , Str "255-66,"
+    , Space
+    , Str "1987-1999."
+    ]
+  , Para
+    [ Str "Ellipses...and."
+    , Space
+    , Str "."
+    , Space
+    , Str ".and"
+    , Space
+    , Str "."
+    , Space
+    , Str "."
+    , Space
+    , Str "."
+    , Space
+    , Str "."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "latex", [], [] )
+    [ Str "LaTeX" ]
+  , BulletList
+    [
+      [ Plain [ Str "\\cite[22-23]{smith.1899}" ] ]
+    ,
+      [ Plain [ Str "\\doublespacing" ] ]
+    ,
+      [ Plain [ Str "$2+2=4$" ] ]
+    ,
+      [ Plain [ Str "$x", Space, Str "\\in", Space, Str "y$" ] ]
+    ,
+      [ Plain
+        [ Str "$\\alpha", Space, Str "\\wedge", Space, Str "\\omega$" ]
+      ]
+    ,
+      [ Plain [ Str "$223$" ] ]
+    ,
+      [ Plain [ Str "$p$-Tree" ] ]
+    ,
+      [ Plain
+        [ Str "$\\frac{d}{dx}f(x)=\\lim_{h\\to"
+        , Space
+        , Str "0}\\frac{f(x+h)-f(x)}{h}$"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Here's"
+        , Space
+        , Str "one"
+        , Space
+        , Str "that"
+        , Space
+        , Str "has"
+        , Space
+        , Str "a"
+        , Space
+        , Str "line"
+        , Space
+        , Str "break"
+        , Space
+        , Str "in"
+        , Space
+        , Str "it:"
+        , Space
+        , Str "$\\alpha"
+        , Space
+        , Str "+"
+        , Space
+        , Str "\\omega"
+        , Space
+        , Str "\\times"
+        , Space
+        , Str "x^2$."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "shouldn't"
+    , Space
+    , Str "be"
+    , Space
+    , Str "math:"
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "To"
+        , Space
+        , Str "get"
+        , Space
+        , Str "the"
+        , Space
+        , Str "famous"
+        , Space
+        , Str "equation,"
+        , Space
+        , Str "write"
+        , Space
+        , Code
+          ( "", [], [] ) "$e = mc^2$"
+        , Str "."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "$22,000"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Emph
+          [ Str "lot" ]
+        , Space
+        , Str "of"
+        , Space
+        , Str "money."
+        , Space
+        , Str "So"
+        , Space
+        , Str "is"
+        , Space
+        , Str "$34,000."
+        , Space
+        , Str "(It"
+        , Space
+        , Str "worked"
+        , Space
+        , Str "if"
+        , Space
+        , Str "\"lot\""
+        , Space
+        , Str "is"
+        , Space
+        , Str "emphasized.)"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Escaped"
+        , Space
+        , Code
+          ( "", [], [] ) "$"
+        , Str ":"
+        , Space
+        , Str "$73"
+        , Space
+        , Emph
+          [ Str "this"
+          , Space
+          , Str "should"
+          , Space
+          , Str "be"
+          , Space
+          , Str "emphasized"
+          ]
+        , Space
+        , Str "23$."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "LaTeX"
+    , Space
+    , Str "table:"
+    ]
+  , Para
+    [ Str "\\begin{tabular}{|l|l|}\\hline"
+    , Space
+    , Str "Animal"
+    , Space
+    , Str "&"
+    , Space
+    , Str "Number"
+    , Space
+    , Str "\\\\"
+    , Space
+    , Str "\\hline"
+    , Space
+    , Str "Dog"
+    , Space
+    , Str "&"
+    , Space
+    , Str "2"
+    , Space
+    , Str "\\\\"
+    , Space
+    , Str "Cat"
+    , Space
+    , Str "&"
+    , Space
+    , Str "1"
+    , Space
+    , Str "\\\\"
+    , Space
+    , Str "\\hline"
+    , Space
+    , Str "\\end{tabular}"
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "special-characters", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "unicode:"
+    ]
+  , BulletList
+    [
+      [ Plain [ Str "I", Space, Str "hat:", Space, Str "\206" ] ]
+    ,
+      [ Plain [ Str "o", Space, Str "umlaut:", Space, Str "\246" ] ]
+    ,
+      [ Plain [ Str "section:", Space, Str "\167" ] ]
+    ,
+      [ Plain
+        [ Str "set", Space, Str "membership:", Space, Str "\8712" ]
+      ]
+    ,
+      [ Plain [ Str "copyright:", Space, Str "\169" ] ]
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "is"
+    , Space
+    , Str "another"
+    , Space
+    , Str "way"
+    , Space
+    , Str "to"
+    , Space
+    , Str "write"
+    , Space
+    , Str "it."
+    ]
+  , Para
+    [ Str "This", Space, Str "&", Space, Str "that." ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "`" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , HorizontalRule
+  , Header 1
+    ( "links", [], [] )
+    [ Str "Links" ]
+  , Header 2
+    ( "explicit", [], [] )
+    [ Str "Explicit" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "URL" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title preceded by two spaces" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title preceded by a tab" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title with \"quotes\" in it" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title with single quotes" )
+    ]
+  , Para
+    [ Str "Email"
+    , Space
+    , Str "link"
+    , Space
+    , Str "(nobody"
+    , Space
+    , Str "[at]"
+    , Space
+    , Str "nowhere.net)"
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Empty" ] ( "", "" ), Str "." ]
+  , Header 2
+    ( "reference", [], [] )
+    [ Str "Reference" ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "With"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "[brackets]" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "b" ]
+      ( "/url/", "" )
+    , Space
+    , Str "by"
+    , Space
+    , Str "itself"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "once" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "twice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "thrice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "[not]"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , CodeBlock
+    ( "", [], [] ) "[not]: /url"
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "Title with \"quotes\" inside" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "biz" ]
+      ( "/url/", "Title with \"quote\" inside" )
+    , Str "."
+    ]
+  , Header 2
+    ( "with-ampersands", [], [] )
+    [ Str "With", Space, Str "ampersands" ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link"
+      , Space
+      , Str "with"
+      , Space
+      , Str "an"
+      , Space
+      , Str "ampersand"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "URL"
+      ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Str "amersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "AT&T" ]
+      ( "http://att.com/", "AT&T" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline", Space, Str "link" ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline"
+      , Space
+      , Str "link"
+      , Space
+      , Str "in"
+      , Space
+      , Str "pointy"
+      , Space
+      , Str "braces"
+      ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "autolinks", [], [] )
+    [ Str "Autolinks" ]
+  , Para
+    [ Str "With"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://example.com/?foo=1&bar=2" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    ]
+  , BulletList
+    [
+      [ Plain [ Str "In", Space, Str "a", Space, Str "list?" ] ]
+    ,
+      [ Plain
+        [ Link
+          ( "", [], [] )
+          [ Str "http://example.com/" ]
+          ( "http://example.com/", "" )
+        ]
+      ]
+    ,
+      [ Plain [ Str "It", Space, Str "should." ] ]
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Str "e-mail"
+    , Space
+    , Str "address:"
+    , Space
+    , Str "nobody"
+    , Space
+    , Str "[at]"
+    , Space
+    , Str "nowhere.net"
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Blockquoted:"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "http://example.com/" ]
+        ( "http://example.com/", "" )
+      ]
+    ]
+  , Para
+    [ Str "Auto-links"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "occur"
+    , Space
+    , Str "here:"
+    , Space
+    , Code
+      ( "", [], [] ) "<http://example.com/>"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "or here: <http://example.com/>"
+  , HorizontalRule
+  , Header 1
+    ( "images", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "From"
+    , Space
+    , Str "\"Voyage"
+    , Space
+    , Str "dans"
+    , Space
+    , Str "la"
+    , Space
+    , Str "Lune\""
+    , Space
+    , Str "by"
+    , Space
+    , Str "Georges"
+    , Space
+    , Str "Melies"
+    , Space
+    , Str "(1902):"
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "lalune" ]
+      ( "lalune.jpg", "Voyage dans la Lune" )
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "movie" ]
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "footnotes", [], [] )
+    [ Str "Footnotes" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference"
+    , Link
+      ( "", [], [] )
+      [ Str "(1)" ]
+      ( "#note_1", "" )
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "another"
+    , Link
+      ( "", [], [] )
+      [ Str "(longnote)" ]
+      ( "#note_longnote", "" )
+    , Str "."
+    , Space
+    , Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Emph
+      [ Str "not" ]
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , Space
+    , Str "because"
+    , Space
+    , Str "it"
+    , Space
+    , Str "contains"
+    , Space
+    , Str "a"
+    , Space
+    , Str "space^(my"
+    , Space
+    , Str "note)."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "(1)" ]
+      ( "#ref_1", "" )
+    , Space
+    , Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "the"
+    , Space
+    , Str "footnote."
+    , Space
+    , Str "It"
+    , Space
+    , Str "can"
+    , Space
+    , Str "go"
+    , Space
+    , Str "anywhere"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "document,"
+    , Space
+    , Str "not"
+    , Space
+    , Str "just"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "end."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "(longnote)" ]
+      ( "#ref_longnote", "" )
+    , Space
+    , Str "Here's"
+    , Space
+    , Str "the"
+    , Space
+    , Str "other"
+    , Space
+    , Str "note."
+    , Space
+    , Str "This"
+    , Space
+    , Str "one"
+    , Space
+    , Str "contains"
+    , Space
+    , Str "multiple"
+    , Space
+    , Str "blocks."
+    ]
+  , Para
+    [ Str "Caret"
+    , Space
+    , Str "characters"
+    , Space
+    , Str "are"
+    , Space
+    , Str "used"
+    , Space
+    , Str "to"
+    , Space
+    , Str "indicate"
+    , Space
+    , Str "that"
+    , Space
+    , Str "the"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "all"
+    , Space
+    , Str "belong"
+    , Space
+    , Str "to"
+    , Space
+    , Str "a"
+    , Space
+    , Str "single"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "(as"
+    , Space
+    , Str "with"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quotes)."
+    ]
+  , CodeBlock
+    ( "", [], [] ) "  { <code> }"
+  , Para
+    [ Str "If"
+    , Space
+    , Str "you"
+    , Space
+    , Str "want,"
+    , Space
+    , Str "you"
+    , Space
+    , Str "can"
+    , Space
+    , Str "use"
+    , Space
+    , Str "a"
+    , Space
+    , Str "caret"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "beginning"
+    , Space
+    , Str "of"
+    , Space
+    , Str "every"
+    , Space
+    , Str "line,"
+    , Space
+    , Str "as"
+    , Space
+    , Str "with"
+    , Space
+    , Str "blockquotes,"
+    , Space
+    , Str "but"
+    , Space
+    , Str "all"
+    , Space
+    , Str "that"
+    , Space
+    , Str "you"
+    , Space
+    , Str "need"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "caret"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "beginning"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "first"
+    , Space
+    , Str "line"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "block"
+    , Space
+    , Str "and"
+    , Space
+    , Str "any"
+    , Space
+    , Str "preceding"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "lines."
+    ]
+  , Para
+    [ Str "text", Space, Emph [ Str "Leading", Space, Str "space" ] ]
+  , Para
+    [ Emph [ Str "Trailing", Space, Str "space" ], Space, Str "text" ]
+  , Para
+    [ Str "text", Space, Emph [ Str "Leading", Space, Str "spaces" ] ]
+  , Para
+    [ Emph [ Str "Trailing", Space, Str "spaces" ], Space, Str "text" ]
+  , Header 1
+    ( "tables", [], [] )
+    [ Str "Tables" ]
+  , Header 2
+    ( "tables-with-headers", [], [] )
+    [ Str "Tables", Space, Str "with", Space, Str "Headers" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Para
+    [ Str "Row", Space, Str "headers" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 1 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 1 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    )
+  , HorizontalRule
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      ]
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      ]
+    , TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      ]
+    , TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 2
+    ( "tables-without-headers", [], [] )
+    [ Str "Tables", Space, Str "without", Space, Str "Headers" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Para
+    [ Str "tbody", Space, Str "tags", Space, Str "omitted" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Para
+    [ Str "empty", Space, Str "head" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Para
+    [ Str "explicit"
+    , Space
+    , Str "body"
+    , Space
+    , Str "and"
+    , Space
+    , Str "foot"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    )
+  , Header 2
+    ( "colspans-and-rowspans", [], [] )
+    [ Str "Colspans", Space, Str "and", Space, Str "Rowspans" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 2 )
+          [ Plain [ Str "1", Space, Str "and", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 3 )
+          [ Plain
+            [ Str "4,"
+            , Space
+            , Str "5,"
+            , Space
+            , Str "and"
+            , Space
+            , Str "6"
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , HorizontalRule
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 3 )
+          [ Plain [ Str "Numbers" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 2 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1", Space, Str "and", Space, Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 2
+    ( "attributes", [], [] )
+    [ Str "Attributes" ]
+  , Table
+    ( "attrib-test-table", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [ "table-head" ], [] )
+      [ Row
+        ( "", [ "table-head-row" ], [] )
+        [ Cell
+          ( "", [], [ ( "abbr", "x" ) ] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 3 )
+          [ Plain [ Str "Cat", Space, Str "X" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [ "main" ], [ ( "part", "body" ) ] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [ ( "part", "row" ) ] )
+        [ Cell
+          ( "", [], [ ( "part", "cell" ) ] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [ ( "valign", "bottom" ) ] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [ ( "style", "color: #151950" ) ] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot
+      ( "", [ "summary" ], [] )
+      [ Row
+        ( "", [], [ ( "bgcolor", "#ccc" ) ] )
+        [ Cell
+          ( "", [], [ ( "square", "true" ) ] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    )
+  , Header 2
+    ( "tag-omission", [], [] )
+    [ Str "Tag", Space, Str "omission" ]
+  , Para
+    [ Str "thead,"
+    , Space
+    , Str "tbody,"
+    , Space
+    , Str "and"
+    , Space
+    , Str "tfoot"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        ]
+      ]
+    )
+  , Header 2
+    ( "empty-tables", [], [] )
+    [ Str "Empty", Space, Str "Tables" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "empty."
+    ]
+  ]

--- a/test/ipynb/simple.out.native
+++ b/test/ipynb/simple.out.native
@@ -1,15 +1,106 @@
-Pandoc (Meta {unMeta = fromList [("jupyter",MetaMap (fromList [("nbformat",MetaString "4"),("nbformat_minor",MetaString "5")]))]})
-[Div ("",["cell","markdown"],[])
- [Header 1 ("lorem-ipsum",[],[]) [Str "Lorem",Space,Str "ipsum"]
- ,Para [Strong [Str "Lorem",Space,Str "ipsum"],Space,Str "dolor",Space,Str "sit",Space,Str "amet,",Space,Str "consectetur",Space,Str "adipiscing",Space,Str "elit.",Space,Str "Nunc",Space,Str "luctus",SoftBreak,Str "bibendum",Space,Str "felis",Space,Str "dictum",Space,Str "sodales."]]
-,Div ("",["cell","code"],[])
- [CodeBlock ("",["python"],[]) "print(\"hello\")"]
-,Div ("",["cell","markdown"],[])
- [Header 2 ("pyout",[],[]) [Str "Pyout"]]
-,Div ("",["cell","code"],[("execution_count","2")])
- [CodeBlock ("",["python"],[]) "from IPython.display import HTML\nHTML(\"\"\"\n<script>\nconsole.log(\"hello\");\n</script>\n<b>HTML</b>\n\"\"\")"
- ,Div ("",["output","execute_result"],[("execution_count","2")])
-  [RawBlock (Format "html") "<script>\nconsole.log(\"hello\");\n</script>\n<b>HTML</b>\nhello"]]
-,Div ("",["cell","markdown"],[("tags","[\"foo\",\"bar\"]")])
- [Header 2 ("image",[],[]) [Str "Image"]
- ,Para [Str "This",Space,Str "image",Space,Image ("",[],[]) [Str "the",Space,Str "moon"] ("lalune.jpg",""),Space,Str "will",Space,Str "be",Space,Str "included",Space,Str "as",Space,Str "a",Space,Str "cell",SoftBreak,Str "attachment."]]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "jupyter"
+        , MetaMap
+          ( fromList
+            [
+              ( "nbformat", MetaString "4" )
+            ,
+              ( "nbformat_minor", MetaString "5" )
+            ]
+          )
+        )
+      ]
+    }
+  )
+  [ Div
+    ( "", [ "cell", "markdown" ], [] )
+    [ Header 1
+      ( "lorem-ipsum", [], [] )
+      [ Str "Lorem", Space, Str "ipsum" ]
+    , Para
+      [ Strong
+        [ Str "Lorem", Space, Str "ipsum" ]
+      , Space
+      , Str "dolor"
+      , Space
+      , Str "sit"
+      , Space
+      , Str "amet,"
+      , Space
+      , Str "consectetur"
+      , Space
+      , Str "adipiscing"
+      , Space
+      , Str "elit."
+      , Space
+      , Str "Nunc"
+      , Space
+      , Str "luctus"
+      , SoftBreak
+      , Str "bibendum"
+      , Space
+      , Str "felis"
+      , Space
+      , Str "dictum"
+      , Space
+      , Str "sodales."
+      ]
+    ]
+  , Div
+    ( "", [ "cell", "code" ], [] )
+    [ CodeBlock ( "", [ "python" ], [] ) "print(\"hello\")" ]
+  , Div
+    ( "", [ "cell", "markdown" ], [] )
+    [ Header 2 ( "pyout", [], [] ) [ Str "Pyout" ] ]
+  , Div
+    ( "", [ "cell", "code" ], [ ( "execution_count", "2" ) ] )
+    [ CodeBlock
+      ( ""
+      , [ "python" ]
+      , []
+      ) "from IPython.display import HTML\nHTML(\"\"\"\n<script>\nconsole.log(\"hello\");\n</script>\n<b>HTML</b>\n\"\"\")"
+    , Div
+      ( ""
+      ,
+        [ "output", "execute_result" ]
+      ,
+        [ ( "execution_count", "2" ) ]
+      )
+      [ RawBlock
+        ( Format "html" ) "<script>\nconsole.log(\"hello\");\n</script>\n<b>HTML</b>\nhello"
+      ]
+    ]
+  , Div
+    ( "", [ "cell", "markdown" ], [ ( "tags", "[\"foo\",\"bar\"]" ) ] )
+    [ Header 2
+      ( "image", [], [] )
+      [ Str "Image" ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "image"
+      , Space
+      , Image
+        ( "", [], [] )
+        [ Str "the", Space, Str "moon" ]
+        ( "lalune.jpg", "" )
+      , Space
+      , Str "will"
+      , Space
+      , Str "be"
+      , Space
+      , Str "included"
+      , Space
+      , Str "as"
+      , Space
+      , Str "a"
+      , Space
+      , Str "cell"
+      , SoftBreak
+      , Str "attachment."
+      ]
+    ]
+  ]

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -1,671 +1,2893 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Space,Str "MacFarlane"],MetaInlines [Str "Anonymous"]]),("title",MetaInlines [Str "Pandoc",Space,Str "Test",Space,Str "Suite"])]})
-[Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc.",Space,Str "Most",Space,Str "of",Space,Str "them",Space,Str "are",Space,Str "adapted",Space,Str "from",Space,Str "John",Space,Str "Gruber's",Space,Str "markdown",Space,Str "test",Space,Str "suite."]
-,Header 1 ("headers",[],[]) [Str "Headers"]
-,Header 2 ("level-2-with-an-embedded-link",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Str "an",SoftBreak,Link ("",[],[]) [Str "embedded",SoftBreak,Str "link"] ("/url","")]
-,Header 3 ("level-3-with-emphasis",[],[]) [Str "Level",Space,Str "3",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 4 ("level-4",[],[]) [Str "Level",Space,Str "4"]
-,Header 5 ("level-5",[],[]) [Str "Level",Space,Str "5"]
-,Header 1 ("level-1",[],[]) [Str "Level",Space,Str "1"]
-,Header 2 ("level-2-with-emphasis",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 3 ("level-3",[],[]) [Str "Level",Space,Str "3"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Header 2 ("level-2",[],[]) [Str "Level",Space,Str "2"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]
-,Para [Str "Here's",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "In",Space,Str "Markdown",Space,Str "1.0.0",Space,Str "and",Space,Str "earlier.",Space,Str "Version",Space,Str "8.",Space,Str "This",Space,Str "line",Space,Str "turns",Space,Str "into",Space,Str "a",Space,Str "list",Space,Str "item.",Space,Str "Because",Space,Str "a",Space,Str "hard-wrapped",Space,Str "line",Space,Str "in",Space,Str "the",Space,Str "middle",Space,Str "of",Space,Str "a",Space,Str "paragraph",Space,Str "looked",Space,Str "like",Space,Str "a",Space,Str "list",Space,Str "item."]
-,Para [Str "Here's",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet.",Space,Str "*",Space,Str "criminey."]
-,Para [Str "There",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "hard",Space,Str "line",Space,Str "break",LineBreak,Str "here."]
-,Header 1 ("block-quotes",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "E-mail",Space,Str "style:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",Space,Str "It",Space,Str "is",Space,Str "pretty",Space,Str "short."]]
-,BlockQuote
- [Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"
- ,Para [Str "A",Space,Str "list:"]
- ,OrderedList (1,DefaultStyle,DefaultDelim)
-  [[Para [Str "item",Space,Str "one"]]
-  ,[Para [Str "item",Space,Str "two"]]]
- ,Para [Str "Nested",Space,Str "block",Space,Str "quotes:"]
- ,BlockQuote
-  [Para [Str "nested"]]
- ,BlockQuote
-  [Para [Str "nested"]]]
-,Para [Str "This",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "block",Space,Str "quote:",Space,Str "2",Space,Str ">",Space,Str "1."]
-,Para [Str "Box-style:"]
-,BlockQuote
- [Para [Str "Example:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"]
-,BlockQuote
- [OrderedList (1,DefaultStyle,DefaultDelim)
-  [[Para [Str "do",Space,Str "laundry"]]
-  ,[Para [Str "take",Space,Str "out",Space,Str "the",Space,Str "trash"]]]]
-,Para [Str "Here's",Space,Str "a",Space,Str "nested",Space,Str "one:"]
-,BlockQuote
- [Para [Str "Joe",Space,Str "said:"]
- ,BlockQuote
-  [Para [Str "Don't",Space,Str "quote",Space,Str "me."]]]
-,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
-,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
-,Header 1 ("lists",[],[]) [Str "Lists"]
-,Header 2 ("unordered",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks",Space,Str "tight:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Asterisks",Space,Str "loose:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "tight:"]
-,BulletList
- [[Para [Str "Plus",Space,Str "1"]]
- ,[Para [Str "Plus",Space,Str "2"]]
- ,[Para [Str "Plus",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Plus",Space,Str "1"]]
- ,[Para [Str "Plus",Space,Str "2"]]
- ,[Para [Str "Plus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "tight:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Header 2 ("ordered",[],[]) [Str "Ordered"]
-,Para [Str "Tight:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "and:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]]
- ,[Para [Str "Three"]]]
-,Para [Str "Loose",Space,Str "using",Space,Str "tabs:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "and",Space,Str "using",Space,Str "spaces:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]]
- ,[Para [Str "Three"]]]
-,Para [Str "Multiple",Space,Str "paragraphs:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "Item",Space,Str "1,",Space,Str "graf",Space,Str "one."]
-  ,Para [Str "Item",Space,Str "1.",Space,Str "graf",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",SoftBreak,Str "dog's",Space,Str "back."]]
- ,[Para [Str "Item",Space,Str "2."]]
- ,[Para [Str "Item",Space,Str "3."]]]
-,Para [Str "List",Space,Str "styles:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- []
-,OrderedList (1,LowerRoman,DefaultDelim)
- []
-,Header 2 ("nested",[],[]) [Str "Nested"]
-,BulletList
- [[Para [Str "Tab"]
-  ,BulletList
-   [[Para [Str "Tab"]
-    ,BulletList
-     [[Para [Str "Tab"]]]]]]]
-,Para [Str "Here's",Space,Str "another:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Para [Str "Same",Space,Str "thing",Space,Str "but",Space,Str "with",Space,Str "paragraphs:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Header 2 ("tabs-and-spaces",[],[]) [Str "Tabs",Space,Str "and",Space,Str "spaces"]
-,BulletList
- [[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "tabs"]]
- ,[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "spaces"]
-  ,BulletList
-   [[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "tabs"]]
-   ,[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "spaces"]]]]]
-,Header 2 ("fancy-list-markers",[],[]) [Str "Fancy",Space,Str "list",Space,Str "markers"]
-,Para [Str "Autonumbering:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "Autonumber."]]
- ,[Para [Str "More."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Para [Str "Nested."]]]]]
-,Header 2 ("definition",[],[]) [Str "Definition"]
-,DefinitionList
- [([Str "Violin"],
-   [[Para [Str "Stringed",Space,Str "musical",Space,Str "instrument."]
-    ,Para [Str "Torture",Space,Str "device."]]])
- ,([Str "Cello",LineBreak,Str "Violoncello"],
-   [[Para [Str "Low-voiced",Space,Str "stringed",Space,Str "instrument."]]])]
-,Header 1 ("inline-markup",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ",",Space,Str "and",Space,Str "so",Space,Emph [Str "is",SoftBreak,Str "this"],Str "."]
-,Para [Str "This",Space,Str "is",Space,Strong [Str "strong"],Str ",",Space,Str "and",Space,Str "so",SoftBreak,Strong [Str "is",Space,Str "this"],Str "."]
-,Para [Str "Empty",Space,Strong [],Space,Str "and",Space,Emph [],Str "."]
-,Para [Str "An",SoftBreak,Emph [Link ("",[],[]) [Str "emphasized",SoftBreak,Str "link"] ("/url","")],Str "."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Str "This",Space,Str "is",Space,Str "code:",Space,Code ("",[],[]) ">",Str ",",Space,Code ("",[],[]) "$",Str ",",SoftBreak,Code ("",[],[]) "\\",Str ",",Space,Code ("",[],[]) "\\$",Str ",",SoftBreak,Code ("",[],[]) "<html>",Str "."]
-,Para [Str "This",Space,Str "is",Space,SmallCaps [Str "small",Space,Str "caps"],Str "."]
-,Para [Str "These",Space,Str "are",Space,Str "all",Space,Str "underlined:",Space,Str "foo",Space,Str "and",Space,Str "bar."]
-,Para [Str "These",Space,Str "are",Space,Str "all",Space,Str "strikethrough:",Space,Strikeout [Str "foo"],Str ",",SoftBreak,Strikeout [Str "bar"],Str ",",Space,Str "and",Space,Strikeout [Str "baz"],Str "."]
-,Header 1 ("smart-quotes-ellipses-dashes",[],[]) [Str "Smart",Space,Str "quotes,",Space,Str "ellipses,",Space,Str "dashes"]
-,Para [Str "\"Hello,\"",Space,Str "said",Space,Str "the",Space,Str "spider.",Space,Str "\"'Shelob'",Space,Str "is",Space,Str "my",Space,Str "name.\""]
-,Para [Str "'A',",Space,Str "'B',",Space,Str "and",Space,Str "'C'",Space,Str "are",Space,Str "letters."]
-,Para [Str "'Oak,'",Space,Str "'elm,'",Space,Str "and",Space,Str "'beech'",Space,Str "are",Space,Str "names",Space,Str "of",Space,Str "trees.",Space,Str "So",Space,Str "is",Space,Str "'pine.'"]
-,Para [Str "'He",Space,Str "said,",Space,Str "\"I",Space,Str "want",Space,Str "to",Space,Str "go.\"'",Space,Str "Were",Space,Str "you",Space,Str "alive",Space,Str "in",Space,Str "the",Space,Str "70's?"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "quoted",Space,Str "'",Code ("",[],[]) "code",Str "'",Space,Str "and",Space,Str "a",SoftBreak,Str "\"",Link ("",[],[]) [Str "quoted",SoftBreak,Str "link"] ("http://example.com/?foo=1&bar=2",""),Str "\"."]
-,Para [Str "Some",Space,Str "dashes:",Space,Str "one---two",Space,Str "---",Space,Str "three--four",Space,Str "--",Space,Str "five."]
-,Para [Str "Dashes",Space,Str "between",Space,Str "numbers:",Space,Str "5-7,",Space,Str "255-66,",Space,Str "1987-1999."]
-,Para [Str "Ellipses...and.",Space,Str ".",Space,Str ".and",Space,Str ".",Space,Str ".",Space,Str ".",Space,Str "."]
-,Header 1 ("latex",[],[]) [Str "LaTeX"]
-,BulletList
- [[Para [Str "\\cite[22-23]{smith.1899}"]]
- ,[Para [Str "\\doublespacing"]]
- ,[Para [Str "$2+2=4$"]]
- ,[Para [Str "$x",Space,Str "\\in",Space,Str "y$"]]
- ,[Para [Str "$\\alpha",Space,Str "\\wedge",Space,Str "\\omega$"]]
- ,[Para [Str "$223$"]]
- ,[Para [Str "$p$-Tree"]]
- ,[Para [Str "$\\frac{d}{dx}f(x)=\\lim_{h\\to",Space,Str "0}\\frac{f(x+h)-f(x)}{h}$"]]
- ,[Para [Str "Here's",Space,Str "one",Space,Str "that",Space,Str "has",Space,Str "a",Space,Str "line",Space,Str "break",Space,Str "in",Space,Str "it:",Space,Str "$\\alpha",Space,Str "+",Space,Str "\\omega",Space,Str "\\times",SoftBreak,Str "x^2$."]]]
-,Para [Str "These",Space,Str "shouldn't",Space,Str "be",Space,Str "math:"]
-,BulletList
- [[Para [Str "To",Space,Str "get",Space,Str "the",Space,Str "famous",Space,Str "equation,",Space,Str "write",SoftBreak,Code ("",[],[]) "$e = mc^2$",Str "."]]
- ,[Para [Str "$22,000",Space,Str "is",Space,Str "a",Space,Emph [Str "lot"],Space,Str "of",Space,Str "money.",Space,Str "So",Space,Str "is",Space,Str "$34,000.",Space,Str "(It",SoftBreak,Str "worked",Space,Str "if",Space,Str "\"lot\"",Space,Str "is",Space,Str "emphasized.)"]]
- ,[Para [Str "Escaped",Space,Code ("",[],[]) "$",Str ":",Space,Str "$73",Space,Emph [Str "this",Space,Str "should",Space,Str "be",SoftBreak,Str "emphasized"],Space,Str "23$."]]]
-,Para [Str "Here's",Space,Str "a",Space,Str "LaTeX",Space,Str "table:"]
-,Para [Str "\\begin{tabular}{|l|l|}\\hline",Space,Str "Animal",Space,Str "&",Space,Str "Number",Space,Str "\\\\",Space,Str "\\hline",Space,Str "Dog",Space,Str "&",SoftBreak,Str "2",Space,Str "\\\\",Space,Str "Cat",Space,Str "&",Space,Str "1",Space,Str "\\\\",Space,Str "\\hline",Space,Str "\\end{tabular}"]
-,Header 1 ("special-characters",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "unicode:"]
-,BulletList
- [[Para [Str "I",Space,Str "hat:",Space,Str "\206"]]
- ,[Para [Str "o",Space,Str "umlaut:",Space,Str "\246"]]
- ,[Para [Str "section:",Space,Str "\167"]]
- ,[Para [Str "set",Space,Str "membership:",Space,Str "elem"]]
- ,[Para [Str "copyright:",Space,Str "\169"]]]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "AT&T",Space,Str "is",Space,Str "another",Space,Str "way",Space,Str "to",Space,Str "write",Space,Str "it."]
-,Para [Str "This",Space,Str "&",Space,Str "that."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "`"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,Header 1 ("links",[],[]) [Str "Links"]
-,Header 2 ("explicit",[],[]) [Str "Explicit"]
-,Para [Str "Just",Space,Str "a",SoftBreak,Link ("",[],[]) [Str "URL"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",SoftBreak,Str "and",Space,Str "title"] ("/url/","title"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",SoftBreak,Str "and",Space,Str "title"] ("/url/","title preceded by two spaces"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",SoftBreak,Str "and",Space,Str "title"] ("/url/","title preceded by a tab"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",SoftBreak,Str "and",Space,Str "title"] ("/url/","title with \"quotes\" in it")]
-,Para [Link ("",[],[]) [Str "URL",SoftBreak,Str "and",Space,Str "title"] ("/url/","title with single quotes")]
-,Para [Str "Email",Space,Str "link",Space,Str "(nobody",Space,Str "[at]",Space,Str "nowhere.net)"]
-,Para [Link ("",[],[]) [Str "Empty"] ("",""),Str "."]
-,Header 2 ("reference",[],[]) [Str "Reference"]
-,Para [Str "Foo",SoftBreak,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",SoftBreak,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",SoftBreak,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "With",Space,Link ("",[],[]) [Str "embedded",SoftBreak,Str "[brackets]"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "b"] ("/url/",""),Space,Str "by",SoftBreak,Str "itself",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "link."]
-,Para [Str "Indented",SoftBreak,Link ("",[],[]) [Str "once"] ("/url",""),Str "."]
-,Para [Str "Indented",SoftBreak,Link ("",[],[]) [Str "twice"] ("/url",""),Str "."]
-,Para [Str "Indented",SoftBreak,Link ("",[],[]) [Str "thrice"] ("/url",""),Str "."]
-,Para [Str "This",Space,Str "should",Space,Str "[not]",Space,Str "be",Space,Str "a",Space,Str "link."]
-,CodeBlock ("",[],[]) "[not]: /url"
-,Para [Str "Foo",SoftBreak,Link ("",[],[]) [Str "bar"] ("/url/","Title with \"quotes\" inside"),Str "."]
-,Para [Str "Foo",SoftBreak,Link ("",[],[]) [Str "biz"] ("/url/","Title with \"quote\" inside"),Str "."]
-,Header 2 ("with-ampersands",[],[]) [Str "With",Space,Str "ampersands"]
-,Para [Str "Here's",Space,Str "a",SoftBreak,Link ("",[],[]) [Str "link",SoftBreak,Str "with",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "URL"] ("http://example.com/?foo=1&bar=2",""),Str "."]
-,Para [Str "Here's",Space,Str "a",Space,Str "link",Space,Str "with",Space,Str "an",Space,Str "amersand",Space,Str "in",Space,Str "the",Space,Str "link",Space,Str "text:",SoftBreak,Link ("",[],[]) [Str "AT&T"] ("http://att.com/","AT&T"),Str "."]
-,Para [Str "Here's",Space,Str "an",SoftBreak,Link ("",[],[]) [Str "inline",SoftBreak,Str "link"] ("/script?foo=1&bar=2",""),Str "."]
-,Para [Str "Here's",Space,Str "an",SoftBreak,Link ("",[],[]) [Str "inline",SoftBreak,Str "link",Space,Str "in",Space,Str "pointy",Space,Str "braces"] ("/script?foo=1&bar=2",""),Str "."]
-,Header 2 ("autolinks",[],[]) [Str "Autolinks"]
-,Para [Str "With",Space,Str "an",Space,Str "ampersand:",SoftBreak,Link ("",[],[]) [Str "http://example.com/?foo=1&bar=2"] ("http://example.com/?foo=1&bar=2","")]
-,BulletList
- [[Para [Str "In",Space,Str "a",Space,Str "list?"]]
- ,[Para [Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
- ,[Para [Str "It",Space,Str "should."]]]
-,Para [Str "An",Space,Str "e-mail",Space,Str "address:",Space,Str "nobody",Space,Str "[at]",Space,Str "nowhere.net"]
-,BlockQuote
- [Para [Str "Blockquoted:",SoftBreak,Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
-,Para [Str "Auto-links",Space,Str "should",Space,Str "not",Space,Str "occur",Space,Str "here:",SoftBreak,Code ("",[],[]) "<http://example.com/>"]
-,CodeBlock ("",[],[]) "or here: <http://example.com/>"
-,Header 1 ("images",[],[]) [Str "Images"]
-,Para [Str "From",Space,Str "\"Voyage",Space,Str "dans",Space,Str "la",Space,Str "Lune\"",Space,Str "by",Space,Str "Georges",Space,Str "Melies",Space,Str "(1902):"]
-,Para [Image ("",[],[]) [] ("lalune.jpg","Voyage dans la Lune")]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "movie",SoftBreak,Image ("",[],[]) [] ("movie.jpg",""),SoftBreak,Str "icon."]
-,Header 1 ("footnotes",[],[]) [Str "Footnotes"]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "footnote",Space,Str "reference",Link ("",[],[]) [Str "(1)"] ("#note_1",""),Str ",",SoftBreak,Str "and",SoftBreak,Str "another",Link ("",[],[]) [Str "(longnote)"] ("#note_longnote",""),Str ".",SoftBreak,Str "This",Space,Str "should",Space,Emph [Str "not"],Space,Str "be",Space,Str "a",Space,Str "footnote",Space,Str "reference,",Space,Str "because",Space,Str "it",SoftBreak,Str "contains",Space,Str "a",Space,Str "space^(my",Space,Str "note)."]
-,Para [Link ("",[],[]) [Str "(1)"] ("#ref_1",""),Space,Str "Here",Space,Str "is",Space,Str "the",Space,Str "footnote.",Space,Str "It",Space,Str "can",SoftBreak,Str "go",Space,Str "anywhere",Space,Str "in",Space,Str "the",Space,Str "document,",Space,Str "not",Space,Str "just",Space,Str "at",Space,Str "the",Space,Str "end."]
-,Para [Link ("",[],[]) [Str "(longnote)"] ("#ref_longnote",""),Space,Str "Here's",SoftBreak,Str "the",Space,Str "other",Space,Str "note.",Space,Str "This",Space,Str "one",Space,Str "contains",Space,Str "multiple",Space,Str "blocks."]
-,Para [Str "Caret",Space,Str "characters",Space,Str "are",Space,Str "used",Space,Str "to",Space,Str "indicate",Space,Str "that",Space,Str "the",Space,Str "blocks",Space,Str "all",Space,Str "belong",Space,Str "to",SoftBreak,Str "a",Space,Str "single",Space,Str "footnote",Space,Str "(as",Space,Str "with",Space,Str "block",Space,Str "quotes)."]
-,CodeBlock ("",[],[]) "  { <code> }"
-,Para [Str "If",Space,Str "you",Space,Str "want,",Space,Str "you",Space,Str "can",Space,Str "use",Space,Str "a",Space,Str "caret",Space,Str "at",Space,Str "the",Space,Str "beginning",Space,Str "of",Space,Str "every",Space,Str "line,",Space,Str "as",SoftBreak,Str "with",Space,Str "blockquotes,",Space,Str "but",Space,Str "all",Space,Str "that",Space,Str "you",Space,Str "need",Space,Str "is",Space,Str "a",Space,Str "caret",Space,Str "at",Space,Str "the",Space,Str "beginning",SoftBreak,Str "of",Space,Str "the",Space,Str "first",Space,Str "line",Space,Str "of",Space,Str "the",Space,Str "block",Space,Str "and",Space,Str "any",Space,Str "preceding",Space,Str "blank",Space,Str "lines."]
-,Para [Str "text",Space,Emph [Str "Leading",Space,Str "space"]]
-,Para [Emph [Str "Trailing",Space,Str "space"],Space,Str "text"]
-,Para [Str "text",Space,Emph [Str "Leading",Space,Str "spaces"]]
-,Para [Emph [Str "Trailing",Space,Str "spaces"],Space,Str "text"]
-,Header 1 ("tables",[],[]) [Str "Tables"]
-,Header 2 ("tables-with-headers",[],[]) [Str "Tables",Space,Str "with",Space,Str "Headers"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "X"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Y"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Z"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 2 ("tables-without-headers",[],[]) [Str "Tables",Space,Str "without",Space,Str "Headers"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 2 ("empty-tables",[],[]) [Str "Empty",Space,Str "Tables"]
-,Para [Str "This",Space,Str "section",Space,Str "should",Space,Str "be",Space,Str "empty."]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaList
+          [ MetaInlines
+            [ Str "John", Space, Str "MacFarlane" ]
+          , MetaInlines
+            [ Str "Anonymous" ]
+          ]
+        )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Pandoc", Space, Str "Test", Space, Str "Suite" ]
+        )
+      ]
+    }
+  )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc."
+    , Space
+    , Str "Most"
+    , Space
+    , Str "of"
+    , Space
+    , Str "them"
+    , Space
+    , Str "are"
+    , Space
+    , Str "adapted"
+    , Space
+    , Str "from"
+    , Space
+    , Str "John"
+    , Space
+    , Str "Gruber's"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "test"
+    , Space
+    , Str "suite."
+    ]
+  , Header 1
+    ( "headers", [], [] )
+    [ Str "Headers" ]
+  , Header 2
+    ( "level-2-with-an-embedded-link", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", SoftBreak, Str "link" ]
+      ( "/url", "" )
+    ]
+  , Header 3
+    ( "level-3-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "3"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 4
+    ( "level-4", [], [] )
+    [ Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "level-5", [], [] )
+    [ Str "Level", Space, Str "5" ]
+  , Header 1
+    ( "level-1", [], [] )
+    [ Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "level-2-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 3
+    ( "level-3", [], [] )
+    [ Str "Level", Space, Str "3" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , Header 2
+    ( "level-2", [], [] )
+    [ Str "Level", Space, Str "2" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , Header 1
+    ( "paragraphs", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "In"
+    , Space
+    , Str "Markdown"
+    , Space
+    , Str "1.0.0"
+    , Space
+    , Str "and"
+    , Space
+    , Str "earlier."
+    , Space
+    , Str "Version"
+    , Space
+    , Str "8."
+    , Space
+    , Str "This"
+    , Space
+    , Str "line"
+    , Space
+    , Str "turns"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    , Space
+    , Str "Because"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard-wrapped"
+    , Space
+    , Str "line"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "middle"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "looked"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    , Space
+    , Str "*"
+    , Space
+    , Str "criminey."
+    ]
+  , Para
+    [ Str "There"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard"
+    , Space
+    , Str "line"
+    , Space
+    , Str "break"
+    , LineBreak
+    , Str "here."
+    ]
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "E-mail", Space, Str "style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , Space
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "pretty"
+      , Space
+      , Str "short."
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Code"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    , Para
+      [ Str "A", Space, Str "list:" ]
+    , OrderedList
+      ( 1, DefaultStyle, DefaultDelim )
+      [
+        [ Para [ Str "item", Space, Str "one" ] ]
+      ,
+        [ Para [ Str "item", Space, Str "two" ] ]
+      ]
+    , Para
+      [ Str "Nested", Space, Str "block", Space, Str "quotes:" ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote:"
+    , Space
+    , Str "2"
+    , Space
+    , Str ">"
+    , Space
+    , Str "1."
+    ]
+  , Para
+    [ Str "Box-style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "Example:" ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    ]
+  , BlockQuote
+    [ OrderedList
+      ( 1, DefaultStyle, DefaultDelim )
+      [
+        [ Para [ Str "do", Space, Str "laundry" ] ]
+      ,
+        [ Para
+          [ Str "take"
+          , Space
+          , Str "out"
+          , Space
+          , Str "the"
+          , Space
+          , Str "trash"
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "nested"
+    , Space
+    , Str "one:"
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Joe", Space, Str "said:" ]
+    , BlockQuote
+      [ Para [ Str "Don't", Space, Str "quote", Space, Str "me." ] ]
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "a"
+    , Space
+    , Str "following"
+    , Space
+    , Str "paragraph."
+    ]
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "unordered", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Asterisks", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Para [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "ordered", [], [] )
+    [ Str "Ordered" ]
+  , Para
+    [ Str "Tight:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "One" ] ]
+    ,
+      [ Para [ Str "Two" ] ]
+    ,
+      [ Para [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Loose", Space, Str "using", Space, Str "tabs:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and", Space, Str "using", Space, Str "spaces:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "One" ] ]
+    ,
+      [ Para [ Str "Two" ] ]
+    ,
+      [ Para [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "paragraphs:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para
+        [ Str "Item"
+        , Space
+        , Str "1,"
+        , Space
+        , Str "graf"
+        , Space
+        , Str "one."
+        ]
+      , Para
+        [ Str "Item"
+        , Space
+        , Str "1."
+        , Space
+        , Str "graf"
+        , Space
+        , Str "two."
+        , Space
+        , Str "The"
+        , Space
+        , Str "quick"
+        , Space
+        , Str "brown"
+        , Space
+        , Str "fox"
+        , Space
+        , Str "jumped"
+        , Space
+        , Str "over"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lazy"
+        , SoftBreak
+        , Str "dog's"
+        , Space
+        , Str "back."
+        ]
+      ]
+    ,
+      [ Para [ Str "Item", Space, Str "2." ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "3." ] ]
+    ]
+  , Para
+    [ Str "List", Space, Str "styles:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim ) []
+  , OrderedList
+    ( 1, LowerRoman, DefaultDelim ) []
+  , Header 2
+    ( "nested", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "Tab" ]
+      , BulletList
+        [
+          [ Para [ Str "Tab" ], BulletList [ [ Para [ Str "Tab" ] ] ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here's", Space, Str "another:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Same"
+    , Space
+    , Str "thing"
+    , Space
+    , Str "but"
+    , Space
+    , Str "with"
+    , Space
+    , Str "paragraphs:"
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "tabs-and-spaces", [], [] )
+    [ Str "Tabs", Space, Str "and", Space, Str "spaces" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "tabs"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "spaces"
+        ]
+      , BulletList
+        [
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "tabs"
+            ]
+          ]
+        ,
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "spaces"
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "fancy-list-markers", [], [] )
+    [ Str "Fancy", Space, Str "list", Space, Str "markers" ]
+  , Para
+    [ Str "Autonumbering:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "Autonumber." ] ]
+    ,
+      [ Para
+        [ Str "More." ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [ [ Para [ Str "Nested." ] ] ]
+      ]
+    ]
+  , Header 2
+    ( "definition", [], [] )
+    [ Str "Definition" ]
+  , DefinitionList
+    [
+      (
+        [ Str "Violin" ]
+      ,
+        [
+          [ Para
+            [ Str "Stringed"
+            , Space
+            , Str "musical"
+            , Space
+            , Str "instrument."
+            ]
+          , Para
+            [ Str "Torture", Space, Str "device." ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Str "Cello", LineBreak, Str "Violoncello" ]
+      ,
+        [
+          [ Para
+            [ Str "Low-voiced"
+            , Space
+            , Str "stringed"
+            , Space
+            , Str "instrument."
+            ]
+          ]
+        ]
+      )
+    ]
+  , Header 1
+    ( "inline-markup", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Emph
+      [ Str "is", SoftBreak, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , SoftBreak
+    , Strong
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Empty"
+    , Space
+    , Strong []
+    , Space
+    , Str "and"
+    , Space
+    , Emph []
+    , Str "."
+    ]
+  , Para
+    [ Str "An"
+    , SoftBreak
+    , Emph
+      [ Link
+        ( "", [], [] )
+        [ Str "emphasized", SoftBreak, Str "link" ]
+        ( "/url", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) ">"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "$"
+    , Str ","
+    , SoftBreak
+    , Code
+      ( "", [], [] ) "\\"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\$"
+    , Str ","
+    , SoftBreak
+    , Code
+      ( "", [], [] ) "<html>"
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , SmallCaps
+      [ Str "small", Space, Str "caps" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "are"
+    , Space
+    , Str "all"
+    , Space
+    , Str "underlined:"
+    , Space
+    , Str "foo"
+    , Space
+    , Str "and"
+    , Space
+    , Str "bar."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "are"
+    , Space
+    , Str "all"
+    , Space
+    , Str "strikethrough:"
+    , Space
+    , Strikeout
+      [ Str "foo" ]
+    , Str ","
+    , SoftBreak
+    , Strikeout
+      [ Str "bar" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Strikeout
+      [ Str "baz" ]
+    , Str "."
+    ]
+  , Header 1
+    ( "smart-quotes-ellipses-dashes", [], [] )
+    [ Str "Smart"
+    , Space
+    , Str "quotes,"
+    , Space
+    , Str "ellipses,"
+    , Space
+    , Str "dashes"
+    ]
+  , Para
+    [ Str "\"Hello,\""
+    , Space
+    , Str "said"
+    , Space
+    , Str "the"
+    , Space
+    , Str "spider."
+    , Space
+    , Str "\"'Shelob'"
+    , Space
+    , Str "is"
+    , Space
+    , Str "my"
+    , Space
+    , Str "name.\""
+    ]
+  , Para
+    [ Str "'A',"
+    , Space
+    , Str "'B',"
+    , Space
+    , Str "and"
+    , Space
+    , Str "'C'"
+    , Space
+    , Str "are"
+    , Space
+    , Str "letters."
+    ]
+  , Para
+    [ Str "'Oak,'"
+    , Space
+    , Str "'elm,'"
+    , Space
+    , Str "and"
+    , Space
+    , Str "'beech'"
+    , Space
+    , Str "are"
+    , Space
+    , Str "names"
+    , Space
+    , Str "of"
+    , Space
+    , Str "trees."
+    , Space
+    , Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Str "'pine.'"
+    ]
+  , Para
+    [ Str "'He"
+    , Space
+    , Str "said,"
+    , Space
+    , Str "\"I"
+    , Space
+    , Str "want"
+    , Space
+    , Str "to"
+    , Space
+    , Str "go.\"'"
+    , Space
+    , Str "Were"
+    , Space
+    , Str "you"
+    , Space
+    , Str "alive"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "70's?"
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "quoted"
+    , Space
+    , Str "'"
+    , Code
+      ( "", [], [] ) "code"
+    , Str "'"
+    , Space
+    , Str "and"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Str "\""
+    , Link
+      ( "", [], [] )
+      [ Str "quoted", SoftBreak, Str "link" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "\"."
+    ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Str "dashes:"
+    , Space
+    , Str "one---two"
+    , Space
+    , Str "---"
+    , Space
+    , Str "three--four"
+    , Space
+    , Str "--"
+    , Space
+    , Str "five."
+    ]
+  , Para
+    [ Str "Dashes"
+    , Space
+    , Str "between"
+    , Space
+    , Str "numbers:"
+    , Space
+    , Str "5-7,"
+    , Space
+    , Str "255-66,"
+    , Space
+    , Str "1987-1999."
+    ]
+  , Para
+    [ Str "Ellipses...and."
+    , Space
+    , Str "."
+    , Space
+    , Str ".and"
+    , Space
+    , Str "."
+    , Space
+    , Str "."
+    , Space
+    , Str "."
+    , Space
+    , Str "."
+    ]
+  , Header 1
+    ( "latex", [], [] )
+    [ Str "LaTeX" ]
+  , BulletList
+    [
+      [ Para [ Str "\\cite[22-23]{smith.1899}" ] ]
+    ,
+      [ Para [ Str "\\doublespacing" ] ]
+    ,
+      [ Para [ Str "$2+2=4$" ] ]
+    ,
+      [ Para [ Str "$x", Space, Str "\\in", Space, Str "y$" ] ]
+    ,
+      [ Para
+        [ Str "$\\alpha", Space, Str "\\wedge", Space, Str "\\omega$" ]
+      ]
+    ,
+      [ Para [ Str "$223$" ] ]
+    ,
+      [ Para [ Str "$p$-Tree" ] ]
+    ,
+      [ Para
+        [ Str "$\\frac{d}{dx}f(x)=\\lim_{h\\to"
+        , Space
+        , Str "0}\\frac{f(x+h)-f(x)}{h}$"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "Here's"
+        , Space
+        , Str "one"
+        , Space
+        , Str "that"
+        , Space
+        , Str "has"
+        , Space
+        , Str "a"
+        , Space
+        , Str "line"
+        , Space
+        , Str "break"
+        , Space
+        , Str "in"
+        , Space
+        , Str "it:"
+        , Space
+        , Str "$\\alpha"
+        , Space
+        , Str "+"
+        , Space
+        , Str "\\omega"
+        , Space
+        , Str "\\times"
+        , SoftBreak
+        , Str "x^2$."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "shouldn't"
+    , Space
+    , Str "be"
+    , Space
+    , Str "math:"
+    ]
+  , BulletList
+    [
+      [ Para
+        [ Str "To"
+        , Space
+        , Str "get"
+        , Space
+        , Str "the"
+        , Space
+        , Str "famous"
+        , Space
+        , Str "equation,"
+        , Space
+        , Str "write"
+        , SoftBreak
+        , Code
+          ( "", [], [] ) "$e = mc^2$"
+        , Str "."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "$22,000"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Emph
+          [ Str "lot" ]
+        , Space
+        , Str "of"
+        , Space
+        , Str "money."
+        , Space
+        , Str "So"
+        , Space
+        , Str "is"
+        , Space
+        , Str "$34,000."
+        , Space
+        , Str "(It"
+        , SoftBreak
+        , Str "worked"
+        , Space
+        , Str "if"
+        , Space
+        , Str "\"lot\""
+        , Space
+        , Str "is"
+        , Space
+        , Str "emphasized.)"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "Escaped"
+        , Space
+        , Code
+          ( "", [], [] ) "$"
+        , Str ":"
+        , Space
+        , Str "$73"
+        , Space
+        , Emph
+          [ Str "this"
+          , Space
+          , Str "should"
+          , Space
+          , Str "be"
+          , SoftBreak
+          , Str "emphasized"
+          ]
+        , Space
+        , Str "23$."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "LaTeX"
+    , Space
+    , Str "table:"
+    ]
+  , Para
+    [ Str "\\begin{tabular}{|l|l|}\\hline"
+    , Space
+    , Str "Animal"
+    , Space
+    , Str "&"
+    , Space
+    , Str "Number"
+    , Space
+    , Str "\\\\"
+    , Space
+    , Str "\\hline"
+    , Space
+    , Str "Dog"
+    , Space
+    , Str "&"
+    , SoftBreak
+    , Str "2"
+    , Space
+    , Str "\\\\"
+    , Space
+    , Str "Cat"
+    , Space
+    , Str "&"
+    , Space
+    , Str "1"
+    , Space
+    , Str "\\\\"
+    , Space
+    , Str "\\hline"
+    , Space
+    , Str "\\end{tabular}"
+    ]
+  , Header 1
+    ( "special-characters", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "unicode:"
+    ]
+  , BulletList
+    [
+      [ Para [ Str "I", Space, Str "hat:", Space, Str "\206" ] ]
+    ,
+      [ Para [ Str "o", Space, Str "umlaut:", Space, Str "\246" ] ]
+    ,
+      [ Para [ Str "section:", Space, Str "\167" ] ]
+    ,
+      [ Para
+        [ Str "set", Space, Str "membership:", Space, Str "elem" ]
+      ]
+    ,
+      [ Para [ Str "copyright:", Space, Str "\169" ] ]
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "is"
+    , Space
+    , Str "another"
+    , Space
+    , Str "way"
+    , Space
+    , Str "to"
+    , Space
+    , Str "write"
+    , Space
+    , Str "it."
+    ]
+  , Para
+    [ Str "This", Space, Str "&", Space, Str "that." ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "`" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , Header 1
+    ( "links", [], [] )
+    [ Str "Links" ]
+  , Header 2
+    ( "explicit", [], [] )
+    [ Str "Explicit" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "URL" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", SoftBreak, Str "and", Space, Str "title" ]
+      ( "/url/", "title" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", SoftBreak, Str "and", Space, Str "title" ]
+      ( "/url/", "title preceded by two spaces" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", SoftBreak, Str "and", Space, Str "title" ]
+      ( "/url/", "title preceded by a tab" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", SoftBreak, Str "and", Space, Str "title" ]
+      ( "/url/", "title with \"quotes\" in it" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", SoftBreak, Str "and", Space, Str "title" ]
+      ( "/url/", "title with single quotes" )
+    ]
+  , Para
+    [ Str "Email"
+    , Space
+    , Str "link"
+    , Space
+    , Str "(nobody"
+    , Space
+    , Str "[at]"
+    , Space
+    , Str "nowhere.net)"
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Empty" ] ( "", "" ), Str "." ]
+  , Header 2
+    ( "reference", [], [] )
+    [ Str "Reference" ]
+  , Para
+    [ Str "Foo"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "With"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", SoftBreak, Str "[brackets]" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "b" ]
+      ( "/url/", "" )
+    , Space
+    , Str "by"
+    , SoftBreak
+    , Str "itself"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , Para
+    [ Str "Indented"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "once" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "twice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "thrice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "[not]"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , CodeBlock
+    ( "", [], [] ) "[not]: /url"
+  , Para
+    [ Str "Foo"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "Title with \"quotes\" inside" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "biz" ]
+      ( "/url/", "Title with \"quote\" inside" )
+    , Str "."
+    ]
+  , Header 2
+    ( "with-ampersands", [], [] )
+    [ Str "With", Space, Str "ampersands" ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "link"
+      , SoftBreak
+      , Str "with"
+      , Space
+      , Str "an"
+      , Space
+      , Str "ampersand"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "URL"
+      ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Str "amersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "text:"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "AT&T" ]
+      ( "http://att.com/", "AT&T" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "an"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "inline", SoftBreak, Str "link" ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "an"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "inline"
+      , SoftBreak
+      , Str "link"
+      , Space
+      , Str "in"
+      , Space
+      , Str "pointy"
+      , Space
+      , Str "braces"
+      ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "autolinks", [], [] )
+    [ Str "Autolinks" ]
+  , Para
+    [ Str "With"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand:"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://example.com/?foo=1&bar=2" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    ]
+  , BulletList
+    [
+      [ Para [ Str "In", Space, Str "a", Space, Str "list?" ] ]
+    ,
+      [ Para
+        [ Link
+          ( "", [], [] )
+          [ Str "http://example.com/" ]
+          ( "http://example.com/", "" )
+        ]
+      ]
+    ,
+      [ Para [ Str "It", Space, Str "should." ] ]
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Str "e-mail"
+    , Space
+    , Str "address:"
+    , Space
+    , Str "nobody"
+    , Space
+    , Str "[at]"
+    , Space
+    , Str "nowhere.net"
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Blockquoted:"
+      , SoftBreak
+      , Link
+        ( "", [], [] )
+        [ Str "http://example.com/" ]
+        ( "http://example.com/", "" )
+      ]
+    ]
+  , Para
+    [ Str "Auto-links"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "occur"
+    , Space
+    , Str "here:"
+    , SoftBreak
+    , Code
+      ( "", [], [] ) "<http://example.com/>"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "or here: <http://example.com/>"
+  , Header 1
+    ( "images", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "From"
+    , Space
+    , Str "\"Voyage"
+    , Space
+    , Str "dans"
+    , Space
+    , Str "la"
+    , Space
+    , Str "Lune\""
+    , Space
+    , Str "by"
+    , Space
+    , Str "Georges"
+    , Space
+    , Str "Melies"
+    , Space
+    , Str "(1902):"
+    ]
+  , Para
+    [ Image ( "", [], [] ) [] ( "lalune.jpg", "Voyage dans la Lune" ) ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "movie"
+    , SoftBreak
+    , Image
+      ( "", [], [] ) []
+      ( "movie.jpg", "" )
+    , SoftBreak
+    , Str "icon."
+    ]
+  , Header 1
+    ( "footnotes", [], [] )
+    [ Str "Footnotes" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference"
+    , Link
+      ( "", [], [] )
+      [ Str "(1)" ]
+      ( "#note_1", "" )
+    , Str ","
+    , SoftBreak
+    , Str "and"
+    , SoftBreak
+    , Str "another"
+    , Link
+      ( "", [], [] )
+      [ Str "(longnote)" ]
+      ( "#note_longnote", "" )
+    , Str "."
+    , SoftBreak
+    , Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Emph
+      [ Str "not" ]
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , Space
+    , Str "because"
+    , Space
+    , Str "it"
+    , SoftBreak
+    , Str "contains"
+    , Space
+    , Str "a"
+    , Space
+    , Str "space^(my"
+    , Space
+    , Str "note)."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "(1)" ]
+      ( "#ref_1", "" )
+    , Space
+    , Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "the"
+    , Space
+    , Str "footnote."
+    , Space
+    , Str "It"
+    , Space
+    , Str "can"
+    , SoftBreak
+    , Str "go"
+    , Space
+    , Str "anywhere"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "document,"
+    , Space
+    , Str "not"
+    , Space
+    , Str "just"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "end."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "(longnote)" ]
+      ( "#ref_longnote", "" )
+    , Space
+    , Str "Here's"
+    , SoftBreak
+    , Str "the"
+    , Space
+    , Str "other"
+    , Space
+    , Str "note."
+    , Space
+    , Str "This"
+    , Space
+    , Str "one"
+    , Space
+    , Str "contains"
+    , Space
+    , Str "multiple"
+    , Space
+    , Str "blocks."
+    ]
+  , Para
+    [ Str "Caret"
+    , Space
+    , Str "characters"
+    , Space
+    , Str "are"
+    , Space
+    , Str "used"
+    , Space
+    , Str "to"
+    , Space
+    , Str "indicate"
+    , Space
+    , Str "that"
+    , Space
+    , Str "the"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "all"
+    , Space
+    , Str "belong"
+    , Space
+    , Str "to"
+    , SoftBreak
+    , Str "a"
+    , Space
+    , Str "single"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "(as"
+    , Space
+    , Str "with"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quotes)."
+    ]
+  , CodeBlock
+    ( "", [], [] ) "  { <code> }"
+  , Para
+    [ Str "If"
+    , Space
+    , Str "you"
+    , Space
+    , Str "want,"
+    , Space
+    , Str "you"
+    , Space
+    , Str "can"
+    , Space
+    , Str "use"
+    , Space
+    , Str "a"
+    , Space
+    , Str "caret"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "beginning"
+    , Space
+    , Str "of"
+    , Space
+    , Str "every"
+    , Space
+    , Str "line,"
+    , Space
+    , Str "as"
+    , SoftBreak
+    , Str "with"
+    , Space
+    , Str "blockquotes,"
+    , Space
+    , Str "but"
+    , Space
+    , Str "all"
+    , Space
+    , Str "that"
+    , Space
+    , Str "you"
+    , Space
+    , Str "need"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "caret"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "beginning"
+    , SoftBreak
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "first"
+    , Space
+    , Str "line"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "block"
+    , Space
+    , Str "and"
+    , Space
+    , Str "any"
+    , Space
+    , Str "preceding"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "lines."
+    ]
+  , Para
+    [ Str "text", Space, Emph [ Str "Leading", Space, Str "space" ] ]
+  , Para
+    [ Emph [ Str "Trailing", Space, Str "space" ], Space, Str "text" ]
+  , Para
+    [ Str "text", Space, Emph [ Str "Leading", Space, Str "spaces" ] ]
+  , Para
+    [ Emph [ Str "Trailing", Space, Str "spaces" ], Space, Str "text" ]
+  , Header 1
+    ( "tables", [], [] )
+    [ Str "Tables" ]
+  , Header 2
+    ( "tables-with-headers", [], [] )
+    [ Str "Tables", Space, Str "with", Space, Str "Headers" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "X" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Y" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Z" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 2
+    ( "tables-without-headers", [], [] )
+    [ Str "Tables", Space, Str "without", Space, Str "Headers" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 2
+    ( "empty-tables", [], [] )
+    [ Str "Empty", Space, Str "Tables" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "section"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "empty."
+    ]
+  ]

--- a/test/jira-reader.native
+++ b/test/jira-reader.native
@@ -1,185 +1,1024 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("",[],[]) [Span ("headers",[],[]) [],Str "Headers"]
-,Header 2 ("",[],[]) [Span ("level-2-with-an-embedded-link",[],[]) [],Str "Level",Space,Str "2",Space,Str "with",Space,Str "an",Space,Link ("",[],[]) [Str "embedded",Space,Str "link"] ("https://test.example/url","")]
-,Header 3 ("",[],[]) [Span ("level-3-with-emphasis",[],[]) [],Str "Level",Space,Str "3",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 4 ("",[],[]) [Str "Level",Space,Str "4"]
-,Header 5 ("",[],[]) [Str "Level",Space,Str "5"]
-,Header 6 ("",[],[]) [Str "Level",Space,Str "6"]
-,Para [Str "h0.",Space,Str "this",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "header."]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Paragraphs"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "Here\8217s",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet.",Space,Str "*",Space,Str "criminey."]
-,Para [Str "There",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "hard",Space,Str "line",Space,Str "break",LineBreak,Str "here."]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "E-mail",Space,Str "style:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",Space,Str "It",Space,Str "is",Space,Str "pretty",Space,Str "short."]]
-,BlockQuote
- [Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,CodeBlock ("",["java"],[]) "sub status {\n    print \"working\";\n}\n"
- ,Para [Str "An",Space,Str "enumeration:"]
- ,OrderedList (1,DefaultStyle,DefaultDelim)
-  [[Para [Str "item",Space,Str "one"]]
-  ,[Para [Str "item",Space,Str "two"]]]]
-,Para [Str "A",Space,Str "following",Space,Str "paragraph."]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",["java"],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n"
-,Para [Str "And:"]
-,CodeBlock ("",["java"],[]) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{\n"
-,HorizontalRule
-,Header 1 ("",[],[]) [Span ("lists",[],[]) [],Str "Lists"]
-,Header 2 ("",[],[]) [Span ("unordered",[],[]) [],Str "Unordered"]
-,Para [Str "Asterisks:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Minuses:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Header 2 ("",[],[]) [Str "Ordered"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "Linebreak",Space,Str "in",Space,Str "paragraph:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "Item",Space,Str "1,",Space,Str "line",Space,Str "one.",LineBreak,Str "Item",Space,Str "1.",Space,Str "line",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",Space,Str "dog\8217s",Space,Str "back."]]
- ,[Para [Str "Item",Space,Str "2."]]
- ,[Para [Str "Item",Space,Str "3."]]]
-,Header 2 ("",[],[]) [Str "Nested"]
-,BulletList
- [[Para [Str "Tab"]
-  ,BulletList
-   [[Para [Str "Tab"]
-    ,BulletList
-     [[Para [Str "Tab"]]]]]]]
-,Para [Str "Here\8217s",Space,Str "another:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Para [Str "Nested",Space,Str "enumerations:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "Essential"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Para [Str "Important"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Para [Str "Relevant"]
-      ,OrderedList (1,DefaultStyle,DefaultDelim)
-       [[Para [Str "Insignificant"]]]]]]]]]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Linebreaks",Space,Str "and",Space,Str "Markup",Space,Str "in",Space,Str "Lists"]
-,BulletList
- [[Para [Strong [Str "apple"],LineBreak,Str "red",Space,Str "fruit"]]
- ,[Para [Strong [Str "orange"],LineBreak,Str "orange",Space,Str "fruit"]]
- ,[Para [Strong [Str "banana"],LineBreak,Str "yellow",Space,Str "fruit"]]]
-,Para [Str "Multiple",Space,Str "blocks",Space,Str "with",Space,Str "italics:"]
-,BulletList
- [[Para [Strong [Emph [Str "apple"]],LineBreak,Str "red",Space,Str "fruit",LineBreak,Str "contains",Space,Str "seeds,",Space,Str "crisp,",Space,Str "pleasant",Space,Str "to",Space,Str "taste"]]
- ,[Para [Strong [Emph [Str "orange"]],LineBreak,Str "orange",Space,Str "fruit"]
-  ,CodeBlock ("",["java"],[]) "{ orange code block }\n"
-  ,BlockQuote
-   [Para [Str "orange",Space,Str "block",Space,Str "quote"]]]]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Colored",Space,Str "Text",Space,Str "Blocks"]
-,Div ("",[],[("color","red")])
- [Para [LineBreak,Str "This",Space,Str "is",Space,Str "red."]]
-,Header 2 ("",[],[]) [Str "Eiffel",Space,Str "65"]
-,Div ("",[],[("color","blue")])
- [Para [LineBreak,Str "da",Space,Str "ba",Space,Str "dee"]]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ",",Space,Str "and",Space,Str "so",Space,Emph [Str "is",Space,Str "this"],Str "."]
-,Para [Str "This",Space,Str "is",Space,Strong [Str "strong"],Str ",",Space,Str "and",Space,Str "so",Space,Strong [Str "is",Space,Str "this"],Str "."]
-,Para [Str "An",Space,Emph [Link ("",[],[]) [Str "emphasized",Space,Str "link"] ("https://my.example/url","")],Str "."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Str "This",Space,Str "is",Space,Str "code:",Space,Code ("",[],[]) ">",Str ",",Space,Code ("",[],[]) "$",Str ",",Space,Code ("",[],[]) "\\",Str ",",Space,Code ("",[],[]) "\\$",Str ",",Space,Code ("",[],[]) "<html>",Str "."]
-,Para [Strikeout [Str "This",Space,Str "is",Space,Emph [Str "strikeout"],Str "."]]
-,Para [Str "Superscripts:",Space,Str "a",Superscript [Str "bc"],Str "d",Space,Str "a",Superscript [Emph [Str "hello"]],Space,Str "a",Superscript [Str "hello\160there"],Str "."]
-,Para [Str "Subscripts:",Space,Str "H",Subscript [Str "2"],Str "O,",Space,Str "C",Subscript [Str "6"],Str "H",Subscript [Str "12"],Str "O",Subscript [Str "6"],Str ",",Space,Str "C",Subscript [Str "\160n\160"],Str "H",Subscript [Emph [Str "2n"]],Str "O",Subscript [Str "n"],Str "."]
-,Para [Str "These",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "superscripts",Space,Str "or",Space,Str "subscripts,",Space,Str "because",Space,Str "of",Space,Str "markers",Space,Str "used",Space,Str "within",Space,Str "words:",Space,Str "a^b",Space,Str "c^d,",Space,Str "a~b",Space,Str "c~d."]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Dashes,",Space,Str "and",Space,Str "emoticons"]
-,Para [Str "Some",Space,Str "dashes:",Space,Str "one",Space,Str "\8211",Space,Str "two",Space,Str "\8212",Space,Str "three."]
-,Para [Str "Sure",Space,Str "\10004",LineBreak,Str "Nope",Space,Str "\10060"]
-,Para [Str "Nice",Space,Str "\128515"]
-,Para [Str "Capital",Space,Str "d:D"]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Math"]
-,BulletList
- [[Para [Str "2\8197+\8197\&2\8196=\8196\&4"]]
- ,[Para [Emph [Str "x"],Str "\8196\8712\8196",Emph [Str "y"]]]
- ,[Para [Emph [Str "\945"],Str "\8197\8743\8197",Emph [Str "\969"]]]
- ,[Para [Emph [Str "p"],Str "-Tree"]]
- ,[Para [Str "Here\8217s",Space,Str "one",Space,Str "more:",Space,Emph [Str "\945"],Str "\8197+\8197",Emph [Str "\969"],Str "\8197\215\8197",Emph [Str "x"],Superscript [Str "2"],Str "."]]]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "unicode:"]
-,BulletList
- [[Para [Str "I",Space,Str "hat:",Space,Str "\206"]]
- ,[Para [Str "o",Space,Str "umlaut:",Space,Str "\246"]]
- ,[Para [Str "section:",Space,Str "\167"]]
- ,[Para [Str "set",Space,Str "membership:",Space,Str "\8712"]]
- ,[Para [Str "copyright:",Space,Str "\169"]]]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "AT&T",Space,Str "is",Space,Str "another",Space,Str "way",Space,Str "to",Space,Str "write",Space,Str "it."]
-,Para [Str "This",Space,Str "&",Space,Str "that."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "`"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Links"]
-,Header 2 ("",[],[]) [Str "Explicit"]
-,Para [Str "Just",Space,Str "a",Space,Link ("",[],[]) [Str "URL"] ("https://example.org/url",""),Str "."]
-,Para [Link ("",[],[]) [Str "File",Space,Str "URL"] ("file://some/file/name/",""),Str "."]
-,Para [Link ("",[],[]) [Str "IRC",Space,Str "link"] ("irc://example.org/pandoc",""),Str "."]
-,Para [Link ("",[],[]) [Str "Email",Space,Str "link"] ("mailto:nobody@nowhere.invalid","")]
-,Para [Str "[Not",Space,Str "a",Space,Str "link|not",Space,Str "a",Space,Str "URL]."]
-,Header 2 ("",[],[]) [Str "Reference"]
-,Para [Str "With",Space,Link ("",[],[]) [Str "embedded",Space,Str "[brackets]"] ("https://example.net/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "https://pandoc.org"] ("https://pandoc.org",""),Space,Str "by",Space,Str "itself",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "link."]
-,Header 2 ("",[],[]) [Str "With",Space,Str "ampersands"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Link ("",[],[]) [Str "link",Space,Str "with",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "URL"] ("http://example.com/?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "link",Space,Str "with",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "link",Space,Str "text:",Space,Link ("",[],[]) [Str "AT&T"] ("http://att.com/",""),Str "."]
-,Header 2 ("",[],[]) [Str "Autolinks"]
-,Para [Str "With",Space,Str "an",Space,Str "ampersand:",Space,Link ("",[],[]) [Str "http://example.com/?foo=1&bar=2"] ("http://example.com/?foo=1&bar=2","")]
-,BulletList
- [[Para [Str "In",Space,Str "a",Space,Str "list?"]]
- ,[Para [Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
- ,[Para [Str "It",Space,Str "should."]]]
-,Para [Str "An",Space,Str "e-mail",Space,Str "address:",Space,Link ("",[],[]) [Str "mailto:nobody@nowhere.invalid"] ("mailto:nobody@nowhere.invalid","")]
-,BlockQuote
- [Para [Str "Blockquoted:",Space,Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
-,CodeBlock ("",["java"],[]) "Autolink should not occur here: <http://example.com/>\n"
-,HorizontalRule
-,Header 1 ("",[],[]) [Str "Images"]
-,Para [Str "From",Space,Str "\"Voyage",Space,Str "dans",Space,Str "la",Space,Str "Lune\"",Space,Str "by",Space,Str "Georges",Space,Str "Melies",Space,Str "(1902):"]
-,Para [Image ("",[],[]) [] ("lalune.jpg","")]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "movie",Space,Image ("",[],[]) [] ("movie.jpg",""),Space,Str "icon."]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "", [], [] )
+    [ Span ( "headers", [], [] ) [], Str "Headers" ]
+  , Header 2
+    ( "", [], [] )
+    [ Span
+      ( "level-2-with-an-embedded-link", [], [] ) []
+    , Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "link" ]
+      ( "https://test.example/url", "" )
+    ]
+  , Header 3
+    ( "", [], [] )
+    [ Span
+      ( "level-3-with-emphasis", [], [] ) []
+    , Str "Level"
+    , Space
+    , Str "3"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "", [], [] )
+    [ Str "Level", Space, Str "5" ]
+  , Header 6
+    ( "", [], [] )
+    [ Str "Level", Space, Str "6" ]
+  , Para
+    [ Str "h0."
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    , Space
+    , Str "*"
+    , Space
+    , Str "criminey."
+    ]
+  , Para
+    [ Str "There"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard"
+    , Space
+    , Str "line"
+    , Space
+    , Str "break"
+    , LineBreak
+    , Str "here."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "E-mail", Space, Str "style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , Space
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "pretty"
+      , Space
+      , Str "short."
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Code"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , CodeBlock
+      ( "", [ "java" ], [] ) "sub status {\n    print \"working\";\n}\n"
+    , Para
+      [ Str "An", Space, Str "enumeration:" ]
+    , OrderedList
+      ( 1, DefaultStyle, DefaultDelim )
+      [
+        [ Para [ Str "item", Space, Str "one" ] ]
+      ,
+        [ Para [ Str "item", Space, Str "two" ] ]
+      ]
+    ]
+  , Para
+    [ Str "A", Space, Str "following", Space, Str "paragraph." ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , [ "java" ]
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , [ "java" ]
+    , []
+    ) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{\n"
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Span ( "lists", [], [] ) [], Str "Lists" ]
+  , Header 2
+    ( "", [], [] )
+    [ Span ( "unordered", [], [] ) [], Str "Unordered" ]
+  , Para
+    [ Str "Asterisks:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Ordered" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Linebreak", Space, Str "in", Space, Str "paragraph:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para
+        [ Str "Item"
+        , Space
+        , Str "1,"
+        , Space
+        , Str "line"
+        , Space
+        , Str "one."
+        , LineBreak
+        , Str "Item"
+        , Space
+        , Str "1."
+        , Space
+        , Str "line"
+        , Space
+        , Str "two."
+        , Space
+        , Str "The"
+        , Space
+        , Str "quick"
+        , Space
+        , Str "brown"
+        , Space
+        , Str "fox"
+        , Space
+        , Str "jumped"
+        , Space
+        , Str "over"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lazy"
+        , Space
+        , Str "dog\8217s"
+        , Space
+        , Str "back."
+        ]
+      ]
+    ,
+      [ Para [ Str "Item", Space, Str "2." ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "3." ] ]
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "Tab" ]
+      , BulletList
+        [
+          [ Para [ Str "Tab" ], BulletList [ [ Para [ Str "Tab" ] ] ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s", Space, Str "another:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Nested", Space, Str "enumerations:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para
+        [ Str "Essential" ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Para
+            [ Str "Important" ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Para
+                [ Str "Relevant" ]
+              , OrderedList
+                ( 1, DefaultStyle, DefaultDelim )
+                [ [ Para [ Str "Insignificant" ] ] ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Linebreaks"
+    , Space
+    , Str "and"
+    , Space
+    , Str "Markup"
+    , Space
+    , Str "in"
+    , Space
+    , Str "Lists"
+    ]
+  , BulletList
+    [
+      [ Para
+        [ Strong
+          [ Str "apple" ]
+        , LineBreak
+        , Str "red"
+        , Space
+        , Str "fruit"
+        ]
+      ]
+    ,
+      [ Para
+        [ Strong
+          [ Str "orange" ]
+        , LineBreak
+        , Str "orange"
+        , Space
+        , Str "fruit"
+        ]
+      ]
+    ,
+      [ Para
+        [ Strong
+          [ Str "banana" ]
+        , LineBreak
+        , Str "yellow"
+        , Space
+        , Str "fruit"
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Multiple"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "with"
+    , Space
+    , Str "italics:"
+    ]
+  , BulletList
+    [
+      [ Para
+        [ Strong
+          [ Emph [ Str "apple" ] ]
+        , LineBreak
+        , Str "red"
+        , Space
+        , Str "fruit"
+        , LineBreak
+        , Str "contains"
+        , Space
+        , Str "seeds,"
+        , Space
+        , Str "crisp,"
+        , Space
+        , Str "pleasant"
+        , Space
+        , Str "to"
+        , Space
+        , Str "taste"
+        ]
+      ]
+    ,
+      [ Para
+        [ Strong
+          [ Emph [ Str "orange" ] ]
+        , LineBreak
+        , Str "orange"
+        , Space
+        , Str "fruit"
+        ]
+      , CodeBlock
+        ( "", [ "java" ], [] ) "{ orange code block }\n"
+      , BlockQuote
+        [ Para
+          [ Str "orange", Space, Str "block", Space, Str "quote" ]
+        ]
+      ]
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Colored", Space, Str "Text", Space, Str "Blocks" ]
+  , Div
+    ( "", [], [ ( "color", "red" ) ] )
+    [ Para
+      [ LineBreak, Str "This", Space, Str "is", Space, Str "red." ]
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Eiffel", Space, Str "65" ]
+  , Div
+    ( "", [], [ ( "color", "blue" ) ] )
+    [ Para [ LineBreak, Str "da", Space, Str "ba", Space, Str "dee" ] ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Emph
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Strong
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Emph
+      [ Link
+        ( "", [], [] )
+        [ Str "emphasized", Space, Str "link" ]
+        ( "https://my.example/url", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) ">"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "<html>"
+    , Str "."
+    ]
+  , Para
+    [ Strikeout
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Emph
+        [ Str "strikeout" ]
+      , Str "."
+      ]
+    ]
+  , Para
+    [ Str "Superscripts:"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "bc" ]
+    , Str "d"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Emph [ Str "hello" ] ]
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "hello\160there" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Subscripts:"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "2" ]
+    , Str "O,"
+    , Space
+    , Str "C"
+    , Subscript
+      [ Str "6" ]
+    , Str "H"
+    , Subscript
+      [ Str "12" ]
+    , Str "O"
+    , Subscript
+      [ Str "6" ]
+    , Str ","
+    , Space
+    , Str "C"
+    , Subscript
+      [ Str "\160n\160" ]
+    , Str "H"
+    , Subscript
+      [ Emph [ Str "2n" ] ]
+    , Str "O"
+    , Subscript
+      [ Str "n" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "superscripts"
+    , Space
+    , Str "or"
+    , Space
+    , Str "subscripts,"
+    , Space
+    , Str "because"
+    , Space
+    , Str "of"
+    , Space
+    , Str "markers"
+    , Space
+    , Str "used"
+    , Space
+    , Str "within"
+    , Space
+    , Str "words:"
+    , Space
+    , Str "a^b"
+    , Space
+    , Str "c^d,"
+    , Space
+    , Str "a~b"
+    , Space
+    , Str "c~d."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Dashes,", Space, Str "and", Space, Str "emoticons" ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Str "dashes:"
+    , Space
+    , Str "one"
+    , Space
+    , Str "\8211"
+    , Space
+    , Str "two"
+    , Space
+    , Str "\8212"
+    , Space
+    , Str "three."
+    ]
+  , Para
+    [ Str "Sure"
+    , Space
+    , Str "\10004"
+    , LineBreak
+    , Str "Nope"
+    , Space
+    , Str "\10060"
+    ]
+  , Para
+    [ Str "Nice", Space, Str "\128515" ]
+  , Para
+    [ Str "Capital", Space, Str "d:D" ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Math" ]
+  , BulletList
+    [
+      [ Para [ Str "2\8197+\8197\&2\8196=\8196\&4" ] ]
+    ,
+      [ Para
+        [ Emph [ Str "x" ], Str "\8196\8712\8196", Emph [ Str "y" ] ]
+      ]
+    ,
+      [ Para
+        [ Emph
+          [ Str "\945" ]
+        , Str "\8197\8743\8197"
+        , Emph
+          [ Str "\969" ]
+        ]
+      ]
+    ,
+      [ Para [ Emph [ Str "p" ], Str "-Tree" ] ]
+    ,
+      [ Para
+        [ Str "Here\8217s"
+        , Space
+        , Str "one"
+        , Space
+        , Str "more:"
+        , Space
+        , Emph
+          [ Str "\945" ]
+        , Str "\8197+\8197"
+        , Emph
+          [ Str "\969" ]
+        , Str "\8197\215\8197"
+        , Emph
+          [ Str "x" ]
+        , Superscript
+          [ Str "2" ]
+        , Str "."
+        ]
+      ]
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "unicode:"
+    ]
+  , BulletList
+    [
+      [ Para [ Str "I", Space, Str "hat:", Space, Str "\206" ] ]
+    ,
+      [ Para [ Str "o", Space, Str "umlaut:", Space, Str "\246" ] ]
+    ,
+      [ Para [ Str "section:", Space, Str "\167" ] ]
+    ,
+      [ Para
+        [ Str "set", Space, Str "membership:", Space, Str "\8712" ]
+      ]
+    ,
+      [ Para [ Str "copyright:", Space, Str "\169" ] ]
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "is"
+    , Space
+    , Str "another"
+    , Space
+    , Str "way"
+    , Space
+    , Str "to"
+    , Space
+    , Str "write"
+    , Space
+    , Str "it."
+    ]
+  , Para
+    [ Str "This", Space, Str "&", Space, Str "that." ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "`" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Links" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Explicit" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "URL" ]
+      ( "https://example.org/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "File", Space, Str "URL" ]
+      ( "file://some/file/name/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "IRC", Space, Str "link" ]
+      ( "irc://example.org/pandoc", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Email", Space, Str "link" ]
+      ( "mailto:nobody@nowhere.invalid", "" )
+    ]
+  , Para
+    [ Str "[Not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link|not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "URL]."
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Reference" ]
+  , Para
+    [ Str "With"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "[brackets]" ]
+      ( "https://example.net/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "https://pandoc.org" ]
+      ( "https://pandoc.org", "" )
+    , Space
+    , Str "by"
+    , Space
+    , Str "itself"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "With", Space, Str "ampersands" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link"
+      , Space
+      , Str "with"
+      , Space
+      , Str "an"
+      , Space
+      , Str "ampersand"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "URL"
+      ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "AT&T" ]
+      ( "http://att.com/", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Autolinks" ]
+  , Para
+    [ Str "With"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://example.com/?foo=1&bar=2" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    ]
+  , BulletList
+    [
+      [ Para [ Str "In", Space, Str "a", Space, Str "list?" ] ]
+    ,
+      [ Para
+        [ Link
+          ( "", [], [] )
+          [ Str "http://example.com/" ]
+          ( "http://example.com/", "" )
+        ]
+      ]
+    ,
+      [ Para [ Str "It", Space, Str "should." ] ]
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Str "e-mail"
+    , Space
+    , Str "address:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:nobody@nowhere.invalid" ]
+      ( "mailto:nobody@nowhere.invalid", "" )
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Blockquoted:"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "http://example.com/" ]
+        ( "http://example.com/", "" )
+      ]
+    ]
+  , CodeBlock
+    ( ""
+    , [ "java" ]
+    , []
+    ) "Autolink should not occur here: <http://example.com/>\n"
+  , HorizontalRule
+  , Header 1
+    ( "", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "From"
+    , Space
+    , Str "\"Voyage"
+    , Space
+    , Str "dans"
+    , Space
+    , Str "la"
+    , Space
+    , Str "Lune\""
+    , Space
+    , Str "by"
+    , Space
+    , Str "Georges"
+    , Space
+    , Str "Melies"
+    , Space
+    , Str "(1902):"
+    ]
+  , Para
+    [ Image ( "", [], [] ) [] ( "lalune.jpg", "" ) ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] ) []
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    ]
+  ]

--- a/test/latex-reader.native
+++ b/test/latex-reader.native
@@ -1,416 +1,2519 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Space,Str "MacFarlane"],MetaInlines [Str "Anonymous"]]),("date",MetaInlines [Str "July",Space,Str "17,",Space,Str "2006"]),("title",MetaInlines [Str "Pandoc",Space,Str "Test",Space,Str "Suite"])]})
-[RawBlock (Format "latex") "\\maketitle"
-,Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc.",Space,Str "Most",Space,Str "of",Space,Str "them",Space,Str "are",Space,Str "adapted",Space,Str "from",SoftBreak,Str "John",Space,Str "Gruber\8217s",Space,Str "markdown",Space,Str "test",Space,Str "suite."]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("headers",[],[]) [Str "Headers"]
-,Header 2 ("level-2-with-an-embedded-link",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Str "an",Space,Link ("",[],[]) [Str "embedded",Space,Str "link"] ("/url","")]
-,Header 3 ("level-3-with-emphasis",[],[]) [Str "Level",Space,Str "3",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Para [Str "Level",Space,Str "4"]
-,Para [Str "Level",Space,Str "5"]
-,Header 1 ("level-1",[],[]) [Str "Level",Space,Str "1"]
-,Header 2 ("level-2-with-emphasis",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 3 ("level-3",[],[]) [Str "Level",Space,Str "3"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Header 2 ("level-2",[],[]) [Str "Level",Space,Str "2"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "In",Space,Str "Markdown",Space,Str "1.0.0",Space,Str "and",Space,Str "earlier.",Space,Str "Version",Space,Str "8.",Space,Str "This",Space,Str "line",Space,Str "turns",Space,Str "into",Space,Str "a",SoftBreak,Str "list",Space,Str "item.",Space,Str "Because",Space,Str "a",Space,Str "hard-wrapped",Space,Str "line",Space,Str "in",Space,Str "the",Space,Str "middle",Space,Str "of",Space,Str "a",Space,Str "paragraph",SoftBreak,Str "looked",Space,Str "like",Space,Str "a",Space,Str "list",Space,Str "item."]
-,Para [Str "Here\8217s",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet.",Space,Str "*",Space,Str "criminey."]
-,Para [Str "There",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "hard",Space,Str "line",Space,Str "break",LineBreak,Str "here."]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("block-quotes",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "E-mail",Space,Str "style:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",Space,Str "It",Space,Str "is",Space,Str "pretty",Space,Str "short."]]
-,BlockQuote
- [Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"
- ,Para [Str "A",Space,Str "list:"]
- ,OrderedList (1,Decimal,Period)
-  [[Para [Str "item",Space,Str "one"]]
-  ,[Para [Str "item",Space,Str "two"]]]
- ,Para [Str "Nested",Space,Str "block",Space,Str "quotes:"]
- ,BlockQuote
-  [Para [Str "nested"]]
- ,BlockQuote
-  [Para [Str "nested"]]]
-,Para [Str "This",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "block",Space,Str "quote:",Space,Str "2",Space,Str ">",Space,Str "1."]
-,Para [Str "Box-style:"]
-,BlockQuote
- [Para [Str "Example:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"]
-,BlockQuote
- [OrderedList (1,Decimal,Period)
-  [[Para [Str "do",Space,Str "laundry"]]
-  ,[Para [Str "take",Space,Str "out",Space,Str "the",Space,Str "trash"]]]]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "nested",Space,Str "one:"]
-,BlockQuote
- [Para [Str "Joe",Space,Str "said:"]
- ,BlockQuote
-  [Para [Str "Don\8217t",Space,Str "quote",Space,Str "me."]]]
-,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
-,Para [Str "this",Space,Str "has",Space,Emph [Str "two",LineBreak,Str "lines"]]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("lists",[],[]) [Str "Lists"]
-,Header 2 ("unordered",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks",Space,Str "tight:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Asterisks",Space,Str "loose:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "tight:"]
-,BulletList
- [[Para [Str "Plus",Space,Str "1"]]
- ,[Para [Str "Plus",Space,Str "2"]]
- ,[Para [Str "Plus",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Plus",Space,Str "1"]]
- ,[Para [Str "Plus",Space,Str "2"]]
- ,[Para [Str "Plus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "tight:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Header 2 ("ordered",[],[]) [Str "Ordered"]
-,Para [Str "Tight:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "and:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]]
- ,[Para [Str "Three"]]]
-,Para [Str "Loose",Space,Str "using",Space,Str "tabs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "and",Space,Str "using",Space,Str "spaces:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]]
- ,[Para [Str "Three"]]]
-,Para [Str "Multiple",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "Item",Space,Str "1,",Space,Str "graf",Space,Str "one."]
-  ,Para [Str "Item",Space,Str "1.",Space,Str "graf",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",Space,Str "dog\8217s",SoftBreak,Str "back."]]
- ,[Para [Str "Item",Space,Str "2."]]
- ,[Para [Str "Item",Space,Str "3."]]]
-,Header 2 ("nested",[],[]) [Str "Nested"]
-,BulletList
- [[Para [Str "Tab"]
-  ,BulletList
-   [[Para [Str "Tab"]
-    ,BulletList
-     [[Para [Str "Tab"]]]]]]]
-,Para [Str "Here\8217s",Space,Str "another:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Para [Str "Same",Space,Str "thing",Space,Str "but",Space,Str "with",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Header 2 ("tabs-and-spaces",[],[]) [Str "Tabs",Space,Str "and",Space,Str "spaces"]
-,BulletList
- [[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "tabs"]]
- ,[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "spaces"]
-  ,BulletList
-   [[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "tabs"]]
-   ,[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",Space,Str "indented",Space,Str "with",Space,Str "spaces"]]]]]
-,Header 2 ("fancy-list-markers",[],[]) [Str "Fancy",Space,Str "list",Space,Str "markers"]
-,OrderedList (2,Decimal,TwoParens)
- [[Para [Str "begins",Space,Str "with",Space,Str "2"]]
- ,[Para [Str "and",Space,Str "now",Space,Str "3"]
-  ,Para [Str "with",Space,Str "a",Space,Str "continuation"]
-  ,OrderedList (4,LowerRoman,Period)
-   [[Para [Str "sublist",Space,Str "with",Space,Str "roman",Space,Str "numerals,",Space,Str "starting",Space,Str "with",Space,Str "4"]]
-   ,[Para [Str "more",Space,Str "items"]
-    ,OrderedList (1,UpperAlpha,TwoParens)
-     [[Para [Str "a",Space,Str "subsublist"]]
-     ,[Para [Str "a",Space,Str "subsublist"]]]]]]]
-,Para [Str "Nesting:"]
-,OrderedList (1,UpperAlpha,Period)
- [[Para [Str "Upper",Space,Str "Alpha"]
-  ,OrderedList (1,UpperRoman,Period)
-   [[Para [Str "Upper",Space,Str "Roman."]
-    ,OrderedList (6,Decimal,TwoParens)
-     [[Para [Str "Decimal",Space,Str "start",Space,Str "with",Space,Str "6"]
-      ,OrderedList (3,LowerAlpha,OneParen)
-       [[Para [Str "Lower",Space,Str "alpha",Space,Str "with",Space,Str "paren"]]]]]]]]]
-,Para [Str "Autonumbering:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "Autonumber."]]
- ,[Para [Str "More."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Para [Str "Nested."]]]]]
-,Para [Str "Should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "list",Space,Str "item:"]
-,Para [Str "M.A.",Space,Str "2007"]
-,Para [Str "B.",Space,Str "Williams"]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("definition-lists",[],[]) [Str "Definition",Space,Str "Lists"]
-,Para [Str "Tight",Space,Str "using",Space,Str "spaces:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Para [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Tight",Space,Str "using",Space,Str "tabs:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Para [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Loose:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Para [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Multiple",Space,Str "blocks",Space,Str "with",Space,Str "italics:"]
-,DefinitionList
- [([Emph [Str "apple"]],
-   [[Para [Str "red",Space,Str "fruit"]
-    ,Para [Str "contains",Space,Str "seeds,",Space,Str "crisp,",Space,Str "pleasant",Space,Str "to",Space,Str "taste"]]])
- ,([Emph [Str "orange"]],
-   [[Para [Str "orange",Space,Str "fruit"]
-    ,CodeBlock ("",[],[]) "{ orange code block }"
-    ,BlockQuote
-     [Para [Str "orange",Space,Str "block",Space,Str "quote"]]]])]
-,Header 1 ("html-blocks",[],[]) [Str "HTML",Space,Str "Blocks"]
-,Para [Str "Simple",Space,Str "block",Space,Str "on",Space,Str "one",Space,Str "line:"]
-,Para [Str "foo",SoftBreak,Str "And",Space,Str "nested",Space,Str "without",Space,Str "indentation:"]
-,Para [Str "foo",SoftBreak,Str "bar",SoftBreak,Str "Interpreted",Space,Str "markdown",Space,Str "in",Space,Str "a",Space,Str "table:"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],SoftBreak,Str "And",Space,Str "this",Space,Str "is",Space,Strong [Str "strong"],SoftBreak,Str "Here\8217s",Space,Str "a",Space,Str "simple",Space,Str "block:"]
-,Para [Str "foo",SoftBreak,Str "This",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "code",Space,Str "block,",Space,Str "though:"]
-,CodeBlock ("",[],[]) "<div>\n    foo\n</div>"
-,Para [Str "As",Space,Str "should",Space,Str "this:"]
-,CodeBlock ("",[],[]) "<div>foo</div>"
-,Para [Str "Now,",Space,Str "nested:"]
-,Para [Str "foo",SoftBreak,Str "This",Space,Str "should",Space,Str "just",Space,Str "be",Space,Str "an",Space,Str "HTML",Space,Str "comment:"]
-,Para [Str "Multiline:"]
-,Para [Str "Code",Space,Str "block:"]
-,CodeBlock ("",[],[]) "<!-- Comment -->"
-,Para [Str "Just",Space,Str "plain",Space,Str "comment,",Space,Str "with",Space,Str "trailing",Space,Str "spaces",Space,Str "on",Space,Str "the",Space,Str "line:"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "<hr />"
-,Para [Str "Hr\8217s:"]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("inline-markup",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ",",Space,Str "and",Space,Str "so",Space,Emph [Str "is",Space,Str "this"],Str "."]
-,Para [Str "This",Space,Str "is",Space,Strong [Str "strong"],Str ",",Space,Str "and",Space,Str "so",Space,Strong [Str "is",Space,Str "this"],Str "."]
-,Para [Str "An",Space,Emph [Link ("",[],[]) [Str "emphasized",Space,Str "link"] ("/url","")],Str "."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Str "This",Space,Str "is",Space,Str "code:",Space,Code ("",[],[]) ">",Str ",",Space,Code ("",[],[]) "$",Str ",",Space,Code ("",[],[]) "\\",Str ",",Space,Code ("",[],[]) "\\$",Str ",",SoftBreak,Code ("",[],[]) "<html>",Str "."]
-,Para [Strikeout [Str "This",Space,Str "is",Space,Emph [Str "strikeout"],Str "."]]
-,Para [Str "Superscripts:",Space,Str "a",Superscript [Str "bc"],Str "d",SoftBreak,Str "a",Superscript [Emph [Str "hello"]],Space,Str "a",Superscript [Str "hello",Space,Str "there"],Str "."]
-,Para [Str "Subscripts:",Space,Str "H",Subscript [Str "2"],Str "O,",Space,Str "H",Subscript [Str "23"],Str "O,",SoftBreak,Str "H",Subscript [Str "many",Space,Str "of",Space,Str "them"],Str "O."]
-,Para [Str "These",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "superscripts",Space,Str "or",Space,Str "subscripts,",Space,Str "because",Space,Str "of",Space,Str "the",SoftBreak,Str "unescaped",Space,Str "spaces:",Space,Str "a^b",Space,Str "c^d,",Space,Str "a",Math InlineMath "\\sim",Str "b",SoftBreak,Str "c",Math InlineMath "\\sim",Str "d."]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("smart-quotes-ellipses-dashes",[],[]) [Str "Smart",Space,Str "quotes,",Space,Str "ellipses,",Space,Str "dashes"]
-,Para [Quoted DoubleQuote [Str "Hello,"],Space,Str "said",Space,Str "the",Space,Str "spider.",Space,Quoted DoubleQuote [Str "\8198",Quoted SingleQuote [Str "Shelob"],Space,Str "is",Space,Str "my",Space,Str "name."]]
-,Para [Quoted SingleQuote [Str "A"],Str ",",Space,Quoted SingleQuote [Str "B"],Str ",",Space,Str "and",Space,Quoted SingleQuote [Str "C"],Space,Str "are",Space,Str "letters."]
-,Para [Quoted SingleQuote [Str "Oak,"],Space,Quoted SingleQuote [Str "elm,"],Space,Str "and",Space,Quoted SingleQuote [Str "beech"],Space,Str "are",Space,Str "names",Space,Str "of",Space,Str "trees.",Space,Str "So",Space,Str "is",Space,Quoted SingleQuote [Str "pine."]]
-,Para [Quoted SingleQuote [Str "He",Space,Str "said,",Space,Quoted DoubleQuote [Str "I",Space,Str "want",Space,Str "to",Space,Str "go."],Str "\8198"],Space,Str "Were",Space,Str "you",Space,Str "alive",Space,Str "in",Space,Str "the",Space,Str "70\8217s?"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "quoted",Space,Quoted SingleQuote [Code ("",[],[]) "code"],Space,Str "and",Space,Str "a",SoftBreak,Quoted DoubleQuote [Link ("",[],[]) [Str "quoted",Space,Str "link"] ("http://example.com/?foo=1&bar=2","")],Str "."]
-,Para [Str "Some",Space,Str "dashes:",Space,Str "one\8212two\8212three\8212four\8212five."]
-,Para [Str "Dashes",Space,Str "between",Space,Str "numbers:",Space,Str "5\8211\&7,",Space,Str "255\8211\&66,",Space,Str "1987\8211\&1999."]
-,Para [Str "Ellipses\8230and\8230and\8230."]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("latex",[],[]) [Str "LaTeX"]
-,BulletList
- [[Para [Cite [Citation {citationId = "smith.1899", citationPrefix = [], citationSuffix = [Str "22-23"], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [RawInline (Format "latex") "\\cite[22-23]{smith.1899}"]]]
- ,[RawBlock (Format "latex") "\\doublespacing"]
- ,[Para [Math InlineMath "2+2=4"]]
- ,[Para [Math InlineMath "x \\in y"]]
- ,[Para [Math InlineMath "\\alpha \\wedge \\omega"]]
- ,[Para [Math InlineMath "223"]]
- ,[Para [Math InlineMath "p",Str "-Tree"]]
- ,[Para [Math InlineMath "\\frac{d}{dx}f(x)=\\lim_{h\\to 0}\\frac{f(x+h)-f(x)}{h}"]]
- ,[Para [Str "Here\8217s",Space,Str "one",Space,Str "that",Space,Str "has",Space,Str "a",Space,Str "line",Space,Str "break",Space,Str "in",Space,Str "it:",SoftBreak,Math InlineMath "\\alpha + \\omega \\times x^2",Str "."]]]
-,Para [Str "These",Space,Str "shouldn\8217t",Space,Str "be",Space,Str "math:"]
-,BulletList
- [[Para [Str "To",Space,Str "get",Space,Str "the",Space,Str "famous",Space,Str "equation,",Space,Str "write",Space,Code ("",[],[]) "$e = mc^2$",Str "."]]
- ,[Para [Str "$22,000",Space,Str "is",Space,Str "a",Space,Emph [Str "lot"],Space,Str "of",Space,Str "money.",Space,Str "So",Space,Str "is",Space,Str "$34,000.",Space,Str "(It",Space,Str "worked",Space,Str "if",SoftBreak,Quoted DoubleQuote [Str "lot"],Space,Str "is",Space,Str "emphasized.)"]]
- ,[Para [Str "Escaped",Space,Code ("",[],[]) "$",Str ":",Space,Str "$73",Space,Emph [Str "this",Space,Str "should",Space,Str "be",Space,Str "emphasized"],Space,Str "23$."]]]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "LaTeX",Space,Str "table:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Animal"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Number"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Dog"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cat"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "A",Space,Str "table",Space,Str "with",Space,Str "one",Space,Str "column:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Animal"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Vegetable"]]]])]
- (TableFoot ("",[],[])
- [])
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("special-characters",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "unicode:"]
-,BulletList
- [[Para [Str "I",Space,Str "hat:",Space,Str "\206"]]
- ,[Para [Str "o",Space,Str "umlaut:",Space,Str "\246"]]
- ,[Para [Str "section:",Space,Str "\167"]]
- ,[Para [Str "set",Space,Str "membership:",Space,Str "\8712"]]
- ,[Para [Str "copyright:",Space,Str "\169"]]]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "AT&T",Space,Str "is",Space,Str "another",Space,Str "way",Space,Str "to",Space,Str "write",Space,Str "it."]
-,Para [Str "This",Space,Str "&",Space,Str "that."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "\8216"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("links",[],[]) [Str "Links"]
-,Header 2 ("explicit",[],[]) [Str "Explicit"]
-,Para [Str "Just",Space,Str "a",Space,Link ("",[],[]) [Str "URL"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","")]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","")]
-,Para [Link ("",[],[]) [Str "with_underscore"] ("/url/with_underscore","")]
-,Para [Link ("",[],[]) [Str "Email",Space,Str "link"] ("mailto:nobody@nowhere.net","")]
-,Para [Link ("",[],[]) [Str "Empty"] ("",""),Str "."]
-,Header 2 ("reference",[],[]) [Str "Reference"]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "With",Space,Link ("",[],[]) [Str "embedded",Space,Str "[brackets]"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "b"] ("/url/",""),Space,Str "by",Space,Str "itself",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "link."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "once"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "twice"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "thrice"] ("/url",""),Str "."]
-,Para [Str "This",Space,Str "should",Space,Str "[not][]",Space,Str "be",Space,Str "a",Space,Str "link."]
-,CodeBlock ("",[],[]) "[not]: /url"
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "biz"] ("/url/",""),Str "."]
-,Header 2 ("with-ampersands",[],[]) [Str "With",Space,Str "ampersands"]
-,Para [Str "Here\8217s",Space,Str "a",SoftBreak,Link ("",[],[]) [Str "link",Space,Str "with",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "URL"] ("http://example.com/?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "link",Space,Str "with",Space,Str "an",Space,Str "amersand",Space,Str "in",Space,Str "the",Space,Str "link",Space,Str "text:",SoftBreak,Link ("",[],[]) [Str "AT&T"] ("http://att.com/",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link"] ("/script?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "an",SoftBreak,Link ("",[],[]) [Str "inline",Space,Str "link",Space,Str "in",Space,Str "pointy",Space,Str "braces"] ("/script?foo=1&bar=2",""),Str "."]
-,Header 2 ("autolinks",[],[]) [Str "Autolinks"]
-,Para [Str "With",Space,Str "an",Space,Str "ampersand:",Space,Link ("",[],[]) [Str "http://example.com/?foo=1&bar=2"] ("http://example.com/?foo=1&bar=2","")]
-,BulletList
- [[Para [Str "In",Space,Str "a",Space,Str "list?"]]
- ,[Para [Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
- ,[Para [Str "It",Space,Str "should."]]]
-,Para [Str "An",Space,Str "e-mail",Space,Str "address:",SoftBreak,Link ("",[],[]) [Str "nobody@nowhere.net"] ("mailto:nobody@nowhere.net","")]
-,BlockQuote
- [Para [Str "Blockquoted:",Space,Link ("",[],[]) [Str "http://example.com/"] ("http://example.com/","")]]
-,Para [Str "Auto-links",Space,Str "should",Space,Str "not",Space,Str "occur",Space,Str "here:",Space,Code ("",[],[]) "<http://example.com/>"]
-,CodeBlock ("",[],[]) "or here: <http://example.com/>"
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("images",[],[]) [Str "Images"]
-,Para [Str "From",Space,Quoted DoubleQuote [Str "Voyage",Space,Str "dans",Space,Str "la",Space,Str "Lune"],Space,Str "by",Space,Str "Georges",Space,Str "Melies",Space,Str "(1902):"]
-,Para [Image ("",[],[]) [Str "image"] ("lalune.jpg","")]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "movie",Space,Image ("",[],[]) [Str "image"] ("movie.jpg",""),Space,Str "icon."]
-,Div ("",["center"],[])
- [HorizontalRule]
-,Header 1 ("footnotes",[],[]) [Str "Footnotes"]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "footnote",SoftBreak,Str "reference,",Note [Para [Str "Here",Space,Str "is",Space,Str "the",Space,Str "footnote.",Space,Str "It",Space,Str "can",Space,Str "go",Space,Str "anywhere",Space,Str "after",Space,Str "the",Space,Str "footnote",SoftBreak,Str "reference.",Space,Str "It",Space,Str "need",Space,Str "not",Space,Str "be",Space,Str "placed",Space,Str "at",Space,Str "the",Space,Str "end",Space,Str "of",Space,Str "the",Space,Str "document."]],SoftBreak,Str "and",SoftBreak,Str "another.",Note [Para [Str "Here\8217s",Space,Str "the",Space,Str "long",Space,Str "note.",Space,Str "This",Space,Str "one",Space,Str "contains",Space,Str "multiple",Space,Str "blocks."],Para [Str "Subsequent",Space,Str "blocks",Space,Str "are",Space,Str "indented",Space,Str "to",Space,Str "show",Space,Str "that",Space,Str "they",Space,Str "belong",Space,Str "to",Space,Str "the",SoftBreak,Str "footnote",Space,Str "(as",Space,Str "with",Space,Str "list",Space,Str "items)."],CodeBlock ("",[],[]) "  { <code> }",Para [Str "If",Space,Str "you",Space,Str "want,",Space,Str "you",Space,Str "can",Space,Str "indent",Space,Str "every",Space,Str "line,",Space,Str "but",Space,Str "you",Space,Str "can",Space,Str "also",Space,Str "be",Space,Str "lazy",SoftBreak,Str "and",Space,Str "just",Space,Str "indent",Space,Str "the",Space,Str "first",Space,Str "line",Space,Str "of",Space,Str "each",Space,Str "block."]],SoftBreak,Str "This",Space,Str "should",Space,Emph [Str "not"],Space,Str "be",Space,Str "a",Space,Str "footnote",Space,Str "reference,",Space,Str "because",Space,Str "it",Space,Str "contains",SoftBreak,Str "a",Space,Str "space.[^my",Space,Str "note]",Space,Str "Here",Space,Str "is",Space,Str "an",Space,Str "inline",SoftBreak,Str "note.",Note [Para [Str "This",Space,Str "is",Space,Emph [Str "easier"],Space,Str "to",Space,Str "type.",Space,Str "Inline",Space,Str "notes",Space,Str "may",Space,Str "contain",SoftBreak,Link ("",[],[]) [Str "links"] ("http://google.com",""),Space,Str "and",Space,Code ("",[],[]) "]",Space,Str "verbatim",Space,Str "characters,",SoftBreak,Str "as",Space,Str "well",Space,Str "as",Space,Str "[bracketed",Space,Str "text]."]]]
-,BlockQuote
- [Para [Str "Notes",Space,Str "can",Space,Str "go",Space,Str "in",Space,Str "quotes.",Note [Para [Str "In",Space,Str "quote."]]]]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "And",Space,Str "in",Space,Str "list",Space,Str "items.",Note [Para [Str "In",Space,Str "list."]]]]]
-,Para [Str "This",Space,Str "paragraph",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "part",Space,Str "of",Space,Str "the",Space,Str "note,",Space,Str "as",Space,Str "it",Space,Str "is",Space,Str "not",SoftBreak,Str "indented."]
-,Header 1 ("escaped-characters",[],[]) [Str "Escaped",Space,Str "characters"]
-,Para [Str "$",Space,Str "%",Space,Str "&",Space,Str "#",Space,Str "_",Space,Str "{",Space,Str "}"]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaList
+          [ MetaInlines
+            [ Str "John", Space, Str "MacFarlane" ]
+          , MetaInlines
+            [ Str "Anonymous" ]
+          ]
+        )
+      ,
+        ( "date"
+        , MetaInlines
+          [ Str "July", Space, Str "17,", Space, Str "2006" ]
+        )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Pandoc", Space, Str "Test", Space, Str "Suite" ]
+        )
+      ]
+    }
+  )
+  [ RawBlock
+    ( Format "latex" ) "\\maketitle"
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc."
+    , Space
+    , Str "Most"
+    , Space
+    , Str "of"
+    , Space
+    , Str "them"
+    , Space
+    , Str "are"
+    , Space
+    , Str "adapted"
+    , Space
+    , Str "from"
+    , SoftBreak
+    , Str "John"
+    , Space
+    , Str "Gruber\8217s"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "test"
+    , Space
+    , Str "suite."
+    ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "headers", [], [] )
+    [ Str "Headers" ]
+  , Header 2
+    ( "level-2-with-an-embedded-link", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "link" ]
+      ( "/url", "" )
+    ]
+  , Header 3
+    ( "level-3-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "3"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Para
+    [ Str "Level", Space, Str "4" ]
+  , Para
+    [ Str "Level", Space, Str "5" ]
+  , Header 1
+    ( "level-1", [], [] )
+    [ Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "level-2-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 3
+    ( "level-3", [], [] )
+    [ Str "Level", Space, Str "3" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , Header 2
+    ( "level-2", [], [] )
+    [ Str "Level", Space, Str "2" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "paragraphs", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "In"
+    , Space
+    , Str "Markdown"
+    , Space
+    , Str "1.0.0"
+    , Space
+    , Str "and"
+    , Space
+    , Str "earlier."
+    , Space
+    , Str "Version"
+    , Space
+    , Str "8."
+    , Space
+    , Str "This"
+    , Space
+    , Str "line"
+    , Space
+    , Str "turns"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Str "list"
+    , Space
+    , Str "item."
+    , Space
+    , Str "Because"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard-wrapped"
+    , Space
+    , Str "line"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "middle"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , SoftBreak
+    , Str "looked"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    , Space
+    , Str "*"
+    , Space
+    , Str "criminey."
+    ]
+  , Para
+    [ Str "There"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard"
+    , Space
+    , Str "line"
+    , Space
+    , Str "break"
+    , LineBreak
+    , Str "here."
+    ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "E-mail", Space, Str "style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , Space
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "pretty"
+      , Space
+      , Str "short."
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Code"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    , Para
+      [ Str "A", Space, Str "list:" ]
+    , OrderedList
+      ( 1, Decimal, Period )
+      [
+        [ Para [ Str "item", Space, Str "one" ] ]
+      ,
+        [ Para [ Str "item", Space, Str "two" ] ]
+      ]
+    , Para
+      [ Str "Nested", Space, Str "block", Space, Str "quotes:" ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote:"
+    , Space
+    , Str "2"
+    , Space
+    , Str ">"
+    , Space
+    , Str "1."
+    ]
+  , Para
+    [ Str "Box-style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "Example:" ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    ]
+  , BlockQuote
+    [ OrderedList
+      ( 1, Decimal, Period )
+      [
+        [ Para [ Str "do", Space, Str "laundry" ] ]
+      ,
+        [ Para
+          [ Str "take"
+          , Space
+          , Str "out"
+          , Space
+          , Str "the"
+          , Space
+          , Str "trash"
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "nested"
+    , Space
+    , Str "one:"
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Joe", Space, Str "said:" ]
+    , BlockQuote
+      [ Para [ Str "Don\8217t", Space, Str "quote", Space, Str "me." ] ]
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "a"
+    , Space
+    , Str "following"
+    , Space
+    , Str "paragraph."
+    ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
+  , Para
+    [ Str "this"
+    , Space
+    , Str "has"
+    , Space
+    , Emph
+      [ Str "two", LineBreak, Str "lines" ]
+    ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "unordered", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Asterisks", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Para [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "ordered", [], [] )
+    [ Str "Ordered" ]
+  , Para
+    [ Str "Tight:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "One" ] ]
+    ,
+      [ Para [ Str "Two" ] ]
+    ,
+      [ Para [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Loose", Space, Str "using", Space, Str "tabs:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and", Space, Str "using", Space, Str "spaces:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "One" ] ]
+    ,
+      [ Para [ Str "Two" ] ]
+    ,
+      [ Para [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "paragraphs:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para
+        [ Str "Item"
+        , Space
+        , Str "1,"
+        , Space
+        , Str "graf"
+        , Space
+        , Str "one."
+        ]
+      , Para
+        [ Str "Item"
+        , Space
+        , Str "1."
+        , Space
+        , Str "graf"
+        , Space
+        , Str "two."
+        , Space
+        , Str "The"
+        , Space
+        , Str "quick"
+        , Space
+        , Str "brown"
+        , Space
+        , Str "fox"
+        , Space
+        , Str "jumped"
+        , Space
+        , Str "over"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lazy"
+        , Space
+        , Str "dog\8217s"
+        , SoftBreak
+        , Str "back."
+        ]
+      ]
+    ,
+      [ Para [ Str "Item", Space, Str "2." ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "3." ] ]
+    ]
+  , Header 2
+    ( "nested", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "Tab" ]
+      , BulletList
+        [
+          [ Para [ Str "Tab" ], BulletList [ [ Para [ Str "Tab" ] ] ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s", Space, Str "another:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Same"
+    , Space
+    , Str "thing"
+    , Space
+    , Str "but"
+    , Space
+    , Str "with"
+    , Space
+    , Str "paragraphs:"
+    ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "tabs-and-spaces", [], [] )
+    [ Str "Tabs", Space, Str "and", Space, Str "spaces" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "tabs"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "spaces"
+        ]
+      , BulletList
+        [
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "tabs"
+            ]
+          ]
+        ,
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "spaces"
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "fancy-list-markers", [], [] )
+    [ Str "Fancy", Space, Str "list", Space, Str "markers" ]
+  , OrderedList
+    ( 2, Decimal, TwoParens )
+    [
+      [ Para [ Str "begins", Space, Str "with", Space, Str "2" ] ]
+    ,
+      [ Para
+        [ Str "and", Space, Str "now", Space, Str "3" ]
+      , Para
+        [ Str "with", Space, Str "a", Space, Str "continuation" ]
+      , OrderedList
+        ( 4, LowerRoman, Period )
+        [
+          [ Para
+            [ Str "sublist"
+            , Space
+            , Str "with"
+            , Space
+            , Str "roman"
+            , Space
+            , Str "numerals,"
+            , Space
+            , Str "starting"
+            , Space
+            , Str "with"
+            , Space
+            , Str "4"
+            ]
+          ]
+        ,
+          [ Para
+            [ Str "more", Space, Str "items" ]
+          , OrderedList
+            ( 1, UpperAlpha, TwoParens )
+            [
+              [ Para [ Str "a", Space, Str "subsublist" ] ]
+            ,
+              [ Para [ Str "a", Space, Str "subsublist" ] ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Nesting:" ]
+  , OrderedList
+    ( 1, UpperAlpha, Period )
+    [
+      [ Para
+        [ Str "Upper", Space, Str "Alpha" ]
+      , OrderedList
+        ( 1, UpperRoman, Period )
+        [
+          [ Para
+            [ Str "Upper", Space, Str "Roman." ]
+          , OrderedList
+            ( 6, Decimal, TwoParens )
+            [
+              [ Para
+                [ Str "Decimal"
+                , Space
+                , Str "start"
+                , Space
+                , Str "with"
+                , Space
+                , Str "6"
+                ]
+              , OrderedList
+                ( 3, LowerAlpha, OneParen )
+                [
+                  [ Para
+                    [ Str "Lower"
+                    , Space
+                    , Str "alpha"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "paren"
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Autonumbering:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Para [ Str "Autonumber." ] ]
+    ,
+      [ Para
+        [ Str "More." ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [ [ Para [ Str "Nested." ] ] ]
+      ]
+    ]
+  , Para
+    [ Str "Should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item:"
+    ]
+  , Para
+    [ Str "M.A.", Space, Str "2007" ]
+  , Para
+    [ Str "B.", Space, Str "Williams" ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "definition-lists", [], [] )
+    [ Str "Definition", Space, Str "Lists" ]
+  , Para
+    [ Str "Tight", Space, Str "using", Space, Str "spaces:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [ [ Para [ Str "red", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [ [ Para [ Str "orange", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "banana" ]
+      ,
+        [ [ Para [ Str "yellow", Space, Str "fruit" ] ] ]
+      )
+    ]
+  , Para
+    [ Str "Tight", Space, Str "using", Space, Str "tabs:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [ [ Para [ Str "red", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [ [ Para [ Str "orange", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "banana" ]
+      ,
+        [ [ Para [ Str "yellow", Space, Str "fruit" ] ] ]
+      )
+    ]
+  , Para
+    [ Str "Loose:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [ [ Para [ Str "red", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [ [ Para [ Str "orange", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "banana" ]
+      ,
+        [ [ Para [ Str "yellow", Space, Str "fruit" ] ] ]
+      )
+    ]
+  , Para
+    [ Str "Multiple"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "with"
+    , Space
+    , Str "italics:"
+    ]
+  , DefinitionList
+    [
+      (
+        [ Emph [ Str "apple" ] ]
+      ,
+        [
+          [ Para
+            [ Str "red", Space, Str "fruit" ]
+          , Para
+            [ Str "contains"
+            , Space
+            , Str "seeds,"
+            , Space
+            , Str "crisp,"
+            , Space
+            , Str "pleasant"
+            , Space
+            , Str "to"
+            , Space
+            , Str "taste"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Emph [ Str "orange" ] ]
+      ,
+        [
+          [ Para
+            [ Str "orange", Space, Str "fruit" ]
+          , CodeBlock
+            ( "", [], [] ) "{ orange code block }"
+          , BlockQuote
+            [ Para
+              [ Str "orange", Space, Str "block", Space, Str "quote" ]
+            ]
+          ]
+        ]
+      )
+    ]
+  , Header 1
+    ( "html-blocks", [], [] )
+    [ Str "HTML", Space, Str "Blocks" ]
+  , Para
+    [ Str "Simple"
+    , Space
+    , Str "block"
+    , Space
+    , Str "on"
+    , Space
+    , Str "one"
+    , Space
+    , Str "line:"
+    ]
+  , Para
+    [ Str "foo"
+    , SoftBreak
+    , Str "And"
+    , Space
+    , Str "nested"
+    , Space
+    , Str "without"
+    , Space
+    , Str "indentation:"
+    ]
+  , Para
+    [ Str "foo"
+    , SoftBreak
+    , Str "bar"
+    , SoftBreak
+    , Str "Interpreted"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "in"
+    , Space
+    , Str "a"
+    , Space
+    , Str "table:"
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , SoftBreak
+    , Str "And"
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , SoftBreak
+    , Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "simple"
+    , Space
+    , Str "block:"
+    ]
+  , Para
+    [ Str "foo"
+    , SoftBreak
+    , Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "code"
+    , Space
+    , Str "block,"
+    , Space
+    , Str "though:"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "<div>\n    foo\n</div>"
+  , Para
+    [ Str "As", Space, Str "should", Space, Str "this:" ]
+  , CodeBlock
+    ( "", [], [] ) "<div>foo</div>"
+  , Para
+    [ Str "Now,", Space, Str "nested:" ]
+  , Para
+    [ Str "foo"
+    , SoftBreak
+    , Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "just"
+    , Space
+    , Str "be"
+    , Space
+    , Str "an"
+    , Space
+    , Str "HTML"
+    , Space
+    , Str "comment:"
+    ]
+  , Para
+    [ Str "Multiline:" ]
+  , Para
+    [ Str "Code", Space, Str "block:" ]
+  , CodeBlock
+    ( "", [], [] ) "<!-- Comment -->"
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "plain"
+    , Space
+    , Str "comment,"
+    , Space
+    , Str "with"
+    , Space
+    , Str "trailing"
+    , Space
+    , Str "spaces"
+    , Space
+    , Str "on"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line:"
+    ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( "", [], [] ) "<hr />"
+  , Para
+    [ Str "Hr\8217s:" ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "inline-markup", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Emph
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Strong
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Emph
+      [ Link
+        ( "", [], [] )
+        [ Str "emphasized", Space, Str "link" ]
+        ( "/url", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) ">"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\$"
+    , Str ","
+    , SoftBreak
+    , Code
+      ( "", [], [] ) "<html>"
+    , Str "."
+    ]
+  , Para
+    [ Strikeout
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Emph
+        [ Str "strikeout" ]
+      , Str "."
+      ]
+    ]
+  , Para
+    [ Str "Superscripts:"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "bc" ]
+    , Str "d"
+    , SoftBreak
+    , Str "a"
+    , Superscript
+      [ Emph [ Str "hello" ] ]
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "hello", Space, Str "there" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Subscripts:"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "2" ]
+    , Str "O,"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "23" ]
+    , Str "O,"
+    , SoftBreak
+    , Str "H"
+    , Subscript
+      [ Str "many", Space, Str "of", Space, Str "them" ]
+    , Str "O."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "superscripts"
+    , Space
+    , Str "or"
+    , Space
+    , Str "subscripts,"
+    , Space
+    , Str "because"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "unescaped"
+    , Space
+    , Str "spaces:"
+    , Space
+    , Str "a^b"
+    , Space
+    , Str "c^d,"
+    , Space
+    , Str "a"
+    , Math InlineMath "\\sim"
+    , Str "b"
+    , SoftBreak
+    , Str "c"
+    , Math InlineMath "\\sim"
+    , Str "d."
+    ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "smart-quotes-ellipses-dashes", [], [] )
+    [ Str "Smart"
+    , Space
+    , Str "quotes,"
+    , Space
+    , Str "ellipses,"
+    , Space
+    , Str "dashes"
+    ]
+  , Para
+    [ Quoted DoubleQuote
+      [ Str "Hello," ]
+    , Space
+    , Str "said"
+    , Space
+    , Str "the"
+    , Space
+    , Str "spider."
+    , Space
+    , Quoted DoubleQuote
+      [ Str "\8198"
+      , Quoted SingleQuote
+        [ Str "Shelob" ]
+      , Space
+      , Str "is"
+      , Space
+      , Str "my"
+      , Space
+      , Str "name."
+      ]
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "A" ]
+    , Str ","
+    , Space
+    , Quoted SingleQuote
+      [ Str "B" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Quoted SingleQuote
+      [ Str "C" ]
+    , Space
+    , Str "are"
+    , Space
+    , Str "letters."
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "Oak," ]
+    , Space
+    , Quoted SingleQuote
+      [ Str "elm," ]
+    , Space
+    , Str "and"
+    , Space
+    , Quoted SingleQuote
+      [ Str "beech" ]
+    , Space
+    , Str "are"
+    , Space
+    , Str "names"
+    , Space
+    , Str "of"
+    , Space
+    , Str "trees."
+    , Space
+    , Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Quoted SingleQuote
+      [ Str "pine." ]
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "He"
+      , Space
+      , Str "said,"
+      , Space
+      , Quoted DoubleQuote
+        [ Str "I"
+        , Space
+        , Str "want"
+        , Space
+        , Str "to"
+        , Space
+        , Str "go."
+        ]
+      , Str "\8198"
+      ]
+    , Space
+    , Str "Were"
+    , Space
+    , Str "you"
+    , Space
+    , Str "alive"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "70\8217s?"
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "quoted"
+    , Space
+    , Quoted SingleQuote
+      [ Code ( "", [], [] ) "code" ]
+    , Space
+    , Str "and"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Quoted DoubleQuote
+      [ Link
+        ( "", [], [] )
+        [ Str "quoted", Space, Str "link" ]
+        ( "http://example.com/?foo=1&bar=2", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Str "dashes:"
+    , Space
+    , Str "one\8212two\8212three\8212four\8212five."
+    ]
+  , Para
+    [ Str "Dashes"
+    , Space
+    , Str "between"
+    , Space
+    , Str "numbers:"
+    , Space
+    , Str "5\8211\&7,"
+    , Space
+    , Str "255\8211\&66,"
+    , Space
+    , Str "1987\8211\&1999."
+    ]
+  , Para
+    [ Str "Ellipses\8230and\8230and\8230." ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "latex", [], [] )
+    [ Str "LaTeX" ]
+  , BulletList
+    [
+      [ Para
+        [ Cite
+          [ Citation
+            { citationId = "smith.1899"
+            , citationPrefix = []
+            , citationSuffix =
+              [ Str "22-23" ]
+            , citationMode = NormalCitation
+            , citationNoteNum = 0
+            , citationHash = 0
+            }
+          ]
+          [ RawInline ( Format "latex" ) "\\cite[22-23]{smith.1899}" ]
+        ]
+      ]
+    ,
+      [ RawBlock ( Format "latex" ) "\\doublespacing" ]
+    ,
+      [ Para [ Math InlineMath "2+2=4" ] ]
+    ,
+      [ Para [ Math InlineMath "x \\in y" ] ]
+    ,
+      [ Para [ Math InlineMath "\\alpha \\wedge \\omega" ] ]
+    ,
+      [ Para [ Math InlineMath "223" ] ]
+    ,
+      [ Para [ Math InlineMath "p", Str "-Tree" ] ]
+    ,
+      [ Para
+        [ Math InlineMath "\\frac{d}{dx}f(x)=\\lim_{h\\to 0}\\frac{f(x+h)-f(x)}{h}" ]
+      ]
+    ,
+      [ Para
+        [ Str "Here\8217s"
+        , Space
+        , Str "one"
+        , Space
+        , Str "that"
+        , Space
+        , Str "has"
+        , Space
+        , Str "a"
+        , Space
+        , Str "line"
+        , Space
+        , Str "break"
+        , Space
+        , Str "in"
+        , Space
+        , Str "it:"
+        , SoftBreak
+        , Math InlineMath "\\alpha + \\omega \\times x^2"
+        , Str "."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "shouldn\8217t"
+    , Space
+    , Str "be"
+    , Space
+    , Str "math:"
+    ]
+  , BulletList
+    [
+      [ Para
+        [ Str "To"
+        , Space
+        , Str "get"
+        , Space
+        , Str "the"
+        , Space
+        , Str "famous"
+        , Space
+        , Str "equation,"
+        , Space
+        , Str "write"
+        , Space
+        , Code
+          ( "", [], [] ) "$e = mc^2$"
+        , Str "."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "$22,000"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Emph
+          [ Str "lot" ]
+        , Space
+        , Str "of"
+        , Space
+        , Str "money."
+        , Space
+        , Str "So"
+        , Space
+        , Str "is"
+        , Space
+        , Str "$34,000."
+        , Space
+        , Str "(It"
+        , Space
+        , Str "worked"
+        , Space
+        , Str "if"
+        , SoftBreak
+        , Quoted DoubleQuote
+          [ Str "lot" ]
+        , Space
+        , Str "is"
+        , Space
+        , Str "emphasized.)"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "Escaped"
+        , Space
+        , Code
+          ( "", [], [] ) "$"
+        , Str ":"
+        , Space
+        , Str "$73"
+        , Space
+        , Emph
+          [ Str "this"
+          , Space
+          , Str "should"
+          , Space
+          , Str "be"
+          , Space
+          , Str "emphasized"
+          ]
+        , Space
+        , Str "23$."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "LaTeX"
+    , Space
+    , Str "table:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [ ( AlignLeft, ColWidthDefault ), ( AlignLeft, ColWidthDefault ) ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Animal" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Number" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Dog" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cat" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "A"
+    , Space
+    , Str "table"
+    , Space
+    , Str "with"
+    , Space
+    , Str "one"
+    , Space
+    , Str "column:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [ ( AlignCenter, ColWidthDefault ) ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Animal" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Vegetable" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "special-characters", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "unicode:"
+    ]
+  , BulletList
+    [
+      [ Para [ Str "I", Space, Str "hat:", Space, Str "\206" ] ]
+    ,
+      [ Para [ Str "o", Space, Str "umlaut:", Space, Str "\246" ] ]
+    ,
+      [ Para [ Str "section:", Space, Str "\167" ] ]
+    ,
+      [ Para
+        [ Str "set", Space, Str "membership:", Space, Str "\8712" ]
+      ]
+    ,
+      [ Para [ Str "copyright:", Space, Str "\169" ] ]
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "is"
+    , Space
+    , Str "another"
+    , Space
+    , Str "way"
+    , Space
+    , Str "to"
+    , Space
+    , Str "write"
+    , Space
+    , Str "it."
+    ]
+  , Para
+    [ Str "This", Space, Str "&", Space, Str "that." ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "\8216" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "links", [], [] )
+    [ Str "Links" ]
+  , Header 2
+    ( "explicit", [], [] )
+    [ Str "Explicit" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "URL" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "with_underscore" ]
+      ( "/url/with_underscore", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Email", Space, Str "link" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Empty" ] ( "", "" ), Str "." ]
+  , Header 2
+    ( "reference", [], [] )
+    [ Str "Reference" ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "With"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "[brackets]" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "b" ]
+      ( "/url/", "" )
+    , Space
+    , Str "by"
+    , Space
+    , Str "itself"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "once" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "twice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "thrice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "[not][]"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , CodeBlock
+    ( "", [], [] ) "[not]: /url"
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "biz" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "with-ampersands", [], [] )
+    [ Str "With", Space, Str "ampersands" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "link"
+      , Space
+      , Str "with"
+      , Space
+      , Str "an"
+      , Space
+      , Str "ampersand"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "URL"
+      ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Str "amersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "text:"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "AT&T" ]
+      ( "http://att.com/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline", Space, Str "link" ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "an"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "inline"
+      , Space
+      , Str "link"
+      , Space
+      , Str "in"
+      , Space
+      , Str "pointy"
+      , Space
+      , Str "braces"
+      ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "autolinks", [], [] )
+    [ Str "Autolinks" ]
+  , Para
+    [ Str "With"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://example.com/?foo=1&bar=2" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    ]
+  , BulletList
+    [
+      [ Para [ Str "In", Space, Str "a", Space, Str "list?" ] ]
+    ,
+      [ Para
+        [ Link
+          ( "", [], [] )
+          [ Str "http://example.com/" ]
+          ( "http://example.com/", "" )
+        ]
+      ]
+    ,
+      [ Para [ Str "It", Space, Str "should." ] ]
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Str "e-mail"
+    , Space
+    , Str "address:"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "nobody@nowhere.net" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Blockquoted:"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "http://example.com/" ]
+        ( "http://example.com/", "" )
+      ]
+    ]
+  , Para
+    [ Str "Auto-links"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "occur"
+    , Space
+    , Str "here:"
+    , Space
+    , Code
+      ( "", [], [] ) "<http://example.com/>"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "or here: <http://example.com/>"
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "images", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "From"
+    , Space
+    , Quoted DoubleQuote
+      [ Str "Voyage"
+      , Space
+      , Str "dans"
+      , Space
+      , Str "la"
+      , Space
+      , Str "Lune"
+      ]
+    , Space
+    , Str "by"
+    , Space
+    , Str "Georges"
+    , Space
+    , Str "Melies"
+    , Space
+    , Str "(1902):"
+    ]
+  , Para
+    [ Image ( "", [], [] ) [ Str "image" ] ( "lalune.jpg", "" ) ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "image" ]
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    ]
+  , Div
+    ( "", [ "center" ], [] ) [ HorizontalRule ]
+  , Header 1
+    ( "footnotes", [], [] )
+    [ Str "Footnotes" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , SoftBreak
+    , Str "reference,"
+    , Note
+      [ Para
+        [ Str "Here"
+        , Space
+        , Str "is"
+        , Space
+        , Str "the"
+        , Space
+        , Str "footnote."
+        , Space
+        , Str "It"
+        , Space
+        , Str "can"
+        , Space
+        , Str "go"
+        , Space
+        , Str "anywhere"
+        , Space
+        , Str "after"
+        , Space
+        , Str "the"
+        , Space
+        , Str "footnote"
+        , SoftBreak
+        , Str "reference."
+        , Space
+        , Str "It"
+        , Space
+        , Str "need"
+        , Space
+        , Str "not"
+        , Space
+        , Str "be"
+        , Space
+        , Str "placed"
+        , Space
+        , Str "at"
+        , Space
+        , Str "the"
+        , Space
+        , Str "end"
+        , Space
+        , Str "of"
+        , Space
+        , Str "the"
+        , Space
+        , Str "document."
+        ]
+      ]
+    , SoftBreak
+    , Str "and"
+    , SoftBreak
+    , Str "another."
+    , Note
+      [ Para
+        [ Str "Here\8217s"
+        , Space
+        , Str "the"
+        , Space
+        , Str "long"
+        , Space
+        , Str "note."
+        , Space
+        , Str "This"
+        , Space
+        , Str "one"
+        , Space
+        , Str "contains"
+        , Space
+        , Str "multiple"
+        , Space
+        , Str "blocks."
+        ]
+      , Para
+        [ Str "Subsequent"
+        , Space
+        , Str "blocks"
+        , Space
+        , Str "are"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "to"
+        , Space
+        , Str "show"
+        , Space
+        , Str "that"
+        , Space
+        , Str "they"
+        , Space
+        , Str "belong"
+        , Space
+        , Str "to"
+        , Space
+        , Str "the"
+        , SoftBreak
+        , Str "footnote"
+        , Space
+        , Str "(as"
+        , Space
+        , Str "with"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items)."
+        ]
+      , CodeBlock
+        ( "", [], [] ) "  { <code> }"
+      , Para
+        [ Str "If"
+        , Space
+        , Str "you"
+        , Space
+        , Str "want,"
+        , Space
+        , Str "you"
+        , Space
+        , Str "can"
+        , Space
+        , Str "indent"
+        , Space
+        , Str "every"
+        , Space
+        , Str "line,"
+        , Space
+        , Str "but"
+        , Space
+        , Str "you"
+        , Space
+        , Str "can"
+        , Space
+        , Str "also"
+        , Space
+        , Str "be"
+        , Space
+        , Str "lazy"
+        , SoftBreak
+        , Str "and"
+        , Space
+        , Str "just"
+        , Space
+        , Str "indent"
+        , Space
+        , Str "the"
+        , Space
+        , Str "first"
+        , Space
+        , Str "line"
+        , Space
+        , Str "of"
+        , Space
+        , Str "each"
+        , Space
+        , Str "block."
+        ]
+      ]
+    , SoftBreak
+    , Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Emph
+      [ Str "not" ]
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , Space
+    , Str "because"
+    , Space
+    , Str "it"
+    , Space
+    , Str "contains"
+    , SoftBreak
+    , Str "a"
+    , Space
+    , Str "space.[^my"
+    , Space
+    , Str "note]"
+    , Space
+    , Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "an"
+    , Space
+    , Str "inline"
+    , SoftBreak
+    , Str "note."
+    , Note
+      [ Para
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Emph
+          [ Str "easier" ]
+        , Space
+        , Str "to"
+        , Space
+        , Str "type."
+        , Space
+        , Str "Inline"
+        , Space
+        , Str "notes"
+        , Space
+        , Str "may"
+        , Space
+        , Str "contain"
+        , SoftBreak
+        , Link
+          ( "", [], [] )
+          [ Str "links" ]
+          ( "http://google.com", "" )
+        , Space
+        , Str "and"
+        , Space
+        , Code
+          ( "", [], [] ) "]"
+        , Space
+        , Str "verbatim"
+        , Space
+        , Str "characters,"
+        , SoftBreak
+        , Str "as"
+        , Space
+        , Str "well"
+        , Space
+        , Str "as"
+        , Space
+        , Str "[bracketed"
+        , Space
+        , Str "text]."
+        ]
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Notes"
+      , Space
+      , Str "can"
+      , Space
+      , Str "go"
+      , Space
+      , Str "in"
+      , Space
+      , Str "quotes."
+      , Note
+        [ Para [ Str "In", Space, Str "quote." ] ]
+      ]
+    ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para
+        [ Str "And"
+        , Space
+        , Str "in"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items."
+        , Note
+          [ Para [ Str "In", Space, Str "list." ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "part"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "note,"
+    , Space
+    , Str "as"
+    , Space
+    , Str "it"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , SoftBreak
+    , Str "indented."
+    ]
+  , Header 1
+    ( "escaped-characters", [], [] )
+    [ Str "Escaped", Space, Str "characters" ]
+  , Para
+    [ Str "$"
+    , Space
+    , Str "%"
+    , Space
+    , Str "&"
+    , Space
+    , Str "#"
+    , Space
+    , Str "_"
+    , Space
+    , Str "{"
+    , Space
+    , Str "}"
+    ]
+  ]

--- a/test/lhs-test-markdown.native
+++ b/test/lhs-test-markdown.native
@@ -1,8 +1,130 @@
-[Header 1 ("lhs-test",[],[]) [Str "lhs",Space,Str "test"]
-,Para [Code ("",[],[]) "unsplit",Space,Str "is",Space,Str "an",Space,Str "arrow",Space,Str "that",Space,Str "takes",Space,Str "a",Space,Str "pair",Space,Str "of",Space,Str "values",Space,Str "and",Space,Str "combines",Space,Str "them",Space,Str "to",SoftBreak,Str "return",Space,Str "a",Space,Str "single",Space,Str "value:"]
-,CodeBlock ("",["haskell","literate"],[]) "unsplit :: (Arrow a) => (b -> c -> d) -> a (b, c) d\nunsplit = arr . uncurry\n          -- arr (\\op (x,y) -> x `op` y)"
-,Para [Code ("",[],[]) "(***)",Space,Str "combines",Space,Str "two",Space,Str "arrows",Space,Str "into",Space,Str "a",Space,Str "new",Space,Str "arrow",Space,Str "by",Space,Str "running",Space,Str "the",Space,Str "two",Space,Str "arrows",Space,Str "on",Space,Str "a",SoftBreak,Str "pair",Space,Str "of",Space,Str "values",Space,Str "(one",Space,Str "arrow",Space,Str "on",Space,Str "the",Space,Str "first",Space,Str "item",Space,Str "of",Space,Str "the",Space,Str "pair",Space,Str "and",Space,Str "one",Space,Str "arrow",Space,Str "on",Space,Str "the",SoftBreak,Str "second",Space,Str "item",Space,Str "of",Space,Str "the",Space,Str "pair)."]
-,CodeBlock ("",[],[]) "f *** g = first f >>> second g"
-,Para [Str "Block",Space,Str "quote:"]
-,BlockQuote
- [Para [Str "foo",Space,Str "bar"]]]
+[ Header 1
+  ( "lhs-test", [], [] )
+  [ Str "lhs", Space, Str "test" ]
+, Para
+  [ Code
+    ( "", [], [] ) "unsplit"
+  , Space
+  , Str "is"
+  , Space
+  , Str "an"
+  , Space
+  , Str "arrow"
+  , Space
+  , Str "that"
+  , Space
+  , Str "takes"
+  , Space
+  , Str "a"
+  , Space
+  , Str "pair"
+  , Space
+  , Str "of"
+  , Space
+  , Str "values"
+  , Space
+  , Str "and"
+  , Space
+  , Str "combines"
+  , Space
+  , Str "them"
+  , Space
+  , Str "to"
+  , SoftBreak
+  , Str "return"
+  , Space
+  , Str "a"
+  , Space
+  , Str "single"
+  , Space
+  , Str "value:"
+  ]
+, CodeBlock
+  ( ""
+  ,
+    [ "haskell", "literate" ]
+  , []
+  ) "unsplit :: (Arrow a) => (b -> c -> d) -> a (b, c) d\nunsplit = arr . uncurry\n          -- arr (\\op (x,y) -> x `op` y)"
+, Para
+  [ Code
+    ( "", [], [] ) "(***)"
+  , Space
+  , Str "combines"
+  , Space
+  , Str "two"
+  , Space
+  , Str "arrows"
+  , Space
+  , Str "into"
+  , Space
+  , Str "a"
+  , Space
+  , Str "new"
+  , Space
+  , Str "arrow"
+  , Space
+  , Str "by"
+  , Space
+  , Str "running"
+  , Space
+  , Str "the"
+  , Space
+  , Str "two"
+  , Space
+  , Str "arrows"
+  , Space
+  , Str "on"
+  , Space
+  , Str "a"
+  , SoftBreak
+  , Str "pair"
+  , Space
+  , Str "of"
+  , Space
+  , Str "values"
+  , Space
+  , Str "(one"
+  , Space
+  , Str "arrow"
+  , Space
+  , Str "on"
+  , Space
+  , Str "the"
+  , Space
+  , Str "first"
+  , Space
+  , Str "item"
+  , Space
+  , Str "of"
+  , Space
+  , Str "the"
+  , Space
+  , Str "pair"
+  , Space
+  , Str "and"
+  , Space
+  , Str "one"
+  , Space
+  , Str "arrow"
+  , Space
+  , Str "on"
+  , Space
+  , Str "the"
+  , SoftBreak
+  , Str "second"
+  , Space
+  , Str "item"
+  , Space
+  , Str "of"
+  , Space
+  , Str "the"
+  , Space
+  , Str "pair)."
+  ]
+, CodeBlock
+  ( "", [], [] ) "f *** g = first f >>> second g"
+, Para
+  [ Str "Block", Space, Str "quote:" ]
+, BlockQuote
+  [ Para [ Str "foo", Space, Str "bar" ] ]
+]

--- a/test/lhs-test.native
+++ b/test/lhs-test.native
@@ -1,8 +1,130 @@
-[Header 1 ("lhs-test",[],[]) [Str "lhs",Space,Str "test"]
-,Para [Code ("",[],[]) "unsplit",Space,Str "is",Space,Str "an",Space,Str "arrow",Space,Str "that",Space,Str "takes",Space,Str "a",Space,Str "pair",Space,Str "of",Space,Str "values",Space,Str "and",Space,Str "combines",Space,Str "them",Space,Str "to",SoftBreak,Str "return",Space,Str "a",Space,Str "single",Space,Str "value:"]
-,CodeBlock ("",["haskell","literate"],[]) "unsplit :: (Arrow a) => (b -> c -> d) -> a (b, c) d\nunsplit = arr . uncurry\n          -- arr (\\op (x,y) -> x `op` y)"
-,Para [Code ("",[],[]) "(***)",Space,Str "combines",Space,Str "two",Space,Str "arrows",Space,Str "into",Space,Str "a",Space,Str "new",Space,Str "arrow",Space,Str "by",Space,Str "running",Space,Str "the",Space,Str "two",Space,Str "arrows",Space,Str "on",Space,Str "a",SoftBreak,Str "pair",Space,Str "of",Space,Str "values",Space,Str "(one",Space,Str "arrow",Space,Str "on",Space,Str "the",Space,Str "first",Space,Str "item",Space,Str "of",Space,Str "the",Space,Str "pair",Space,Str "and",Space,Str "one",Space,Str "arrow",Space,Str "on",Space,Str "the",SoftBreak,Str "second",Space,Str "item",Space,Str "of",Space,Str "the",Space,Str "pair)."]
-,CodeBlock ("",[],[]) "f *** g = first f >>> second g"
-,Para [Str "Block",Space,Str "quote:"]
-,BlockQuote
- [Para [Str "foo",Space,Str "bar"]]]
+[ Header 1
+  ( "lhs-test", [], [] )
+  [ Str "lhs", Space, Str "test" ]
+, Para
+  [ Code
+    ( "", [], [] ) "unsplit"
+  , Space
+  , Str "is"
+  , Space
+  , Str "an"
+  , Space
+  , Str "arrow"
+  , Space
+  , Str "that"
+  , Space
+  , Str "takes"
+  , Space
+  , Str "a"
+  , Space
+  , Str "pair"
+  , Space
+  , Str "of"
+  , Space
+  , Str "values"
+  , Space
+  , Str "and"
+  , Space
+  , Str "combines"
+  , Space
+  , Str "them"
+  , Space
+  , Str "to"
+  , SoftBreak
+  , Str "return"
+  , Space
+  , Str "a"
+  , Space
+  , Str "single"
+  , Space
+  , Str "value:"
+  ]
+, CodeBlock
+  ( ""
+  ,
+    [ "haskell", "literate" ]
+  , []
+  ) "unsplit :: (Arrow a) => (b -> c -> d) -> a (b, c) d\nunsplit = arr . uncurry\n          -- arr (\\op (x,y) -> x `op` y)"
+, Para
+  [ Code
+    ( "", [], [] ) "(***)"
+  , Space
+  , Str "combines"
+  , Space
+  , Str "two"
+  , Space
+  , Str "arrows"
+  , Space
+  , Str "into"
+  , Space
+  , Str "a"
+  , Space
+  , Str "new"
+  , Space
+  , Str "arrow"
+  , Space
+  , Str "by"
+  , Space
+  , Str "running"
+  , Space
+  , Str "the"
+  , Space
+  , Str "two"
+  , Space
+  , Str "arrows"
+  , Space
+  , Str "on"
+  , Space
+  , Str "a"
+  , SoftBreak
+  , Str "pair"
+  , Space
+  , Str "of"
+  , Space
+  , Str "values"
+  , Space
+  , Str "(one"
+  , Space
+  , Str "arrow"
+  , Space
+  , Str "on"
+  , Space
+  , Str "the"
+  , Space
+  , Str "first"
+  , Space
+  , Str "item"
+  , Space
+  , Str "of"
+  , Space
+  , Str "the"
+  , Space
+  , Str "pair"
+  , Space
+  , Str "and"
+  , Space
+  , Str "one"
+  , Space
+  , Str "arrow"
+  , Space
+  , Str "on"
+  , Space
+  , Str "the"
+  , SoftBreak
+  , Str "second"
+  , Space
+  , Str "item"
+  , Space
+  , Str "of"
+  , Space
+  , Str "the"
+  , Space
+  , Str "pair)."
+  ]
+, CodeBlock
+  ( "", [], [] ) "f *** g = first f >>> second g"
+, Para
+  [ Str "Block", Space, Str "quote:" ]
+, BlockQuote
+  [ Para [ Str "foo", Space, Str "bar" ] ]
+]

--- a/test/man-reader.native
+++ b/test/man-reader.native
@@ -1,300 +1,986 @@
-Pandoc (Meta {unMeta = fromList [("date",MetaInlines [Str "Oct",Space,Str "17,",Space,Str "2018"]),("section",MetaInlines []),("title",MetaInlines [Str "Pandoc",Space,Str "Man",Space,Str "tests"])]})
-[Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc."]
-,Para [Str "*",Space,Str "*",Space,Str "*",Space,Str "*",Space,Str "*"]
-,Header 1 ("",[],[]) [Str "Headers"]
-,Header 1 ("",[],[]) [Str "Level",Space,Str "1"]
-,Header 2 ("",[],[]) [Str "Level",Space,Str "2"]
-,Para [Str "*",Space,Str "*",Space,Str "*",Space,Str "*",Space,Str "*"]
-,Header 1 ("",[],[]) [Str "Paragraphs"]
-,Para [Str "Here's",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "Another",Space,Str "paragraph",Space,Str "In",Space,Str "Markdown",Space,Str "1.0.0",Space,Str "and",Space,Str "earlier.",Space,Str "Version",Space,Str "8.",Space,Str "This",Space,Str "line",Space,Str "turns",Space,Str "into",Space,Str "a",Space,Str "list",Space,Str "item.",Space,Str "Because",Space,Str "a",Space,Str "hard-wrapped",Space,Str "line",Space,Str "in",Space,Str "the",Space,Str "middle",Space,Str "of",Space,Str "a",Space,Str "paragraph",Space,Str "looked",Space,Str "like",Space,Str "a",Space,Str "list",Space,Str "item."]
-,Para [Str "There",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "hard",Space,Str "line",Space,Str "break"]
-,Para [Str "here."]
-,Para [Str "*",Space,Str "*",Space,Str "*",Space,Str "*",Space,Str "*"]
-,Header 1 ("",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
-,BlockQuote
- [CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"]
-,Para [Str "A",Space,Str "list:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "item",Space,Str "one"]]
- ,[Para [Str "item",Space,Str "two"]]]
-,Header 1 ("",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "\tthis code line is indented by one tab"
-,Para [Str "*",Space,Str "*",Space,Str "*",Space,Str "*",Space,Str "*"]
-,Header 1 ("",[],[]) [Str "Lists"]
-,Header 2 ("",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Header 2 ("",[],[]) [Str "Ordered"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Header 2 ("",[],[]) [Str "Nested"]
-,BulletList
- [[Para [Str "Tab"]
-  ,BulletList
-   [[Para [Str "Tab"]
-    ,BulletList
-     [[Para [Str "Tab"]]]]]]]
-,Para [Str "Here's",Space,Str "another:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Para [Str "Same",Space,Str "thing:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Para [Str "Fee"]]
-   ,[Para [Str "Fie"]]
-   ,[Para [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Header 2 ("",[],[]) [Str "different",Space,Str "styles:"]
-,OrderedList (1,UpperAlpha,Period)
- [[Para [Str "Upper",Space,Str "Alpha"]
-  ,OrderedList (1,UpperRoman,Period)
-   [[Para [Str "Upper",Space,Str "Roman."]
-    ,OrderedList (6,Decimal,TwoParens)
-     [[Para [Str "Decimal",Space,Str "start",Space,Str "with",Space,Str "6"]
-      ,OrderedList (3,LowerAlpha,OneParen)
-       [[Para [Str "Lower",Space,Str "alpha",Space,Str "with",Space,Str "paren"]]]]]]]]]
-,Header 2 ("",[],[]) [Str "Ordered"]
-,Para [Str "Definition",Space,Str "lists"]
-,DefinitionList
- [([Strong [Str "term1"]],
-   [[Para [Str "definition",Space,Str "1"]
-    ,Para [Str "continued"]]])
- ,([Strong [Str "term2"]],
-   [[Para [Str "definition",Space,Str "2",Space,Str "*",Space,Str "*",Space,Str "*",Space,Str "*",Space,Str "*"]]])]
-,Header 1 ("",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "`"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,Header 1 ("",[],[]) [Str "Links"]
-,Para [Link ("",[],[]) [Str "some",Space,Str "randomsite"] ("http://example.com",""),Str "."]
-,Para [Link ("",[],[]) [Str "my",Space,Str "email",Space,Str "address"] ("mailto:me@example.com",""),Str "."]
-,Header 1 ("",[],[]) [Str "Macros"]
-,Para [Strong [Str "Me",Space,Str "Myself"],Space,Str "and",Space,Str "I.",Space,Emph [Str "The",Space,Str "author",Space,Str "is",Space,Str "John",Space,Str "Jones."],Space,Str "It's",Space,Str "The",Space,Strong [Str "Author"],Str "."]
-,Header 1 ("",[],[]) [Str "Tables"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left",Space,Emph [Str "more"]]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Centered",Space,Str "Header"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left",Space,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right",Space,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default",Space,Str "aligned"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",Space,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",Space,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",Space,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Table",Space,Str "without",Space,Str "column",Space,Str "headers:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidth 0.5)
- ,(AlignLeft,ColWidth 0.5)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "a"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "one"]
-    ,Para [Str "two"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [CodeBlock ("",[],[]) "some\n   code"]]])]
- (TableFoot ("",[],[])
- [])]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "date"
+        , MetaInlines
+          [ Str "Oct", Space, Str "17,", Space, Str "2018" ]
+        )
+      ,
+        ( "section", MetaInlines [] )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Pandoc", Space, Str "Man", Space, Str "tests" ]
+        )
+      ]
+    }
+  )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc."
+    ]
+  , Para
+    [ Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Headers" ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Level", Space, Str "2" ]
+  , Para
+    [ Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here's"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "Another"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "In"
+    , Space
+    , Str "Markdown"
+    , Space
+    , Str "1.0.0"
+    , Space
+    , Str "and"
+    , Space
+    , Str "earlier."
+    , Space
+    , Str "Version"
+    , Space
+    , Str "8."
+    , Space
+    , Str "This"
+    , Space
+    , Str "line"
+    , Space
+    , Str "turns"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    , Space
+    , Str "Because"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard-wrapped"
+    , Space
+    , Str "line"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "middle"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "looked"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    ]
+  , Para
+    [ Str "There"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard"
+    , Space
+    , Str "line"
+    , Space
+    , Str "break"
+    ]
+  , Para
+    [ Str "here." ]
+  , Para
+    [ Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "Code"
+    , Space
+    , Str "in"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote:"
+    ]
+  , BlockQuote
+    [ CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    ]
+  , Para
+    [ Str "A", Space, Str "list:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "item", Space, Str "one" ] ]
+    ,
+      [ Para [ Str "item", Space, Str "two" ] ]
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( "", [], [] ) "\tthis code line is indented by one tab"
+  , Para
+    [ Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    , Space
+    , Str "*"
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Ordered" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "Tab" ]
+      , BulletList
+        [
+          [ Para [ Str "Tab" ], BulletList [ [ Para [ Str "Tab" ] ] ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here's", Space, Str "another:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Same", Space, Str "thing:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Para [ Str "Fee" ] ]
+        ,
+          [ Para [ Str "Fie" ] ]
+        ,
+          [ Para [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "different", Space, Str "styles:" ]
+  , OrderedList
+    ( 1, UpperAlpha, Period )
+    [
+      [ Para
+        [ Str "Upper", Space, Str "Alpha" ]
+      , OrderedList
+        ( 1, UpperRoman, Period )
+        [
+          [ Para
+            [ Str "Upper", Space, Str "Roman." ]
+          , OrderedList
+            ( 6, Decimal, TwoParens )
+            [
+              [ Para
+                [ Str "Decimal"
+                , Space
+                , Str "start"
+                , Space
+                , Str "with"
+                , Space
+                , Str "6"
+                ]
+              , OrderedList
+                ( 3, LowerAlpha, OneParen )
+                [
+                  [ Para
+                    [ Str "Lower"
+                    , Space
+                    , Str "alpha"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "paren"
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Ordered" ]
+  , Para
+    [ Str "Definition", Space, Str "lists" ]
+  , DefinitionList
+    [
+      (
+        [ Strong [ Str "term1" ] ]
+      ,
+        [
+          [ Para
+            [ Str "definition", Space, Str "1" ]
+          , Para
+            [ Str "continued" ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Strong [ Str "term2" ] ]
+      ,
+        [
+          [ Para
+            [ Str "definition"
+            , Space
+            , Str "2"
+            , Space
+            , Str "*"
+            , Space
+            , Str "*"
+            , Space
+            , Str "*"
+            , Space
+            , Str "*"
+            , Space
+            , Str "*"
+            ]
+          ]
+        ]
+      )
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "`" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Links" ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "some", Space, Str "randomsite" ]
+      ( "http://example.com", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "my", Space, Str "email", Space, Str "address" ]
+      ( "mailto:me@example.com", "" )
+    , Str "."
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Macros" ]
+  , Para
+    [ Strong
+      [ Str "Me", Space, Str "Myself" ]
+    , Space
+    , Str "and"
+    , Space
+    , Str "I."
+    , Space
+    , Emph
+      [ Str "The"
+      , Space
+      , Str "author"
+      , Space
+      , Str "is"
+      , Space
+      , Str "John"
+      , Space
+      , Str "Jones."
+      ]
+    , Space
+    , Str "It's"
+    , Space
+    , Str "The"
+    , Space
+    , Strong
+      [ Str "Author" ]
+    , Str "."
+    ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Tables" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignRight, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Right" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Center" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Default" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignRight, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Right" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Center" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left", Space, Emph [ Str "more" ] ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignRight, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Centered", Space, Str "Header" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Left", Space, Str "Aligned" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Right", Space, Str "Aligned" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Default", Space, Str "aligned" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "First" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "row" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Example"
+            , Space
+            , Str "of"
+            , Space
+            , Str "a"
+            , Space
+            , Str "row"
+            , Space
+            , Str "that"
+            , Space
+            , Str "spans"
+            , Space
+            , Str "multiple"
+            , Space
+            , Str "lines."
+            ]
+          ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Second" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "row" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Here\8217s"
+            , Space
+            , Str "another"
+            , Space
+            , Str "one."
+            , Space
+            , Str "Note"
+            , Space
+            , Str "the"
+            , Space
+            , Str "blank"
+            , Space
+            , Str "line"
+            , Space
+            , Str "between"
+            , Space
+            , Str "rows."
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Table"
+    , Space
+    , Str "without"
+    , Space
+    , Str "column"
+    , Space
+    , Str "headers:"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignRight, ColWidthDefault )
+    ,
+      ( AlignLeft, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignRight, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "12" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "123" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [ ( AlignRight, ColWidth 0.5 ), ( AlignLeft, ColWidth 0.5 ) ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "a" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "one" ], Para [ Str "two" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ CodeBlock ( "", [], [] ) "some\n   code" ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  ]

--- a/test/markdown-citations.native
+++ b/test/markdown-citations.native
@@ -1,17 +1,539 @@
-[Header 1 ("pandoc-with-citeproc-hs",[],[]) [Str "Pandoc",Space,Str "with",Space,Str "citeproc-hs"]
-,BulletList
- [[Para [Cite [Citation {citationId = "nonexistent", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 1, citationHash = 0}] [Str "[@nonexistent]"]]]
- ,[Para [Cite [Citation {citationId = "nonexistent", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 2, citationHash = 0}] [Str "@nonexistent"]]]
- ,[Para [Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 3, citationHash = 0}] [Str "@item1"],Space,Str "says",Space,Str "blah."]]
- ,[Para [Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [Str "p.\160\&30"], citationMode = AuthorInText, citationNoteNum = 4, citationHash = 0}] [Str "@item1",Space,Str "[p.",Space,Str "30]"],Space,Str "says",Space,Str "blah."]]
- ,[Para [Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [Str "p.\160\&30,",Space,Str "with",Space,Str "suffix"], citationMode = AuthorInText, citationNoteNum = 5, citationHash = 0}] [Str "@item1",Space,Str "[p.",Space,Str "30,",Space,Str "with",Space,Str "suffix]"],Space,Str "says",Space,Str "blah."]]
- ,[Para [Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 6, citationHash = 0},Citation {citationId = "item2", citationPrefix = [], citationSuffix = [Space,Str "p.\160\&30"], citationMode = SuppressAuthor, citationNoteNum = 6, citationHash = 0},Citation {citationId = "\1087\1091\1085\1082\1090\&3", citationPrefix = [Str "see",Space,Str "also"], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 6, citationHash = 0}] [Str "@item1",Space,Str "[-@item2",Space,Str "p.",Space,Str "30;",Space,Str "see",Space,Str "also",Space,Str "@\1087\1091\1085\1082\1090\&3]"],Space,Str "says",Space,Str "blah."]]
- ,[Para [Str "In",Space,Str "a",Space,Str "note.",Note [Para [Cite [Citation {citationId = "\1087\1091\1085\1082\1090\&3", citationPrefix = [], citationSuffix = [Str "p.\160\&12"], citationMode = AuthorInText, citationNoteNum = 7, citationHash = 0}] [Str "@\1087\1091\1085\1082\1090\&3",Space,Str "[p.",Space,Str "12]"],Space,Str "and",Space,Str "a",Space,Str "citation",Space,Str "without",Space,Str "locators",Space,Cite [Citation {citationId = "\1087\1091\1085\1082\1090\&3", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 7, citationHash = 0}] [Str "[@\1087\1091\1085\1082\1090\&3]"],Str "."]]]]
- ,[Para [Str "A",Space,Str "citation",Space,Str "group",Space,Cite [Citation {citationId = "item1", citationPrefix = [Str "see"], citationSuffix = [Space,Str "chap.\160\&3"], citationMode = NormalCitation, citationNoteNum = 8, citationHash = 0},Citation {citationId = "\1087\1091\1085\1082\1090\&3", citationPrefix = [Str "also"], citationSuffix = [Space,Str "p.\160\&34-35"], citationMode = NormalCitation, citationNoteNum = 8, citationHash = 0}] [Str "[see",Space,Str "@item1",Space,Str "chap.",Space,Str "3;",Space,Str "also",Space,Str "@\1087\1091\1085\1082\1090\&3",Space,Str "p.",Space,Str "34-35]"],Str "."]]
- ,[Para [Str "Another",Space,Str "one",Space,Cite [Citation {citationId = "item1", citationPrefix = [Str "see"], citationSuffix = [Space,Str "p.\160\&34-35"], citationMode = NormalCitation, citationNoteNum = 9, citationHash = 0}] [Str "[see",Space,Str "@item1",Space,Str "p.",Space,Str "34-35]"],Str "."]]
- ,[Para [Str "And",Space,Str "another",Space,Str "one",Space,Str "in",Space,Str "a",Space,Str "note.",Note [Para [Str "Some",Space,Str "citations",Space,Cite [Citation {citationId = "item1", citationPrefix = [Str "see"], citationSuffix = [Space,Str "chap.\160\&3"], citationMode = NormalCitation, citationNoteNum = 10, citationHash = 0},Citation {citationId = "\1087\1091\1085\1082\1090\&3", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 10, citationHash = 0},Citation {citationId = "item2", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 10, citationHash = 0}] [Str "[see",Space,Str "@item1",Space,Str "chap.",Space,Str "3;",Space,Str "@\1087\1091\1085\1082\1090\&3;",Space,Str "@item2]"],Str "."]]]]
- ,[Para [Str "Citation",Space,Str "with",Space,Str "a",Space,Str "suffix",Space,Str "and",Space,Str "locator",Space,Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [Space,Str "pp.\160\&33,",Space,Str "35-37,",Space,Str "and",Space,Str "nowhere",Space,Str "else"], citationMode = NormalCitation, citationNoteNum = 11, citationHash = 0}] [Str "[@item1",Space,Str "pp.",Space,Str "33,",Space,Str "35-37,",Space,Str "and",Space,Str "nowhere",Space,Str "else]"],Str "."]]
- ,[Para [Str "Citation",Space,Str "with",Space,Str "suffix",Space,Str "only",Space,Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [Space,Str "and",Space,Str "nowhere",Space,Str "else"], citationMode = NormalCitation, citationNoteNum = 12, citationHash = 0}] [Str "[@item1",Space,Str "and",Space,Str "nowhere",Space,Str "else]"],Str "."]]
- ,[Para [Str "Now",Space,Str "some",Space,Str "modifiers.",Note [Para [Str "Like",Space,Str "a",Space,Str "citation",Space,Str "without",Space,Str "author:",Space,Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [], citationMode = SuppressAuthor, citationNoteNum = 13, citationHash = 0}] [Str "[-@item1]"],Str ",",Space,Str "and",Space,Str "now",Space,Str "Doe",Space,Str "with",Space,Str "a",Space,Str "locator",Space,Cite [Citation {citationId = "item2", citationPrefix = [], citationSuffix = [Space,Str "p.\160\&44"], citationMode = SuppressAuthor, citationNoteNum = 13, citationHash = 0}] [Str "[-@item2",Space,Str "p.",Space,Str "44]"],Str "."]]]]
- ,[Para [Str "With",Space,Str "some",Space,Str "markup",Space,Cite [Citation {citationId = "item1", citationPrefix = [Emph [Str "see"]], citationSuffix = [Space,Str "p.\160",Strong [Str "32"]], citationMode = NormalCitation, citationNoteNum = 14, citationHash = 0}] [Str "[*see*",Space,Str "@item1",Space,Str "p.",Space,Str "**32**]"],Str "."]]]
-,Header 1 ("references",[],[]) [Str "References"]]
+[ Header 1
+  ( "pandoc-with-citeproc-hs", [], [] )
+  [ Str "Pandoc", Space, Str "with", Space, Str "citeproc-hs" ]
+, BulletList
+  [
+    [ Para
+      [ Cite
+        [ Citation
+          { citationId = "nonexistent"
+          , citationPrefix = []
+          , citationSuffix = []
+          , citationMode = NormalCitation
+          , citationNoteNum = 1
+          , citationHash = 0
+          }
+        ]
+        [ Str "[@nonexistent]" ]
+      ]
+    ]
+  ,
+    [ Para
+      [ Cite
+        [ Citation
+          { citationId = "nonexistent"
+          , citationPrefix = []
+          , citationSuffix = []
+          , citationMode = AuthorInText
+          , citationNoteNum = 2
+          , citationHash = 0
+          }
+        ]
+        [ Str "@nonexistent" ]
+      ]
+    ]
+  ,
+    [ Para
+      [ Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix = []
+          , citationSuffix = []
+          , citationMode = AuthorInText
+          , citationNoteNum = 3
+          , citationHash = 0
+          }
+        ]
+        [ Str "@item1" ]
+      , Space
+      , Str "says"
+      , Space
+      , Str "blah."
+      ]
+    ]
+  ,
+    [ Para
+      [ Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix = []
+          , citationSuffix =
+            [ Str "p.\160\&30" ]
+          , citationMode = AuthorInText
+          , citationNoteNum = 4
+          , citationHash = 0
+          }
+        ]
+        [ Str "@item1", Space, Str "[p.", Space, Str "30]" ]
+      , Space
+      , Str "says"
+      , Space
+      , Str "blah."
+      ]
+    ]
+  ,
+    [ Para
+      [ Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix = []
+          , citationSuffix =
+            [ Str "p.\160\&30,"
+            , Space
+            , Str "with"
+            , Space
+            , Str "suffix"
+            ]
+          , citationMode = AuthorInText
+          , citationNoteNum = 5
+          , citationHash = 0
+          }
+        ]
+        [ Str "@item1"
+        , Space
+        , Str "[p."
+        , Space
+        , Str "30,"
+        , Space
+        , Str "with"
+        , Space
+        , Str "suffix]"
+        ]
+      , Space
+      , Str "says"
+      , Space
+      , Str "blah."
+      ]
+    ]
+  ,
+    [ Para
+      [ Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix = []
+          , citationSuffix = []
+          , citationMode = AuthorInText
+          , citationNoteNum = 6
+          , citationHash = 0
+          }
+        , Citation
+          { citationId = "item2"
+          , citationPrefix = []
+          , citationSuffix =
+            [ Space, Str "p.\160\&30" ]
+          , citationMode = SuppressAuthor
+          , citationNoteNum = 6
+          , citationHash = 0
+          }
+        , Citation
+          { citationId = "\1087\1091\1085\1082\1090\&3"
+          , citationPrefix =
+            [ Str "see", Space, Str "also" ]
+          , citationSuffix = []
+          , citationMode = NormalCitation
+          , citationNoteNum = 6
+          , citationHash = 0
+          }
+        ]
+        [ Str "@item1"
+        , Space
+        , Str "[-@item2"
+        , Space
+        , Str "p."
+        , Space
+        , Str "30;"
+        , Space
+        , Str "see"
+        , Space
+        , Str "also"
+        , Space
+        , Str "@\1087\1091\1085\1082\1090\&3]"
+        ]
+      , Space
+      , Str "says"
+      , Space
+      , Str "blah."
+      ]
+    ]
+  ,
+    [ Para
+      [ Str "In"
+      , Space
+      , Str "a"
+      , Space
+      , Str "note."
+      , Note
+        [ Para
+          [ Cite
+            [ Citation
+              { citationId = "\1087\1091\1085\1082\1090\&3"
+              , citationPrefix = []
+              , citationSuffix =
+                [ Str "p.\160\&12" ]
+              , citationMode = AuthorInText
+              , citationNoteNum = 7
+              , citationHash = 0
+              }
+            ]
+            [ Str "@\1087\1091\1085\1082\1090\&3"
+            , Space
+            , Str "[p."
+            , Space
+            , Str "12]"
+            ]
+          , Space
+          , Str "and"
+          , Space
+          , Str "a"
+          , Space
+          , Str "citation"
+          , Space
+          , Str "without"
+          , Space
+          , Str "locators"
+          , Space
+          , Cite
+            [ Citation
+              { citationId = "\1087\1091\1085\1082\1090\&3"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = NormalCitation
+              , citationNoteNum = 7
+              , citationHash = 0
+              }
+            ]
+            [ Str "[@\1087\1091\1085\1082\1090\&3]" ]
+          , Str "."
+          ]
+        ]
+      ]
+    ]
+  ,
+    [ Para
+      [ Str "A"
+      , Space
+      , Str "citation"
+      , Space
+      , Str "group"
+      , Space
+      , Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix =
+            [ Str "see" ]
+          , citationSuffix =
+            [ Space, Str "chap.\160\&3" ]
+          , citationMode = NormalCitation
+          , citationNoteNum = 8
+          , citationHash = 0
+          }
+        , Citation
+          { citationId = "\1087\1091\1085\1082\1090\&3"
+          , citationPrefix =
+            [ Str "also" ]
+          , citationSuffix =
+            [ Space, Str "p.\160\&34-35" ]
+          , citationMode = NormalCitation
+          , citationNoteNum = 8
+          , citationHash = 0
+          }
+        ]
+        [ Str "[see"
+        , Space
+        , Str "@item1"
+        , Space
+        , Str "chap."
+        , Space
+        , Str "3;"
+        , Space
+        , Str "also"
+        , Space
+        , Str "@\1087\1091\1085\1082\1090\&3"
+        , Space
+        , Str "p."
+        , Space
+        , Str "34-35]"
+        ]
+      , Str "."
+      ]
+    ]
+  ,
+    [ Para
+      [ Str "Another"
+      , Space
+      , Str "one"
+      , Space
+      , Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix =
+            [ Str "see" ]
+          , citationSuffix =
+            [ Space, Str "p.\160\&34-35" ]
+          , citationMode = NormalCitation
+          , citationNoteNum = 9
+          , citationHash = 0
+          }
+        ]
+        [ Str "[see"
+        , Space
+        , Str "@item1"
+        , Space
+        , Str "p."
+        , Space
+        , Str "34-35]"
+        ]
+      , Str "."
+      ]
+    ]
+  ,
+    [ Para
+      [ Str "And"
+      , Space
+      , Str "another"
+      , Space
+      , Str "one"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "note."
+      , Note
+        [ Para
+          [ Str "Some"
+          , Space
+          , Str "citations"
+          , Space
+          , Cite
+            [ Citation
+              { citationId = "item1"
+              , citationPrefix =
+                [ Str "see" ]
+              , citationSuffix =
+                [ Space, Str "chap.\160\&3" ]
+              , citationMode = NormalCitation
+              , citationNoteNum = 10
+              , citationHash = 0
+              }
+            , Citation
+              { citationId = "\1087\1091\1085\1082\1090\&3"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = NormalCitation
+              , citationNoteNum = 10
+              , citationHash = 0
+              }
+            , Citation
+              { citationId = "item2"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = NormalCitation
+              , citationNoteNum = 10
+              , citationHash = 0
+              }
+            ]
+            [ Str "[see"
+            , Space
+            , Str "@item1"
+            , Space
+            , Str "chap."
+            , Space
+            , Str "3;"
+            , Space
+            , Str "@\1087\1091\1085\1082\1090\&3;"
+            , Space
+            , Str "@item2]"
+            ]
+          , Str "."
+          ]
+        ]
+      ]
+    ]
+  ,
+    [ Para
+      [ Str "Citation"
+      , Space
+      , Str "with"
+      , Space
+      , Str "a"
+      , Space
+      , Str "suffix"
+      , Space
+      , Str "and"
+      , Space
+      , Str "locator"
+      , Space
+      , Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix = []
+          , citationSuffix =
+            [ Space
+            , Str "pp.\160\&33,"
+            , Space
+            , Str "35-37,"
+            , Space
+            , Str "and"
+            , Space
+            , Str "nowhere"
+            , Space
+            , Str "else"
+            ]
+          , citationMode = NormalCitation
+          , citationNoteNum = 11
+          , citationHash = 0
+          }
+        ]
+        [ Str "[@item1"
+        , Space
+        , Str "pp."
+        , Space
+        , Str "33,"
+        , Space
+        , Str "35-37,"
+        , Space
+        , Str "and"
+        , Space
+        , Str "nowhere"
+        , Space
+        , Str "else]"
+        ]
+      , Str "."
+      ]
+    ]
+  ,
+    [ Para
+      [ Str "Citation"
+      , Space
+      , Str "with"
+      , Space
+      , Str "suffix"
+      , Space
+      , Str "only"
+      , Space
+      , Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix = []
+          , citationSuffix =
+            [ Space
+            , Str "and"
+            , Space
+            , Str "nowhere"
+            , Space
+            , Str "else"
+            ]
+          , citationMode = NormalCitation
+          , citationNoteNum = 12
+          , citationHash = 0
+          }
+        ]
+        [ Str "[@item1"
+        , Space
+        , Str "and"
+        , Space
+        , Str "nowhere"
+        , Space
+        , Str "else]"
+        ]
+      , Str "."
+      ]
+    ]
+  ,
+    [ Para
+      [ Str "Now"
+      , Space
+      , Str "some"
+      , Space
+      , Str "modifiers."
+      , Note
+        [ Para
+          [ Str "Like"
+          , Space
+          , Str "a"
+          , Space
+          , Str "citation"
+          , Space
+          , Str "without"
+          , Space
+          , Str "author:"
+          , Space
+          , Cite
+            [ Citation
+              { citationId = "item1"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = SuppressAuthor
+              , citationNoteNum = 13
+              , citationHash = 0
+              }
+            ]
+            [ Str "[-@item1]" ]
+          , Str ","
+          , Space
+          , Str "and"
+          , Space
+          , Str "now"
+          , Space
+          , Str "Doe"
+          , Space
+          , Str "with"
+          , Space
+          , Str "a"
+          , Space
+          , Str "locator"
+          , Space
+          , Cite
+            [ Citation
+              { citationId = "item2"
+              , citationPrefix = []
+              , citationSuffix =
+                [ Space, Str "p.\160\&44" ]
+              , citationMode = SuppressAuthor
+              , citationNoteNum = 13
+              , citationHash = 0
+              }
+            ]
+            [ Str "[-@item2", Space, Str "p.", Space, Str "44]" ]
+          , Str "."
+          ]
+        ]
+      ]
+    ]
+  ,
+    [ Para
+      [ Str "With"
+      , Space
+      , Str "some"
+      , Space
+      , Str "markup"
+      , Space
+      , Cite
+        [ Citation
+          { citationId = "item1"
+          , citationPrefix =
+            [ Emph [ Str "see" ] ]
+          , citationSuffix =
+            [ Space, Str "p.\160", Strong [ Str "32" ] ]
+          , citationMode = NormalCitation
+          , citationNoteNum = 14
+          , citationHash = 0
+          }
+        ]
+        [ Str "[*see*"
+        , Space
+        , Str "@item1"
+        , Space
+        , Str "p."
+        , Space
+        , Str "**32**]"
+        ]
+      , Str "."
+      ]
+    ]
+  ]
+, Header 1
+  ( "references", [], [] )
+  [ Str "References" ]
+]

--- a/test/markdown-reader-more.native
+++ b/test/markdown-reader-more.native
@@ -1,311 +1,1227 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "Author",Space,Str "One"],MetaInlines [Str "Author",Space,Str "Two"],MetaInlines [Str "Author",Space,Str "Three"],MetaInlines [Str "Author",Space,Str "Four"]]),("title",MetaInlines [Str "Title",SoftBreak,Str "spanning",Space,Str "multiple",Space,Str "lines"])]})
-[Header 1 ("additional-markdown-reader-tests",[],[]) [Str "Additional",Space,Str "markdown",Space,Str "reader",Space,Str "tests"]
-,Header 2 ("blank-line-before-url-in-link-reference",[],[]) [Str "Blank",Space,Str "line",Space,Str "before",Space,Str "URL",Space,Str "in",Space,Str "link",Space,Str "reference"]
-,Para [Link ("",[],[]) [Str "foo"] ("/url",""),Space,Str "and",Space,Link ("",[],[]) [Str "bar"] ("/url","title")]
-,Header 2 ("raw-context-environments",[],[]) [Str "Raw",Space,Str "ConTeXt",Space,Str "environments"]
-,RawBlock (Format "tex") "\\placeformula \\startformula"
-,Para [Str "L_{1}",Space,Str "=",Space,Str "L_{2}",SoftBreak,RawInline (Format "tex") "\\stopformula"]
-,RawBlock (Format "tex") "\\start[a2]\n\\start[a2]\n\\stop[a2]\n\\stop[a2]"
-,Header 2 ("raw-latex-environments",[],[]) [Str "Raw",Space,Str "LaTeX",Space,Str "environments"]
-,RawBlock (Format "tex") "\\begin{center}\n\\begin{tikzpicture}[baseline={([yshift=+-.5ex]current bounding box.center)}, level distance=24pt]\n\\Tree [.{S} [.NP John\\index{i} ] [.VP [.V likes ] [.NP himself\\index{i,*j} ]]]\n\\end{tikzpicture}\n\\end{center}"
-,Header 2 ("urls-with-spaces-and-punctuation",[],[]) [Str "URLs",Space,Str "with",Space,Str "spaces",Space,Str "and",Space,Str "punctuation"]
-,Para [Link ("",[],[]) [Str "foo"] ("/bar%20and%20baz",""),SoftBreak,Link ("",[],[]) [Str "foo"] ("/bar%20and%20baz",""),SoftBreak,Link ("",[],[]) [Str "foo"] ("/bar%20and%20baz",""),SoftBreak,Link ("",[],[]) [Str "foo"] ("bar%20baz","title")]
-,Para [Link ("",[],[]) [Str "baz"] ("/foo%20foo",""),Space,Link ("",[],[]) [Str "bam"] ("/foo%20fee",""),Space,Link ("",[],[]) [Str "bork"] ("/foo/zee%20zob","title")]
-,Para [Link ("",[],[]) [Str "Ward\8217s",Space,Str "method."] ("http://en.wikipedia.org/wiki/Ward's_method","")]
-,Header 2 ("horizontal-rules-with-spaces-at-end",[],[]) [Str "Horizontal",Space,Str "rules",Space,Str "with",Space,Str "spaces",Space,Str "at",Space,Str "end"]
-,HorizontalRule
-,HorizontalRule
-,Header 2 ("raw-html-before-header",[],[]) [Str "Raw",Space,Str "HTML",Space,Str "before",Space,Str "header"]
-,Para [RawInline (Format "html") "<a>",RawInline (Format "html") "</a>"]
-,Header 3 ("my-header",[],[]) [Str "my",Space,Str "header"]
-,Header 2 ("in-math",[],[]) [Str "$",Space,Str "in",Space,Str "math"]
-,Para [Math InlineMath "\\$2 + \\$3"]
-,Para [Math InlineMath "x = \\text{the $n$th root of $y$}"]
-,Para [Str "This",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "math:"]
-,Para [Str "$PATH",Space,Str "90",Space,Str "$PATH"]
-,Header 2 ("commented-out-list-item",[],[]) [Str "Commented-out",Space,Str "list",Space,Str "item"]
-,BulletList
- [[Plain [Str "one",SoftBreak,RawInline (Format "html") "<!--\n- two\n-->"]]
- ,[Plain [Str "three"]]]
-,Header 2 ("indented-code-at-beginning-of-list",[],[]) [Str "Indented",Space,Str "code",Space,Str "at",Space,Str "beginning",Space,Str "of",Space,Str "list"]
-,BulletList
- [[CodeBlock ("",[],[]) "code\ncode"
-  ,OrderedList (1,Decimal,Period)
-   [[CodeBlock ("",[],[]) "code\ncode"]
-   ,[CodeBlock ("",[],[]) "code\ncode"]]
-  ,BulletList
-   [[CodeBlock ("",[],[]) "code\ncode"]
-   ,[Plain [Str "no",Space,Str "code"]]]]]
-,Header 2 ("backslash-newline",[],[]) [Str "Backslash",Space,Str "newline"]
-,Para [Str "hi",LineBreak,Str "there"]
-,Header 2 ("code-spans",[],[]) [Str "Code",Space,Str "spans"]
-,Para [Code ("",[],[]) "hi\\"]
-,Para [Code ("",[],[]) "hi there"]
-,Para [Code ("",[],[]) "hi````there"]
-,Para [Str "`hi"]
-,Para [Str "there`"]
-,Header 2 ("multilingual-urls",[],[]) [Str "Multilingual",Space,Str "URLs"]
-,Para [Link ("",["uri"],[]) [Str "http://\27979.com?\27979=\27979"] ("http://\27979.com?\27979=\27979","")]
-,Para [Link ("",[],[]) [Str "foo"] ("/bar/\27979?x=\27979","title")]
-,Para [Link ("",["email"],[]) [Str "\27979@foo.\27979.baz"] ("mailto:\27979@foo.\27979.baz","")]
-,Header 2 ("numbered-examples",[],[]) [Str "Numbered",Space,Str "examples"]
-,OrderedList (1,Example,TwoParens)
- [[Plain [Str "First",Space,Str "example."]]
- ,[Plain [Str "Second",Space,Str "example."]]]
-,Para [Str "Explanation",Space,Str "of",Space,Str "examples",Space,Str "(2)",Space,Str "and",Space,Str "(3)."]
-,OrderedList (3,Example,TwoParens)
- [[Plain [Str "Third",Space,Str "example."]]]
-,Header 2 ("macros",[],[]) [Str "Macros"]
-,RawBlock (Format "tex") "\\newcommand{\\tuple}[1]{\\langle #1 \\rangle}"
-,Para [Math InlineMath "\\langle x,y \\rangle"]
-,Header 2 ("case-insensitive-references",[],[]) [Str "Case-insensitive",Space,Str "references"]
-,Para [Link ("",[],[]) [Str "Fum"] ("/fum","")]
-,Para [Link ("",[],[]) [Str "FUM"] ("/fum","")]
-,Para [Link ("",[],[]) [Str "bat"] ("/bat","")]
-,Header 2 ("curly-smart-quotes",[],[]) [Str "Curly",Space,Str "smart",Space,Str "quotes"]
-,Para [Quoted DoubleQuote [Str "Hi"]]
-,Para [Quoted SingleQuote [Str "Hi"]]
-,Header 2 ("consecutive-lists",[],[]) [Str "Consecutive",Space,Str "lists"]
-,BulletList
- [[Plain [Str "one"]]
- ,[Plain [Str "two"]]]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "one"]]
- ,[Plain [Str "two"]]]
-,OrderedList (1,LowerAlpha,Period)
- [[Plain [Str "one"]]
- ,[Plain [Str "two"]]]
-,Header 2 ("implicit-header-references",[],[]) [Str "Implicit",Space,Str "header",Space,Str "references"]
-,Header 3 ("my-header-1",[],[]) [Str "My",Space,Str "header"]
-,Header 3 ("my-other-header",[],[]) [Str "My",Space,Str "other",Space,Str "header"]
-,Para [Str "A",Space,Str "link",Space,Str "to",Space,Link ("",[],[]) [Str "My",Space,Str "header"] ("#my-header-1",""),Str "."]
-,Para [Str "Another",Space,Str "link",Space,Str "to",Space,Link ("",[],[]) [Str "it"] ("#my-header-1",""),Str "."]
-,Para [Str "Should",Space,Str "be",Space,Link ("",[],[]) [Str "case",Space,Str "insensitive"] ("#my-header-1",""),Str "."]
-,Para [Str "Link",Space,Str "to",Space,Link ("",[],[]) [Str "Explicit",Space,Str "header",Space,Str "attributes"] ("#foobar",""),Str "."]
-,Para [Str "But",Space,Str "this",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "link",Space,Str "to",Space,Link ("",[],[]) [Str "My",Space,Str "other",Space,Str "header"] ("/foo",""),Str ",",Space,Str "since",Space,Str "the",Space,Str "reference",Space,Str "is",Space,Str "defined."]
-,Header 2 ("foobar",["baz"],[("key","val")]) [Str "Explicit",Space,Str "header",Space,Str "attributes"]
-,BlockQuote
- [Header 2 ("foobar",["baz"],[("key","val")]) [Str "Header",Space,Str "attributes",Space,Str "inside",Space,Str "block",Space,Str "quote"]]
-,Header 2 ("line-blocks",[],[]) [Str "Line",Space,Str "blocks"]
-,LineBlock
- [[Str "But",Space,Str "can",Space,Str "a",Space,Str "bee",Space,Str "be",Space,Str "said",Space,Str "to",Space,Str "be"]
- ,[Str "\160\160\160\160or",Space,Str "not",Space,Str "to",Space,Str "be",Space,Str "an",Space,Str "entire",Space,Str "bee,"]
- ,[Str "\160\160\160\160\160\160\160\160when",Space,Str "half",Space,Str "the",Space,Str "bee",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "bee,"]
- ,[Str "\160\160\160\160\160\160\160\160\160\160\160\160due",Space,Str "to",Space,Str "some",Space,Str "ancient",Space,Str "injury?"]
- ,[]
- ,[Str "Continuation",Space,Str "line"]
- ,[Str "\160\160and",Space,Str "another"]]
-,Header 2 ("grid-tables",[],[]) [Str "Grid",Space,Str "Tables"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.2638888888888889)
- ,(AlignDefault,ColWidth 0.16666666666666666)
- ,(AlignDefault,ColWidth 0.18055555555555555)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a",SoftBreak,Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b",SoftBreak,Str "b",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Headless"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.2638888888888889)
- ,(AlignDefault,ColWidth 0.16666666666666666)
- ,(AlignDefault,ColWidth 0.18055555555555555)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a",SoftBreak,Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b",SoftBreak,Str "b",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "With",Space,Str "alignments"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidth 0.2638888888888889)
- ,(AlignLeft,ColWidth 0.16666666666666666)
- ,(AlignCenter,ColWidth 0.18055555555555555)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a",SoftBreak,Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b",SoftBreak,Str "b",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Headless",Space,Str "with",Space,Str "alignments"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidth 0.2638888888888889)
- ,(AlignLeft,ColWidth 0.16666666666666666)
- ,(AlignCenter,ColWidth 0.18055555555555555)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a",SoftBreak,Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b",SoftBreak,Str "b",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Spaces",Space,Str "at",Space,Str "ends",Space,Str "of",Space,Str "lines"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.2638888888888889)
- ,(AlignDefault,ColWidth 0.16666666666666666)
- ,(AlignDefault,ColWidth 0.18055555555555555)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a",SoftBreak,Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b",SoftBreak,Str "b",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiple",Space,Str "blocks",Space,Str "in",Space,Str "a",Space,Str "cell"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.2638888888888889)
- ,(AlignDefault,ColWidth 0.16666666666666666)
- ,(AlignDefault,ColWidth 0.18055555555555555)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Header 1 ("col-1",[],[]) [Str "col",Space,Str "1"]
-    ,Plain [Str "col",Space,Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Header 1 ("col-2",[],[]) [Str "col",Space,Str "2"]
-    ,Plain [Str "col",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Header 1 ("col-3",[],[]) [Str "col",Space,Str "3"]
-    ,Plain [Str "col",Space,Str "3"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "r1",Space,Str "a"]
-    ,Para [Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [BulletList
-     [[Plain [Str "b"]]
-     ,[Plain [Str "b",Space,Str "2"]]
-     ,[Plain [Str "b",Space,Str "2"]]]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2",SoftBreak,Str "c",Space,Str "2"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Empty",Space,Str "cells"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 5.555555555555555e-2)
- ,(AlignDefault,ColWidth 5.555555555555555e-2)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]])]
- (TableFoot ("",[],[])
- [])
-,Header 2 ("entities-in-links-and-titles",[],[]) [Str "Entities",Space,Str "in",Space,Str "links",Space,Str "and",Space,Str "titles"]
-,Para [Link ("",[],[]) [Str "link"] ("/\252rl","\246\246!")]
-,Para [Link ("",["uri"],[]) [Str "http://g\246\246gle.com"] ("http://g\246\246gle.com","")]
-,Para [Link ("",["email"],[]) [Str "me@ex\228mple.com"] ("mailto:me@ex\228mple.com","")]
-,Para [Link ("",[],[]) [Str "foobar"] ("/\252rl","\246\246!")]
-,Header 2 ("parentheses-in-urls",[],[]) [Str "Parentheses",Space,Str "in",Space,Str "URLs"]
-,Para [Link ("",[],[]) [Str "link"] ("/hi(there)","")]
-,Para [Link ("",[],[]) [Str "link"] ("/hithere)","")]
-,Para [Link ("",[],[]) [Str "linky"] ("hi_(there_(nested))","")]
-,Header 2 ("backslashes-in-link-references",[],[]) [Str "Backslashes",Space,Str "in",Space,Str "link",Space,Str "references"]
-,Para [Link ("",[],[]) [Str "*",RawInline (Format "tex") "\\a"] ("b","")]
-,Header 2 ("reference-link-fallbacks",[],[]) [Str "Reference",Space,Str "link",Space,Str "fallbacks"]
-,Para [Str "[",Emph [Str "not",Space,Str "a",Space,Str "link"],Str "]",Space,Str "[",Emph [Str "nope"],Str "]\8230"]
-,Header 2 ("reference-link-followed-by-a-citation",[],[]) [Str "Reference",Space,Str "link",Space,Str "followed",Space,Str "by",Space,Str "a",Space,Str "citation"]
-,Para [Str "MapReduce",Space,Str "is",Space,Str "a",Space,Str "paradigm",Space,Str "popularized",Space,Str "by",Space,Link ("",[],[]) [Str "Google"] ("http://google.com",""),Space,Cite [Citation {citationId = "mapreduce", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 2, citationHash = 0}] [Str "[@mapreduce]"],Space,Str "as",Space,Str "its",SoftBreak,Str "most",Space,Str "vocal",Space,Str "proponent."]
-,Header 2 ("empty-reference-links",[],[]) [Str "Empty",Space,Str "reference",Space,Str "links"]
-,Para [Str "bar"]
-,Para [Link ("",[],[]) [Str "foo2"] ("","")]
-,Header 2 ("wrapping-shouldnt-introduce-new-list-items",[],[]) [Str "Wrapping",Space,Str "shouldn\8217t",Space,Str "introduce",Space,Str "new",Space,Str "list",Space,Str "items"]
-,BulletList
- [[Plain [Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "blah",Space,Str "2015."]]]
-,Header 2 ("bracketed-spans",[],[]) [Str "Bracketed",Space,Str "spans"]
-,Para [Span ("id",["class"],[("key","val")]) [Emph [Str "foo"],Space,Str "bar",Space,Str "baz",Space,Link ("",[],[]) [Str "link"] ("url","")]]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaList
+          [ MetaInlines
+            [ Str "Author", Space, Str "One" ]
+          , MetaInlines
+            [ Str "Author", Space, Str "Two" ]
+          , MetaInlines
+            [ Str "Author", Space, Str "Three" ]
+          , MetaInlines
+            [ Str "Author", Space, Str "Four" ]
+          ]
+        )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Title"
+          , SoftBreak
+          , Str "spanning"
+          , Space
+          , Str "multiple"
+          , Space
+          , Str "lines"
+          ]
+        )
+      ]
+    }
+  )
+  [ Header 1
+    ( "additional-markdown-reader-tests", [], [] )
+    [ Str "Additional"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "reader"
+    , Space
+    , Str "tests"
+    ]
+  , Header 2
+    ( "blank-line-before-url-in-link-reference", [], [] )
+    [ Str "Blank"
+    , Space
+    , Str "line"
+    , Space
+    , Str "before"
+    , Space
+    , Str "URL"
+    , Space
+    , Str "in"
+    , Space
+    , Str "link"
+    , Space
+    , Str "reference"
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "foo" ]
+      ( "/url", "" )
+    , Space
+    , Str "and"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url", "title" )
+    ]
+  , Header 2
+    ( "raw-context-environments", [], [] )
+    [ Str "Raw", Space, Str "ConTeXt", Space, Str "environments" ]
+  , RawBlock
+    ( Format "tex" ) "\\placeformula \\startformula"
+  , Para
+    [ Str "L_{1}"
+    , Space
+    , Str "="
+    , Space
+    , Str "L_{2}"
+    , SoftBreak
+    , RawInline
+      ( Format "tex" ) "\\stopformula"
+    ]
+  , RawBlock
+    ( Format "tex" ) "\\start[a2]\n\\start[a2]\n\\stop[a2]\n\\stop[a2]"
+  , Header 2
+    ( "raw-latex-environments", [], [] )
+    [ Str "Raw", Space, Str "LaTeX", Space, Str "environments" ]
+  , RawBlock
+    ( Format "tex" ) "\\begin{center}\n\\begin{tikzpicture}[baseline={([yshift=+-.5ex]current bounding box.center)}, level distance=24pt]\n\\Tree [.{S} [.NP John\\index{i} ] [.VP [.V likes ] [.NP himself\\index{i,*j} ]]]\n\\end{tikzpicture}\n\\end{center}"
+  , Header 2
+    ( "urls-with-spaces-and-punctuation", [], [] )
+    [ Str "URLs"
+    , Space
+    , Str "with"
+    , Space
+    , Str "spaces"
+    , Space
+    , Str "and"
+    , Space
+    , Str "punctuation"
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "foo" ]
+      ( "/bar%20and%20baz", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "foo" ]
+      ( "/bar%20and%20baz", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "foo" ]
+      ( "/bar%20and%20baz", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "foo" ]
+      ( "bar%20baz", "title" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "baz" ]
+      ( "/foo%20foo", "" )
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bam" ]
+      ( "/foo%20fee", "" )
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bork" ]
+      ( "/foo/zee%20zob", "title" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Ward\8217s", Space, Str "method." ]
+      ( "http://en.wikipedia.org/wiki/Ward's_method", "" )
+    ]
+  , Header 2
+    ( "horizontal-rules-with-spaces-at-end", [], [] )
+    [ Str "Horizontal"
+    , Space
+    , Str "rules"
+    , Space
+    , Str "with"
+    , Space
+    , Str "spaces"
+    , Space
+    , Str "at"
+    , Space
+    , Str "end"
+    ]
+  , HorizontalRule
+  , HorizontalRule
+  , Header 2
+    ( "raw-html-before-header", [], [] )
+    [ Str "Raw"
+    , Space
+    , Str "HTML"
+    , Space
+    , Str "before"
+    , Space
+    , Str "header"
+    ]
+  , Para
+    [ RawInline
+      ( Format "html" ) "<a>"
+    , RawInline
+      ( Format "html" ) "</a>"
+    ]
+  , Header 3
+    ( "my-header", [], [] )
+    [ Str "my", Space, Str "header" ]
+  , Header 2
+    ( "in-math", [], [] )
+    [ Str "$", Space, Str "in", Space, Str "math" ]
+  , Para
+    [ Math InlineMath "\\$2 + \\$3" ]
+  , Para
+    [ Math InlineMath "x = \\text{the $n$th root of $y$}" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "math:"
+    ]
+  , Para
+    [ Str "$PATH", Space, Str "90", Space, Str "$PATH" ]
+  , Header 2
+    ( "commented-out-list-item", [], [] )
+    [ Str "Commented-out", Space, Str "list", Space, Str "item" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "one"
+        , SoftBreak
+        , RawInline
+          ( Format "html" ) "<!--\n- two\n-->"
+        ]
+      ]
+    ,
+      [ Plain [ Str "three" ] ]
+    ]
+  , Header 2
+    ( "indented-code-at-beginning-of-list", [], [] )
+    [ Str "Indented"
+    , Space
+    , Str "code"
+    , Space
+    , Str "at"
+    , Space
+    , Str "beginning"
+    , Space
+    , Str "of"
+    , Space
+    , Str "list"
+    ]
+  , BulletList
+    [
+      [ CodeBlock
+        ( "", [], [] ) "code\ncode"
+      , OrderedList
+        ( 1, Decimal, Period )
+        [
+          [ CodeBlock ( "", [], [] ) "code\ncode" ]
+        ,
+          [ CodeBlock ( "", [], [] ) "code\ncode" ]
+        ]
+      , BulletList
+        [
+          [ CodeBlock ( "", [], [] ) "code\ncode" ]
+        ,
+          [ Plain [ Str "no", Space, Str "code" ] ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "backslash-newline", [], [] )
+    [ Str "Backslash", Space, Str "newline" ]
+  , Para
+    [ Str "hi", LineBreak, Str "there" ]
+  , Header 2
+    ( "code-spans", [], [] )
+    [ Str "Code", Space, Str "spans" ]
+  , Para
+    [ Code ( "", [], [] ) "hi\\" ]
+  , Para
+    [ Code ( "", [], [] ) "hi there" ]
+  , Para
+    [ Code ( "", [], [] ) "hi````there" ]
+  , Para
+    [ Str "`hi" ]
+  , Para
+    [ Str "there`" ]
+  , Header 2
+    ( "multilingual-urls", [], [] )
+    [ Str "Multilingual", Space, Str "URLs" ]
+  , Para
+    [ Link
+      ( "", [ "uri" ], [] )
+      [ Str "http://\27979.com?\27979=\27979" ]
+      ( "http://\27979.com?\27979=\27979", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "foo" ]
+      ( "/bar/\27979?x=\27979", "title" )
+    ]
+  , Para
+    [ Link
+      ( "", [ "email" ], [] )
+      [ Str "\27979@foo.\27979.baz" ]
+      ( "mailto:\27979@foo.\27979.baz", "" )
+    ]
+  , Header 2
+    ( "numbered-examples", [], [] )
+    [ Str "Numbered", Space, Str "examples" ]
+  , OrderedList
+    ( 1, Example, TwoParens )
+    [
+      [ Plain [ Str "First", Space, Str "example." ] ]
+    ,
+      [ Plain [ Str "Second", Space, Str "example." ] ]
+    ]
+  , Para
+    [ Str "Explanation"
+    , Space
+    , Str "of"
+    , Space
+    , Str "examples"
+    , Space
+    , Str "(2)"
+    , Space
+    , Str "and"
+    , Space
+    , Str "(3)."
+    ]
+  , OrderedList
+    ( 3, Example, TwoParens )
+    [ [ Plain [ Str "Third", Space, Str "example." ] ] ]
+  , Header 2
+    ( "macros", [], [] )
+    [ Str "Macros" ]
+  , RawBlock
+    ( Format "tex" ) "\\newcommand{\\tuple}[1]{\\langle #1 \\rangle}"
+  , Para
+    [ Math InlineMath "\\langle x,y \\rangle" ]
+  , Header 2
+    ( "case-insensitive-references", [], [] )
+    [ Str "Case-insensitive", Space, Str "references" ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Fum" ] ( "/fum", "" ) ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "FUM" ] ( "/fum", "" ) ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "bat" ] ( "/bat", "" ) ]
+  , Header 2
+    ( "curly-smart-quotes", [], [] )
+    [ Str "Curly", Space, Str "smart", Space, Str "quotes" ]
+  , Para
+    [ Quoted DoubleQuote [ Str "Hi" ] ]
+  , Para
+    [ Quoted SingleQuote [ Str "Hi" ] ]
+  , Header 2
+    ( "consecutive-lists", [], [] )
+    [ Str "Consecutive", Space, Str "lists" ]
+  , BulletList
+    [ [ Plain [ Str "one" ] ], [ Plain [ Str "two" ] ] ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [ [ Plain [ Str "one" ] ], [ Plain [ Str "two" ] ] ]
+  , OrderedList
+    ( 1, LowerAlpha, Period )
+    [ [ Plain [ Str "one" ] ], [ Plain [ Str "two" ] ] ]
+  , Header 2
+    ( "implicit-header-references", [], [] )
+    [ Str "Implicit", Space, Str "header", Space, Str "references" ]
+  , Header 3
+    ( "my-header-1", [], [] )
+    [ Str "My", Space, Str "header" ]
+  , Header 3
+    ( "my-other-header", [], [] )
+    [ Str "My", Space, Str "other", Space, Str "header" ]
+  , Para
+    [ Str "A"
+    , Space
+    , Str "link"
+    , Space
+    , Str "to"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "My", Space, Str "header" ]
+      ( "#my-header-1", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Another"
+    , Space
+    , Str "link"
+    , Space
+    , Str "to"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "it" ]
+      ( "#my-header-1", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Should"
+    , Space
+    , Str "be"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "case", Space, Str "insensitive" ]
+      ( "#my-header-1", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Link"
+    , Space
+    , Str "to"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "Explicit", Space, Str "header", Space, Str "attributes" ]
+      ( "#foobar", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "But"
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "to"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "My", Space, Str "other", Space, Str "header" ]
+      ( "/foo", "" )
+    , Str ","
+    , Space
+    , Str "since"
+    , Space
+    , Str "the"
+    , Space
+    , Str "reference"
+    , Space
+    , Str "is"
+    , Space
+    , Str "defined."
+    ]
+  , Header 2
+    ( "foobar", [ "baz" ], [ ( "key", "val" ) ] )
+    [ Str "Explicit", Space, Str "header", Space, Str "attributes" ]
+  , BlockQuote
+    [ Header 2
+      ( "foobar", [ "baz" ], [ ( "key", "val" ) ] )
+      [ Str "Header"
+      , Space
+      , Str "attributes"
+      , Space
+      , Str "inside"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote"
+      ]
+    ]
+  , Header 2
+    ( "line-blocks", [], [] )
+    [ Str "Line", Space, Str "blocks" ]
+  , LineBlock
+    [
+      [ Str "But"
+      , Space
+      , Str "can"
+      , Space
+      , Str "a"
+      , Space
+      , Str "bee"
+      , Space
+      , Str "be"
+      , Space
+      , Str "said"
+      , Space
+      , Str "to"
+      , Space
+      , Str "be"
+      ]
+    ,
+      [ Str "\160\160\160\160or"
+      , Space
+      , Str "not"
+      , Space
+      , Str "to"
+      , Space
+      , Str "be"
+      , Space
+      , Str "an"
+      , Space
+      , Str "entire"
+      , Space
+      , Str "bee,"
+      ]
+    ,
+      [ Str "\160\160\160\160\160\160\160\160when"
+      , Space
+      , Str "half"
+      , Space
+      , Str "the"
+      , Space
+      , Str "bee"
+      , Space
+      , Str "is"
+      , Space
+      , Str "not"
+      , Space
+      , Str "a"
+      , Space
+      , Str "bee,"
+      ]
+    ,
+      [ Str "\160\160\160\160\160\160\160\160\160\160\160\160due"
+      , Space
+      , Str "to"
+      , Space
+      , Str "some"
+      , Space
+      , Str "ancient"
+      , Space
+      , Str "injury?"
+      ]
+    , []
+    ,
+      [ Str "Continuation", Space, Str "line" ]
+    ,
+      [ Str "\160\160and", Space, Str "another" ]
+    ]
+  , Header 2
+    ( "grid-tables", [], [] )
+    [ Str "Grid", Space, Str "Tables" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 0.2638888888888889 )
+    ,
+      ( AlignDefault, ColWidth 0.16666666666666666 )
+    ,
+      ( AlignDefault, ColWidth 0.18055555555555555 )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "3" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "r1"
+            , Space
+            , Str "a"
+            , SoftBreak
+            , Str "r1"
+            , Space
+            , Str "bis"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b", SoftBreak, Str "b", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c", SoftBreak, Str "c", Space, Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Headless" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 0.2638888888888889 )
+    ,
+      ( AlignDefault, ColWidth 0.16666666666666666 )
+    ,
+      ( AlignDefault, ColWidth 0.18055555555555555 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "r1"
+            , Space
+            , Str "a"
+            , SoftBreak
+            , Str "r1"
+            , Space
+            , Str "bis"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b", SoftBreak, Str "b", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c", SoftBreak, Str "c", Space, Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "With", Space, Str "alignments" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignRight, ColWidth 0.2638888888888889 )
+    ,
+      ( AlignLeft, ColWidth 0.16666666666666666 )
+    ,
+      ( AlignCenter, ColWidth 0.18055555555555555 )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "3" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "r1"
+            , Space
+            , Str "a"
+            , SoftBreak
+            , Str "r1"
+            , Space
+            , Str "bis"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b", SoftBreak, Str "b", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c", SoftBreak, Str "c", Space, Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Headless", Space, Str "with", Space, Str "alignments" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignRight, ColWidth 0.2638888888888889 )
+    ,
+      ( AlignLeft, ColWidth 0.16666666666666666 )
+    ,
+      ( AlignCenter, ColWidth 0.18055555555555555 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "r1"
+            , Space
+            , Str "a"
+            , SoftBreak
+            , Str "r1"
+            , Space
+            , Str "bis"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b", SoftBreak, Str "b", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c", SoftBreak, Str "c", Space, Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Spaces"
+    , Space
+    , Str "at"
+    , Space
+    , Str "ends"
+    , Space
+    , Str "of"
+    , Space
+    , Str "lines"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 0.2638888888888889 )
+    ,
+      ( AlignDefault, ColWidth 0.16666666666666666 )
+    ,
+      ( AlignDefault, ColWidth 0.18055555555555555 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "r1"
+            , Space
+            , Str "a"
+            , SoftBreak
+            , Str "r1"
+            , Space
+            , Str "bis"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b", SoftBreak, Str "b", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c", SoftBreak, Str "c", Space, Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Multiple"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "in"
+    , Space
+    , Str "a"
+    , Space
+    , Str "cell"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 0.2638888888888889 )
+    ,
+      ( AlignDefault, ColWidth 0.16666666666666666 )
+    ,
+      ( AlignDefault, ColWidth 0.18055555555555555 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Header 1
+            ( "col-1", [], [] )
+            [ Str "col", Space, Str "1" ]
+          , Plain
+            [ Str "col", Space, Str "1" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Header 1
+            ( "col-2", [], [] )
+            [ Str "col", Space, Str "2" ]
+          , Plain
+            [ Str "col", Space, Str "2" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Header 1
+            ( "col-3", [], [] )
+            [ Str "col", Space, Str "3" ]
+          , Plain
+            [ Str "col", Space, Str "3" ]
+          ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para
+            [ Str "r1", Space, Str "a" ]
+          , Para
+            [ Str "r1", Space, Str "bis" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ BulletList
+            [
+              [ Plain [ Str "b" ] ]
+            ,
+              [ Plain [ Str "b", Space, Str "2" ] ]
+            ,
+              [ Plain [ Str "b", Space, Str "2" ] ]
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "c"
+            , SoftBreak
+            , Str "c"
+            , Space
+            , Str "2"
+            , SoftBreak
+            , Str "c"
+            , Space
+            , Str "2"
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Empty", Space, Str "cells" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 5.555555555555555 e- 2 )
+    ,
+      ( AlignDefault, ColWidth 5.555555555555555 e- 2 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 2
+    ( "entities-in-links-and-titles", [], [] )
+    [ Str "Entities"
+    , Space
+    , Str "in"
+    , Space
+    , Str "links"
+    , Space
+    , Str "and"
+    , Space
+    , Str "titles"
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "link" ] ( "/\252rl", "\246\246!" ) ]
+  , Para
+    [ Link
+      ( "", [ "uri" ], [] )
+      [ Str "http://g\246\246gle.com" ]
+      ( "http://g\246\246gle.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [ "email" ], [] )
+      [ Str "me@ex\228mple.com" ]
+      ( "mailto:me@ex\228mple.com", "" )
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "foobar" ] ( "/\252rl", "\246\246!" ) ]
+  , Header 2
+    ( "parentheses-in-urls", [], [] )
+    [ Str "Parentheses", Space, Str "in", Space, Str "URLs" ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "link" ] ( "/hi(there)", "" ) ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "link" ] ( "/hithere)", "" ) ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "linky" ]
+      ( "hi_(there_(nested))", "" )
+    ]
+  , Header 2
+    ( "backslashes-in-link-references", [], [] )
+    [ Str "Backslashes"
+    , Space
+    , Str "in"
+    , Space
+    , Str "link"
+    , Space
+    , Str "references"
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "*", RawInline ( Format "tex" ) "\\a" ]
+      ( "b", "" )
+    ]
+  , Header 2
+    ( "reference-link-fallbacks", [], [] )
+    [ Str "Reference", Space, Str "link", Space, Str "fallbacks" ]
+  , Para
+    [ Str "["
+    , Emph
+      [ Str "not", Space, Str "a", Space, Str "link" ]
+    , Str "]"
+    , Space
+    , Str "["
+    , Emph
+      [ Str "nope" ]
+    , Str "]\8230"
+    ]
+  , Header 2
+    ( "reference-link-followed-by-a-citation", [], [] )
+    [ Str "Reference"
+    , Space
+    , Str "link"
+    , Space
+    , Str "followed"
+    , Space
+    , Str "by"
+    , Space
+    , Str "a"
+    , Space
+    , Str "citation"
+    ]
+  , Para
+    [ Str "MapReduce"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paradigm"
+    , Space
+    , Str "popularized"
+    , Space
+    , Str "by"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "Google" ]
+      ( "http://google.com", "" )
+    , Space
+    , Cite
+      [ Citation
+        { citationId = "mapreduce"
+        , citationPrefix = []
+        , citationSuffix = []
+        , citationMode = NormalCitation
+        , citationNoteNum = 2
+        , citationHash = 0
+        }
+      ]
+      [ Str "[@mapreduce]" ]
+    , Space
+    , Str "as"
+    , Space
+    , Str "its"
+    , SoftBreak
+    , Str "most"
+    , Space
+    , Str "vocal"
+    , Space
+    , Str "proponent."
+    ]
+  , Header 2
+    ( "empty-reference-links", [], [] )
+    [ Str "Empty", Space, Str "reference", Space, Str "links" ]
+  , Para
+    [ Str "bar" ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "foo2" ] ( "", "" ) ]
+  , Header 2
+    ( "wrapping-shouldnt-introduce-new-list-items", [], [] )
+    [ Str "Wrapping"
+    , Space
+    , Str "shouldn\8217t"
+    , Space
+    , Str "introduce"
+    , Space
+    , Str "new"
+    , Space
+    , Str "list"
+    , Space
+    , Str "items"
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "blah"
+        , Space
+        , Str "2015."
+        ]
+      ]
+    ]
+  , Header 2
+    ( "bracketed-spans", [], [] )
+    [ Str "Bracketed", Space, Str "spans" ]
+  , Para
+    [ Span
+      ( "id", [ "class" ], [ ( "key", "val" ) ] )
+      [ Emph
+        [ Str "foo" ]
+      , Space
+      , Str "bar"
+      , Space
+      , Str "baz"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "link" ]
+        ( "url", "" )
+      ]
+    ]
+  ]

--- a/test/mediawiki-reader.native
+++ b/test/mediawiki-reader.native
@@ -1,418 +1,1444 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("header",[],[]) [Str "header"]
-,Header 2 ("header_level_two",[],[]) [Str "header",Space,Str "level",Space,Str "two"]
-,Header 3 ("header_level_3",[],[]) [Str "header",Space,Str "level",Space,Str "3"]
-,Header 4 ("header_level_four",[],[]) [Str "header",Space,Emph [Str "level"],Space,Str "four"]
-,Header 5 ("header_level_5",[],[]) [Str "header",Space,Str "level",Space,Str "5"]
-,Header 6 ("header_level_6",[],[]) [Str "header",Space,Str "level",Space,Str "6"]
-,Para [Str "=======",Space,Str "not",Space,Str "a",Space,Str "header",Space,Str "========"]
-,Para [Code ("",[],[]) "==\160not\160a\160header\160=="]
-,Header 2 ("emph_and_strong",[],[]) [Str "emph",Space,Str "and",Space,Str "strong"]
-,Para [Emph [Str "emph"],Space,Strong [Str "strong"]]
-,Para [Strong [Emph [Str "strong",Space,Str "and",Space,Str "emph"]]]
-,Para [Strong [Emph [Str "emph",Space,Str "inside"],Space,Str "strong"]]
-,Para [Strong [Str "strong",Space,Str "with",Space,Emph [Str "emph"]]]
-,Para [Emph [Strong [Str "strong",Space,Str "inside"],Space,Str "emph"]]
-,Header 2 ("horizontal_rule",[],[]) [Str "horizontal",Space,Str "rule"]
-,Para [Str "top"]
-,HorizontalRule
-,Para [Str "bottom"]
-,HorizontalRule
-,Header 2 ("nowiki",[],[]) [Str "nowiki"]
-,Para [Str "''not",Space,Str "emph''"]
-,Header 2 ("strikeout",[],[]) [Str "strikeout"]
-,Para [Strikeout [Str "This",Space,Str "is",Space,Emph [Str "struck",Space,Str "out"]]]
-,Header 2 ("entities",[],[]) [Str "entities"]
-,Para [Str "hi",Space,Str "&",Space,Str "low"]
-,Para [Str "hi",Space,Str "&",Space,Str "low"]
-,Para [Str "G\246del"]
-,Para [Str "\777\2730"]
-,Header 2 ("comments",[],[]) [Str "comments"]
-,Para [Str "inline",Space,Str "comment"]
-,Para [Str "between",Space,Str "blocks"]
-,Header 2 ("linebreaks",[],[]) [Str "linebreaks"]
-,Para [Str "hi",LineBreak,Str "there"]
-,Para [Str "hi",LineBreak,Str "there"]
-,Header 2 ("indents",[],[]) [Str ":",Space,Str "indents"]
-,Para [Str "hi"]
-,DefinitionList
- [([],
-   [[Plain [Str "there"]]])]
-,Para [Str "bud"]
-,Para [Str "hi"]
-,DefinitionList
- [([],
-   [[DefinitionList
-     [([],
-       [[Plain [Str "there"]]])]]])]
-,Para [Str "bud"]
-,Header 2 ("p_tags",[],[]) [Str "p",Space,Str "tags"]
-,Para [Str "hi",Space,Str "there"]
-,Para [Str "bud"]
-,Para [Str "another"]
-,Header 2 ("raw_html",[],[]) [Str "raw",Space,Str "html"]
-,Para [Str "hi",Space,RawInline (Format "html") "<span style=\"color:red\">",Emph [Str "there"],RawInline (Format "html") "</span>",Str "."]
-,Para [RawInline (Format "html") "<ins>",Str "inserted",RawInline (Format "html") "</ins>"]
-,RawBlock (Format "html") "<div class=\"special\">"
-,Para [Str "hi",Space,Emph [Str "there"]]
-,RawBlock (Format "html") "</div>"
-,Header 2 ("sup_sub_del",[],[]) [Str "sup,",Space,Str "sub,",Space,Str "del"]
-,Para [Str "H",Subscript [Str "2"],Str "O",Space,Str "base",Superscript [Emph [Str "exponent"]],SoftBreak,Strikeout [Str "hello"]]
-,Header 2 ("inline_code",[],[]) [Str "inline",Space,Str "code"]
-,Para [Code ("",[],[]) "*\8594*",Space,Code ("",[],[]) "typed",Space,Code ("",["haskell"],[]) ">>="]
-,Header 2 ("code_blocks",[],[]) [Str "code",Space,Str "blocks"]
-,CodeBlock ("",[],[]) "case xs of\n     (_:_) -> reverse xs\n     []    -> ['*']"
-,CodeBlock ("",["haskell"],[]) "case xs of\n     (_:_) -> reverse xs\n     []    -> ['*']"
-,CodeBlock ("",["ruby","numberLines"],[("startFrom","100")]) "widgets.each do |w|\n  print w.price\nend"
-,Header 2 ("block_quotes",[],[]) [Str "block",Space,Str "quotes"]
-,Para [Str "Regular",Space,Str "paragraph"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote."]
- ,Para [Str "With",Space,Str "two",Space,Str "paragraphs."]]
-,Para [Str "Nother",Space,Str "paragraph."]
-,Header 2 ("external_links",[],[]) [Str "external",Space,Str "links"]
-,Para [Link ("",[],[]) [Emph [Str "Google"],Space,Str "search",Space,Str "engine"] ("http://google.com","")]
-,Para [Link ("",[],[]) [Str "http://pandoc.org"] ("http://pandoc.org","")]
-,Para [Link ("",[],[]) [Str "1"] ("http://google.com",""),Space,Link ("",[],[]) [Str "2"] ("http://yahoo.com","")]
-,Para [Link ("",[],[]) [Str "email",Space,Str "me"] ("mailto:info@example.org","")]
-,Header 2 ("internal_links",[],[]) [Str "internal",Space,Str "links"]
-,Para [Link ("",[],[]) [Str "Help"] ("Help","wikilink")]
-,Para [Link ("",[],[]) [Str "the",Space,Str "help",Space,Str "page"] ("Help","wikilink")]
-,Para [Link ("",[],[]) [Str "Helpers"] ("Help","wikilink")]
-,Para [Link ("",[],[]) [Str "Help"] ("Help","wikilink"),Str "ers"]
-,Para [Link ("",[],[]) [Str "Contents"] ("Help:Contents","wikilink")]
-,Para [Link ("",[],[]) [Str "#My",Space,Str "anchor"] ("#My_anchor","wikilink")]
-,Para [Link ("",[],[]) [Str "and",Space,Str "text"] ("Page#with_anchor","wikilink")]
-,Header 2 ("images",[],[]) [Str "images"]
-,Para [Image ("",[],[]) [Str "caption"] ("example.jpg","fig:caption")]
-,Para [Image ("",[],[]) [Str "the",Space,Emph [Str "caption"],Space,Str "with",Space,Link ("",[],[]) [Str "external",Space,Str "link"] ("http://google.com","")] ("example.jpg","fig:the caption with external link")]
-,Para [Image ("",[],[("width","30"),("height","40")]) [Str "caption"] ("example.jpg","fig:caption")]
-,Para [Image ("",[],[("width","30")]) [Str "caption"] ("example.jpg","fig:caption")]
-,Para [Image ("",[],[("width","30")]) [Str "caption"] ("example.jpg","fig:caption")]
-,Para [Image ("",[],[]) [Str "example.jpg"] ("example.jpg","fig:example.jpg")]
-,Para [Image ("",[],[]) [Str "example_es.jpg"] ("example_es.jpg","fig:example_es.jpg")]
-,Header 2 ("lists",[],[]) [Str "lists"]
-,BulletList
- [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]
- ,[Plain [Str "with",Space,Str "an",Space,Str "asterisk",Space,Str "(*)."]
-  ,BulletList
-   [[Plain [Str "More",Space,Str "asterisks",Space,Str "gives",Space,Str "deeper"]
-    ,BulletList
-     [[Plain [Str "and",Space,Str "deeper",Space,Str "levels."]]]]]]
- ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels."]
-  ,BulletList
-   [[BulletList
-     [[Plain [Str "But",Space,Str "jumping",Space,Str "levels",Space,Str "creates",Space,Str "empty",Space,Str "space."]]]]]]]
-,Para [Str "Any",Space,Str "other",Space,Str "start",Space,Str "ends",Space,Str "the",Space,Str "list."]
-,BulletList
- [[BulletList
-   [[Plain [Str "two"]]]]
- ,[Plain [Str "one"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]
- ,[Plain [Str "with",Space,Str "a",Space,Str "number",Space,Str "sign",Space,Str "(#)."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "More",Space,Str "number",Space,Str "signs",Space,Str "gives",Space,Str "deeper"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "and",Space,Str "deeper"]]
-     ,[Plain [Str "levels."]]]]]]
- ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "But",Space,Str "jumping",Space,Str "levels",Space,Str "creates",Space,Str "empty",Space,Str "space."]]]]]]
- ,[Plain [Str "Blank",Space,Str "lines"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "end",Space,Str "the",Space,Str "list",Space,Str "and",Space,Str "start",Space,Str "another."]]]
-,Para [Str "Any",Space,Str "other",Space,Str "start",Space,Str "also",SoftBreak,Str "ends",Space,Str "the",Space,Str "list."]
-,DefinitionList
- [([Str "item",Space,Str "1"],
-   [[Plain [Str "definition",Space,Str "1"]]])
- ,([Str "item",Space,Str "2"],
-   [[Plain [Str "definition",Space,Str "2-1"]]
-   ,[Plain [Str "definition",Space,Str "2-2"]]])]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "one"]]
- ,[Plain [Str "two"]
-  ,BulletList
-   [[Plain [Str "two",Space,Str "point",Space,Str "one"]]
-   ,[Plain [Str "two",Space,Str "point",Space,Str "two"]]]]
- ,[Plain [Str "three"]
-  ,DefinitionList
-   [([Str "three",Space,Str "item",Space,Str "one"],
-     [[Plain [Str "three",Space,Str "def",Space,Str "one"]]])]]
- ,[Plain [Str "four"]
-  ,DefinitionList
-   [([],
-     [[Plain [Str "four",Space,Str "def",Space,Str "one"]]
-     ,[Plain [Str "this",Space,Str "looks",Space,Str "like",Space,Str "a",Space,Str "continuation"]]
-     ,[Plain [Str "and",Space,Str "is",Space,Str "often",Space,Str "used"]]
-     ,[Plain [Str "instead",LineBreak,Str "of",Space,Str "<br/>"]]])]]
- ,[Plain [RawInline (Format "mediawiki") "{{{template\n|author=John\n|title=My Book\n}}}"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "five",Space,Str "sub",Space,Str "1"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "five",Space,Str "sub",Space,Str "1",Space,Str "sub",Space,Str "1"]]]]
-   ,[Plain [Str "five",Space,Str "sub",Space,Str "2"]]]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "list",Space,Str "item",Space,Emph [Str "emph"]]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "list",Space,Str "item",Space,Str "B1"]]
-   ,[Plain [Str "list",Space,Str "item",Space,Str "B2"]]]
-  ,Para [Str "continuing",Space,Str "list",Space,Str "item",Space,Str "A1"]]
- ,[Plain [Str "list",Space,Str "item",Space,Str "A2"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "abc"]]
- ,[Plain [Str "def"]]
- ,[Plain [Str "ghi"]]]
-,OrderedList (9,DefaultStyle,DefaultDelim)
- [[Plain [Str "Amsterdam"]]
- ,[Plain [Str "Rotterdam"]]
- ,[Plain [Str "The",Space,Str "Hague"]]]
-,Header 2 ("math",[],[]) [Str "math"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Math InlineMath "x=\\frac{y^\\pi}{z}",Str "."]
-,Para [Str "With",Space,Str "spaces:",Space,Math InlineMath "x=\\frac{y^\\pi}{z}",Str "."]
-,Header 2 ("preformatted_blocks",[],[]) [Str "preformatted",Space,Str "blocks"]
-,Para [Code ("",[],[]) "Start\160each\160line\160with\160a\160space.",LineBreak,Code ("",[],[]) "Text\160is\160",Strong [Code ("",[],[]) "preformatted"],Code ("",[],[]) "\160and",LineBreak,Emph [Code ("",[],[]) "markups"],Code ("",[],[]) "\160",Strong [Emph [Code ("",[],[]) "can"]],Code ("",[],[]) "\160be\160done."]
-,Para [Code ("",[],[]) "\160hell\160\160\160\160\160\160yeah"]
-,Para [Code ("",[],[]) "Start\160with\160a\160space\160in\160the\160first\160column,",LineBreak,Code ("",[],[]) "(before\160the\160<nowiki>).",LineBreak,Code ("",[],[]) "",LineBreak,Code ("",[],[]) "Then\160your\160block\160format\160will\160be",LineBreak,Code ("",[],[]) "\160\160\160\160maintained.",LineBreak,Code ("",[],[]) "",LineBreak,Code ("",[],[]) "This\160is\160good\160for\160copying\160in\160code\160blocks:",LineBreak,Code ("",[],[]) "",LineBreak,Code ("",[],[]) "def\160function():",LineBreak,Code ("",[],[]) "\160\160\160\160\"\"\"documentation\160string\"\"\"",LineBreak,Code ("",[],[]) "",LineBreak,Code ("",[],[]) "\160\160\160\160if\160True:",LineBreak,Code ("",[],[]) "\160\160\160\160\160\160\160\160print\160True",LineBreak,Code ("",[],[]) "\160\160\160\160else:",LineBreak,Code ("",[],[]) "\160\160\160\160\160\160\160\160print\160False"]
-,Para [Str "Not"]
-,RawBlock (Format "html") "<hr/>"
-,Para [Str "preformatted"]
-,Para [Str "Don't",Space,Str "need"]
-,Para [Code ("",[],[]) "a\160blank\160line"]
-,Para [Str "around",Space,Str "a",Space,Str "preformatted",Space,Str "block."]
-,Header 2 ("templates",[],[]) [Str "templates"]
-,RawBlock (Format "mediawiki") "{{Welcome}}"
-,RawBlock (Format "mediawiki") "{{Foo:Bar}}"
-,RawBlock (Format "mediawiki") "{{Thankyou|all your effort|Me}}"
-,Para [Str "Written",Space,RawInline (Format "mediawiki") "{{{date}}}",Space,Str "by",Space,RawInline (Format "mediawiki") "{{{name}}}",Str "."]
-,Header 2 ("tables",[],[]) [Str "tables"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Apple"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Pie"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Butter"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Ice",Space,Str "cream"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Food",Space,Str "complements"]])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Orange"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Apple"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Pie"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Butter"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Ice",Space,Str "cream"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Food",Space,Str "complements"]])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Orange"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Apple"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Bread"]
-    ,Para [Str "and",Space,Str "cheese"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Pie"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "apple"]]
-     ,[Plain [Str "carrot"]]]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Apple"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "more"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Pie"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "more"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Butter"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Ice",Space,Str "cream"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "and",Space,Str "more"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidth 0.25)
- ,(AlignRight,ColWidth 0.125)
- ,(AlignCenter,ColWidth 0.125)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "Center"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "left"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "15.00"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "centered"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "more"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "2.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "more"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Apple"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Table ("",[],[]) (Caption Nothing
-     [])
-     [(AlignDefault,ColWidthDefault)
-     ,(AlignDefault,ColWidthDefault)]
-     (TableHead ("",[],[])
-     [Row ("",[],[])
-      [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-       [Para [Str "fruit"]]
-      ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-       [Para [Str "topping"]]]])
-     [(TableBody ("",[],[]) (RowHeadColumns 0)
-      []
-      [Row ("",[],[])
-       [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-        [Para [Str "apple"]]
-       ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-        [Para [Str "ice",Space,Str "cream"]]]])]
-     (TableFoot ("",[],[])
-     [])]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Butter"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Ice",Space,Str "cream"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Orange"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Paragraph",Space,Str "after",Space,Str "the",Space,Str "table."]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "fruit"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Para [Str "topping"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "apple"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "ice",Space,Str "cream"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 2 ("notes",[],[]) [Str "notes"]
-,Para [Str "My",Space,Str "note!",Note [Plain [Str "This."]]]
-,Para [Str "URL",Space,Str "note.",Note [Plain [Link ("",[],[]) [Str "http://docs.python.org/library/functions.html#range"] ("http://docs.python.org/library/functions.html#range","")]]]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "header", [], [] )
+    [ Str "header" ]
+  , Header 2
+    ( "header_level_two", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "two" ]
+  , Header 3
+    ( "header_level_3", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "3" ]
+  , Header 4
+    ( "header_level_four", [], [] )
+    [ Str "header", Space, Emph [ Str "level" ], Space, Str "four" ]
+  , Header 5
+    ( "header_level_5", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "5" ]
+  , Header 6
+    ( "header_level_6", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "6" ]
+  , Para
+    [ Str "======="
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    , Space
+    , Str "========"
+    ]
+  , Para
+    [ Code ( "", [], [] ) "==\160not\160a\160header\160==" ]
+  , Header 2
+    ( "emph_and_strong", [], [] )
+    [ Str "emph", Space, Str "and", Space, Str "strong" ]
+  , Para
+    [ Emph [ Str "emph" ], Space, Strong [ Str "strong" ] ]
+  , Para
+    [ Strong
+      [ Emph [ Str "strong", Space, Str "and", Space, Str "emph" ] ]
+    ]
+  , Para
+    [ Strong
+      [ Emph [ Str "emph", Space, Str "inside" ], Space, Str "strong" ]
+    ]
+  , Para
+    [ Strong
+      [ Str "strong", Space, Str "with", Space, Emph [ Str "emph" ] ]
+    ]
+  , Para
+    [ Emph
+      [ Strong
+        [ Str "strong", Space, Str "inside" ]
+      , Space
+      , Str "emph"
+      ]
+    ]
+  , Header 2
+    ( "horizontal_rule", [], [] )
+    [ Str "horizontal", Space, Str "rule" ]
+  , Para
+    [ Str "top" ]
+  , HorizontalRule
+  , Para
+    [ Str "bottom" ]
+  , HorizontalRule
+  , Header 2
+    ( "nowiki", [], [] )
+    [ Str "nowiki" ]
+  , Para
+    [ Str "''not", Space, Str "emph''" ]
+  , Header 2
+    ( "strikeout", [], [] )
+    [ Str "strikeout" ]
+  , Para
+    [ Strikeout
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Emph
+        [ Str "struck", Space, Str "out" ]
+      ]
+    ]
+  , Header 2
+    ( "entities", [], [] )
+    [ Str "entities" ]
+  , Para
+    [ Str "hi", Space, Str "&", Space, Str "low" ]
+  , Para
+    [ Str "hi", Space, Str "&", Space, Str "low" ]
+  , Para
+    [ Str "G\246del" ]
+  , Para
+    [ Str "\777\2730" ]
+  , Header 2
+    ( "comments", [], [] )
+    [ Str "comments" ]
+  , Para
+    [ Str "inline", Space, Str "comment" ]
+  , Para
+    [ Str "between", Space, Str "blocks" ]
+  , Header 2
+    ( "linebreaks", [], [] )
+    [ Str "linebreaks" ]
+  , Para
+    [ Str "hi", LineBreak, Str "there" ]
+  , Para
+    [ Str "hi", LineBreak, Str "there" ]
+  , Header 2
+    ( "indents", [], [] )
+    [ Str ":", Space, Str "indents" ]
+  , Para
+    [ Str "hi" ]
+  , DefinitionList
+    [ ( [], [ [ Plain [ Str "there" ] ] ] ) ]
+  , Para
+    [ Str "bud" ]
+  , Para
+    [ Str "hi" ]
+  , DefinitionList
+    [
+      ( []
+      ,
+        [ [ DefinitionList [ ( [], [ [ Plain [ Str "there" ] ] ] ) ] ] ]
+      )
+    ]
+  , Para
+    [ Str "bud" ]
+  , Header 2
+    ( "p_tags", [], [] )
+    [ Str "p", Space, Str "tags" ]
+  , Para
+    [ Str "hi", Space, Str "there" ]
+  , Para
+    [ Str "bud" ]
+  , Para
+    [ Str "another" ]
+  , Header 2
+    ( "raw_html", [], [] )
+    [ Str "raw", Space, Str "html" ]
+  , Para
+    [ Str "hi"
+    , Space
+    , RawInline
+      ( Format "html" ) "<span style=\"color:red\">"
+    , Emph
+      [ Str "there" ]
+    , RawInline
+      ( Format "html" ) "</span>"
+    , Str "."
+    ]
+  , Para
+    [ RawInline
+      ( Format "html" ) "<ins>"
+    , Str "inserted"
+    , RawInline
+      ( Format "html" ) "</ins>"
+    ]
+  , RawBlock
+    ( Format "html" ) "<div class=\"special\">"
+  , Para
+    [ Str "hi", Space, Emph [ Str "there" ] ]
+  , RawBlock
+    ( Format "html" ) "</div>"
+  , Header 2
+    ( "sup_sub_del", [], [] )
+    [ Str "sup,", Space, Str "sub,", Space, Str "del" ]
+  , Para
+    [ Str "H"
+    , Subscript
+      [ Str "2" ]
+    , Str "O"
+    , Space
+    , Str "base"
+    , Superscript
+      [ Emph [ Str "exponent" ] ]
+    , SoftBreak
+    , Strikeout
+      [ Str "hello" ]
+    ]
+  , Header 2
+    ( "inline_code", [], [] )
+    [ Str "inline", Space, Str "code" ]
+  , Para
+    [ Code
+      ( "", [], [] ) "*\8594*"
+    , Space
+    , Code
+      ( "", [], [] ) "typed"
+    , Space
+    , Code
+      ( "", [ "haskell" ], [] ) ">>="
+    ]
+  , Header 2
+    ( "code_blocks", [], [] )
+    [ Str "code", Space, Str "blocks" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "case xs of\n     (_:_) -> reverse xs\n     []    -> ['*']"
+  , CodeBlock
+    ( ""
+    , [ "haskell" ]
+    , []
+    ) "case xs of\n     (_:_) -> reverse xs\n     []    -> ['*']"
+  , CodeBlock
+    ( ""
+    ,
+      [ "ruby", "numberLines" ]
+    ,
+      [ ( "startFrom", "100" ) ]
+    ) "widgets.each do |w|\n  print w.price\nend"
+  , Header 2
+    ( "block_quotes", [], [] )
+    [ Str "block", Space, Str "quotes" ]
+  , Para
+    [ Str "Regular", Space, Str "paragraph" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      ]
+    , Para
+      [ Str "With", Space, Str "two", Space, Str "paragraphs." ]
+    ]
+  , Para
+    [ Str "Nother", Space, Str "paragraph." ]
+  , Header 2
+    ( "external_links", [], [] )
+    [ Str "external", Space, Str "links" ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Emph
+        [ Str "Google" ]
+      , Space
+      , Str "search"
+      , Space
+      , Str "engine"
+      ]
+      ( "http://google.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "http://pandoc.org" ]
+      ( "http://pandoc.org", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "1" ]
+      ( "http://google.com", "" )
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "2" ]
+      ( "http://yahoo.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "email", Space, Str "me" ]
+      ( "mailto:info@example.org", "" )
+    ]
+  , Header 2
+    ( "internal_links", [], [] )
+    [ Str "internal", Space, Str "links" ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Help" ] ( "Help", "wikilink" ) ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "the", Space, Str "help", Space, Str "page" ]
+      ( "Help", "wikilink" )
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Helpers" ] ( "Help", "wikilink" ) ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Help" ]
+      ( "Help", "wikilink" )
+    , Str "ers"
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Contents" ]
+      ( "Help:Contents", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "#My", Space, Str "anchor" ]
+      ( "#My_anchor", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "and", Space, Str "text" ]
+      ( "Page#with_anchor", "wikilink" )
+    ]
+  , Header 2
+    ( "images", [], [] )
+    [ Str "images" ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "caption" ]
+      ( "example.jpg", "fig:caption" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "the"
+      , Space
+      , Emph
+        [ Str "caption" ]
+      , Space
+      , Str "with"
+      , Space
+      , Link
+        ( "", [], [] )
+        [ Str "external", Space, Str "link" ]
+        ( "http://google.com", "" )
+      ]
+      ( "example.jpg", "fig:the caption with external link" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [ ( "width", "30" ), ( "height", "40" ) ] )
+      [ Str "caption" ]
+      ( "example.jpg", "fig:caption" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [ ( "width", "30" ) ] )
+      [ Str "caption" ]
+      ( "example.jpg", "fig:caption" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [ ( "width", "30" ) ] )
+      [ Str "caption" ]
+      ( "example.jpg", "fig:caption" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "example.jpg" ]
+      ( "example.jpg", "fig:example.jpg" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "example_es.jpg" ]
+      ( "example_es.jpg", "fig:example_es.jpg" )
+    ]
+  , Header 2
+    ( "lists", [], [] )
+    [ Str "lists" ]
+  , BulletList
+    [
+      [ Plain [ Str "Start", Space, Str "each", Space, Str "line" ] ]
+    ,
+      [ Plain
+        [ Str "with"
+        , Space
+        , Str "an"
+        , Space
+        , Str "asterisk"
+        , Space
+        , Str "(*)."
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "More"
+            , Space
+            , Str "asterisks"
+            , Space
+            , Str "gives"
+            , Space
+            , Str "deeper"
+            ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "and", Space, Str "deeper", Space, Str "levels." ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Line"
+        , Space
+        , Str "breaks"
+        , LineBreak
+        , Str "don't"
+        , Space
+        , Str "break"
+        , Space
+        , Str "levels."
+        ]
+      , BulletList
+        [
+          [ BulletList
+            [
+              [ Plain
+                [ Str "But"
+                , Space
+                , Str "jumping"
+                , Space
+                , Str "levels"
+                , Space
+                , Str "creates"
+                , Space
+                , Str "empty"
+                , Space
+                , Str "space."
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Any"
+    , Space
+    , Str "other"
+    , Space
+    , Str "start"
+    , Space
+    , Str "ends"
+    , Space
+    , Str "the"
+    , Space
+    , Str "list."
+    ]
+  , BulletList
+    [
+      [ BulletList [ [ Plain [ Str "two" ] ] ] ]
+    ,
+      [ Plain [ Str "one" ] ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "Start", Space, Str "each", Space, Str "line" ] ]
+    ,
+      [ Plain
+        [ Str "with"
+        , Space
+        , Str "a"
+        , Space
+        , Str "number"
+        , Space
+        , Str "sign"
+        , Space
+        , Str "(#)."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "More"
+            , Space
+            , Str "number"
+            , Space
+            , Str "signs"
+            , Space
+            , Str "gives"
+            , Space
+            , Str "deeper"
+            ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain [ Str "and", Space, Str "deeper" ] ]
+            ,
+              [ Plain [ Str "levels." ] ]
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Line"
+        , Space
+        , Str "breaks"
+        , LineBreak
+        , Str "don't"
+        , Space
+        , Str "break"
+        , Space
+        , Str "levels."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain
+                [ Str "But"
+                , Space
+                , Str "jumping"
+                , Space
+                , Str "levels"
+                , Space
+                , Str "creates"
+                , Space
+                , Str "empty"
+                , Space
+                , Str "space."
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain [ Str "Blank", Space, Str "lines" ] ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "end"
+        , Space
+        , Str "the"
+        , Space
+        , Str "list"
+        , Space
+        , Str "and"
+        , Space
+        , Str "start"
+        , Space
+        , Str "another."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Any"
+    , Space
+    , Str "other"
+    , Space
+    , Str "start"
+    , Space
+    , Str "also"
+    , SoftBreak
+    , Str "ends"
+    , Space
+    , Str "the"
+    , Space
+    , Str "list."
+    ]
+  , DefinitionList
+    [
+      (
+        [ Str "item", Space, Str "1" ]
+      ,
+        [ [ Plain [ Str "definition", Space, Str "1" ] ] ]
+      )
+    ,
+      (
+        [ Str "item", Space, Str "2" ]
+      ,
+        [
+          [ Plain [ Str "definition", Space, Str "2-1" ] ]
+        ,
+          [ Plain [ Str "definition", Space, Str "2-2" ] ]
+        ]
+      )
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "one" ] ]
+    ,
+      [ Plain
+        [ Str "two" ]
+      , BulletList
+        [
+          [ Plain [ Str "two", Space, Str "point", Space, Str "one" ] ]
+        ,
+          [ Plain [ Str "two", Space, Str "point", Space, Str "two" ] ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "three" ]
+      , DefinitionList
+        [
+          (
+            [ Str "three", Space, Str "item", Space, Str "one" ]
+          ,
+            [
+              [ Plain
+                [ Str "three", Space, Str "def", Space, Str "one" ]
+              ]
+            ]
+          )
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "four" ]
+      , DefinitionList
+        [
+          ( []
+          ,
+            [
+              [ Plain
+                [ Str "four", Space, Str "def", Space, Str "one" ]
+              ]
+            ,
+              [ Plain
+                [ Str "this"
+                , Space
+                , Str "looks"
+                , Space
+                , Str "like"
+                , Space
+                , Str "a"
+                , Space
+                , Str "continuation"
+                ]
+              ]
+            ,
+              [ Plain
+                [ Str "and"
+                , Space
+                , Str "is"
+                , Space
+                , Str "often"
+                , Space
+                , Str "used"
+                ]
+              ]
+            ,
+              [ Plain
+                [ Str "instead"
+                , LineBreak
+                , Str "of"
+                , Space
+                , Str "<br/>"
+                ]
+              ]
+            ]
+          )
+        ]
+      ]
+    ,
+      [ Plain
+        [ RawInline
+          ( Format "mediawiki" ) "{{{template\n|author=John\n|title=My Book\n}}}"
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "five", Space, Str "sub", Space, Str "1" ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain
+                [ Str "five"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "1"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "1"
+                ]
+              ]
+            ]
+          ]
+        ,
+          [ Plain [ Str "five", Space, Str "sub", Space, Str "2" ] ]
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "list", Space, Str "item", Space, Emph [ Str "emph" ] ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain [ Str "list", Space, Str "item", Space, Str "B1" ] ]
+        ,
+          [ Plain [ Str "list", Space, Str "item", Space, Str "B2" ] ]
+        ]
+      , Para
+        [ Str "continuing"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "A1"
+        ]
+      ]
+    ,
+      [ Plain [ Str "list", Space, Str "item", Space, Str "A2" ] ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "abc" ] ]
+    ,
+      [ Plain [ Str "def" ] ]
+    ,
+      [ Plain [ Str "ghi" ] ]
+    ]
+  , OrderedList
+    ( 9, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "Amsterdam" ] ]
+    ,
+      [ Plain [ Str "Rotterdam" ] ]
+    ,
+      [ Plain [ Str "The", Space, Str "Hague" ] ]
+    ]
+  , Header 2
+    ( "math", [], [] )
+    [ Str "math" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Math InlineMath "x=\\frac{y^\\pi}{z}"
+    , Str "."
+    ]
+  , Para
+    [ Str "With"
+    , Space
+    , Str "spaces:"
+    , Space
+    , Math InlineMath "x=\\frac{y^\\pi}{z}"
+    , Str "."
+    ]
+  , Header 2
+    ( "preformatted_blocks", [], [] )
+    [ Str "preformatted", Space, Str "blocks" ]
+  , Para
+    [ Code
+      ( "", [], [] ) "Start\160each\160line\160with\160a\160space."
+    , LineBreak
+    , Code
+      ( "", [], [] ) "Text\160is\160"
+    , Strong
+      [ Code ( "", [], [] ) "preformatted" ]
+    , Code
+      ( "", [], [] ) "\160and"
+    , LineBreak
+    , Emph
+      [ Code ( "", [], [] ) "markups" ]
+    , Code
+      ( "", [], [] ) "\160"
+    , Strong
+      [ Emph [ Code ( "", [], [] ) "can" ] ]
+    , Code
+      ( "", [], [] ) "\160be\160done."
+    ]
+  , Para
+    [ Code ( "", [], [] ) "\160hell\160\160\160\160\160\160yeah" ]
+  , Para
+    [ Code
+      ( ""
+      , []
+      , []
+      ) "Start\160with\160a\160space\160in\160the\160first\160column,"
+    , LineBreak
+    , Code
+      ( "", [], [] ) "(before\160the\160<nowiki>)."
+    , LineBreak
+    , Code
+      ( "", [], [] ) ""
+    , LineBreak
+    , Code
+      ( "", [], [] ) "Then\160your\160block\160format\160will\160be"
+    , LineBreak
+    , Code
+      ( "", [], [] ) "\160\160\160\160maintained."
+    , LineBreak
+    , Code
+      ( "", [], [] ) ""
+    , LineBreak
+    , Code
+      ( ""
+      , []
+      , []
+      ) "This\160is\160good\160for\160copying\160in\160code\160blocks:"
+    , LineBreak
+    , Code
+      ( "", [], [] ) ""
+    , LineBreak
+    , Code
+      ( "", [], [] ) "def\160function():"
+    , LineBreak
+    , Code
+      ( ""
+      , []
+      , []
+      ) "\160\160\160\160\"\"\"documentation\160string\"\"\""
+    , LineBreak
+    , Code
+      ( "", [], [] ) ""
+    , LineBreak
+    , Code
+      ( "", [], [] ) "\160\160\160\160if\160True:"
+    , LineBreak
+    , Code
+      ( "", [], [] ) "\160\160\160\160\160\160\160\160print\160True"
+    , LineBreak
+    , Code
+      ( "", [], [] ) "\160\160\160\160else:"
+    , LineBreak
+    , Code
+      ( "", [], [] ) "\160\160\160\160\160\160\160\160print\160False"
+    ]
+  , Para
+    [ Str "Not" ]
+  , RawBlock
+    ( Format "html" ) "<hr/>"
+  , Para
+    [ Str "preformatted" ]
+  , Para
+    [ Str "Don't", Space, Str "need" ]
+  , Para
+    [ Code ( "", [], [] ) "a\160blank\160line" ]
+  , Para
+    [ Str "around"
+    , Space
+    , Str "a"
+    , Space
+    , Str "preformatted"
+    , Space
+    , Str "block."
+    ]
+  , Header 2
+    ( "templates", [], [] )
+    [ Str "templates" ]
+  , RawBlock
+    ( Format "mediawiki" ) "{{Welcome}}"
+  , RawBlock
+    ( Format "mediawiki" ) "{{Foo:Bar}}"
+  , RawBlock
+    ( Format "mediawiki" ) "{{Thankyou|all your effort|Me}}"
+  , Para
+    [ Str "Written"
+    , Space
+    , RawInline
+      ( Format "mediawiki" ) "{{{date}}}"
+    , Space
+    , Str "by"
+    , Space
+    , RawInline
+      ( Format "mediawiki" ) "{{{name}}}"
+    , Str "."
+    ]
+  , Header 2
+    ( "tables", [], [] )
+    [ Str "tables" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Apple" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Pie" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Butter" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Ice", Space, Str "cream" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing
+      [ Plain [ Str "Food", Space, Str "complements" ] ]
+    )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Apple" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Pie" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Butter" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Ice", Space, Str "cream" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing
+      [ Plain [ Str "Food", Space, Str "complements" ] ]
+    )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Apple" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para
+            [ Str "Bread" ]
+          , Para
+            [ Str "and", Space, Str "cheese" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para
+            [ Str "Pie" ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [ [ Plain [ Str "apple" ] ], [ Plain [ Str "carrot" ] ] ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Apple" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "more" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Pie" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "more" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Butter" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Ice", Space, Str "cream" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "and", Space, Str "more" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignLeft, ColWidth 0.25 )
+    ,
+      ( AlignRight, ColWidth 0.125 )
+    ,
+      ( AlignCenter, ColWidth 0.125 )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Left" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Right" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Center" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "left" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "15.00" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "centered" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "more" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "2.0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "more" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Apple" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Table
+            ( "", [], [] )
+            ( Caption Nothing [] )
+            [
+              ( AlignDefault, ColWidthDefault )
+            ,
+              ( AlignDefault, ColWidthDefault )
+            ]
+            ( TableHead
+              ( "", [], [] )
+              [ Row
+                ( "", [], [] )
+                [ Cell
+                  ( "", [], [] ) AlignDefault
+                  ( RowSpan 1 )
+                  ( ColSpan 1 )
+                  [ Para [ Str "fruit" ] ]
+                , Cell
+                  ( "", [], [] ) AlignDefault
+                  ( RowSpan 1 )
+                  ( ColSpan 1 )
+                  [ Para [ Str "topping" ] ]
+                ]
+              ]
+            )
+            [ TableBody
+              ( "", [], [] )
+              ( RowHeadColumns 0 ) []
+              [ Row
+                ( "", [], [] )
+                [ Cell
+                  ( "", [], [] ) AlignDefault
+                  ( RowSpan 1 )
+                  ( ColSpan 1 )
+                  [ Para [ Str "apple" ] ]
+                , Cell
+                  ( "", [], [] ) AlignDefault
+                  ( RowSpan 1 )
+                  ( ColSpan 1 )
+                  [ Para [ Str "ice", Space, Str "cream" ] ]
+                ]
+              ]
+            ]
+            ( TableFoot ( "", [], [] ) [] )
+          ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Butter" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Ice", Space, Str "cream" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [ ( AlignDefault, ColWidthDefault ) ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Orange" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Paragraph"
+    , Space
+    , Str "after"
+    , Space
+    , Str "the"
+    , Space
+    , Str "table."
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "fruit" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "topping" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "apple" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "ice", Space, Str "cream" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 2
+    ( "notes", [], [] )
+    [ Str "notes" ]
+  , Para
+    [ Str "My", Space, Str "note!", Note [ Plain [ Str "This." ] ] ]
+  , Para
+    [ Str "URL"
+    , Space
+    , Str "note."
+    , Note
+      [ Plain
+        [ Link
+          ( "", [], [] )
+          [ Str "http://docs.python.org/library/functions.html#range" ]
+          ( "http://docs.python.org/library/functions.html#range", "" )
+        ]
+      ]
+    ]
+  ]

--- a/test/opml-reader.native
+++ b/test/opml-reader.native
@@ -1,66 +1,232 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "Dave",Space,Str "Winer"]]),("date",MetaInlines [Str "Thu,",Space,Str "14",Space,Str "Jul",Space,Str "2005",Space,Str "23:41:05",Space,Str "GMT"]),("title",MetaInlines [Str "States"])]})
-[Header 1 ("",[],[]) [Str "United",Space,Str "States"]
-,Header 2 ("",[],[]) [Str "Far",Space,Str "West"]
-,Header 3 ("",[],[]) [Str "Alaska"]
-,Header 3 ("",[],[]) [Str "California"]
-,Header 3 ("",[],[]) [Str "Hawaii"]
-,Header 3 ("",[],[]) [Strong [Str "Nevada"]]
-,Para [Str "I",Space,Str "lived",Space,Str "here",Space,Emph [Str "once"],Str "."]
-,Para [Str "Loved",Space,Str "it."]
-,Header 4 ("",[],[]) [Link ("",[],[]) [Str "Reno"] ("http://www.reno.gov","")]
-,Header 4 ("",[],[]) [Str "Las",Space,Str "Vegas"]
-,Header 4 ("",[],[]) [Str "Ely"]
-,Header 4 ("",[],[]) [Str "Gerlach"]
-,Header 3 ("",[],[]) [Str "Oregon"]
-,Header 3 ("",[],[]) [Str "Washington"]
-,Header 2 ("",[],[]) [Str "Great",Space,Str "Plains"]
-,Header 3 ("",[],[]) [Str "Kansas"]
-,Header 3 ("",[],[]) [Str "Nebraska"]
-,Header 3 ("",[],[]) [Str "North",Space,Str "Dakota"]
-,Header 3 ("",[],[]) [Str "Oklahoma"]
-,Header 3 ("",[],[]) [Str "South",Space,Str "Dakota"]
-,Header 2 ("",[],[]) [Str "Mid-Atlantic"]
-,Header 3 ("",[],[]) [Str "Delaware"]
-,Header 3 ("",[],[]) [Str "Maryland"]
-,Header 3 ("",[],[]) [Str "New",Space,Str "Jersey"]
-,Header 3 ("",[],[]) [Str "New",Space,Str "York"]
-,Header 3 ("",[],[]) [Str "Pennsylvania"]
-,Header 2 ("",[],[]) [Str "Midwest"]
-,Header 3 ("",[],[]) [Str "Illinois"]
-,Header 3 ("",[],[]) [Str "Indiana"]
-,Header 3 ("",[],[]) [Str "Iowa"]
-,Header 3 ("",[],[]) [Str "Kentucky"]
-,Header 3 ("",[],[]) [Str "Michigan"]
-,Header 3 ("",[],[]) [Str "Minnesota"]
-,Header 3 ("",[],[]) [Str "Missouri"]
-,Header 3 ("",[],[]) [Str "Ohio"]
-,Header 3 ("",[],[]) [Str "West",Space,Str "Virginia"]
-,Header 3 ("",[],[]) [Str "Wisconsin"]
-,Header 2 ("",[],[]) [Str "Mountains"]
-,Header 3 ("",[],[]) [Str "Colorado"]
-,Header 3 ("",[],[]) [Str "Idaho"]
-,Header 3 ("",[],[]) [Str "Montana"]
-,Header 3 ("",[],[]) [Str "Utah"]
-,Header 3 ("",[],[]) [Str "Wyoming"]
-,Header 2 ("",[],[]) [Str "New",Space,Str "England"]
-,Header 3 ("",[],[]) [Str "Connecticut"]
-,Header 3 ("",[],[]) [Str "Maine"]
-,Header 3 ("",[],[]) [Str "Massachusetts"]
-,Header 3 ("",[],[]) [Str "New",Space,Str "Hampshire"]
-,Header 3 ("",[],[]) [Str "Rhode",Space,Str "Island"]
-,Header 3 ("",[],[]) [Str "Vermont"]
-,Header 2 ("",[],[]) [Str "South"]
-,Header 3 ("",[],[]) [Str "Alabama"]
-,Header 3 ("",[],[]) [Str "Arkansas"]
-,Header 3 ("",[],[]) [Str "Florida"]
-,Header 3 ("",[],[]) [Str "Georgia"]
-,Header 3 ("",[],[]) [Str "Louisiana"]
-,Header 3 ("",[],[]) [Str "Mississippi"]
-,Header 3 ("",[],[]) [Str "North",Space,Str "Carolina"]
-,Header 3 ("",[],[]) [Str "South",Space,Str "Carolina"]
-,Header 3 ("",[],[]) [Str "Tennessee"]
-,Header 3 ("",[],[]) [Str "Virginia"]
-,Header 2 ("",[],[]) [Str "Southwest"]
-,Header 3 ("",[],[]) [Str "Arizona"]
-,Header 3 ("",[],[]) [Str "New",Space,Str "Mexico"]
-,Header 3 ("",[],[]) [Str "Texas"]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaList
+          [ MetaInlines [ Str "Dave", Space, Str "Winer" ] ]
+        )
+      ,
+        ( "date"
+        , MetaInlines
+          [ Str "Thu,"
+          , Space
+          , Str "14"
+          , Space
+          , Str "Jul"
+          , Space
+          , Str "2005"
+          , Space
+          , Str "23:41:05"
+          , Space
+          , Str "GMT"
+          ]
+        )
+      ,
+        ( "title", MetaInlines [ Str "States" ] )
+      ]
+    }
+  )
+  [ Header 1
+    ( "", [], [] )
+    [ Str "United", Space, Str "States" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Far", Space, Str "West" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Alaska" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "California" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Hawaii" ]
+  , Header 3
+    ( "", [], [] )
+    [ Strong [ Str "Nevada" ] ]
+  , Para
+    [ Str "I"
+    , Space
+    , Str "lived"
+    , Space
+    , Str "here"
+    , Space
+    , Emph
+      [ Str "once" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Loved", Space, Str "it." ]
+  , Header 4
+    ( "", [], [] )
+    [ Link ( "", [], [] ) [ Str "Reno" ] ( "http://www.reno.gov", "" ) ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Las", Space, Str "Vegas" ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Ely" ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Gerlach" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Oregon" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Washington" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Great", Space, Str "Plains" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Kansas" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Nebraska" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "North", Space, Str "Dakota" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Oklahoma" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "South", Space, Str "Dakota" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Mid-Atlantic" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Delaware" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Maryland" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "New", Space, Str "Jersey" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "New", Space, Str "York" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Pennsylvania" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Midwest" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Illinois" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Indiana" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Iowa" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Kentucky" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Michigan" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Minnesota" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Missouri" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Ohio" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "West", Space, Str "Virginia" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Wisconsin" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Mountains" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Colorado" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Idaho" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Montana" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Utah" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Wyoming" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "New", Space, Str "England" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Connecticut" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Maine" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Massachusetts" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "New", Space, Str "Hampshire" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Rhode", Space, Str "Island" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Vermont" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "South" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Alabama" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Arkansas" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Florida" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Georgia" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Louisiana" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Mississippi" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "North", Space, Str "Carolina" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "South", Space, Str "Carolina" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Tennessee" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Virginia" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Southwest" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Arizona" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "New", Space, Str "Mexico" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Texas" ]
+  ]

--- a/test/org-select-tags.native
+++ b/test/org-select-tags.native
@@ -1,7 +1,99 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("will-appear-because-it-is-the-ancestor-of-something-tagged-yes",[],[]) [Str "Will",Space,Str "appear",Space,Str "because",Space,Str "it",Space,Str "is",Space,Str "the",Space,Str "ancestor",Space,Str "of",Space,Str "something",Space,Str "tagged",Space,Str "\"yes\""]
-,Header 2 ("will-appear",[],[]) [Str "Will",Space,Str "appear",Space,Span ("",["tag"],[("tag-name","yes")]) [SmallCaps [Str "yes"]]]
-,Header 3 ("will-appear-since-the-entire-subtree-of-something-selected-will-appear",[],[]) [Str "Will",Space,Str "appear",Space,Str "since",Space,Str "the",Space,Str "entire",Space,Str "subtree",Space,Str "of",Space,Str "something",Space,Str "selected",Space,Str "will",Space,Str "appear"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Para [Str "Will",Space,Str "appear"]]]
-,Header 2 ("will-appear-because-it-is-the-ancestor-of-something-listed-in-select-tags",[],[]) [Str "Will",Space,Str "appear",Space,Str "because",Space,Str "it",Space,Str "is",Space,Str "the",Space,Str "ancestor",Space,Str "of",Space,Str "something",Space,Str "listed",Space,Str "in",Space,Str "SELECT-TAGS"]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "will-appear-because-it-is-the-ancestor-of-something-tagged-yes"
+    , []
+    , []
+    )
+    [ Str "Will"
+    , Space
+    , Str "appear"
+    , Space
+    , Str "because"
+    , Space
+    , Str "it"
+    , Space
+    , Str "is"
+    , Space
+    , Str "the"
+    , Space
+    , Str "ancestor"
+    , Space
+    , Str "of"
+    , Space
+    , Str "something"
+    , Space
+    , Str "tagged"
+    , Space
+    , Str "\"yes\""
+    ]
+  , Header 2
+    ( "will-appear", [], [] )
+    [ Str "Will"
+    , Space
+    , Str "appear"
+    , Space
+    , Span
+      ( "", [ "tag" ], [ ( "tag-name", "yes" ) ] )
+      [ SmallCaps [ Str "yes" ] ]
+    ]
+  , Header 3
+    ( "will-appear-since-the-entire-subtree-of-something-selected-will-appear"
+    , []
+    , []
+    )
+    [ Str "Will"
+    , Space
+    , Str "appear"
+    , Space
+    , Str "since"
+    , Space
+    , Str "the"
+    , Space
+    , Str "entire"
+    , Space
+    , Str "subtree"
+    , Space
+    , Str "of"
+    , Space
+    , Str "something"
+    , Space
+    , Str "selected"
+    , Space
+    , Str "will"
+    , Space
+    , Str "appear"
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [ [ Para [ Str "Will", Space, Str "appear" ] ] ]
+  , Header 2
+    ( "will-appear-because-it-is-the-ancestor-of-something-listed-in-select-tags"
+    , []
+    , []
+    )
+    [ Str "Will"
+    , Space
+    , Str "appear"
+    , Space
+    , Str "because"
+    , Space
+    , Str "it"
+    , Space
+    , Str "is"
+    , Space
+    , Str "the"
+    , Space
+    , Str "ancestor"
+    , Space
+    , Str "of"
+    , Space
+    , Str "something"
+    , Space
+    , Str "listed"
+    , Space
+    , Str "in"
+    , Space
+    , Str "SELECT-TAGS"
+    ]
+  ]

--- a/test/pipe-tables.native
+++ b/test/pipe-tables.native
@@ -1,326 +1,850 @@
-[Para [Str "Simplest",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Simple",Space,Str "table",Space,Str "with",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Demonstration",Space,Str "of",Space,Str "simple",Space,Str "table",Space,Str "syntax."]])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Simple",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Headerless",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Table",Space,Str "without",Space,Str "sides:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Fruit"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Quantity"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "apple"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "17"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "pear"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "302"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "One-column:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "hi"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "lo"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Header-less",Space,Str "one-column:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "hi"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Indented",Space,Str "left",Space,Str "column:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Number",Space,Str "of",Space,Str "siblings"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Salary"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "33"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "44"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Long",Space,Str "pipe",Space,Str "table",Space,Str "with",Space,Str "relative",Space,Str "widths:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.15517241379310345)
- ,(AlignDefault,ColWidth 0.1724137931034483)
- ,(AlignDefault,ColWidth 0.6724137931034483)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "this",Space,Str "is",Space,Str "a",Space,Str "table",Space,Str "cell"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "and",Space,Str "this",Space,Str "is",Space,Str "a",Space,Str "really",Space,Str "long",Space,Str "table",Space,Str "cell",Space,Str "that",Space,Str "will",Space,Str "probably",Space,Str "need",Space,Str "wrapping"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Pipe",Space,Str "table",Space,Str "with",Space,Str "no",Space,Str "body:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Header"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Pipe",Space,Str "table",Space,Str "with",Space,Str "tricky",Space,Str "cell",Space,Str "contents",Space,Str "(see",Space,Str "#2765):"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "IP_gene8-_1st"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "IP_gene8+_1st"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "IP_gene8-_1st"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1.0000000"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "0.4357325"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "IP_gene8+_1st"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "0.4357325"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1.0000000"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "foo",Code ("",[],[]) "bar|baz"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "and|escaped"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3.0000000"]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Para
+  [ Str "Simplest"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default3" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Simple", Space, Str "table", Space, Str "with", Space, Str "caption:" ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing
+    [ Plain
+      [ Str "Demonstration"
+      , Space
+      , Str "of"
+      , Space
+      , Str "simple"
+      , Space
+      , Str "table"
+      , Space
+      , Str "syntax."
+      ]
+    ]
+  )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Simple"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Headerless"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Table", Space, Str "without", Space, Str "sides:" ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignDefault, ColWidthDefault ), ( AlignRight, ColWidthDefault ) ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Fruit" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Quantity" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "apple" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "5" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "orange" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "17" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "pear" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "302" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "One-column:" ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignDefault, ColWidthDefault ) ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "hi" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "lo" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Header-less", Space, Str "one-column:" ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignCenter, ColWidthDefault ) ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "hi" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Indented", Space, Str "left", Space, Str "column:" ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignRight, ColWidthDefault ), ( AlignLeft, ColWidthDefault ) ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Number", Space, Str "of", Space, Str "siblings" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Salary" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "3" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "33" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "4" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "44" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Long"
+  , Space
+  , Str "pipe"
+  , Space
+  , Str "table"
+  , Space
+  , Str "with"
+  , Space
+  , Str "relative"
+  , Space
+  , Str "widths:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidth 0.15517241379310345 )
+  ,
+    ( AlignDefault, ColWidth 0.1724137931034483 )
+  ,
+    ( AlignDefault, ColWidth 0.6724137931034483 )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default2" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default3" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "this"
+          , Space
+          , Str "is"
+          , Space
+          , Str "a"
+          , Space
+          , Str "table"
+          , Space
+          , Str "cell"
+          ]
+        ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "and"
+          , Space
+          , Str "this"
+          , Space
+          , Str "is"
+          , Space
+          , Str "a"
+          , Space
+          , Str "really"
+          , Space
+          , Str "long"
+          , Space
+          , Str "table"
+          , Space
+          , Str "cell"
+          , Space
+          , Str "that"
+          , Space
+          , Str "will"
+          , Space
+          , Str "probably"
+          , Space
+          , Str "need"
+          , Space
+          , Str "wrapping"
+          ]
+        ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Pipe"
+  , Space
+  , Str "table"
+  , Space
+  , Str "with"
+  , Space
+  , Str "no"
+  , Space
+  , Str "body:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [ ( AlignDefault, ColWidthDefault ) ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Header" ] ]
+      ]
+    ]
+  )
+  [ TableBody ( "", [], [] ) ( RowHeadColumns 0 ) [] [] ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Pipe"
+  , Space
+  , Str "table"
+  , Space
+  , Str "with"
+  , Space
+  , Str "tricky"
+  , Space
+  , Str "cell"
+  , Space
+  , Str "contents"
+  , Space
+  , Str "(see"
+  , Space
+  , Str "#2765):"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignRight, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "IP_gene8-_1st" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "IP_gene8+_1st" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "IP_gene8-_1st" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1.0000000" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "0.4357325" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "IP_gene8+_1st" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "0.4357325" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1.0000000" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "foo", Code ( "", [], [] ) "bar|baz" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "and|escaped" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "3.0000000" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]

--- a/test/rst-reader.native
+++ b/test/rst-reader.native
@@ -1,443 +1,1874 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Space,Str "MacFarlane"],MetaInlines [Str "Anonymous"]]),("date",MetaInlines [Str "July",Space,Str "17,",Space,Str "2006"]),("revision",MetaBlocks [Para [Str "3"]]),("subtitle",MetaInlines [Str "Subtitle"]),("title",MetaInlines [Str "Pandoc",Space,Str "Test",Space,Str "Suite"])]})
-[Header 1 ("level-one-header",[],[]) [Str "Level",Space,Str "one",Space,Str "header"]
-,Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc.",Space,Str "Most",Space,Str "of",Space,Str "them",Space,Str "are",Space,Str "adapted",Space,Str "from",SoftBreak,Str "John",Space,Str "Gruber\8217s",Space,Str "markdown",Space,Str "test",Space,Str "suite."]
-,Header 2 ("level-two-header",[],[]) [Str "Level",Space,Str "two",Space,Str "header"]
-,Header 3 ("level-three",[],[]) [Str "Level",Space,Str "three"]
-,Header 4 ("level-four-with-emphasis",[],[]) [Str "Level",Space,Str "four",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 5 ("level-five",[],[]) [Str "Level",Space,Str "five"]
-,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "In",Space,Str "Markdown",Space,Str "1.0.0",Space,Str "and",Space,Str "earlier.",Space,Str "Version",SoftBreak,Str "8.",Space,Str "This",Space,Str "line",Space,Str "turns",Space,Str "into",Space,Str "a",Space,Str "list",Space,Str "item.",SoftBreak,Str "Because",Space,Str "a",Space,Str "hard-wrapped",Space,Str "line",Space,Str "in",Space,Str "the",SoftBreak,Str "middle",Space,Str "of",Space,Str "a",Space,Str "paragraph",Space,Str "looked",Space,Str "like",Space,Str "a",SoftBreak,Str "list",Space,Str "item."]
-,Para [Str "Here\8217s",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet.",SoftBreak,Str "*",Space,Str "criminey."]
-,Para [Str "Horizontal",Space,Str "rule:"]
-,HorizontalRule
-,Para [Str "Another:"]
-,HorizontalRule
-,Header 1 ("block-quotes",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "block",Space,Str "quote:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",SoftBreak,Str "It",Space,Str "is",Space,Str "pretty",Space,Str "short."]]
-,Para [Str "Here\8217s",Space,Str "another,",Space,Str "differently",Space,Str "indented:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",SoftBreak,Str "It\8217s",Space,Str "indented",Space,Str "with",Space,Str "a",Space,Str "tab."]
- ,Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"
- ,Para [Str "List",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,OrderedList (1,Decimal,Period)
-  [[Plain [Str "item",Space,Str "one"]]
-  ,[Plain [Str "item",Space,Str "two"]]]
- ,Para [Str "Nested",Space,Str "block",Space,Str "quotes:"]
- ,BlockQuote
-  [Para [Str "nested"]
-  ,BlockQuote
-   [Para [Str "nested"]]]]
-,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}"
-,CodeBlock ("",[],[]) "this code block is indented by one tab"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "this block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
-,Para [Str "And:"]
-,CodeBlock ("",["python"],[]) "def my_function(x):\n    return x + 1"
-,Para [Str "If",Space,Str "we",Space,Str "use",Space,Str "the",Space,Str "highlight",Space,Str "directive,",Space,Str "we",Space,Str "can",Space,Str "specify",Space,Str "a",Space,Str "default",Space,Str "language",SoftBreak,Str "for",Space,Str "literate",Space,Str "blocks."]
-,CodeBlock ("",["haskell"],[]) "-- this code is in haskell\ndata Tree = Leaf | Node Tree Tree"
-,CodeBlock ("",["haskell"],[]) "-- this code is in haskell too\ndata Nat = Zero | Succ Nat"
-,CodeBlock ("",["javascript"],[]) "-- this code is in javascript\nlet f = (x, y) => x + y"
-,Header 1 ("lists",[],[]) [Str "Lists"]
-,Header 2 ("unordered",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "asterisk",Space,Str "1"]]
- ,[Plain [Str "asterisk",Space,Str "2"]]
- ,[Plain [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Asterisks",Space,Str "loose:"]
-,BulletList
- [[Plain [Str "asterisk",Space,Str "1"]]
- ,[Plain [Str "asterisk",Space,Str "2"]]
- ,[Plain [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "Plus",Space,Str "1"]]
- ,[Plain [Str "Plus",Space,Str "2"]]
- ,[Plain [Str "Plus",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "loose:"]
-,BulletList
- [[Plain [Str "Plus",Space,Str "1"]]
- ,[Plain [Str "Plus",Space,Str "2"]]
- ,[Plain [Str "Plus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "Minus",Space,Str "1"]]
- ,[Plain [Str "Minus",Space,Str "2"]]
- ,[Plain [Str "Minus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "loose:"]
-,BulletList
- [[Plain [Str "Minus",Space,Str "1"]]
- ,[Plain [Str "Minus",Space,Str "2"]]
- ,[Plain [Str "Minus",Space,Str "3"]]]
-,Header 2 ("ordered",[],[]) [Str "Ordered"]
-,Para [Str "Tight:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second"]]
- ,[Plain [Str "Third"]]]
-,Para [Str "and:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "One"]]
- ,[Plain [Str "Two"]]
- ,[Plain [Str "Three"]]]
-,Para [Str "Loose",Space,Str "using",Space,Str "tabs:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second"]]
- ,[Plain [Str "Third"]]]
-,Para [Str "and",Space,Str "using",Space,Str "spaces:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "One"]]
- ,[Plain [Str "Two"]]
- ,[Plain [Str "Three"]]]
-,Para [Str "Multiple",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "Item",Space,Str "1,",Space,Str "graf",Space,Str "one."]
-  ,Para [Str "Item",Space,Str "1.",Space,Str "graf",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",Space,Str "dog\8217s",SoftBreak,Str "back."]]
- ,[Para [Str "Item",Space,Str "2."]]
- ,[Para [Str "Item",Space,Str "3."]]]
-,Para [Str "Nested:"]
-,BulletList
- [[Plain [Str "Tab"]
-  ,BulletList
-   [[Plain [Str "Tab"]
-    ,BulletList
-     [[Plain [Str "Tab"]]]]]]]
-,Para [Str "Here\8217s",Space,Str "another:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BlockQuote
-   [BulletList
-    [[Plain [Str "Fee"]]
-    ,[Plain [Str "Fie"]]
-    ,[Plain [Str "Foe"]]]]]
- ,[Para [Str "Third"]]]
-,Header 2 ("fancy-list-markers",[],[]) [Str "Fancy",Space,Str "list",Space,Str "markers"]
-,OrderedList (2,Decimal,TwoParens)
- [[Para [Str "begins",Space,Str "with",Space,Str "2"]]
- ,[Para [Str "and",Space,Str "now",Space,Str "3"]
-  ,Para [Str "with",Space,Str "a",Space,Str "continuation"]
-  ,OrderedList (4,LowerRoman,Period)
-   [[Plain [Str "sublist",Space,Str "with",Space,Str "roman",Space,Str "numerals,",Space,Str "starting",Space,Str "with",Space,Str "4"]]
-   ,[Plain [Str "more",Space,Str "items"]
-    ,OrderedList (1,UpperAlpha,TwoParens)
-     [[Plain [Str "a",Space,Str "subsublist"]]
-     ,[Plain [Str "a",Space,Str "subsublist"]]]]]]]
-,Para [Str "Nesting:"]
-,OrderedList (1,UpperAlpha,Period)
- [[Plain [Str "Upper",Space,Str "Alpha"]
-  ,OrderedList (1,UpperRoman,Period)
-   [[Plain [Str "Upper",Space,Str "Roman."]
-    ,OrderedList (6,Decimal,TwoParens)
-     [[Plain [Str "Decimal",Space,Str "start",Space,Str "with",Space,Str "6"]
-      ,OrderedList (3,LowerAlpha,OneParen)
-       [[Plain [Str "Lower",Space,Str "alpha",Space,Str "with",Space,Str "paren"]]]]]]]]]
-,Para [Str "Autonumbering:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Autonumber."]]
- ,[Plain [Str "More."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "Nested."]]]]]
-,Para [Str "Autonumbering",Space,Str "with",Space,Str "explicit",Space,Str "start:"]
-,OrderedList (4,LowerAlpha,TwoParens)
- [[Plain [Str "item",Space,Str "1"]]
- ,[Plain [Str "item",Space,Str "2"]]]
-,Header 2 ("definition",[],[]) [Str "Definition"]
-,DefinitionList
- [([Str "term",Space,Str "1"],
-   [[Para [Str "Definition",Space,Str "1."]]])
- ,([Str "term",Space,Str "2"],
-   [[Para [Str "Definition",Space,Str "2,",Space,Str "paragraph",Space,Str "1."]
-    ,Para [Str "Definition",Space,Str "2,",Space,Str "paragraph",Space,Str "2."]]])
- ,([Str "term",Space,Str "with",Space,Emph [Str "emphasis"]],
-   [[Para [Str "Definition",Space,Str "3."]]])]
-,Header 1 ("field-lists",[],[]) [Str "Field",Space,Str "Lists"]
-,BlockQuote
- [DefinitionList
-  [([Str "address"],
-    [[Para [Str "61",Space,Str "Main",Space,Str "St."]]])
-  ,([Str "city"],
-    [[Para [Emph [Str "Nowhere"],Str ",",Space,Str "MA,",SoftBreak,Str "USA"]]])
-  ,([Str "phone"],
-    [[Para [Str "123-4567"]]])]]
-,DefinitionList
- [([Str "address"],
-   [[Para [Str "61",Space,Str "Main",Space,Str "St."]]])
- ,([Str "city"],
-   [[Para [Emph [Str "Nowhere"],Str ",",Space,Str "MA,",SoftBreak,Str "USA"]]])
- ,([Str "phone"],
-   [[Para [Str "123-4567"]]])]
-,Header 1 ("html-blocks",[],[]) [Str "HTML",Space,Str "Blocks"]
-,Para [Str "Simple",Space,Str "block",Space,Str "on",Space,Str "one",Space,Str "line:"]
-,RawBlock (Format "html") "<div>foo</div>"
-,Para [Str "Now,",Space,Str "nested:"]
-,RawBlock (Format "html") "<div>\n    <div>\n        <div>\n            foo\n        </div>\n    </div>\n</div>"
-,Header 1 ("latex-block",[],[]) [Str "LaTeX",Space,Str "Block"]
-,RawBlock (Format "latex") "\\begin{tabular}{|l|l|}\\hline\nAnimal & Number \\\\ \\hline\nDog    & 2      \\\\\nCat    & 1      \\\\ \\hline\n\\end{tabular}"
-,Header 1 ("inline-markup",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ".",Space,Str "This",Space,Str "is",Space,Strong [Str "strong"],Str "."]
-,Para [Str "This",Space,Str "is",Space,Str "code:",Space,Code ("",[],[]) ">",Str ",",Space,Code ("",[],[]) "$",Str ",",Space,Code ("",[],[]) "\\",Str ",",Space,Code ("",[],[]) "\\$",Str ",",Space,Code ("",[],[]) "<html>",Str "."]
-,Para [Str "This",Space,Str "is",Subscript [Str "subscripted"],Space,Str "and",Space,Str "this",Space,Str "is",Space,Superscript [Str "superscripted"],Str "."]
-,Header 1 ("special-characters",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "unicode:"]
-,BulletList
- [[Plain [Str "I",Space,Str "hat:",Space,Str "\206"]]
- ,[Plain [Str "o",Space,Str "umlaut:",Space,Str "\246"]]
- ,[Plain [Str "section:",Space,Str "\167"]]
- ,[Plain [Str "set",Space,Str "membership:",Space,Str "\8712"]]
- ,[Plain [Str "copyright:",Space,Str "\169"]]]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "This",Space,Str "&",Space,Str "that."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "`"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,Header 1 ("links",[],[]) [Str "Links"]
-,Para [Str "Explicit:",Space,Str "a",Space,Link ("",[],[]) [Str "URL"] ("/url/",""),Str "."]
-,Para [Str "Explicit",Space,Str "with",Space,Str "no",Space,Str "label:",Space,Link ("",[],[]) [Str "foo"] ("foo",""),Str "."]
-,Para [Str "Two",Space,Str "anonymous",Space,Str "links:",Space,Link ("",[],[]) [Str "the",Space,Str "first"] ("/url1/",""),Space,Str "and",Space,Link ("",[],[]) [Str "the",Space,Str "second"] ("/url2/","")]
-,Para [Str "Reference",Space,Str "links:",Space,Link ("",[],[]) [Str "link1"] ("/url1/",""),Space,Str "and",Space,Link ("",[],[]) [Str "link2"] ("/url2/",""),Space,Str "and",Space,Link ("",[],[]) [Str "link1"] ("/url1/",""),Space,Str "again."]
-,Para [Str "Another",Space,Link ("",[],[]) [Str "style",Space,Str "of",Space,Str "reference",Space,Str "link"] ("/url1/",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "a",Space,Link ("",[],[]) [Str "link",Space,Str "with",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "URL"] ("http://example.com/?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "link",Space,Str "with",Space,Str "an",Space,Str "amersand",Space,Str "in",Space,Str "the",Space,Str "link",Space,Str "text:",Space,Link ("",[],[]) [Str "AT&T"] ("/url/",""),Str "."]
-,Para [Str "Autolinks:",Space,Link ("",[],[]) [Str "http://example.com/?foo=1&bar=2"] ("http://example.com/?foo=1&bar=2",""),Space,Str "and",Space,Link ("",[],[]) [Str "nobody@nowhere.net"] ("mailto:nobody@nowhere.net",""),Str "."]
-,Para [Str "But",Space,Str "not",Space,Str "here:"]
-,CodeBlock ("",[],[]) "http://example.com/"
-,Header 1 ("images",[],[]) [Str "Images"]
-,Para [Str "From",Space,Quoted DoubleQuote [Str "Voyage",Space,Str "dans",Space,Str "la",Space,Str "Lune"],Space,Str "by",Space,Str "Georges",Space,Str "Melies",Space,Str "(1902):"]
-,Para [Image ("",[],[]) [Str "image"] ("lalune.jpg","")]
-,Para [Image ("",[],[("height","2343px")]) [Str "Voyage dans la Lune"] ("lalune.jpg","")]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "movie",Space,Image ("",[],[]) [Str "movie"] ("movie.jpg",""),Space,Str "icon."]
-,Para [Str "And",Space,Str "an",Space,Link ("",[],[]) [Image ("",[],[]) [Str "A movie"] ("movie.jpg","")] ("/url",""),Str "."]
-,Header 1 ("comments",[],[]) [Str "Comments"]
-,Para [Str "First",Space,Str "paragraph"]
-,Para [Str "Another",Space,Str "paragraph"]
-,Para [Str "A",Space,Str "third",Space,Str "paragraph"]
-,Header 1 ("line-blocks",[],[]) [Str "Line",Space,Str "blocks"]
-,LineBlock
- [[Str "But",Space,Str "can",Space,Str "a",Space,Str "bee",Space,Str "be",Space,Str "said",Space,Str "to",Space,Str "be"]
- ,[Str "\160\160\160\160or",Space,Str "not",Space,Str "to",Space,Str "be",Space,Str "an",Space,Str "entire",Space,Str "bee,"]
- ,[Str "\160\160\160\160\160\160\160\160when",Space,Str "half",Space,Str "the",Space,Str "bee",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "bee,"]
- ,[Str "\160\160\160\160\160\160\160\160\160\160\160\160due",Space,Str "to",Space,Str "some",Space,Str "ancient",Space,Str "injury?"]
- ,[]
- ,[Str "Continuation",Space,Str "line"]
- ,[Str "\160\160and",Space,Str "another"]]
-,Header 1 ("simple-tables",[],[]) [Str "Simple",Space,Str "Tables"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Headless"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 1 ("grid-tables",[],[]) [Str "Grid",Space,Str "Tables"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.2375)
- ,(AlignDefault,ColWidth 0.15)
- ,(AlignDefault,ColWidth 0.1625)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "col",Space,Str "3"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a",SoftBreak,Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b",SoftBreak,Str "b",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Headless"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.2375)
- ,(AlignDefault,ColWidth 0.15)
- ,(AlignDefault,ColWidth 0.1625)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a",SoftBreak,Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b",SoftBreak,Str "b",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Spaces",Space,Str "at",Space,Str "ends",Space,Str "of",Space,Str "lines"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.2375)
- ,(AlignDefault,ColWidth 0.15)
- ,(AlignDefault,ColWidth 0.1625)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r1",Space,Str "a",SoftBreak,Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b",SoftBreak,Str "b",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "r2",Space,Str "d"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiple",Space,Str "blocks",Space,Str "in",Space,Str "a",Space,Str "cell"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.2375)
- ,(AlignDefault,ColWidth 0.15)
- ,(AlignDefault,ColWidth 0.1625)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "r1",Space,Str "a"]
-    ,Para [Str "r1",Space,Str "bis"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [BulletList
-     [[Plain [Str "b"]]
-     ,[Plain [Str "b",Space,Str "2"]]
-     ,[Plain [Str "b",Space,Str "2"]]]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c",SoftBreak,Str "c",Space,Str "2",SoftBreak,Str "c",Space,Str "2"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 1 ("footnotes",[],[]) [Str "Footnotes"]
-,Para [Note [Para [Str "Note",Space,Str "with",Space,Str "one",Space,Str "line."]]]
-,Para [Note [Para [Str "Note",Space,Str "with",SoftBreak,Str "continuation",Space,Str "line."]]]
-,Para [Note [Para [Str "Note",Space,Str "with"],Para [Str "continuation",Space,Str "block."]]]
-,Para [Note [Para [Str "Note",Space,Str "with",SoftBreak,Str "continuation",Space,Str "line"],Para [Str "and",Space,Str "a",Space,Str "second",Space,Str "para."]]]
-,Para [Str "Not",Space,Str "in",Space,Str "note."]
-,Header 1 ("math",[],[]) [Str "Math"]
-,Para [Str "Some",Space,Str "inline",Space,Str "math",Space,Math InlineMath "E=mc^2",Str ".",Space,Str "Now",Space,Str "some",SoftBreak,Str "display",Space,Str "math:"]
-,Para [Math DisplayMath "E=mc^2"]
-,Para [Math DisplayMath "E = mc^2"]
-,Para [Math DisplayMath "E = mc^2",Math DisplayMath "\\alpha = \\beta"]
-,Para [Math DisplayMath "\\begin{aligned}\nE &= mc^2\\\\\nF &= \\pi E\n\\end{aligned}",Math DisplayMath "F &= \\gamma \\alpha^2"]
-,Para [Str "All",Space,Str "done."]
-,Header 1 ("default-role",[],[]) [Str "Default-Role"]
-,Para [Str "Try",Space,Str "changing",Space,Str "the",Space,Str "default",Space,Str "role",Space,Str "to",Space,Str "a",Space,Str "few",Space,Str "different",Space,Str "things."]
-,Header 2 ("doesnt-break-title-parsing",[],[]) [Str "Doesn\8217t",Space,Str "Break",Space,Str "Title",Space,Str "Parsing"]
-,Para [Str "Inline",Space,Str "math:",Space,Math InlineMath "E=mc^2",Space,Str "or",Space,Math InlineMath "E=mc^2",Space,Str "or",Space,Math InlineMath "E=mc^2",Str ".",SoftBreak,Str "Other",Space,Str "roles:",Space,Superscript [Str "super"],Str ",",Space,Subscript [Str "sub"],Str "."]
-,Para [Math DisplayMath "\\alpha = beta",Math DisplayMath "E = mc^2"]
-,Para [Str "Some",Space,Superscript [Str "of"],Space,Str "these",Space,Superscript [Str "words"],Space,Str "are",Space,Str "in",Space,Superscript [Str "superscript"],Str "."]
-,Para [Str "Reset",Space,Str "default-role",Space,Str "to",Space,Str "the",Space,Str "default",Space,Str "default."]
-,Para [Str "And",Space,Str "now",Space,Span ("",["title-ref"],[]) [Str "some-invalid-string-3231231"],Space,Str "is",Space,Str "nonsense."]
-,Para [Str "And",Space,Str "now",Space,Str "with",Space,RawInline (Format "html") "<b>inline</b> <span id=\"test\">HTML</span>",Str "."]
-,Para [Str "And",Space,Str "some",Space,Str "inline",Space,Str "haskell",Space,Code ("",["haskell"],[]) "fmap id [1,2..10]",Str "."]
-,Para [Str "Indirect",Space,Str "python",Space,Str "role",Space,Code ("",["py","python","indirect"],[]) "[x*x for x in [1,2,3,4,5]]",Str "."]
-,Para [Str "Different",Space,Str "indirect",Space,Str "C",Space,Code ("",["c","different-indirect"],[]) "int x = 15;",Str "."]
-,Header 2 ("literal-symbols",[],[]) [Str "Literal",Space,Str "symbols"]
-,Para [Str "2*2",Space,Str "=",Space,Str "4*1"]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaList
+          [ MetaInlines
+            [ Str "John", Space, Str "MacFarlane" ]
+          , MetaInlines
+            [ Str "Anonymous" ]
+          ]
+        )
+      ,
+        ( "date"
+        , MetaInlines
+          [ Str "July", Space, Str "17,", Space, Str "2006" ]
+        )
+      ,
+        ( "revision", MetaBlocks [ Para [ Str "3" ] ] )
+      ,
+        ( "subtitle", MetaInlines [ Str "Subtitle" ] )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Pandoc", Space, Str "Test", Space, Str "Suite" ]
+        )
+      ]
+    }
+  )
+  [ Header 1
+    ( "level-one-header", [], [] )
+    [ Str "Level", Space, Str "one", Space, Str "header" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc."
+    , Space
+    , Str "Most"
+    , Space
+    , Str "of"
+    , Space
+    , Str "them"
+    , Space
+    , Str "are"
+    , Space
+    , Str "adapted"
+    , Space
+    , Str "from"
+    , SoftBreak
+    , Str "John"
+    , Space
+    , Str "Gruber\8217s"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "test"
+    , Space
+    , Str "suite."
+    ]
+  , Header 2
+    ( "level-two-header", [], [] )
+    [ Str "Level", Space, Str "two", Space, Str "header" ]
+  , Header 3
+    ( "level-three", [], [] )
+    [ Str "Level", Space, Str "three" ]
+  , Header 4
+    ( "level-four-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "four"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 5
+    ( "level-five", [], [] )
+    [ Str "Level", Space, Str "five" ]
+  , Header 1
+    ( "paragraphs", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "In"
+    , Space
+    , Str "Markdown"
+    , Space
+    , Str "1.0.0"
+    , Space
+    , Str "and"
+    , Space
+    , Str "earlier."
+    , Space
+    , Str "Version"
+    , SoftBreak
+    , Str "8."
+    , Space
+    , Str "This"
+    , Space
+    , Str "line"
+    , Space
+    , Str "turns"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    , SoftBreak
+    , Str "Because"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard-wrapped"
+    , Space
+    , Str "line"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "middle"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "looked"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Str "list"
+    , Space
+    , Str "item."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    , SoftBreak
+    , Str "*"
+    , Space
+    , Str "criminey."
+    ]
+  , Para
+    [ Str "Horizontal", Space, Str "rule:" ]
+  , HorizontalRule
+  , Para
+    [ Str "Another:" ]
+  , HorizontalRule
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote:"
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , SoftBreak
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "pretty"
+      , Space
+      , Str "short."
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "another,"
+    , Space
+    , Str "differently"
+    , Space
+    , Str "indented:"
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , SoftBreak
+      , Str "It\8217s"
+      , Space
+      , Str "indented"
+      , Space
+      , Str "with"
+      , Space
+      , Str "a"
+      , Space
+      , Str "tab."
+      ]
+    , Para
+      [ Str "Code"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    , Para
+      [ Str "List"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , OrderedList
+      ( 1, Decimal, Period )
+      [
+        [ Plain [ Str "item", Space, Str "one" ] ]
+      ,
+        [ Plain [ Str "item", Space, Str "two" ] ]
+      ]
+    , Para
+      [ Str "Nested", Space, Str "block", Space, Str "quotes:" ]
+    , BlockQuote
+      [ Para [ Str "nested" ], BlockQuote [ Para [ Str "nested" ] ] ]
+    ]
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}"
+  , CodeBlock
+    ( "", [], [] ) "this code block is indented by one tab"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "this block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( "", [ "python" ], [] ) "def my_function(x):\n    return x + 1"
+  , Para
+    [ Str "If"
+    , Space
+    , Str "we"
+    , Space
+    , Str "use"
+    , Space
+    , Str "the"
+    , Space
+    , Str "highlight"
+    , Space
+    , Str "directive,"
+    , Space
+    , Str "we"
+    , Space
+    , Str "can"
+    , Space
+    , Str "specify"
+    , Space
+    , Str "a"
+    , Space
+    , Str "default"
+    , Space
+    , Str "language"
+    , SoftBreak
+    , Str "for"
+    , Space
+    , Str "literate"
+    , Space
+    , Str "blocks."
+    ]
+  , CodeBlock
+    ( ""
+    , [ "haskell" ]
+    , []
+    ) "-- this code is in haskell\ndata Tree = Leaf | Node Tree Tree"
+  , CodeBlock
+    ( ""
+    , [ "haskell" ]
+    , []
+    ) "-- this code is in haskell too\ndata Nat = Zero | Succ Nat"
+  , CodeBlock
+    ( ""
+    , [ "javascript" ]
+    , []
+    ) "-- this code is in javascript\nlet f = (x, y) => x + y"
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "unordered", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Asterisks", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Plain [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "ordered", [], [] )
+    [ Str "Ordered" ]
+  , Para
+    [ Str "Tight:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain [ Str "Second" ] ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "One" ] ]
+    ,
+      [ Plain [ Str "Two" ] ]
+    ,
+      [ Plain [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Loose", Space, Str "using", Space, Str "tabs:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain [ Str "Second" ] ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and", Space, Str "using", Space, Str "spaces:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "One" ] ]
+    ,
+      [ Plain [ Str "Two" ] ]
+    ,
+      [ Plain [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "paragraphs:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para
+        [ Str "Item", Space, Str "1,", Space, Str "graf", Space, Str "one." ]
+      , Para
+        [ Str "Item"
+        , Space
+        , Str "1."
+        , Space
+        , Str "graf"
+        , Space
+        , Str "two."
+        , Space
+        , Str "The"
+        , Space
+        , Str "quick"
+        , Space
+        , Str "brown"
+        , Space
+        , Str "fox"
+        , Space
+        , Str "jumped"
+        , Space
+        , Str "over"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lazy"
+        , Space
+        , Str "dog\8217s"
+        , SoftBreak
+        , Str "back."
+        ]
+      ]
+    ,
+      [ Para [ Str "Item", Space, Str "2." ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "3." ] ]
+    ]
+  , Para
+    [ Str "Nested:" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Tab" ]
+      , BulletList
+        [ [ Plain [ Str "Tab" ], BulletList [ [ Plain [ Str "Tab" ] ] ] ] ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s", Space, Str "another:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BlockQuote
+        [ BulletList
+          [
+            [ Plain [ Str "Fee" ] ]
+          ,
+            [ Plain [ Str "Fie" ] ]
+          ,
+            [ Plain [ Str "Foe" ] ]
+          ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "fancy-list-markers", [], [] )
+    [ Str "Fancy", Space, Str "list", Space, Str "markers" ]
+  , OrderedList
+    ( 2, Decimal, TwoParens )
+    [
+      [ Para [ Str "begins", Space, Str "with", Space, Str "2" ] ]
+    ,
+      [ Para
+        [ Str "and", Space, Str "now", Space, Str "3" ]
+      , Para
+        [ Str "with", Space, Str "a", Space, Str "continuation" ]
+      , OrderedList
+        ( 4, LowerRoman, Period )
+        [
+          [ Plain
+            [ Str "sublist"
+            , Space
+            , Str "with"
+            , Space
+            , Str "roman"
+            , Space
+            , Str "numerals,"
+            , Space
+            , Str "starting"
+            , Space
+            , Str "with"
+            , Space
+            , Str "4"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "more", Space, Str "items" ]
+          , OrderedList
+            ( 1, UpperAlpha, TwoParens )
+            [
+              [ Plain [ Str "a", Space, Str "subsublist" ] ]
+            ,
+              [ Plain [ Str "a", Space, Str "subsublist" ] ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Nesting:" ]
+  , OrderedList
+    ( 1, UpperAlpha, Period )
+    [
+      [ Plain
+        [ Str "Upper", Space, Str "Alpha" ]
+      , OrderedList
+        ( 1, UpperRoman, Period )
+        [
+          [ Plain
+            [ Str "Upper", Space, Str "Roman." ]
+          , OrderedList
+            ( 6, Decimal, TwoParens )
+            [
+              [ Plain
+                [ Str "Decimal"
+                , Space
+                , Str "start"
+                , Space
+                , Str "with"
+                , Space
+                , Str "6"
+                ]
+              , OrderedList
+                ( 3, LowerAlpha, OneParen )
+                [
+                  [ Plain
+                    [ Str "Lower"
+                    , Space
+                    , Str "alpha"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "paren"
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Autonumbering:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "Autonumber." ] ]
+    ,
+      [ Plain
+        [ Str "More." ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [ [ Plain [ Str "Nested." ] ] ]
+      ]
+    ]
+  , Para
+    [ Str "Autonumbering"
+    , Space
+    , Str "with"
+    , Space
+    , Str "explicit"
+    , Space
+    , Str "start:"
+    ]
+  , OrderedList
+    ( 4, LowerAlpha, TwoParens )
+    [
+      [ Plain [ Str "item", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "item", Space, Str "2" ] ]
+    ]
+  , Header 2
+    ( "definition", [], [] )
+    [ Str "Definition" ]
+  , DefinitionList
+    [
+      (
+        [ Str "term", Space, Str "1" ]
+      ,
+        [ [ Para [ Str "Definition", Space, Str "1." ] ] ]
+      )
+    ,
+      (
+        [ Str "term", Space, Str "2" ]
+      ,
+        [
+          [ Para
+            [ Str "Definition"
+            , Space
+            , Str "2,"
+            , Space
+            , Str "paragraph"
+            , Space
+            , Str "1."
+            ]
+          , Para
+            [ Str "Definition"
+            , Space
+            , Str "2,"
+            , Space
+            , Str "paragraph"
+            , Space
+            , Str "2."
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Str "term", Space, Str "with", Space, Emph [ Str "emphasis" ] ]
+      ,
+        [ [ Para [ Str "Definition", Space, Str "3." ] ] ]
+      )
+    ]
+  , Header 1
+    ( "field-lists", [], [] )
+    [ Str "Field", Space, Str "Lists" ]
+  , BlockQuote
+    [ DefinitionList
+      [
+        (
+          [ Str "address" ]
+        ,
+          [ [ Para [ Str "61", Space, Str "Main", Space, Str "St." ] ] ]
+        )
+      ,
+        (
+          [ Str "city" ]
+        ,
+          [
+            [ Para
+              [ Emph
+                [ Str "Nowhere" ]
+              , Str ","
+              , Space
+              , Str "MA,"
+              , SoftBreak
+              , Str "USA"
+              ]
+            ]
+          ]
+        )
+      ,
+        ( [ Str "phone" ], [ [ Para [ Str "123-4567" ] ] ] )
+      ]
+    ]
+  , DefinitionList
+    [
+      (
+        [ Str "address" ]
+      ,
+        [ [ Para [ Str "61", Space, Str "Main", Space, Str "St." ] ] ]
+      )
+    ,
+      (
+        [ Str "city" ]
+      ,
+        [
+          [ Para
+            [ Emph
+              [ Str "Nowhere" ]
+            , Str ","
+            , Space
+            , Str "MA,"
+            , SoftBreak
+            , Str "USA"
+            ]
+          ]
+        ]
+      )
+    ,
+      ( [ Str "phone" ], [ [ Para [ Str "123-4567" ] ] ] )
+    ]
+  , Header 1
+    ( "html-blocks", [], [] )
+    [ Str "HTML", Space, Str "Blocks" ]
+  , Para
+    [ Str "Simple"
+    , Space
+    , Str "block"
+    , Space
+    , Str "on"
+    , Space
+    , Str "one"
+    , Space
+    , Str "line:"
+    ]
+  , RawBlock
+    ( Format "html" ) "<div>foo</div>"
+  , Para
+    [ Str "Now,", Space, Str "nested:" ]
+  , RawBlock
+    ( Format "html" ) "<div>\n    <div>\n        <div>\n            foo\n        </div>\n    </div>\n</div>"
+  , Header 1
+    ( "latex-block", [], [] )
+    [ Str "LaTeX", Space, Str "Block" ]
+  , RawBlock
+    ( Format "latex" ) "\\begin{tabular}{|l|l|}\\hline\nAnimal & Number \\\\ \\hline\nDog    & 2      \\\\\nCat    & 1      \\\\ \\hline\n\\end{tabular}"
+  , Header 1
+    ( "inline-markup", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str "."
+    , Space
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) ">"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "<html>"
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Subscript
+      [ Str "subscripted" ]
+    , Space
+    , Str "and"
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Superscript
+      [ Str "superscripted" ]
+    , Str "."
+    ]
+  , Header 1
+    ( "special-characters", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "Here", Space, Str "is", Space, Str "some", Space, Str "unicode:" ]
+  , BulletList
+    [
+      [ Plain [ Str "I", Space, Str "hat:", Space, Str "\206" ] ]
+    ,
+      [ Plain [ Str "o", Space, Str "umlaut:", Space, Str "\246" ] ]
+    ,
+      [ Plain [ Str "section:", Space, Str "\167" ] ]
+    ,
+      [ Plain [ Str "set", Space, Str "membership:", Space, Str "\8712" ] ]
+    ,
+      [ Plain [ Str "copyright:", Space, Str "\169" ] ]
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "This", Space, Str "&", Space, Str "that." ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "`" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , Header 1
+    ( "links", [], [] )
+    [ Str "Links" ]
+  , Para
+    [ Str "Explicit:"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "URL" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Explicit"
+    , Space
+    , Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "label:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "foo" ]
+      ( "foo", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Two"
+    , Space
+    , Str "anonymous"
+    , Space
+    , Str "links:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "the", Space, Str "first" ]
+      ( "/url1/", "" )
+    , Space
+    , Str "and"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "the", Space, Str "second" ]
+      ( "/url2/", "" )
+    ]
+  , Para
+    [ Str "Reference"
+    , Space
+    , Str "links:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link1" ]
+      ( "/url1/", "" )
+    , Space
+    , Str "and"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link2" ]
+      ( "/url2/", "" )
+    , Space
+    , Str "and"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link1" ]
+      ( "/url1/", "" )
+    , Space
+    , Str "again."
+    ]
+  , Para
+    [ Str "Another"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "style"
+      , Space
+      , Str "of"
+      , Space
+      , Str "reference"
+      , Space
+      , Str "link"
+      ]
+      ( "/url1/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link"
+      , Space
+      , Str "with"
+      , Space
+      , Str "an"
+      , Space
+      , Str "ampersand"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "URL"
+      ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Str "amersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "AT&T" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Autolinks:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://example.com/?foo=1&bar=2" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Space
+    , Str "and"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "nobody@nowhere.net" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "But", Space, Str "not", Space, Str "here:" ]
+  , CodeBlock
+    ( "", [], [] ) "http://example.com/"
+  , Header 1
+    ( "images", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "From"
+    , Space
+    , Quoted DoubleQuote
+      [ Str "Voyage", Space, Str "dans", Space, Str "la", Space, Str "Lune" ]
+    , Space
+    , Str "by"
+    , Space
+    , Str "Georges"
+    , Space
+    , Str "Melies"
+    , Space
+    , Str "(1902):"
+    ]
+  , Para
+    [ Image ( "", [], [] ) [ Str "image" ] ( "lalune.jpg", "" ) ]
+  , Para
+    [ Image
+      ( "", [], [ ( "height", "2343px" ) ] )
+      [ Str "Voyage dans la Lune" ]
+      ( "lalune.jpg", "" )
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "movie" ]
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Image ( "", [], [] ) [ Str "A movie" ] ( "movie.jpg", "" ) ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Header 1
+    ( "comments", [], [] )
+    [ Str "Comments" ]
+  , Para
+    [ Str "First", Space, Str "paragraph" ]
+  , Para
+    [ Str "Another", Space, Str "paragraph" ]
+  , Para
+    [ Str "A", Space, Str "third", Space, Str "paragraph" ]
+  , Header 1
+    ( "line-blocks", [], [] )
+    [ Str "Line", Space, Str "blocks" ]
+  , LineBlock
+    [
+      [ Str "But"
+      , Space
+      , Str "can"
+      , Space
+      , Str "a"
+      , Space
+      , Str "bee"
+      , Space
+      , Str "be"
+      , Space
+      , Str "said"
+      , Space
+      , Str "to"
+      , Space
+      , Str "be"
+      ]
+    ,
+      [ Str "\160\160\160\160or"
+      , Space
+      , Str "not"
+      , Space
+      , Str "to"
+      , Space
+      , Str "be"
+      , Space
+      , Str "an"
+      , Space
+      , Str "entire"
+      , Space
+      , Str "bee,"
+      ]
+    ,
+      [ Str "\160\160\160\160\160\160\160\160when"
+      , Space
+      , Str "half"
+      , Space
+      , Str "the"
+      , Space
+      , Str "bee"
+      , Space
+      , Str "is"
+      , Space
+      , Str "not"
+      , Space
+      , Str "a"
+      , Space
+      , Str "bee,"
+      ]
+    ,
+      [ Str "\160\160\160\160\160\160\160\160\160\160\160\160due"
+      , Space
+      , Str "to"
+      , Space
+      , Str "some"
+      , Space
+      , Str "ancient"
+      , Space
+      , Str "injury?"
+      ]
+    , []
+    ,
+      [ Str "Continuation", Space, Str "line" ]
+    ,
+      [ Str "\160\160and", Space, Str "another" ]
+    ]
+  , Header 1
+    ( "simple-tables", [], [] )
+    [ Str "Simple", Space, Str "Tables" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "3" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r1", Space, Str "a" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Headless" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r1", Space, Str "a" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 1
+    ( "grid-tables", [], [] )
+    [ Str "Grid", Space, Str "Tables" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 0.2375 )
+    ,
+      ( AlignDefault, ColWidth 0.15 )
+    ,
+      ( AlignDefault, ColWidth 0.1625 )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "col", Space, Str "3" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "r1", Space, Str "a", SoftBreak, Str "r1", Space, Str "bis" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b", SoftBreak, Str "b", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c", SoftBreak, Str "c", Space, Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Headless" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 0.2375 )
+    ,
+      ( AlignDefault, ColWidth 0.15 )
+    ,
+      ( AlignDefault, ColWidth 0.1625 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "r1", Space, Str "a", SoftBreak, Str "r1", Space, Str "bis" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b", SoftBreak, Str "b", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c", SoftBreak, Str "c", Space, Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Spaces"
+    , Space
+    , Str "at"
+    , Space
+    , Str "ends"
+    , Space
+    , Str "of"
+    , Space
+    , Str "lines"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 0.2375 )
+    ,
+      ( AlignDefault, ColWidth 0.15 )
+    ,
+      ( AlignDefault, ColWidth 0.1625 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "r1", Space, Str "a", SoftBreak, Str "r1", Space, Str "bis" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b", SoftBreak, Str "b", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c", SoftBreak, Str "c", Space, Str "2" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "r2", Space, Str "d" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "Multiple"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "in"
+    , Space
+    , Str "a"
+    , Space
+    , Str "cell"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidth 0.2375 )
+    ,
+      ( AlignDefault, ColWidth 0.15 )
+    ,
+      ( AlignDefault, ColWidth 0.1625 )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para
+            [ Str "r1", Space, Str "a" ]
+          , Para
+            [ Str "r1", Space, Str "bis" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ BulletList
+            [
+              [ Plain [ Str "b" ] ]
+            ,
+              [ Plain [ Str "b", Space, Str "2" ] ]
+            ,
+              [ Plain [ Str "b", Space, Str "2" ] ]
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "c"
+            , SoftBreak
+            , Str "c"
+            , Space
+            , Str "2"
+            , SoftBreak
+            , Str "c"
+            , Space
+            , Str "2"
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 1
+    ( "footnotes", [], [] )
+    [ Str "Footnotes" ]
+  , Para
+    [ Note
+      [ Para
+        [ Str "Note", Space, Str "with", Space, Str "one", Space, Str "line." ]
+      ]
+    ]
+  , Para
+    [ Note
+      [ Para
+        [ Str "Note"
+        , Space
+        , Str "with"
+        , SoftBreak
+        , Str "continuation"
+        , Space
+        , Str "line."
+        ]
+      ]
+    ]
+  , Para
+    [ Note
+      [ Para
+        [ Str "Note", Space, Str "with" ]
+      , Para
+        [ Str "continuation", Space, Str "block." ]
+      ]
+    ]
+  , Para
+    [ Note
+      [ Para
+        [ Str "Note"
+        , Space
+        , Str "with"
+        , SoftBreak
+        , Str "continuation"
+        , Space
+        , Str "line"
+        ]
+      , Para
+        [ Str "and", Space, Str "a", Space, Str "second", Space, Str "para." ]
+      ]
+    ]
+  , Para
+    [ Str "Not", Space, Str "in", Space, Str "note." ]
+  , Header 1
+    ( "math", [], [] )
+    [ Str "Math" ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Str "inline"
+    , Space
+    , Str "math"
+    , Space
+    , Math InlineMath "E=mc^2"
+    , Str "."
+    , Space
+    , Str "Now"
+    , Space
+    , Str "some"
+    , SoftBreak
+    , Str "display"
+    , Space
+    , Str "math:"
+    ]
+  , Para
+    [ Math DisplayMath "E=mc^2" ]
+  , Para
+    [ Math DisplayMath "E = mc^2" ]
+  , Para
+    [ Math DisplayMath "E = mc^2", Math DisplayMath "\\alpha = \\beta" ]
+  , Para
+    [ Math DisplayMath "\\begin{aligned}\nE &= mc^2\\\\\nF &= \\pi E\n\\end{aligned}"
+    , Math DisplayMath "F &= \\gamma \\alpha^2"
+    ]
+  , Para
+    [ Str "All", Space, Str "done." ]
+  , Header 1
+    ( "default-role", [], [] )
+    [ Str "Default-Role" ]
+  , Para
+    [ Str "Try"
+    , Space
+    , Str "changing"
+    , Space
+    , Str "the"
+    , Space
+    , Str "default"
+    , Space
+    , Str "role"
+    , Space
+    , Str "to"
+    , Space
+    , Str "a"
+    , Space
+    , Str "few"
+    , Space
+    , Str "different"
+    , Space
+    , Str "things."
+    ]
+  , Header 2
+    ( "doesnt-break-title-parsing", [], [] )
+    [ Str "Doesn\8217t"
+    , Space
+    , Str "Break"
+    , Space
+    , Str "Title"
+    , Space
+    , Str "Parsing"
+    ]
+  , Para
+    [ Str "Inline"
+    , Space
+    , Str "math:"
+    , Space
+    , Math InlineMath "E=mc^2"
+    , Space
+    , Str "or"
+    , Space
+    , Math InlineMath "E=mc^2"
+    , Space
+    , Str "or"
+    , Space
+    , Math InlineMath "E=mc^2"
+    , Str "."
+    , SoftBreak
+    , Str "Other"
+    , Space
+    , Str "roles:"
+    , Space
+    , Superscript
+      [ Str "super" ]
+    , Str ","
+    , Space
+    , Subscript
+      [ Str "sub" ]
+    , Str "."
+    ]
+  , Para
+    [ Math DisplayMath "\\alpha = beta", Math DisplayMath "E = mc^2" ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Superscript
+      [ Str "of" ]
+    , Space
+    , Str "these"
+    , Space
+    , Superscript
+      [ Str "words" ]
+    , Space
+    , Str "are"
+    , Space
+    , Str "in"
+    , Space
+    , Superscript
+      [ Str "superscript" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Reset"
+    , Space
+    , Str "default-role"
+    , Space
+    , Str "to"
+    , Space
+    , Str "the"
+    , Space
+    , Str "default"
+    , Space
+    , Str "default."
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "now"
+    , Space
+    , Span
+      ( "", [ "title-ref" ], [] )
+      [ Str "some-invalid-string-3231231" ]
+    , Space
+    , Str "is"
+    , Space
+    , Str "nonsense."
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "now"
+    , Space
+    , Str "with"
+    , Space
+    , RawInline
+      ( Format "html" ) "<b>inline</b> <span id=\"test\">HTML</span>"
+    , Str "."
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "some"
+    , Space
+    , Str "inline"
+    , Space
+    , Str "haskell"
+    , Space
+    , Code
+      ( "", [ "haskell" ], [] ) "fmap id [1,2..10]"
+    , Str "."
+    ]
+  , Para
+    [ Str "Indirect"
+    , Space
+    , Str "python"
+    , Space
+    , Str "role"
+    , Space
+    , Code
+      ( "", [ "py", "python", "indirect" ], [] ) "[x*x for x in [1,2,3,4,5]]"
+    , Str "."
+    ]
+  , Para
+    [ Str "Different"
+    , Space
+    , Str "indirect"
+    , Space
+    , Str "C"
+    , Space
+    , Code
+      ( "", [ "c", "different-indirect" ], [] ) "int x = 15;"
+    , Str "."
+    ]
+  , Header 2
+    ( "literal-symbols", [], [] )
+    [ Str "Literal", Space, Str "symbols" ]
+  , Para
+    [ Str "2*2", Space, Str "=", Space, Str "4*1" ]
+  ]

--- a/test/rtf/accent.native
+++ b/test/rtf/accent.native
@@ -1,2 +1,18 @@
-Pandoc (Meta {unMeta = fromList []})
-[Para [Str "le",Space,Str "caf\233",Space,Str "o\249",Space,Str "on",Space,Str "ne",Space,Str "fume",Space,Str "pas"]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Para
+    [ Str "le"
+    , Space
+    , Str "caf\233"
+    , Space
+    , Str "o\249"
+    , Space
+    , Str "on"
+    , Space
+    , Str "ne"
+    , Space
+    , Str "fume"
+    , Space
+    , Str "pas"
+    ]
+  ]

--- a/test/rtf/bookmark.native
+++ b/test/rtf/bookmark.native
@@ -1,3 +1,11 @@
-Pandoc (Meta {unMeta = fromList []})
-[Para [Span ("bookmark_1",[],[]) [Str "Bookmark_1"]]
-,Para [Link ("",[],[]) [Str "click",Space,Str "me"] ("#bookmark_1","")]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Para
+    [ Span ( "bookmark_1", [], [] ) [ Str "Bookmark_1" ] ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "click", Space, Str "me" ]
+      ( "#bookmark_1", "" )
+    ]
+  ]

--- a/test/rtf/footnote.native
+++ b/test/rtf/footnote.native
@@ -1,2 +1,130 @@
-Pandoc (Meta {unMeta = fromList []})
-[Para [Str "Mead's",Space,Str "landmark",Space,Str "study",Space,Str "has",Space,Str "been",Space,Str "amply",Space,Str "annotated.",Note [Para [Str "See",Space,Str "Sahlins,",Space,Str "Bateson,",Space,Str "and",Space,Str "Geertz",Space,Str "for",Space,Str "a",Space,Str "complete",Space,Str "bibliography."]],Space,Str "It",Space,Str "was",Space,Str "her",Space,Str "work",Space,Str "in",Space,Str "America",Space,Str "during",Space,Str "the",Space,Str "Second",Space,Str "World",Space,Str "War,",Space,Str "however,",Space,Str "that",Space,Str "forms",Space,Str "the",Space,Str "basis",Space,Str "for",Space,Str "the",Space,Str "paper.",Space,Str "As",Space,Str "others",Space,Str "have",Space,Str "noted,",Note [Para [Str "A",Space,Str "complete",Space,Str "bibliography",Space,Str "will",Space,Str "be",Space,Str "found",Space,Str "at",Space,Str "the",Space,Str "end",Space,Str "of",Space,Str "this",Space,Str "chapter."]],Space,Str "this",Space,Str "period",Space,Str "was",Space,Str "a",Space,Str "turning",Space,Str "point",Space,Str "for",Space,Str "Margaret",Space,Str "Mead."]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Para
+    [ Str "Mead's"
+    , Space
+    , Str "landmark"
+    , Space
+    , Str "study"
+    , Space
+    , Str "has"
+    , Space
+    , Str "been"
+    , Space
+    , Str "amply"
+    , Space
+    , Str "annotated."
+    , Note
+      [ Para
+        [ Str "See"
+        , Space
+        , Str "Sahlins,"
+        , Space
+        , Str "Bateson,"
+        , Space
+        , Str "and"
+        , Space
+        , Str "Geertz"
+        , Space
+        , Str "for"
+        , Space
+        , Str "a"
+        , Space
+        , Str "complete"
+        , Space
+        , Str "bibliography."
+        ]
+      ]
+    , Space
+    , Str "It"
+    , Space
+    , Str "was"
+    , Space
+    , Str "her"
+    , Space
+    , Str "work"
+    , Space
+    , Str "in"
+    , Space
+    , Str "America"
+    , Space
+    , Str "during"
+    , Space
+    , Str "the"
+    , Space
+    , Str "Second"
+    , Space
+    , Str "World"
+    , Space
+    , Str "War,"
+    , Space
+    , Str "however,"
+    , Space
+    , Str "that"
+    , Space
+    , Str "forms"
+    , Space
+    , Str "the"
+    , Space
+    , Str "basis"
+    , Space
+    , Str "for"
+    , Space
+    , Str "the"
+    , Space
+    , Str "paper."
+    , Space
+    , Str "As"
+    , Space
+    , Str "others"
+    , Space
+    , Str "have"
+    , Space
+    , Str "noted,"
+    , Note
+      [ Para
+        [ Str "A"
+        , Space
+        , Str "complete"
+        , Space
+        , Str "bibliography"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "found"
+        , Space
+        , Str "at"
+        , Space
+        , Str "the"
+        , Space
+        , Str "end"
+        , Space
+        , Str "of"
+        , Space
+        , Str "this"
+        , Space
+        , Str "chapter."
+        ]
+      ]
+    , Space
+    , Str "this"
+    , Space
+    , Str "period"
+    , Space
+    , Str "was"
+    , Space
+    , Str "a"
+    , Space
+    , Str "turning"
+    , Space
+    , Str "point"
+    , Space
+    , Str "for"
+    , Space
+    , Str "Margaret"
+    , Space
+    , Str "Mead."
+    ]
+  ]

--- a/test/rtf/formatting.native
+++ b/test/rtf/formatting.native
@@ -1,10 +1,51 @@
-Pandoc (Meta {unMeta = fromList [("operator",MetaInlines [Str "John",Space,Str "MacFarlane"])]})
-[Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "test",Space,Str "of",Space,Str "FORMATTING.",Space,Str "This",Space,Str "is",Space,Str "hidden:",Space,Str "."]
-,Para [SmallCaps [Str "Small",Space,Str "Caps"]]
-,Para [Strong [Str "bold"]]
-,Para [Emph [Str "italics"]]
-,Para [Strong [Str "bold",Space,Emph [Str "and",Space,Str "italics"]]]
-,Para [Underline [Str "underlined"]]
-,Para [Strikeout [Str "strikeout"]]
-,Para [Str "x",Superscript [Str "superscript"]]
-,Para [Str "x",Subscript [Str "subscript"]]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "operator"
+        , MetaInlines
+          [ Str "John", Space, Str "MacFarlane" ]
+        )
+      ]
+    }
+  )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "test"
+    , Space
+    , Str "of"
+    , Space
+    , Str "FORMATTING."
+    , Space
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "hidden:"
+    , Space
+    , Str "."
+    ]
+  , Para
+    [ SmallCaps [ Str "Small", Space, Str "Caps" ] ]
+  , Para
+    [ Strong [ Str "bold" ] ]
+  , Para
+    [ Emph [ Str "italics" ] ]
+  , Para
+    [ Strong
+      [ Str "bold", Space, Emph [ Str "and", Space, Str "italics" ] ]
+    ]
+  , Para
+    [ Underline [ Str "underlined" ] ]
+  , Para
+    [ Strikeout [ Str "strikeout" ] ]
+  , Para
+    [ Str "x", Superscript [ Str "superscript" ] ]
+  , Para
+    [ Str "x", Subscript [ Str "subscript" ] ]
+  ]

--- a/test/rtf/heading.native
+++ b/test/rtf/heading.native
@@ -1,5 +1,14 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("",[],[]) [Str "Heading",Space,Str "1"]
-,Header 2 ("",[],[]) [Str "Heading",Space,Str "2"]
-,Header 3 ("",[],[]) [Str "Heading",Space,Str "3"]
-,Para [Str "Paragraph"]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "", [], [] )
+    [ Str "Heading", Space, Str "1" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Heading", Space, Str "2" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Heading", Space, Str "3" ]
+  , Para
+    [ Str "Paragraph" ]
+  ]

--- a/test/rtf/image.native
+++ b/test/rtf/image.native
@@ -1,2 +1,9 @@
-Pandoc (Meta {unMeta = fromList []})
-[Para [Image ("",[],[("width","2.0in"),("height","2.0in")]) [Str "image"] ("f9d88c3dbe18f6a7f5670e994a947d51216cdf0e.jpg","")]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Para
+    [ Image
+      ( "", [], [ ( "width", "2.0in" ), ( "height", "2.0in" ) ] )
+      [ Str "image" ]
+      ( "f9d88c3dbe18f6a7f5670e994a947d51216cdf0e.jpg", "" )
+    ]
+  ]

--- a/test/rtf/link.native
+++ b/test/rtf/link.native
@@ -1,2 +1,5 @@
-Pandoc (Meta {unMeta = fromList []})
-[Para [Link ("",[],[]) [Str "pandoc"] ("http://pandoc.org","")]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Para
+    [ Link ( "", [], [] ) [ Str "pandoc" ] ( "http://pandoc.org", "" ) ]
+  ]

--- a/test/rtf/list_complex.native
+++ b/test/rtf/list_complex.native
@@ -1,24 +1,84 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaInlines [Str "Cynthia",Space,Str "Johnson"]),("operator",MetaInlines [Str "John",Space,Str "MacFarlane"]),("title",MetaInlines [Str "Text",Space,Str "before",Space,Str "list"])]})
-[OrderedList (1,Decimal,Period)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]
-  ,OrderedList (1,LowerAlpha,Period)
-   [[Para [Str "Three"]]
-   ,[Para [Str "Four"]
-    ,OrderedList (1,LowerRoman,Period)
-     [[Para [Str "Five"]]
-     ,[Para [Str "Six"]
-      ,OrderedList (1,UpperAlpha,Period)
-       [[Para [Str "Seven"]]
-       ,[Para [Str "Eight"]
-        ,OrderedList (1,UpperRoman,Period)
-         [[Para [Str "Nine"]]
-         ,[Para [Str "Ten"]
-          ,BulletList
-           [[Para [Str "Eleven"]]
-           ,[Para [Str "Twelve"]]]]]]]]]]]]]
-,Para [Str "Out",Space,Str "of",Space,Str "list!"]
-,Para [Str "Start",Space,Str "with"]
-,OrderedList (7,Decimal,Period)
- [[Para [Str "Seven",Space,Str "Start"]]
- ,[Para [Str "Eight",Space,Str "Continue"]]]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaInlines
+          [ Str "Cynthia", Space, Str "Johnson" ]
+        )
+      ,
+        ( "operator"
+        , MetaInlines
+          [ Str "John", Space, Str "MacFarlane" ]
+        )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Text", Space, Str "before", Space, Str "list" ]
+        )
+      ]
+    }
+  )
+  [ OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "One" ] ]
+    ,
+      [ Para
+        [ Str "Two" ]
+      , OrderedList
+        ( 1, LowerAlpha, Period )
+        [
+          [ Para [ Str "Three" ] ]
+        ,
+          [ Para
+            [ Str "Four" ]
+          , OrderedList
+            ( 1, LowerRoman, Period )
+            [
+              [ Para [ Str "Five" ] ]
+            ,
+              [ Para
+                [ Str "Six" ]
+              , OrderedList
+                ( 1, UpperAlpha, Period )
+                [
+                  [ Para [ Str "Seven" ] ]
+                ,
+                  [ Para
+                    [ Str "Eight" ]
+                  , OrderedList
+                    ( 1, UpperRoman, Period )
+                    [
+                      [ Para [ Str "Nine" ] ]
+                    ,
+                      [ Para
+                        [ Str "Ten" ]
+                      , BulletList
+                        [
+                          [ Para [ Str "Eleven" ] ]
+                        ,
+                          [ Para [ Str "Twelve" ] ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Out", Space, Str "of", Space, Str "list!" ]
+  , Para
+    [ Str "Start", Space, Str "with" ]
+  , OrderedList
+    ( 7, Decimal, Period )
+    [
+      [ Para [ Str "Seven", Space, Str "Start" ] ]
+    ,
+      [ Para [ Str "Eight", Space, Str "Continue" ] ]
+    ]
+  ]

--- a/test/rtf/list_simple.native
+++ b/test/rtf/list_simple.native
@@ -1,8 +1,11 @@
-Pandoc (Meta {unMeta = fromList []})
-[BulletList
- [[Para [Str "one"]]
- ,[Para [Str "two"]
-  ,BulletList
-   [[Para [Str "sub"]]]]]
-,BulletList
- [[Para [Str "new",Space,Str "list"]]]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ BulletList
+    [
+      [ Para [ Str "one" ] ]
+    ,
+      [ Para [ Str "two" ], BulletList [ [ Para [ Str "sub" ] ] ] ]
+    ]
+  , BulletList
+    [ [ Para [ Str "new", Space, Str "list" ] ] ]
+  ]

--- a/test/rtf/table_error_codes.native
+++ b/test/rtf/table_error_codes.native
@@ -1,146 +1,369 @@
-Pandoc (Meta {unMeta = fromList []})
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Code"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "Error"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocFailOnWarningError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocAppError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocTemplateError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "6"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocOptionError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "21"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocUnknownReaderError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "22"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocUnknownWriterError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "23"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocUnsupportedExtensionError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "24"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocCiteprocError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "31"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocEpubSubdirectoryError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "43"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocPDFError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "44"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocXMLError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "47"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocPDFProgramNotFoundError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "61"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocHttpError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "62"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocShouldNeverHappenError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "63"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocSomeError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "64"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocParseError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "65"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocParsecError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "66"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocMakePDFError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "67"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocSyntaxMapError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "83"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocFilterError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "91"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocMacroLoop"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "92"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocUTF8DecodingError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "93"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocIpynbDecodingError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "94"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocUnsupportedCharsetError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "97"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocCouldNotFindDataFileError"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "99"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "PandocResourceNotFound"]]]])]
- (TableFoot ("",[],[])
- [])]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Code" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "Error" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocFailOnWarningError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocAppError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocTemplateError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "6" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocOptionError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "21" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocUnknownReaderError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "22" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocUnknownWriterError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "23" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocUnsupportedExtensionError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "24" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocCiteprocError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "31" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocEpubSubdirectoryError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "43" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocPDFError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "44" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocXMLError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "47" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocPDFProgramNotFoundError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "61" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocHttpError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "62" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocShouldNeverHappenError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "63" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocSomeError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "64" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocParseError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "65" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocParsecError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "66" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocMakePDFError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "67" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocSyntaxMapError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "83" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocFilterError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "91" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocMacroLoop" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "92" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocUTF8DecodingError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "93" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocIpynbDecodingError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "94" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocUnsupportedCharsetError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "97" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocCouldNotFindDataFileError" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "99" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "PandocResourceNotFound" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  ]

--- a/test/rtf/table_simple.native
+++ b/test/rtf/table_simple.native
@@ -1,31 +1,68 @@
-Pandoc (Meta {unMeta = fromList []})
-[Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "A"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "B"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "C"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "D"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "E"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "F"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "G"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Para [Str "H"]]]])]
- (TableFoot ("",[],[])
- [])]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "A" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "B" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "C" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "D" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "E" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "F" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "G" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Para [ Str "H" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  ]

--- a/test/rtf/unicode.native
+++ b/test/rtf/unicode.native
@@ -1,2 +1,3 @@
-Pandoc (Meta {unMeta = fromList []})
-[Para [Str "\8220hi\8221\8216hi\8217\61623\945\228"]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Para [ Str "\8220hi\8221\8216hi\8217\61623\945\228" ] ]

--- a/test/tables-rstsubset.native
+++ b/test/tables-rstsubset.native
@@ -1,301 +1,913 @@
-[Para [Str "Simple",Space,Str "table",Space,Str "with",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Demonstration",Space,Str "of",Space,Str "simple",Space,Str "table",Space,Str "syntax."]])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Simple",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Simple",Space,Str "table",Space,Str "indented",Space,Str "two",Space,Str "spaces:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Demonstration",Space,Str "of",Space,Str "simple",Space,Str "table",Space,Str "syntax."]])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "with",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Here\8217s",Space,Str "the",Space,Str "caption.",Space,Str "It",Space,Str "may",Space,Str "span",Space,Str "multiple",Space,Str "lines."]])
- [(AlignDefault,ColWidth 0.1375)
- ,(AlignDefault,ColWidth 0.125)
- ,(AlignDefault,ColWidth 0.15)
- ,(AlignDefault,ColWidth 0.3375)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Centered",SoftBreak,Str "Header"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left",SoftBreak,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right",SoftBreak,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default",Space,Str "aligned"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",SoftBreak,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",SoftBreak,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",SoftBreak,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.1375)
- ,(AlignDefault,ColWidth 0.125)
- ,(AlignDefault,ColWidth 0.15)
- ,(AlignDefault,ColWidth 0.3375)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Centered",SoftBreak,Str "Header"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left",SoftBreak,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right",SoftBreak,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default",Space,Str "aligned"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",SoftBreak,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",SoftBreak,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",SoftBreak,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Table",Space,Str "without",Space,Str "column",Space,Str "headers:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "without",Space,Str "column",Space,Str "headers:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidth 0.1375)
- ,(AlignDefault,ColWidth 0.125)
- ,(AlignDefault,ColWidth 0.15)
- ,(AlignDefault,ColWidth 0.3375)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",SoftBreak,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",SoftBreak,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",SoftBreak,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Para
+  [ Str "Simple", Space, Str "table", Space, Str "with", Space, Str "caption:" ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing
+    [ Plain
+      [ Str "Demonstration"
+      , Space
+      , Str "of"
+      , Space
+      , Str "simple"
+      , Space
+      , Str "table"
+      , Space
+      , Str "syntax."
+      ]
+    ]
+  )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Simple"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Simple"
+  , Space
+  , Str "table"
+  , Space
+  , Str "indented"
+  , Space
+  , Str "two"
+  , Space
+  , Str "spaces:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing
+    [ Plain
+      [ Str "Demonstration"
+      , Space
+      , Str "of"
+      , Space
+      , Str "simple"
+      , Space
+      , Str "table"
+      , Space
+      , Str "syntax."
+      ]
+    ]
+  )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Multiline"
+  , Space
+  , Str "table"
+  , Space
+  , Str "with"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing
+    [ Plain
+      [ Str "Here\8217s"
+      , Space
+      , Str "the"
+      , Space
+      , Str "caption."
+      , Space
+      , Str "It"
+      , Space
+      , Str "may"
+      , Space
+      , Str "span"
+      , Space
+      , Str "multiple"
+      , Space
+      , Str "lines."
+      ]
+    ]
+  )
+  [
+    ( AlignDefault, ColWidth 0.15 )
+  ,
+    ( AlignDefault, ColWidth 0.1375 )
+  ,
+    ( AlignDefault, ColWidth 0.1625 )
+  ,
+    ( AlignDefault, ColWidth 0.35 )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Centered", SoftBreak, Str "Header" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left", SoftBreak, Str "Aligned" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right", SoftBreak, Str "Aligned" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default", Space, Str "aligned" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "First" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Example"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "row"
+          , Space
+          , Str "that"
+          , SoftBreak
+          , Str "spans"
+          , Space
+          , Str "multiple"
+          , Space
+          , Str "lines."
+          ]
+        ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Second" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "5.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Here\8217s"
+          , Space
+          , Str "another"
+          , Space
+          , Str "one."
+          , Space
+          , Str "Note"
+          , SoftBreak
+          , Str "the"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "line"
+          , Space
+          , Str "between"
+          , SoftBreak
+          , Str "rows."
+          ]
+        ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Multiline"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidth 0.15 )
+  ,
+    ( AlignDefault, ColWidth 0.1375 )
+  ,
+    ( AlignDefault, ColWidth 0.1625 )
+  ,
+    ( AlignDefault, ColWidth 0.35 )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Centered", SoftBreak, Str "Header" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left", SoftBreak, Str "Aligned" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right", SoftBreak, Str "Aligned" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default", Space, Str "aligned" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "First" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Example"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "row"
+          , Space
+          , Str "that"
+          , SoftBreak
+          , Str "spans"
+          , Space
+          , Str "multiple"
+          , Space
+          , Str "lines."
+          ]
+        ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Second" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "5.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Here\8217s"
+          , Space
+          , Str "another"
+          , Space
+          , Str "one."
+          , Space
+          , Str "Note"
+          , SoftBreak
+          , Str "the"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "line"
+          , Space
+          , Str "between"
+          , SoftBreak
+          , Str "rows."
+          ]
+        ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "column"
+  , Space
+  , Str "headers:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 ) []
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Multiline"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "column"
+  , Space
+  , Str "headers:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignDefault, ColWidth 0.15 )
+  ,
+    ( AlignDefault, ColWidth 0.1375 )
+  ,
+    ( AlignDefault, ColWidth 0.1625 )
+  ,
+    ( AlignDefault, ColWidth 0.35 )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "First" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Example"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "row"
+          , Space
+          , Str "that"
+          , SoftBreak
+          , Str "spans"
+          , Space
+          , Str "multiple"
+          , Space
+          , Str "lines."
+          ]
+        ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Second" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "5.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Here\8217s"
+          , Space
+          , Str "another"
+          , Space
+          , Str "one."
+          , Space
+          , Str "Note"
+          , SoftBreak
+          , Str "the"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "line"
+          , Space
+          , Str "between"
+          , SoftBreak
+          , Str "rows."
+          ]
+        ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]

--- a/test/tables.haddock
+++ b/test/tables.haddock
@@ -40,33 +40,33 @@ Demonstration of simple table syntax.
 
 Multiline table with caption:
 
-+----------+---------+-----------+--------------------------+
-| Centered | Left    | Right     | Default aligned          |
-| Header   | Aligned | Aligned   |                          |
-+==========+=========+===========+==========================+
-| First    | row     | 12.0      | Example of a row that    |
-|          |         |           | spans multiple lines.    |
-+----------+---------+-----------+--------------------------+
-| Second   | row     | 5.0       | Here’s another one. Note |
-|          |         |           | the blank line between   |
-|          |         |           | rows.                    |
-+----------+---------+-----------+--------------------------+
++-----------+----------+------------+---------------------------+
+| Centered  | Left     | Right      | Default aligned           |
+| Header    | Aligned  | Aligned    |                           |
++===========+==========+============+===========================+
+| First     | row      | 12.0       | Example of a row that     |
+|           |          |            | spans multiple lines.     |
++-----------+----------+------------+---------------------------+
+| Second    | row      | 5.0        | Here’s another one. Note  |
+|           |          |            | the blank line between    |
+|           |          |            | rows.                     |
++-----------+----------+------------+---------------------------+
 
 Here’s the caption. It may span multiple lines.
 
 Multiline table without caption:
 
-+----------+---------+-----------+--------------------------+
-| Centered | Left    | Right     | Default aligned          |
-| Header   | Aligned | Aligned   |                          |
-+==========+=========+===========+==========================+
-| First    | row     | 12.0      | Example of a row that    |
-|          |         |           | spans multiple lines.    |
-+----------+---------+-----------+--------------------------+
-| Second   | row     | 5.0       | Here’s another one. Note |
-|          |         |           | the blank line between   |
-|          |         |           | rows.                    |
-+----------+---------+-----------+--------------------------+
++-----------+----------+------------+---------------------------+
+| Centered  | Left     | Right      | Default aligned           |
+| Header    | Aligned  | Aligned    |                           |
++===========+==========+============+===========================+
+| First     | row      | 12.0       | Example of a row that     |
+|           |          |            | spans multiple lines.     |
++-----------+----------+------------+---------------------------+
+| Second    | row      | 5.0        | Here’s another one. Note  |
+|           |          |            | the blank line between    |
+|           |          |            | rows.                     |
++-----------+----------+------------+---------------------------+
 
 Table without column headers:
 
@@ -80,11 +80,11 @@ Table without column headers:
 
 Multiline table without column headers:
 
-+----------+---------+-----------+--------------------------+
-| First    | row     | 12.0      | Example of a row that    |
-|          |         |           | spans multiple lines.    |
-+----------+---------+-----------+--------------------------+
-| Second   | row     | 5.0       | Here’s another one. Note |
-|          |         |           | the blank line between   |
-|          |         |           | rows.                    |
-+----------+---------+-----------+--------------------------+
++-----------+----------+------------+---------------------------+
+| First     | row      | 12.0       | Example of a row that     |
+|           |          |            | spans multiple lines.     |
++-----------+----------+------------+---------------------------+
+| Second    | row      | 5.0        | Here’s another one. Note  |
+|           |          |            | the blank line between    |
+|           |          |            | rows.                     |
++-----------+----------+------------+---------------------------+

--- a/test/tables.markdown
+++ b/test/tables.markdown
@@ -28,33 +28,33 @@ Simple table indented two spaces:
 
 Multiline table with caption:
 
-  --------------------------------------------------------------
+  ---------------------------------------------------------------
    Centered   Left              Right Default aligned
     Header    Aligned         Aligned 
-  ----------- ---------- ------------ --------------------------
-     First    row                12.0 Example of a row that
-                                      spans multiple lines.
+  ----------- ---------- ------------ ---------------------------
+     First    row                12.0 Example of a row that spans
+                                      multiple lines.
 
     Second    row                 5.0 Here's another one. Note
                                       the blank line between
                                       rows.
-  --------------------------------------------------------------
+  ---------------------------------------------------------------
 
   : Here's the caption. It may span multiple lines.
 
 Multiline table without caption:
 
-  --------------------------------------------------------------
+  ---------------------------------------------------------------
    Centered   Left              Right Default aligned
     Header    Aligned         Aligned 
-  ----------- ---------- ------------ --------------------------
-     First    row                12.0 Example of a row that
-                                      spans multiple lines.
+  ----------- ---------- ------------ ---------------------------
+     First    row                12.0 Example of a row that spans
+                                      multiple lines.
 
     Second    row                 5.0 Here's another one. Note
                                       the blank line between
                                       rows.
-  --------------------------------------------------------------
+  ---------------------------------------------------------------
 
 Table without column headers:
 
@@ -66,11 +66,11 @@ Table without column headers:
 
 Multiline table without column headers:
 
-  ----------- ---------- ------------ --------------------------
-     First    row                12.0 Example of a row that
-                                      spans multiple lines.
+  ----------- ---------- ------------ ---------------------------
+     First    row                12.0 Example of a row that spans
+                                      multiple lines.
 
     Second    row                 5.0 Here's another one. Note
                                       the blank line between
                                       rows.
-  ----------- ---------- ------------ --------------------------
+  ----------- ---------- ------------ ---------------------------

--- a/test/tables.muse
+++ b/test/tables.muse
@@ -23,24 +23,24 @@ Simple table indented two spaces:
 
 Multiline table with caption:
 
-+----------+---------+-----------+--------------------------+
-| First    | row     | 12.0      | Example of a row that    |
-|          |         |           | spans multiple lines.    |
-+----------+---------+-----------+--------------------------+
-| Second   | row     | 5.0       | Here’s another one. Note |
-|          |         |           | the blank line between   |
-|          |         |           | rows.                    |
-+----------+---------+-----------+--------------------------+
++-----------+----------+------------+---------------------------+
+| First     | row      | 12.0       | Example of a row that     |
+|           |          |            | spans multiple lines.     |
++-----------+----------+------------+---------------------------+
+| Second    | row      | 5.0        | Here’s another one. Note  |
+|           |          |            | the blank line between    |
+|           |          |            | rows.                     |
++-----------+----------+------------+---------------------------+
 Multiline table without caption:
 
-+----------+---------+-----------+--------------------------+
-| First    | row     | 12.0      | Example of a row that    |
-|          |         |           | spans multiple lines.    |
-+----------+---------+-----------+--------------------------+
-| Second   | row     | 5.0       | Here’s another one. Note |
-|          |         |           | the blank line between   |
-|          |         |           | rows.                    |
-+----------+---------+-----------+--------------------------+
++-----------+----------+------------+---------------------------+
+| First     | row      | 12.0       | Example of a row that     |
+|           |          |            | spans multiple lines.     |
++-----------+----------+------------+---------------------------+
+| Second    | row      | 5.0        | Here’s another one. Note  |
+|           |          |            | the blank line between    |
+|           |          |            | rows.                     |
++-----------+----------+------------+---------------------------+
 Table without column headers:
 
  12  | 12  | 12  | 12
@@ -49,11 +49,11 @@ Table without column headers:
 
 Multiline table without column headers:
 
-+----------+---------+-----------+--------------------------+
-| First    | row     | 12.0      | Example of a row that    |
-|          |         |           | spans multiple lines.    |
-+----------+---------+-----------+--------------------------+
-| Second   | row     | 5.0       | Here’s another one. Note |
-|          |         |           | the blank line between   |
-|          |         |           | rows.                    |
-+----------+---------+-----------+--------------------------+
++-----------+----------+------------+---------------------------+
+| First     | row      | 12.0       | Example of a row that     |
+|           |          |            | spans multiple lines.     |
++-----------+----------+------------+---------------------------+
+| Second    | row      | 5.0        | Here’s another one. Note  |
+|           |          |            | the blank line between    |
+|           |          |            | rows.                     |
++-----------+----------+------------+---------------------------+

--- a/test/tables.native
+++ b/test/tables.native
@@ -1,293 +1,891 @@
-[Para [Str "Simple",Space,Str "table",Space,Str "with",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Demonstration",Space,Str "of",Space,Str "simple",Space,Str "table",Space,Str "syntax."]])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Simple",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Simple",Space,Str "table",Space,Str "indented",Space,Str "two",Space,Str "spaces:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Demonstration",Space,Str "of",Space,Str "simple",Space,Str "table",Space,Str "syntax."]])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Center"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "with",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [Plain [Str "Here\8217s",Space,Str "the",Space,Str "caption.",SoftBreak,Str "It",Space,Str "may",Space,Str "span",Space,Str "multiple",Space,Str "lines."]])
- [(AlignCenter,ColWidth 0.15)
- ,(AlignLeft,ColWidth 0.1375)
- ,(AlignRight,ColWidth 0.1625)
- ,(AlignLeft,ColWidth 0.35)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Centered",SoftBreak,Str "Header"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left",SoftBreak,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right",SoftBreak,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default",Space,Str "aligned"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",Space,Str "spans",SoftBreak,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",SoftBreak,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",Space,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "without",Space,Str "caption:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidth 0.15)
- ,(AlignLeft,ColWidth 0.1375)
- ,(AlignRight,ColWidth 0.1625)
- ,(AlignLeft,ColWidth 0.35)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Centered",SoftBreak,Str "Header"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Left",SoftBreak,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Right",SoftBreak,Str "Aligned"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Default",Space,Str "aligned"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",Space,Str "spans",SoftBreak,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",SoftBreak,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",Space,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Table",Space,Str "without",Space,Str "column",Space,Str "headers:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "123"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "Multiline",Space,Str "table",Space,Str "without",Space,Str "column",Space,Str "headers:"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidth 0.15)
- ,(AlignLeft,ColWidth 0.1375)
- ,(AlignRight,ColWidth 0.1625)
- ,(AlignDefault,ColWidth 0.35)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "First"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "12.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",Space,Str "spans",SoftBreak,Str "multiple",Space,Str "lines."]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Second"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "row"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5.0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",SoftBreak,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",Space,Str "rows."]]]])]
- (TableFoot ("",[],[])
- [])]
+[ Para
+  [ Str "Simple", Space, Str "table", Space, Str "with", Space, Str "caption:" ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing
+    [ Plain
+      [ Str "Demonstration"
+      , Space
+      , Str "of"
+      , Space
+      , Str "simple"
+      , Space
+      , Str "table"
+      , Space
+      , Str "syntax."
+      ]
+    ]
+  )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Simple"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Simple"
+  , Space
+  , Str "table"
+  , Space
+  , Str "indented"
+  , Space
+  , Str "two"
+  , Space
+  , Str "spaces:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing
+    [ Plain
+      [ Str "Demonstration"
+      , Space
+      , Str "of"
+      , Space
+      , Str "simple"
+      , Space
+      , Str "table"
+      , Space
+      , Str "syntax."
+      ]
+    ]
+  )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignDefault, ColWidthDefault )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Center" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Multiline"
+  , Space
+  , Str "table"
+  , Space
+  , Str "with"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing
+    [ Plain
+      [ Str "Here\8217s"
+      , Space
+      , Str "the"
+      , Space
+      , Str "caption."
+      , SoftBreak
+      , Str "It"
+      , Space
+      , Str "may"
+      , Space
+      , Str "span"
+      , Space
+      , Str "multiple"
+      , Space
+      , Str "lines."
+      ]
+    ]
+  )
+  [
+    ( AlignCenter, ColWidth 0.15 )
+  ,
+    ( AlignLeft, ColWidth 0.1375 )
+  ,
+    ( AlignRight, ColWidth 0.1625 )
+  ,
+    ( AlignLeft, ColWidth 0.35 )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Centered", SoftBreak, Str "Header" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left", SoftBreak, Str "Aligned" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right", SoftBreak, Str "Aligned" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default", Space, Str "aligned" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "First" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Example"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "row"
+          , Space
+          , Str "that"
+          , Space
+          , Str "spans"
+          , SoftBreak
+          , Str "multiple"
+          , Space
+          , Str "lines."
+          ]
+        ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Second" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "5.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Here\8217s"
+          , Space
+          , Str "another"
+          , Space
+          , Str "one."
+          , Space
+          , Str "Note"
+          , SoftBreak
+          , Str "the"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "line"
+          , Space
+          , Str "between"
+          , Space
+          , Str "rows."
+          ]
+        ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Multiline"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "caption:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignCenter, ColWidth 0.15 )
+  ,
+    ( AlignLeft, ColWidth 0.1375 )
+  ,
+    ( AlignRight, ColWidth 0.1625 )
+  ,
+    ( AlignLeft, ColWidth 0.35 )
+  ]
+  ( TableHead
+    ( "", [], [] )
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Centered", SoftBreak, Str "Header" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Left", SoftBreak, Str "Aligned" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Right", SoftBreak, Str "Aligned" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Default", Space, Str "aligned" ] ]
+      ]
+    ]
+  )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "First" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Example"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "row"
+          , Space
+          , Str "that"
+          , Space
+          , Str "spans"
+          , SoftBreak
+          , Str "multiple"
+          , Space
+          , Str "lines."
+          ]
+        ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Second" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "5.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Here\8217s"
+          , Space
+          , Str "another"
+          , Space
+          , Str "one."
+          , Space
+          , Str "Note"
+          , SoftBreak
+          , Str "the"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "line"
+          , Space
+          , Str "between"
+          , Space
+          , Str "rows."
+          ]
+        ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "column"
+  , Space
+  , Str "headers:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignRight, ColWidthDefault )
+  ,
+    ( AlignLeft, ColWidthDefault )
+  ,
+    ( AlignCenter, ColWidthDefault )
+  ,
+    ( AlignRight, ColWidthDefault )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "123" ] ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "1" ] ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+, Para
+  [ Str "Multiline"
+  , Space
+  , Str "table"
+  , Space
+  , Str "without"
+  , Space
+  , Str "column"
+  , Space
+  , Str "headers:"
+  ]
+, Table
+  ( "", [], [] )
+  ( Caption Nothing [] )
+  [
+    ( AlignCenter, ColWidth 0.15 )
+  ,
+    ( AlignLeft, ColWidth 0.1375 )
+  ,
+    ( AlignRight, ColWidth 0.1625 )
+  ,
+    ( AlignDefault, ColWidth 0.35 )
+  ]
+  ( TableHead ( "", [], [] ) [] )
+  [ TableBody
+    ( "", [], [] )
+    ( RowHeadColumns 0 ) []
+    [ Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "First" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "12.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Example"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "row"
+          , Space
+          , Str "that"
+          , Space
+          , Str "spans"
+          , SoftBreak
+          , Str "multiple"
+          , Space
+          , Str "lines."
+          ]
+        ]
+      ]
+    , Row
+      ( "", [], [] )
+      [ Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "Second" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "row" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain [ Str "5.0" ] ]
+      , Cell
+        ( "", [], [] ) AlignDefault
+        ( RowSpan 1 )
+        ( ColSpan 1 )
+        [ Plain
+          [ Str "Here\8217s"
+          , Space
+          , Str "another"
+          , Space
+          , Str "one."
+          , Space
+          , Str "Note"
+          , SoftBreak
+          , Str "the"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "line"
+          , Space
+          , Str "between"
+          , Space
+          , Str "rows."
+          ]
+        ]
+      ]
+    ]
+  ]
+  ( TableFoot ( "", [], [] ) [] )
+]

--- a/test/tables.opendocument
+++ b/test/tables.opendocument
@@ -201,8 +201,8 @@ syntax.</text:p>
 </table:table>
 <text:p text:style-name="First_20_paragraph">Multiline table with
 caption:</text:p>
-<text:p text:style-name="TableCaption">Here’s the caption. It may span
-multiple lines.</text:p>
+<text:p text:style-name="TableCaption">Here’s the caption. It may span multiple
+lines.</text:p>
 <table:table table:name="Table4" table:style-name="Table4">
   <table:table-column table:style-name="Table4.A" />
   <table:table-column table:style-name="Table4.B" />

--- a/test/tables.plain
+++ b/test/tables.plain
@@ -28,33 +28,33 @@ Simple table indented two spaces:
 
 Multiline table with caption:
 
-  --------------------------------------------------------------
+  ---------------------------------------------------------------
    Centered   Left              Right Default aligned
     Header    Aligned         Aligned 
-  ----------- ---------- ------------ --------------------------
-     First    row                12.0 Example of a row that
-                                      spans multiple lines.
+  ----------- ---------- ------------ ---------------------------
+     First    row                12.0 Example of a row that spans
+                                      multiple lines.
 
     Second    row                 5.0 Here’s another one. Note
                                       the blank line between
                                       rows.
-  --------------------------------------------------------------
+  ---------------------------------------------------------------
 
   : Here’s the caption. It may span multiple lines.
 
 Multiline table without caption:
 
-  --------------------------------------------------------------
+  ---------------------------------------------------------------
    Centered   Left              Right Default aligned
     Header    Aligned         Aligned 
-  ----------- ---------- ------------ --------------------------
-     First    row                12.0 Example of a row that
-                                      spans multiple lines.
+  ----------- ---------- ------------ ---------------------------
+     First    row                12.0 Example of a row that spans
+                                      multiple lines.
 
     Second    row                 5.0 Here’s another one. Note
                                       the blank line between
                                       rows.
-  --------------------------------------------------------------
+  ---------------------------------------------------------------
 
 Table without column headers:
 
@@ -66,11 +66,11 @@ Table without column headers:
 
 Multiline table without column headers:
 
-  ----------- ---------- ------------ --------------------------
-     First    row                12.0 Example of a row that
-                                      spans multiple lines.
+  ----------- ---------- ------------ ---------------------------
+     First    row                12.0 Example of a row that spans
+                                      multiple lines.
 
     Second    row                 5.0 Here’s another one. Note
                                       the blank line between
                                       rows.
-  ----------- ---------- ------------ --------------------------
+  ----------- ---------- ------------ ---------------------------

--- a/test/tables.rst
+++ b/test/tables.rst
@@ -36,31 +36,31 @@ Multiline table with caption:
 
 .. table:: Here’s the caption. It may span multiple lines.
 
-   +----------+---------+-----------+--------------------------+
-   | Centered | Left    | Right     | Default aligned          |
-   | Header   | Aligned | Aligned   |                          |
-   +==========+=========+===========+==========================+
-   | First    | row     | 12.0      | Example of a row that    |
-   |          |         |           | spans multiple lines.    |
-   +----------+---------+-----------+--------------------------+
-   | Second   | row     | 5.0       | Here’s another one. Note |
-   |          |         |           | the blank line between   |
-   |          |         |           | rows.                    |
-   +----------+---------+-----------+--------------------------+
+   +-----------+----------+------------+---------------------------+
+   | Centered  | Left     | Right      | Default aligned           |
+   | Header    | Aligned  | Aligned    |                           |
+   +===========+==========+============+===========================+
+   | First     | row      | 12.0       | Example of a row that     |
+   |           |          |            | spans multiple lines.     |
+   +-----------+----------+------------+---------------------------+
+   | Second    | row      | 5.0        | Here’s another one. Note  |
+   |           |          |            | the blank line between    |
+   |           |          |            | rows.                     |
+   +-----------+----------+------------+---------------------------+
 
 Multiline table without caption:
 
-+----------+---------+-----------+--------------------------+
-| Centered | Left    | Right     | Default aligned          |
-| Header   | Aligned | Aligned   |                          |
-+==========+=========+===========+==========================+
-| First    | row     | 12.0      | Example of a row that    |
-|          |         |           | spans multiple lines.    |
-+----------+---------+-----------+--------------------------+
-| Second   | row     | 5.0       | Here’s another one. Note |
-|          |         |           | the blank line between   |
-|          |         |           | rows.                    |
-+----------+---------+-----------+--------------------------+
++-----------+----------+------------+---------------------------+
+| Centered  | Left     | Right      | Default aligned           |
+| Header    | Aligned  | Aligned    |                           |
++===========+==========+============+===========================+
+| First     | row      | 12.0       | Example of a row that     |
+|           |          |            | spans multiple lines.     |
++-----------+----------+------------+---------------------------+
+| Second    | row      | 5.0        | Here’s another one. Note  |
+|           |          |            | the blank line between    |
+|           |          |            | rows.                     |
++-----------+----------+------------+---------------------------+
 
 Table without column headers:
 
@@ -72,11 +72,11 @@ Table without column headers:
 
 Multiline table without column headers:
 
-+----------+---------+-----------+--------------------------+
-| First    | row     | 12.0      | Example of a row that    |
-|          |         |           | spans multiple lines.    |
-+----------+---------+-----------+--------------------------+
-| Second   | row     | 5.0       | Here’s another one. Note |
-|          |         |           | the blank line between   |
-|          |         |           | rows.                    |
-+----------+---------+-----------+--------------------------+
++-----------+----------+------------+---------------------------+
+| First     | row      | 12.0       | Example of a row that     |
+|           |          |            | spans multiple lines.     |
++-----------+----------+------------+---------------------------+
+| Second    | row      | 5.0        | Here’s another one. Note  |
+|           |          |            | the blank line between    |
+|           |          |            | rows.                     |
++-----------+----------+------------+---------------------------+

--- a/test/tables/planets.latex
+++ b/test/tables/planets.latex
@@ -18,13 +18,13 @@
 & & Earth & 5.97 & 12,756 & 5514 & 9.8 & 24.0 & 149.6 & 15 & 1 & Our world \\
 & & Mars & 0.642 & 6,792 & 3933 & 3.7 & 24.7 & 227.9 & -65 & 2 & The red
 planet \\
-\multirow{4}{*}{Jovian planets} & \multirow{2}{*}{Gas giants} & Jupiter & 1898
-& 142,984 & 1326 & 23.1 & 9.9 & 778.6 & -110 & 67 & The largest planet \\
+\multirow{4}{*}{Jovian planets} & \multirow{2}{*}{Gas giants} & Jupiter & 1898 &
+142,984 & 1326 & 23.1 & 9.9 & 778.6 & -110 & 67 & The largest planet \\
 & & Saturn & 568 & 120,536 & 687 & 9.0 & 10.7 & 1433.5 & -140 & 62 & \\
 & \multirow{2}{*}{Ice giants} & Uranus & 86.8 & 51,118 & 1271 & 8.7 & 17.2 &
 2872.5 & -195 & 27 & \\
 & & Neptune & 102 & 49,528 & 1638 & 11.0 & 16.1 & 4495.1 & -200 & 14 & \\
-\multicolumn{2}{c}{Dwarf planets} & Pluto & 0.0146 & 2,370 & 2095 & 0.7 &
-153.3 & 5906.4 & -225 & 5 & Declassified as a planet in 2006. \\
+\multicolumn{2}{c}{Dwarf planets} & Pluto & 0.0146 & 2,370 & 2095 & 0.7 & 153.3
+& 5906.4 & -225 & 5 & Declassified as a planet in 2006. \\
 \bottomrule
 \end{longtable}

--- a/test/testsuite.native
+++ b/test/testsuite.native
@@ -1,409 +1,2491 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Space,Str "MacFarlane"],MetaInlines [Str "Anonymous"]]),("date",MetaInlines [Str "July",Space,Str "17,",Space,Str "2006"]),("title",MetaInlines [Str "Pandoc",Space,Str "Test",Space,Str "Suite"])]})
-[Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc.",Space,Str "Most",Space,Str "of",Space,Str "them",Space,Str "are",Space,Str "adapted",Space,Str "from",SoftBreak,Str "John",Space,Str "Gruber\8217s",Space,Str "markdown",Space,Str "test",Space,Str "suite."]
-,HorizontalRule
-,Header 1 ("headers",[],[]) [Str "Headers"]
-,Header 2 ("level-2-with-an-embedded-link",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Str "an",Space,Link ("",[],[]) [Str "embedded",Space,Str "link"] ("/url","")]
-,Header 3 ("level-3-with-emphasis",[],[]) [Str "Level",Space,Str "3",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 4 ("level-4",[],[]) [Str "Level",Space,Str "4"]
-,Header 5 ("level-5",[],[]) [Str "Level",Space,Str "5"]
-,Header 1 ("level-1",[],[]) [Str "Level",Space,Str "1"]
-,Header 2 ("level-2-with-emphasis",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 3 ("level-3",[],[]) [Str "Level",Space,Str "3"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Header 2 ("level-2",[],[]) [Str "Level",Space,Str "2"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,HorizontalRule
-,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "In",Space,Str "Markdown",Space,Str "1.0.0",Space,Str "and",Space,Str "earlier.",Space,Str "Version",SoftBreak,Str "8.",Space,Str "This",Space,Str "line",Space,Str "turns",Space,Str "into",Space,Str "a",Space,Str "list",Space,Str "item.",SoftBreak,Str "Because",Space,Str "a",Space,Str "hard-wrapped",Space,Str "line",Space,Str "in",Space,Str "the",SoftBreak,Str "middle",Space,Str "of",Space,Str "a",Space,Str "paragraph",Space,Str "looked",Space,Str "like",Space,Str "a",SoftBreak,Str "list",Space,Str "item."]
-,Para [Str "Here\8217s",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet.",SoftBreak,Str "*",Space,Str "criminey."]
-,Para [Str "There",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "hard",Space,Str "line",Space,Str "break",LineBreak,Str "here."]
-,HorizontalRule
-,Header 1 ("block-quotes",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "E-mail",Space,Str "style:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",SoftBreak,Str "It",Space,Str "is",Space,Str "pretty",Space,Str "short."]]
-,BlockQuote
- [Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"
- ,Para [Str "A",Space,Str "list:"]
- ,OrderedList (1,Decimal,Period)
-  [[Plain [Str "item",Space,Str "one"]]
-  ,[Plain [Str "item",Space,Str "two"]]]
- ,Para [Str "Nested",Space,Str "block",Space,Str "quotes:"]
- ,BlockQuote
-  [Para [Str "nested"]]
- ,BlockQuote
-  [Para [Str "nested"]]]
-,Para [Str "This",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "block",Space,Str "quote:",Space,Str "2",SoftBreak,Str ">",Space,Str "1."]
-,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
-,HorizontalRule
-,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
-,HorizontalRule
-,Header 1 ("lists",[],[]) [Str "Lists"]
-,Header 2 ("unordered",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "asterisk",Space,Str "1"]]
- ,[Plain [Str "asterisk",Space,Str "2"]]
- ,[Plain [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Asterisks",Space,Str "loose:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "Plus",Space,Str "1"]]
- ,[Plain [Str "Plus",Space,Str "2"]]
- ,[Plain [Str "Plus",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Plus",Space,Str "1"]]
- ,[Para [Str "Plus",Space,Str "2"]]
- ,[Para [Str "Plus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "Minus",Space,Str "1"]]
- ,[Plain [Str "Minus",Space,Str "2"]]
- ,[Plain [Str "Minus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Header 2 ("ordered",[],[]) [Str "Ordered"]
-,Para [Str "Tight:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second"]]
- ,[Plain [Str "Third"]]]
-,Para [Str "and:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "One"]]
- ,[Plain [Str "Two"]]
- ,[Plain [Str "Three"]]]
-,Para [Str "Loose",Space,Str "using",Space,Str "tabs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "and",Space,Str "using",Space,Str "spaces:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]]
- ,[Para [Str "Three"]]]
-,Para [Str "Multiple",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "Item",Space,Str "1,",Space,Str "graf",Space,Str "one."]
-  ,Para [Str "Item",Space,Str "1.",Space,Str "graf",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",Space,Str "dog\8217s",SoftBreak,Str "back."]]
- ,[Para [Str "Item",Space,Str "2."]]
- ,[Para [Str "Item",Space,Str "3."]]]
-,Header 2 ("nested",[],[]) [Str "Nested"]
-,BulletList
- [[Plain [Str "Tab"]
-  ,BulletList
-   [[Plain [Str "Tab"]
-    ,BulletList
-     [[Plain [Str "Tab"]]]]]]]
-,Para [Str "Here\8217s",Space,Str "another:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second:"]
-  ,BulletList
-   [[Plain [Str "Fee"]]
-   ,[Plain [Str "Fie"]]
-   ,[Plain [Str "Foe"]]]]
- ,[Plain [Str "Third"]]]
-,Para [Str "Same",Space,Str "thing",Space,Str "but",Space,Str "with",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Plain [Str "Fee"]]
-   ,[Plain [Str "Fie"]]
-   ,[Plain [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Header 2 ("tabs-and-spaces",[],[]) [Str "Tabs",Space,Str "and",Space,Str "spaces"]
-,BulletList
- [[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",SoftBreak,Str "indented",Space,Str "with",Space,Str "tabs"]]
- ,[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",SoftBreak,Str "indented",Space,Str "with",Space,Str "spaces"]
-  ,BulletList
-   [[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",SoftBreak,Str "indented",Space,Str "with",Space,Str "tabs"]]
-   ,[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",SoftBreak,Str "indented",Space,Str "with",Space,Str "spaces"]]]]]
-,Header 2 ("fancy-list-markers",[],[]) [Str "Fancy",Space,Str "list",Space,Str "markers"]
-,OrderedList (2,Decimal,TwoParens)
- [[Para [Str "begins",Space,Str "with",Space,Str "2"]]
- ,[Para [Str "and",Space,Str "now",Space,Str "3"]
-  ,Para [Str "with",Space,Str "a",Space,Str "continuation"]
-  ,OrderedList (4,LowerRoman,Period)
-   [[Plain [Str "sublist",Space,Str "with",Space,Str "roman",Space,Str "numerals,",SoftBreak,Str "starting",Space,Str "with",Space,Str "4"]]
-   ,[Plain [Str "more",Space,Str "items"]
-    ,OrderedList (1,UpperAlpha,TwoParens)
-     [[Plain [Str "a",Space,Str "subsublist"]]
-     ,[Plain [Str "a",Space,Str "subsublist"]]]]]]]
-,Para [Str "Nesting:"]
-,OrderedList (1,UpperAlpha,Period)
- [[Plain [Str "Upper",Space,Str "Alpha"]
-  ,OrderedList (1,UpperRoman,Period)
-   [[Plain [Str "Upper",Space,Str "Roman."]
-    ,OrderedList (6,Decimal,TwoParens)
-     [[Plain [Str "Decimal",Space,Str "start",Space,Str "with",Space,Str "6"]
-      ,OrderedList (3,LowerAlpha,OneParen)
-       [[Plain [Str "Lower",Space,Str "alpha",Space,Str "with",Space,Str "paren"]]]]]]]]]
-,Para [Str "Autonumbering:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Autonumber."]]
- ,[Plain [Str "More."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "Nested."]]]]]
-,Para [Str "Should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "list",Space,Str "item:"]
-,Para [Str "M.A.\160\&2007"]
-,Para [Str "B.",Space,Str "Williams"]
-,HorizontalRule
-,Header 1 ("definition-lists",[],[]) [Str "Definition",Space,Str "Lists"]
-,Para [Str "Tight",Space,Str "using",Space,Str "spaces:"]
-,DefinitionList
- [([Str "apple"],
-   [[Plain [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Plain [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Plain [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Tight",Space,Str "using",Space,Str "tabs:"]
-,DefinitionList
- [([Str "apple"],
-   [[Plain [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Plain [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Plain [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Loose:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Para [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Multiple",Space,Str "blocks",Space,Str "with",Space,Str "italics:"]
-,DefinitionList
- [([Emph [Str "apple"]],
-   [[Para [Str "red",Space,Str "fruit"]
-    ,Para [Str "contains",Space,Str "seeds,",SoftBreak,Str "crisp,",Space,Str "pleasant",Space,Str "to",Space,Str "taste"]]])
- ,([Emph [Str "orange"]],
-   [[Para [Str "orange",Space,Str "fruit"]
-    ,CodeBlock ("",[],[]) "{ orange code block }"
-    ,BlockQuote
-     [Para [Str "orange",Space,Str "block",Space,Str "quote"]]]])]
-,Para [Str "Multiple",Space,Str "definitions,",Space,Str "tight:"]
-,DefinitionList
- [([Str "apple"],
-   [[Plain [Str "red",Space,Str "fruit"]]
-   ,[Plain [Str "computer"]]])
- ,([Str "orange"],
-   [[Plain [Str "orange",Space,Str "fruit"]]
-   ,[Plain [Str "bank"]]])]
-,Para [Str "Multiple",Space,Str "definitions,",Space,Str "loose:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]
-   ,[Para [Str "computer"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]
-   ,[Para [Str "bank"]]])]
-,Para [Str "Blank",Space,Str "line",Space,Str "after",Space,Str "term,",Space,Str "indented",Space,Str "marker,",Space,Str "alternate",Space,Str "markers:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]
-   ,[Para [Str "computer"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]
-    ,OrderedList (1,Decimal,Period)
-     [[Plain [Str "sublist"]]
-     ,[Plain [Str "sublist"]]]]])]
-,Header 1 ("html-blocks",[],[]) [Str "HTML",Space,Str "Blocks"]
-,Para [Str "Simple",Space,Str "block",Space,Str "on",Space,Str "one",Space,Str "line:"]
-,Div ("",[],[])
- [Plain [Str "foo"]]
-,Para [Str "And",Space,Str "nested",Space,Str "without",Space,Str "indentation:"]
-,Div ("",[],[])
- [Div ("",[],[])
-  [Div ("",[],[])
-   [Para [Str "foo"]]]
- ,Div ("",[],[])
-  [Plain [Str "bar"]]]
-,Para [Str "Interpreted",Space,Str "markdown",Space,Str "in",Space,Str "a",Space,Str "table:"]
-,RawBlock (Format "html") "<table>"
-,RawBlock (Format "html") "<tr>"
-,RawBlock (Format "html") "<td>"
-,Plain [Str "This",Space,Str "is",Space,Emph [Str "emphasized"]]
-,RawBlock (Format "html") "</td>"
-,RawBlock (Format "html") "<td>"
-,Plain [Str "And",Space,Str "this",Space,Str "is",Space,Strong [Str "strong"]]
-,RawBlock (Format "html") "</td>"
-,RawBlock (Format "html") "</tr>"
-,RawBlock (Format "html") "</table>"
-,RawBlock (Format "html") "<script type=\"text/javascript\">document.write('This *should not* be interpreted as markdown');</script>"
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "simple",Space,Str "block:"]
-,Div ("",[],[])
- [Para [Str "foo"]]
-,Para [Str "This",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "code",Space,Str "block,",Space,Str "though:"]
-,CodeBlock ("",[],[]) "<div>\n    foo\n</div>"
-,Para [Str "As",Space,Str "should",Space,Str "this:"]
-,CodeBlock ("",[],[]) "<div>foo</div>"
-,Para [Str "Now,",Space,Str "nested:"]
-,Div ("",[],[])
- [Div ("",[],[])
-  [Div ("",[],[])
-   [Plain [Str "foo"]]]]
-,Para [Str "This",Space,Str "should",Space,Str "just",Space,Str "be",Space,Str "an",Space,Str "HTML",Space,Str "comment:"]
-,RawBlock (Format "html") "<!-- Comment -->"
-,Para [Str "Multiline:"]
-,RawBlock (Format "html") "<!--\nBlah\nBlah\n-->"
-,RawBlock (Format "html") "<!--\n    This is another comment.\n-->"
-,Para [Str "Code",Space,Str "block:"]
-,CodeBlock ("",[],[]) "<!-- Comment -->"
-,Para [Str "Just",Space,Str "plain",Space,Str "comment,",Space,Str "with",Space,Str "trailing",Space,Str "spaces",Space,Str "on",Space,Str "the",Space,Str "line:"]
-,RawBlock (Format "html") "<!-- foo -->"
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "<hr />"
-,Para [Str "Hr\8217s:"]
-,RawBlock (Format "html") "<hr>"
-,RawBlock (Format "html") "<hr />"
-,RawBlock (Format "html") "<hr />"
-,RawBlock (Format "html") "<hr>"
-,RawBlock (Format "html") "<hr />"
-,RawBlock (Format "html") "<hr />"
-,RawBlock (Format "html") "<hr class=\"foo\" id=\"bar\" />"
-,RawBlock (Format "html") "<hr class=\"foo\" id=\"bar\" />"
-,RawBlock (Format "html") "<hr class=\"foo\" id=\"bar\">"
-,HorizontalRule
-,Header 1 ("inline-markup",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ",",Space,Str "and",Space,Str "so",Space,Emph [Str "is",Space,Str "this"],Str "."]
-,Para [Str "This",Space,Str "is",Space,Strong [Str "strong"],Str ",",Space,Str "and",Space,Str "so",Space,Strong [Str "is",Space,Str "this"],Str "."]
-,Para [Str "An",Space,Emph [Link ("",[],[]) [Str "emphasized",Space,Str "link"] ("/url","")],Str "."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Str "This",Space,Str "is",Space,Str "code:",Space,Code ("",[],[]) ">",Str ",",Space,Code ("",[],[]) "$",Str ",",Space,Code ("",[],[]) "\\",Str ",",Space,Code ("",[],[]) "\\$",Str ",",Space,Code ("",[],[]) "<html>",Str "."]
-,Para [Strikeout [Str "This",Space,Str "is",Space,Emph [Str "strikeout"],Str "."]]
-,Para [Str "Superscripts:",Space,Str "a",Superscript [Str "bc"],Str "d",Space,Str "a",Superscript [Emph [Str "hello"]],Space,Str "a",Superscript [Str "hello\160there"],Str "."]
-,Para [Str "Subscripts:",Space,Str "H",Subscript [Str "2"],Str "O,",Space,Str "H",Subscript [Str "23"],Str "O,",Space,Str "H",Subscript [Str "many\160of\160them"],Str "O."]
-,Para [Str "These",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "superscripts",Space,Str "or",Space,Str "subscripts,",SoftBreak,Str "because",Space,Str "of",Space,Str "the",Space,Str "unescaped",Space,Str "spaces:",Space,Str "a^b",Space,Str "c^d,",Space,Str "a~b",Space,Str "c~d."]
-,HorizontalRule
-,Header 1 ("smart-quotes-ellipses-dashes",[],[]) [Str "Smart",Space,Str "quotes,",Space,Str "ellipses,",Space,Str "dashes"]
-,Para [Quoted DoubleQuote [Str "Hello,"],Space,Str "said",Space,Str "the",Space,Str "spider.",Space,Quoted DoubleQuote [Quoted SingleQuote [Str "Shelob"],Space,Str "is",Space,Str "my",Space,Str "name."]]
-,Para [Quoted SingleQuote [Str "A"],Str ",",Space,Quoted SingleQuote [Str "B"],Str ",",Space,Str "and",Space,Quoted SingleQuote [Str "C"],Space,Str "are",Space,Str "letters."]
-,Para [Quoted SingleQuote [Str "Oak,"],Space,Quoted SingleQuote [Str "elm,"],Space,Str "and",Space,Quoted SingleQuote [Str "beech"],Space,Str "are",Space,Str "names",Space,Str "of",Space,Str "trees.",SoftBreak,Str "So",Space,Str "is",Space,Quoted SingleQuote [Str "pine."]]
-,Para [Quoted SingleQuote [Str "He",Space,Str "said,",Space,Quoted DoubleQuote [Str "I",Space,Str "want",Space,Str "to",Space,Str "go."]],Space,Str "Were",Space,Str "you",Space,Str "alive",Space,Str "in",Space,Str "the",SoftBreak,Str "70\8217s?"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "quoted",Space,Quoted SingleQuote [Code ("",[],[]) "code"],Space,Str "and",Space,Str "a",Space,Quoted DoubleQuote [Link ("",[],[]) [Str "quoted",Space,Str "link"] ("http://example.com/?foo=1&bar=2","")],Str "."]
-,Para [Str "Some",Space,Str "dashes:",Space,Str "one\8212two",Space,Str "\8212",Space,Str "three\8212four",Space,Str "\8212",Space,Str "five."]
-,Para [Str "Dashes",Space,Str "between",Space,Str "numbers:",Space,Str "5\8211\&7,",Space,Str "255\8211\&66,",Space,Str "1987\8211\&1999."]
-,Para [Str "Ellipses\8230and\8230and\8230."]
-,HorizontalRule
-,Header 1 ("latex",[],[]) [Str "LaTeX"]
-,BulletList
- [[Plain [RawInline (Format "tex") "\\cite[22-23]{smith.1899}"]]
- ,[Plain [Math InlineMath "2+2=4"]]
- ,[Plain [Math InlineMath "x \\in y"]]
- ,[Plain [Math InlineMath "\\alpha \\wedge \\omega"]]
- ,[Plain [Math InlineMath "223"]]
- ,[Plain [Math InlineMath "p",Str "-Tree"]]
- ,[Plain [Str "Here\8217s",Space,Str "some",Space,Str "display",Space,Str "math:",SoftBreak,Math DisplayMath "\\frac{d}{dx}f(x)=\\lim_{h\\to 0}\\frac{f(x+h)-f(x)}{h}"]]
- ,[Plain [Str "Here\8217s",Space,Str "one",Space,Str "that",Space,Str "has",Space,Str "a",Space,Str "line",Space,Str "break",Space,Str "in",Space,Str "it:",Space,Math InlineMath "\\alpha + \\omega \\times x^2",Str "."]]]
-,Para [Str "These",Space,Str "shouldn\8217t",Space,Str "be",Space,Str "math:"]
-,BulletList
- [[Plain [Str "To",Space,Str "get",Space,Str "the",Space,Str "famous",Space,Str "equation,",Space,Str "write",Space,Code ("",[],[]) "$e = mc^2$",Str "."]]
- ,[Plain [Str "$22,000",Space,Str "is",Space,Str "a",Space,Emph [Str "lot"],Space,Str "of",Space,Str "money.",Space,Str "So",Space,Str "is",Space,Str "$34,000.",SoftBreak,Str "(It",Space,Str "worked",Space,Str "if",Space,Quoted DoubleQuote [Str "lot"],Space,Str "is",Space,Str "emphasized.)"]]
- ,[Plain [Str "Shoes",Space,Str "($20)",Space,Str "and",Space,Str "socks",Space,Str "($5)."]]
- ,[Plain [Str "Escaped",Space,Code ("",[],[]) "$",Str ":",Space,Str "$73",Space,Emph [Str "this",Space,Str "should",Space,Str "be",Space,Str "emphasized"],Space,Str "23$."]]]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "LaTeX",Space,Str "table:"]
-,RawBlock (Format "tex") "\\begin{tabular}{|l|l|}\\hline\nAnimal & Number \\\\ \\hline\nDog    & 2      \\\\\nCat    & 1      \\\\ \\hline\n\\end{tabular}"
-,HorizontalRule
-,Header 1 ("special-characters",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "unicode:"]
-,BulletList
- [[Plain [Str "I",Space,Str "hat:",Space,Str "\206"]]
- ,[Plain [Str "o",Space,Str "umlaut:",Space,Str "\246"]]
- ,[Plain [Str "section:",Space,Str "\167"]]
- ,[Plain [Str "set",Space,Str "membership:",Space,Str "\8712"]]
- ,[Plain [Str "copyright:",Space,Str "\169"]]]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "AT&T",Space,Str "is",Space,Str "another",Space,Str "way",Space,Str "to",Space,Str "write",Space,Str "it."]
-,Para [Str "This",Space,Str "&",Space,Str "that."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "`"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,HorizontalRule
-,Header 1 ("links",[],[]) [Str "Links"]
-,Header 2 ("explicit",[],[]) [Str "Explicit"]
-,Para [Str "Just",Space,Str "a",Space,Link ("",[],[]) [Str "URL"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title preceded by two spaces"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title preceded by a tab"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title with \"quotes\" in it")]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title with single quotes")]
-,Para [Link ("",[],[]) [Str "with_underscore"] ("/url/with_underscore","")]
-,Para [Link ("",[],[]) [Str "Email",Space,Str "link"] ("mailto:nobody@nowhere.net","")]
-,Para [Link ("",[],[]) [Str "Empty"] ("",""),Str "."]
-,Header 2 ("reference",[],[]) [Str "Reference"]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "With",Space,Link ("",[],[]) [Str "embedded",Space,Str "[brackets]"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "b"] ("/url/",""),Space,Str "by",Space,Str "itself",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "link."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "once"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "twice"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "thrice"] ("/url",""),Str "."]
-,Para [Str "This",Space,Str "should",Space,Str "[not][]",Space,Str "be",Space,Str "a",Space,Str "link."]
-,CodeBlock ("",[],[]) "[not]: /url"
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/","Title with \"quotes\" inside"),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "biz"] ("/url/","Title with \"quote\" inside"),Str "."]
-,Header 2 ("with-ampersands",[],[]) [Str "With",Space,Str "ampersands"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Link ("",[],[]) [Str "link",Space,Str "with",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "URL"] ("http://example.com/?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "link",Space,Str "with",Space,Str "an",Space,Str "amersand",Space,Str "in",Space,Str "the",Space,Str "link",Space,Str "text:",Space,Link ("",[],[]) [Str "AT&T"] ("http://att.com/","AT&T"),Str "."]
-,Para [Str "Here\8217s",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link"] ("/script?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link",Space,Str "in",Space,Str "pointy",Space,Str "braces"] ("/script?foo=1&bar=2",""),Str "."]
-,Header 2 ("autolinks",[],[]) [Str "Autolinks"]
-,Para [Str "With",Space,Str "an",Space,Str "ampersand:",Space,Link ("",["uri"],[]) [Str "http://example.com/?foo=1&bar=2"] ("http://example.com/?foo=1&bar=2","")]
-,BulletList
- [[Plain [Str "In",Space,Str "a",Space,Str "list?"]]
- ,[Plain [Link ("",["uri"],[]) [Str "http://example.com/"] ("http://example.com/","")]]
- ,[Plain [Str "It",Space,Str "should."]]]
-,Para [Str "An",Space,Str "e-mail",Space,Str "address:",Space,Link ("",["email"],[]) [Str "nobody@nowhere.net"] ("mailto:nobody@nowhere.net","")]
-,BlockQuote
- [Para [Str "Blockquoted:",Space,Link ("",["uri"],[]) [Str "http://example.com/"] ("http://example.com/","")]]
-,Para [Str "Auto-links",Space,Str "should",Space,Str "not",Space,Str "occur",Space,Str "here:",Space,Code ("",[],[]) "<http://example.com/>"]
-,CodeBlock ("",[],[]) "or here: <http://example.com/>"
-,HorizontalRule
-,Header 1 ("images",[],[]) [Str "Images"]
-,Para [Str "From",Space,Quoted DoubleQuote [Str "Voyage",Space,Str "dans",Space,Str "la",Space,Str "Lune"],Space,Str "by",Space,Str "Georges",Space,Str "Melies",Space,Str "(1902):"]
-,Para [Image ("",[],[]) [Str "lalune"] ("lalune.jpg","fig:Voyage dans la Lune")]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "movie",Space,Image ("",[],[]) [Str "movie"] ("movie.jpg",""),Space,Str "icon."]
-,HorizontalRule
-,Header 1 ("footnotes",[],[]) [Str "Footnotes"]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "footnote",Space,Str "reference,",Note [Para [Str "Here",Space,Str "is",Space,Str "the",Space,Str "footnote.",Space,Str "It",Space,Str "can",Space,Str "go",Space,Str "anywhere",Space,Str "after",Space,Str "the",Space,Str "footnote",SoftBreak,Str "reference.",Space,Str "It",Space,Str "need",Space,Str "not",Space,Str "be",Space,Str "placed",Space,Str "at",Space,Str "the",Space,Str "end",Space,Str "of",Space,Str "the",Space,Str "document."]],Space,Str "and",Space,Str "another.",Note [Para [Str "Here\8217s",Space,Str "the",Space,Str "long",Space,Str "note.",Space,Str "This",Space,Str "one",Space,Str "contains",Space,Str "multiple",SoftBreak,Str "blocks."],Para [Str "Subsequent",Space,Str "blocks",Space,Str "are",Space,Str "indented",Space,Str "to",Space,Str "show",Space,Str "that",Space,Str "they",Space,Str "belong",Space,Str "to",Space,Str "the",SoftBreak,Str "footnote",Space,Str "(as",Space,Str "with",Space,Str "list",Space,Str "items)."],CodeBlock ("",[],[]) "  { <code> }",Para [Str "If",Space,Str "you",Space,Str "want,",Space,Str "you",Space,Str "can",Space,Str "indent",Space,Str "every",Space,Str "line,",Space,Str "but",Space,Str "you",Space,Str "can",Space,Str "also",Space,Str "be",SoftBreak,Str "lazy",Space,Str "and",Space,Str "just",Space,Str "indent",Space,Str "the",Space,Str "first",Space,Str "line",Space,Str "of",Space,Str "each",Space,Str "block."]],SoftBreak,Str "This",Space,Str "should",Space,Emph [Str "not"],Space,Str "be",Space,Str "a",Space,Str "footnote",Space,Str "reference,",Space,Str "because",Space,Str "it",SoftBreak,Str "contains",Space,Str "a",Space,Str "space.[^my",Space,Str "note]",Space,Str "Here",Space,Str "is",Space,Str "an",Space,Str "inline",Space,Str "note.",Note [Para [Str "This",SoftBreak,Str "is",Space,Emph [Str "easier"],Space,Str "to",Space,Str "type.",Space,Str "Inline",Space,Str "notes",Space,Str "may",Space,Str "contain",SoftBreak,Link ("",[],[]) [Str "links"] ("http://google.com",""),Space,Str "and",Space,Code ("",[],[]) "]",Space,Str "verbatim",Space,Str "characters,",SoftBreak,Str "as",Space,Str "well",Space,Str "as",Space,Str "[bracketed",Space,Str "text]."]]]
-,BlockQuote
- [Para [Str "Notes",Space,Str "can",Space,Str "go",Space,Str "in",Space,Str "quotes.",Note [Para [Str "In",Space,Str "quote."]]]]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "And",Space,Str "in",Space,Str "list",Space,Str "items.",Note [Para [Str "In",Space,Str "list."]]]]]
-,Para [Str "This",Space,Str "paragraph",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "part",Space,Str "of",Space,Str "the",Space,Str "note,",Space,Str "as",Space,Str "it",Space,Str "is",Space,Str "not",Space,Str "indented."]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaList
+          [ MetaInlines
+            [ Str "John", Space, Str "MacFarlane" ]
+          , MetaInlines
+            [ Str "Anonymous" ]
+          ]
+        )
+      ,
+        ( "date"
+        , MetaInlines
+          [ Str "July", Space, Str "17,", Space, Str "2006" ]
+        )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Pandoc", Space, Str "Test", Space, Str "Suite" ]
+        )
+      ]
+    }
+  )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc."
+    , Space
+    , Str "Most"
+    , Space
+    , Str "of"
+    , Space
+    , Str "them"
+    , Space
+    , Str "are"
+    , Space
+    , Str "adapted"
+    , Space
+    , Str "from"
+    , SoftBreak
+    , Str "John"
+    , Space
+    , Str "Gruber\8217s"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "test"
+    , Space
+    , Str "suite."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "headers", [], [] )
+    [ Str "Headers" ]
+  , Header 2
+    ( "level-2-with-an-embedded-link", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "link" ]
+      ( "/url", "" )
+    ]
+  , Header 3
+    ( "level-3-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "3"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 4
+    ( "level-4", [], [] )
+    [ Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "level-5", [], [] )
+    [ Str "Level", Space, Str "5" ]
+  , Header 1
+    ( "level-1", [], [] )
+    [ Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "level-2-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 3
+    ( "level-3", [], [] )
+    [ Str "Level", Space, Str "3" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , Header 2
+    ( "level-2", [], [] )
+    [ Str "Level", Space, Str "2" ]
+  , Para
+    [ Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "paragraphs", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "In"
+    , Space
+    , Str "Markdown"
+    , Space
+    , Str "1.0.0"
+    , Space
+    , Str "and"
+    , Space
+    , Str "earlier."
+    , Space
+    , Str "Version"
+    , SoftBreak
+    , Str "8."
+    , Space
+    , Str "This"
+    , Space
+    , Str "line"
+    , Space
+    , Str "turns"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    , SoftBreak
+    , Str "Because"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard-wrapped"
+    , Space
+    , Str "line"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "middle"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "looked"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Str "list"
+    , Space
+    , Str "item."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    , SoftBreak
+    , Str "*"
+    , Space
+    , Str "criminey."
+    ]
+  , Para
+    [ Str "There"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard"
+    , Space
+    , Str "line"
+    , Space
+    , Str "break"
+    , LineBreak
+    , Str "here."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "E-mail", Space, Str "style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , SoftBreak
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "pretty"
+      , Space
+      , Str "short."
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Code"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    , Para
+      [ Str "A", Space, Str "list:" ]
+    , OrderedList
+      ( 1, Decimal, Period )
+      [
+        [ Plain [ Str "item", Space, Str "one" ] ]
+      ,
+        [ Plain [ Str "item", Space, Str "two" ] ]
+      ]
+    , Para
+      [ Str "Nested", Space, Str "block", Space, Str "quotes:" ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote:"
+    , Space
+    , Str "2"
+    , SoftBreak
+    , Str ">"
+    , Space
+    , Str "1."
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "a"
+    , Space
+    , Str "following"
+    , Space
+    , Str "paragraph."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
+  , HorizontalRule
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "unordered", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Asterisks", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "ordered", [], [] )
+    [ Str "Ordered" ]
+  , Para
+    [ Str "Tight:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain [ Str "Second" ] ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "One" ] ]
+    ,
+      [ Plain [ Str "Two" ] ]
+    ,
+      [ Plain [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Loose", Space, Str "using", Space, Str "tabs:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and", Space, Str "using", Space, Str "spaces:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "One" ] ]
+    ,
+      [ Para [ Str "Two" ] ]
+    ,
+      [ Para [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "paragraphs:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para
+        [ Str "Item"
+        , Space
+        , Str "1,"
+        , Space
+        , Str "graf"
+        , Space
+        , Str "one."
+        ]
+      , Para
+        [ Str "Item"
+        , Space
+        , Str "1."
+        , Space
+        , Str "graf"
+        , Space
+        , Str "two."
+        , Space
+        , Str "The"
+        , Space
+        , Str "quick"
+        , Space
+        , Str "brown"
+        , Space
+        , Str "fox"
+        , Space
+        , Str "jumped"
+        , Space
+        , Str "over"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lazy"
+        , Space
+        , Str "dog\8217s"
+        , SoftBreak
+        , Str "back."
+        ]
+      ]
+    ,
+      [ Para [ Str "Item", Space, Str "2." ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "3." ] ]
+    ]
+  , Header 2
+    ( "nested", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Tab" ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "Tab" ]
+          , BulletList
+            [ [ Plain [ Str "Tab" ] ] ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s", Space, Str "another:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Plain [ Str "Fee" ] ]
+        ,
+          [ Plain [ Str "Fie" ] ]
+        ,
+          [ Plain [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Same"
+    , Space
+    , Str "thing"
+    , Space
+    , Str "but"
+    , Space
+    , Str "with"
+    , Space
+    , Str "paragraphs:"
+    ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Plain [ Str "Fee" ] ]
+        ,
+          [ Plain [ Str "Fie" ] ]
+        ,
+          [ Plain [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "tabs-and-spaces", [], [] )
+    [ Str "Tabs", Space, Str "and", Space, Str "spaces" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , SoftBreak
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "tabs"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , SoftBreak
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "spaces"
+        ]
+      , BulletList
+        [
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , SoftBreak
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "tabs"
+            ]
+          ]
+        ,
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , SoftBreak
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "spaces"
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "fancy-list-markers", [], [] )
+    [ Str "Fancy", Space, Str "list", Space, Str "markers" ]
+  , OrderedList
+    ( 2, Decimal, TwoParens )
+    [
+      [ Para [ Str "begins", Space, Str "with", Space, Str "2" ] ]
+    ,
+      [ Para
+        [ Str "and", Space, Str "now", Space, Str "3" ]
+      , Para
+        [ Str "with", Space, Str "a", Space, Str "continuation" ]
+      , OrderedList
+        ( 4, LowerRoman, Period )
+        [
+          [ Plain
+            [ Str "sublist"
+            , Space
+            , Str "with"
+            , Space
+            , Str "roman"
+            , Space
+            , Str "numerals,"
+            , SoftBreak
+            , Str "starting"
+            , Space
+            , Str "with"
+            , Space
+            , Str "4"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "more", Space, Str "items" ]
+          , OrderedList
+            ( 1, UpperAlpha, TwoParens )
+            [
+              [ Plain [ Str "a", Space, Str "subsublist" ] ]
+            ,
+              [ Plain [ Str "a", Space, Str "subsublist" ] ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Nesting:" ]
+  , OrderedList
+    ( 1, UpperAlpha, Period )
+    [
+      [ Plain
+        [ Str "Upper", Space, Str "Alpha" ]
+      , OrderedList
+        ( 1, UpperRoman, Period )
+        [
+          [ Plain
+            [ Str "Upper", Space, Str "Roman." ]
+          , OrderedList
+            ( 6, Decimal, TwoParens )
+            [
+              [ Plain
+                [ Str "Decimal"
+                , Space
+                , Str "start"
+                , Space
+                , Str "with"
+                , Space
+                , Str "6"
+                ]
+              , OrderedList
+                ( 3, LowerAlpha, OneParen )
+                [
+                  [ Plain
+                    [ Str "Lower"
+                    , Space
+                    , Str "alpha"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "paren"
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Autonumbering:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "Autonumber." ] ]
+    ,
+      [ Plain
+        [ Str "More." ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [ [ Plain [ Str "Nested." ] ] ]
+      ]
+    ]
+  , Para
+    [ Str "Should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item:"
+    ]
+  , Para
+    [ Str "M.A.\160\&2007" ]
+  , Para
+    [ Str "B.", Space, Str "Williams" ]
+  , HorizontalRule
+  , Header 1
+    ( "definition-lists", [], [] )
+    [ Str "Definition", Space, Str "Lists" ]
+  , Para
+    [ Str "Tight", Space, Str "using", Space, Str "spaces:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [ [ Plain [ Str "red", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [ [ Plain [ Str "orange", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "banana" ]
+      ,
+        [ [ Plain [ Str "yellow", Space, Str "fruit" ] ] ]
+      )
+    ]
+  , Para
+    [ Str "Tight", Space, Str "using", Space, Str "tabs:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [ [ Plain [ Str "red", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [ [ Plain [ Str "orange", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "banana" ]
+      ,
+        [ [ Plain [ Str "yellow", Space, Str "fruit" ] ] ]
+      )
+    ]
+  , Para
+    [ Str "Loose:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [ [ Para [ Str "red", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [ [ Para [ Str "orange", Space, Str "fruit" ] ] ]
+      )
+    ,
+      (
+        [ Str "banana" ]
+      ,
+        [ [ Para [ Str "yellow", Space, Str "fruit" ] ] ]
+      )
+    ]
+  , Para
+    [ Str "Multiple"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "with"
+    , Space
+    , Str "italics:"
+    ]
+  , DefinitionList
+    [
+      (
+        [ Emph [ Str "apple" ] ]
+      ,
+        [
+          [ Para
+            [ Str "red", Space, Str "fruit" ]
+          , Para
+            [ Str "contains"
+            , Space
+            , Str "seeds,"
+            , SoftBreak
+            , Str "crisp,"
+            , Space
+            , Str "pleasant"
+            , Space
+            , Str "to"
+            , Space
+            , Str "taste"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Emph [ Str "orange" ] ]
+      ,
+        [
+          [ Para
+            [ Str "orange", Space, Str "fruit" ]
+          , CodeBlock
+            ( "", [], [] ) "{ orange code block }"
+          , BlockQuote
+            [ Para
+              [ Str "orange", Space, Str "block", Space, Str "quote" ]
+            ]
+          ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "definitions,", Space, Str "tight:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [
+          [ Plain [ Str "red", Space, Str "fruit" ] ]
+        ,
+          [ Plain [ Str "computer" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [
+          [ Plain [ Str "orange", Space, Str "fruit" ] ]
+        ,
+          [ Plain [ Str "bank" ] ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "definitions,", Space, Str "loose:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [
+          [ Para [ Str "red", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "computer" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [
+          [ Para [ Str "orange", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "bank" ] ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Blank"
+    , Space
+    , Str "line"
+    , Space
+    , Str "after"
+    , Space
+    , Str "term,"
+    , Space
+    , Str "indented"
+    , Space
+    , Str "marker,"
+    , Space
+    , Str "alternate"
+    , Space
+    , Str "markers:"
+    ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [
+          [ Para [ Str "red", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "computer" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [
+          [ Para
+            [ Str "orange", Space, Str "fruit" ]
+          , OrderedList
+            ( 1, Decimal, Period )
+            [ [ Plain [ Str "sublist" ] ], [ Plain [ Str "sublist" ] ] ]
+          ]
+        ]
+      )
+    ]
+  , Header 1
+    ( "html-blocks", [], [] )
+    [ Str "HTML", Space, Str "Blocks" ]
+  , Para
+    [ Str "Simple"
+    , Space
+    , Str "block"
+    , Space
+    , Str "on"
+    , Space
+    , Str "one"
+    , Space
+    , Str "line:"
+    ]
+  , Div
+    ( "", [], [] )
+    [ Plain [ Str "foo" ] ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "nested"
+    , Space
+    , Str "without"
+    , Space
+    , Str "indentation:"
+    ]
+  , Div
+    ( "", [], [] )
+    [ Div
+      ( "", [], [] )
+      [ Div ( "", [], [] ) [ Para [ Str "foo" ] ] ]
+    , Div
+      ( "", [], [] )
+      [ Plain [ Str "bar" ] ]
+    ]
+  , Para
+    [ Str "Interpreted"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "in"
+    , Space
+    , Str "a"
+    , Space
+    , Str "table:"
+    ]
+  , RawBlock
+    ( Format "html" ) "<table>"
+  , RawBlock
+    ( Format "html" ) "<tr>"
+  , RawBlock
+    ( Format "html" ) "<td>"
+  , Plain
+    [ Str "This", Space, Str "is", Space, Emph [ Str "emphasized" ] ]
+  , RawBlock
+    ( Format "html" ) "</td>"
+  , RawBlock
+    ( Format "html" ) "<td>"
+  , Plain
+    [ Str "And"
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    ]
+  , RawBlock
+    ( Format "html" ) "</td>"
+  , RawBlock
+    ( Format "html" ) "</tr>"
+  , RawBlock
+    ( Format "html" ) "</table>"
+  , RawBlock
+    ( Format "html" ) "<script type=\"text/javascript\">document.write('This *should not* be interpreted as markdown');</script>"
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "simple"
+    , Space
+    , Str "block:"
+    ]
+  , Div
+    ( "", [], [] )
+    [ Para [ Str "foo" ] ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "code"
+    , Space
+    , Str "block,"
+    , Space
+    , Str "though:"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "<div>\n    foo\n</div>"
+  , Para
+    [ Str "As", Space, Str "should", Space, Str "this:" ]
+  , CodeBlock
+    ( "", [], [] ) "<div>foo</div>"
+  , Para
+    [ Str "Now,", Space, Str "nested:" ]
+  , Div
+    ( "", [], [] )
+    [ Div
+      ( "", [], [] )
+      [ Div ( "", [], [] ) [ Plain [ Str "foo" ] ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "just"
+    , Space
+    , Str "be"
+    , Space
+    , Str "an"
+    , Space
+    , Str "HTML"
+    , Space
+    , Str "comment:"
+    ]
+  , RawBlock
+    ( Format "html" ) "<!-- Comment -->"
+  , Para
+    [ Str "Multiline:" ]
+  , RawBlock
+    ( Format "html" ) "<!--\nBlah\nBlah\n-->"
+  , RawBlock
+    ( Format "html" ) "<!--\n    This is another comment.\n-->"
+  , Para
+    [ Str "Code", Space, Str "block:" ]
+  , CodeBlock
+    ( "", [], [] ) "<!-- Comment -->"
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "plain"
+    , Space
+    , Str "comment,"
+    , Space
+    , Str "with"
+    , Space
+    , Str "trailing"
+    , Space
+    , Str "spaces"
+    , Space
+    , Str "on"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line:"
+    ]
+  , RawBlock
+    ( Format "html" ) "<!-- foo -->"
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( "", [], [] ) "<hr />"
+  , Para
+    [ Str "Hr\8217s:" ]
+  , RawBlock
+    ( Format "html" ) "<hr>"
+  , RawBlock
+    ( Format "html" ) "<hr />"
+  , RawBlock
+    ( Format "html" ) "<hr />"
+  , RawBlock
+    ( Format "html" ) "<hr>"
+  , RawBlock
+    ( Format "html" ) "<hr />"
+  , RawBlock
+    ( Format "html" ) "<hr />"
+  , RawBlock
+    ( Format "html" ) "<hr class=\"foo\" id=\"bar\" />"
+  , RawBlock
+    ( Format "html" ) "<hr class=\"foo\" id=\"bar\" />"
+  , RawBlock
+    ( Format "html" ) "<hr class=\"foo\" id=\"bar\">"
+  , HorizontalRule
+  , Header 1
+    ( "inline-markup", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Emph
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Strong
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Emph
+      [ Link
+        ( "", [], [] )
+        [ Str "emphasized", Space, Str "link" ]
+        ( "/url", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) ">"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "<html>"
+    , Str "."
+    ]
+  , Para
+    [ Strikeout
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Emph
+        [ Str "strikeout" ]
+      , Str "."
+      ]
+    ]
+  , Para
+    [ Str "Superscripts:"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "bc" ]
+    , Str "d"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Emph [ Str "hello" ] ]
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "hello\160there" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Subscripts:"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "2" ]
+    , Str "O,"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "23" ]
+    , Str "O,"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "many\160of\160them" ]
+    , Str "O."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "superscripts"
+    , Space
+    , Str "or"
+    , Space
+    , Str "subscripts,"
+    , SoftBreak
+    , Str "because"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "unescaped"
+    , Space
+    , Str "spaces:"
+    , Space
+    , Str "a^b"
+    , Space
+    , Str "c^d,"
+    , Space
+    , Str "a~b"
+    , Space
+    , Str "c~d."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "smart-quotes-ellipses-dashes", [], [] )
+    [ Str "Smart"
+    , Space
+    , Str "quotes,"
+    , Space
+    , Str "ellipses,"
+    , Space
+    , Str "dashes"
+    ]
+  , Para
+    [ Quoted DoubleQuote
+      [ Str "Hello," ]
+    , Space
+    , Str "said"
+    , Space
+    , Str "the"
+    , Space
+    , Str "spider."
+    , Space
+    , Quoted DoubleQuote
+      [ Quoted SingleQuote
+        [ Str "Shelob" ]
+      , Space
+      , Str "is"
+      , Space
+      , Str "my"
+      , Space
+      , Str "name."
+      ]
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "A" ]
+    , Str ","
+    , Space
+    , Quoted SingleQuote
+      [ Str "B" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Quoted SingleQuote
+      [ Str "C" ]
+    , Space
+    , Str "are"
+    , Space
+    , Str "letters."
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "Oak," ]
+    , Space
+    , Quoted SingleQuote
+      [ Str "elm," ]
+    , Space
+    , Str "and"
+    , Space
+    , Quoted SingleQuote
+      [ Str "beech" ]
+    , Space
+    , Str "are"
+    , Space
+    , Str "names"
+    , Space
+    , Str "of"
+    , Space
+    , Str "trees."
+    , SoftBreak
+    , Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Quoted SingleQuote
+      [ Str "pine." ]
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "He"
+      , Space
+      , Str "said,"
+      , Space
+      , Quoted DoubleQuote
+        [ Str "I"
+        , Space
+        , Str "want"
+        , Space
+        , Str "to"
+        , Space
+        , Str "go."
+        ]
+      ]
+    , Space
+    , Str "Were"
+    , Space
+    , Str "you"
+    , Space
+    , Str "alive"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "70\8217s?"
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "quoted"
+    , Space
+    , Quoted SingleQuote
+      [ Code ( "", [], [] ) "code" ]
+    , Space
+    , Str "and"
+    , Space
+    , Str "a"
+    , Space
+    , Quoted DoubleQuote
+      [ Link
+        ( "", [], [] )
+        [ Str "quoted", Space, Str "link" ]
+        ( "http://example.com/?foo=1&bar=2", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Str "dashes:"
+    , Space
+    , Str "one\8212two"
+    , Space
+    , Str "\8212"
+    , Space
+    , Str "three\8212four"
+    , Space
+    , Str "\8212"
+    , Space
+    , Str "five."
+    ]
+  , Para
+    [ Str "Dashes"
+    , Space
+    , Str "between"
+    , Space
+    , Str "numbers:"
+    , Space
+    , Str "5\8211\&7,"
+    , Space
+    , Str "255\8211\&66,"
+    , Space
+    , Str "1987\8211\&1999."
+    ]
+  , Para
+    [ Str "Ellipses\8230and\8230and\8230." ]
+  , HorizontalRule
+  , Header 1
+    ( "latex", [], [] )
+    [ Str "LaTeX" ]
+  , BulletList
+    [
+      [ Plain
+        [ RawInline ( Format "tex" ) "\\cite[22-23]{smith.1899}" ]
+      ]
+    ,
+      [ Plain [ Math InlineMath "2+2=4" ] ]
+    ,
+      [ Plain [ Math InlineMath "x \\in y" ] ]
+    ,
+      [ Plain [ Math InlineMath "\\alpha \\wedge \\omega" ] ]
+    ,
+      [ Plain [ Math InlineMath "223" ] ]
+    ,
+      [ Plain [ Math InlineMath "p", Str "-Tree" ] ]
+    ,
+      [ Plain
+        [ Str "Here\8217s"
+        , Space
+        , Str "some"
+        , Space
+        , Str "display"
+        , Space
+        , Str "math:"
+        , SoftBreak
+        , Math DisplayMath "\\frac{d}{dx}f(x)=\\lim_{h\\to 0}\\frac{f(x+h)-f(x)}{h}"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Here\8217s"
+        , Space
+        , Str "one"
+        , Space
+        , Str "that"
+        , Space
+        , Str "has"
+        , Space
+        , Str "a"
+        , Space
+        , Str "line"
+        , Space
+        , Str "break"
+        , Space
+        , Str "in"
+        , Space
+        , Str "it:"
+        , Space
+        , Math InlineMath "\\alpha + \\omega \\times x^2"
+        , Str "."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "shouldn\8217t"
+    , Space
+    , Str "be"
+    , Space
+    , Str "math:"
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "To"
+        , Space
+        , Str "get"
+        , Space
+        , Str "the"
+        , Space
+        , Str "famous"
+        , Space
+        , Str "equation,"
+        , Space
+        , Str "write"
+        , Space
+        , Code
+          ( "", [], [] ) "$e = mc^2$"
+        , Str "."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "$22,000"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Emph
+          [ Str "lot" ]
+        , Space
+        , Str "of"
+        , Space
+        , Str "money."
+        , Space
+        , Str "So"
+        , Space
+        , Str "is"
+        , Space
+        , Str "$34,000."
+        , SoftBreak
+        , Str "(It"
+        , Space
+        , Str "worked"
+        , Space
+        , Str "if"
+        , Space
+        , Quoted DoubleQuote
+          [ Str "lot" ]
+        , Space
+        , Str "is"
+        , Space
+        , Str "emphasized.)"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Shoes"
+        , Space
+        , Str "($20)"
+        , Space
+        , Str "and"
+        , Space
+        , Str "socks"
+        , Space
+        , Str "($5)."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Escaped"
+        , Space
+        , Code
+          ( "", [], [] ) "$"
+        , Str ":"
+        , Space
+        , Str "$73"
+        , Space
+        , Emph
+          [ Str "this"
+          , Space
+          , Str "should"
+          , Space
+          , Str "be"
+          , Space
+          , Str "emphasized"
+          ]
+        , Space
+        , Str "23$."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "LaTeX"
+    , Space
+    , Str "table:"
+    ]
+  , RawBlock
+    ( Format "tex" ) "\\begin{tabular}{|l|l|}\\hline\nAnimal & Number \\\\ \\hline\nDog    & 2      \\\\\nCat    & 1      \\\\ \\hline\n\\end{tabular}"
+  , HorizontalRule
+  , Header 1
+    ( "special-characters", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "unicode:"
+    ]
+  , BulletList
+    [
+      [ Plain [ Str "I", Space, Str "hat:", Space, Str "\206" ] ]
+    ,
+      [ Plain [ Str "o", Space, Str "umlaut:", Space, Str "\246" ] ]
+    ,
+      [ Plain [ Str "section:", Space, Str "\167" ] ]
+    ,
+      [ Plain
+        [ Str "set", Space, Str "membership:", Space, Str "\8712" ]
+      ]
+    ,
+      [ Plain [ Str "copyright:", Space, Str "\169" ] ]
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "is"
+    , Space
+    , Str "another"
+    , Space
+    , Str "way"
+    , Space
+    , Str "to"
+    , Space
+    , Str "write"
+    , Space
+    , Str "it."
+    ]
+  , Para
+    [ Str "This", Space, Str "&", Space, Str "that." ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "`" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , HorizontalRule
+  , Header 1
+    ( "links", [], [] )
+    [ Str "Links" ]
+  , Header 2
+    ( "explicit", [], [] )
+    [ Str "Explicit" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "URL" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title preceded by two spaces" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title preceded by a tab" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title with \"quotes\" in it" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title with single quotes" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "with_underscore" ]
+      ( "/url/with_underscore", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Email", Space, Str "link" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Empty" ] ( "", "" ), Str "." ]
+  , Header 2
+    ( "reference", [], [] )
+    [ Str "Reference" ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "With"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "[brackets]" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "b" ]
+      ( "/url/", "" )
+    , Space
+    , Str "by"
+    , Space
+    , Str "itself"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "once" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "twice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "thrice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "[not][]"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , CodeBlock
+    ( "", [], [] ) "[not]: /url"
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "Title with \"quotes\" inside" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "biz" ]
+      ( "/url/", "Title with \"quote\" inside" )
+    , Str "."
+    ]
+  , Header 2
+    ( "with-ampersands", [], [] )
+    [ Str "With", Space, Str "ampersands" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link"
+      , Space
+      , Str "with"
+      , Space
+      , Str "an"
+      , Space
+      , Str "ampersand"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "URL"
+      ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Str "amersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "AT&T" ]
+      ( "http://att.com/", "AT&T" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline", Space, Str "link" ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline"
+      , Space
+      , Str "link"
+      , Space
+      , Str "in"
+      , Space
+      , Str "pointy"
+      , Space
+      , Str "braces"
+      ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "autolinks", [], [] )
+    [ Str "Autolinks" ]
+  , Para
+    [ Str "With"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand:"
+    , Space
+    , Link
+      ( "", [ "uri" ], [] )
+      [ Str "http://example.com/?foo=1&bar=2" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    ]
+  , BulletList
+    [
+      [ Plain [ Str "In", Space, Str "a", Space, Str "list?" ] ]
+    ,
+      [ Plain
+        [ Link
+          ( "", [ "uri" ], [] )
+          [ Str "http://example.com/" ]
+          ( "http://example.com/", "" )
+        ]
+      ]
+    ,
+      [ Plain [ Str "It", Space, Str "should." ] ]
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Str "e-mail"
+    , Space
+    , Str "address:"
+    , Space
+    , Link
+      ( "", [ "email" ], [] )
+      [ Str "nobody@nowhere.net" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Blockquoted:"
+      , Space
+      , Link
+        ( "", [ "uri" ], [] )
+        [ Str "http://example.com/" ]
+        ( "http://example.com/", "" )
+      ]
+    ]
+  , Para
+    [ Str "Auto-links"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "occur"
+    , Space
+    , Str "here:"
+    , Space
+    , Code
+      ( "", [], [] ) "<http://example.com/>"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "or here: <http://example.com/>"
+  , HorizontalRule
+  , Header 1
+    ( "images", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "From"
+    , Space
+    , Quoted DoubleQuote
+      [ Str "Voyage"
+      , Space
+      , Str "dans"
+      , Space
+      , Str "la"
+      , Space
+      , Str "Lune"
+      ]
+    , Space
+    , Str "by"
+    , Space
+    , Str "Georges"
+    , Space
+    , Str "Melies"
+    , Space
+    , Str "(1902):"
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "lalune" ]
+      ( "lalune.jpg", "fig:Voyage dans la Lune" )
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "movie" ]
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "footnotes", [], [] )
+    [ Str "Footnotes" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , Note
+      [ Para
+        [ Str "Here"
+        , Space
+        , Str "is"
+        , Space
+        , Str "the"
+        , Space
+        , Str "footnote."
+        , Space
+        , Str "It"
+        , Space
+        , Str "can"
+        , Space
+        , Str "go"
+        , Space
+        , Str "anywhere"
+        , Space
+        , Str "after"
+        , Space
+        , Str "the"
+        , Space
+        , Str "footnote"
+        , SoftBreak
+        , Str "reference."
+        , Space
+        , Str "It"
+        , Space
+        , Str "need"
+        , Space
+        , Str "not"
+        , Space
+        , Str "be"
+        , Space
+        , Str "placed"
+        , Space
+        , Str "at"
+        , Space
+        , Str "the"
+        , Space
+        , Str "end"
+        , Space
+        , Str "of"
+        , Space
+        , Str "the"
+        , Space
+        , Str "document."
+        ]
+      ]
+    , Space
+    , Str "and"
+    , Space
+    , Str "another."
+    , Note
+      [ Para
+        [ Str "Here\8217s"
+        , Space
+        , Str "the"
+        , Space
+        , Str "long"
+        , Space
+        , Str "note."
+        , Space
+        , Str "This"
+        , Space
+        , Str "one"
+        , Space
+        , Str "contains"
+        , Space
+        , Str "multiple"
+        , SoftBreak
+        , Str "blocks."
+        ]
+      , Para
+        [ Str "Subsequent"
+        , Space
+        , Str "blocks"
+        , Space
+        , Str "are"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "to"
+        , Space
+        , Str "show"
+        , Space
+        , Str "that"
+        , Space
+        , Str "they"
+        , Space
+        , Str "belong"
+        , Space
+        , Str "to"
+        , Space
+        , Str "the"
+        , SoftBreak
+        , Str "footnote"
+        , Space
+        , Str "(as"
+        , Space
+        , Str "with"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items)."
+        ]
+      , CodeBlock
+        ( "", [], [] ) "  { <code> }"
+      , Para
+        [ Str "If"
+        , Space
+        , Str "you"
+        , Space
+        , Str "want,"
+        , Space
+        , Str "you"
+        , Space
+        , Str "can"
+        , Space
+        , Str "indent"
+        , Space
+        , Str "every"
+        , Space
+        , Str "line,"
+        , Space
+        , Str "but"
+        , Space
+        , Str "you"
+        , Space
+        , Str "can"
+        , Space
+        , Str "also"
+        , Space
+        , Str "be"
+        , SoftBreak
+        , Str "lazy"
+        , Space
+        , Str "and"
+        , Space
+        , Str "just"
+        , Space
+        , Str "indent"
+        , Space
+        , Str "the"
+        , Space
+        , Str "first"
+        , Space
+        , Str "line"
+        , Space
+        , Str "of"
+        , Space
+        , Str "each"
+        , Space
+        , Str "block."
+        ]
+      ]
+    , SoftBreak
+    , Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Emph
+      [ Str "not" ]
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , Space
+    , Str "because"
+    , Space
+    , Str "it"
+    , SoftBreak
+    , Str "contains"
+    , Space
+    , Str "a"
+    , Space
+    , Str "space.[^my"
+    , Space
+    , Str "note]"
+    , Space
+    , Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "an"
+    , Space
+    , Str "inline"
+    , Space
+    , Str "note."
+    , Note
+      [ Para
+        [ Str "This"
+        , SoftBreak
+        , Str "is"
+        , Space
+        , Emph
+          [ Str "easier" ]
+        , Space
+        , Str "to"
+        , Space
+        , Str "type."
+        , Space
+        , Str "Inline"
+        , Space
+        , Str "notes"
+        , Space
+        , Str "may"
+        , Space
+        , Str "contain"
+        , SoftBreak
+        , Link
+          ( "", [], [] )
+          [ Str "links" ]
+          ( "http://google.com", "" )
+        , Space
+        , Str "and"
+        , Space
+        , Code
+          ( "", [], [] ) "]"
+        , Space
+        , Str "verbatim"
+        , Space
+        , Str "characters,"
+        , SoftBreak
+        , Str "as"
+        , Space
+        , Str "well"
+        , Space
+        , Str "as"
+        , Space
+        , Str "[bracketed"
+        , Space
+        , Str "text]."
+        ]
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Notes"
+      , Space
+      , Str "can"
+      , Space
+      , Str "go"
+      , Space
+      , Str "in"
+      , Space
+      , Str "quotes."
+      , Note
+        [ Para [ Str "In", Space, Str "quote." ] ]
+      ]
+    ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain
+        [ Str "And"
+        , Space
+        , Str "in"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items."
+        , Note
+          [ Para [ Str "In", Space, Str "list." ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "part"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "note,"
+    , Space
+    , Str "as"
+    , Space
+    , Str "it"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "indented."
+    ]
+  ]

--- a/test/textile-reader.native
+++ b/test/textile-reader.native
@@ -1,243 +1,1317 @@
-Pandoc (Meta {unMeta = fromList []})
-[Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc",Space,Str "Textile",Space,Str "Reader.",Space,Str "Part",Space,Str "of",Space,Str "it",Space,Str "comes",LineBreak,Str "from",Space,Str "John",Space,Str "Gruber\8217s",Space,Str "markdown",Space,Str "test",Space,Str "suite."]
-,HorizontalRule
-,Header 1 ("headers",[],[]) [Str "Headers"]
-,Header 2 ("level-2-with-an-embedded-link",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Str "an",Space,Link ("",[],[]) [Str "embedded",Space,Str "link"] ("http://www.example.com","")]
-,Header 3 ("level-3-with-emphasis",[],[]) [Str "Level",Space,Str "3",Space,Str "with",Space,Strong [Str "emphasis"]]
-,Header 4 ("level-4",[],[]) [Str "Level",Space,Str "4"]
-,Header 5 ("level-5",[],[]) [Str "Level",Space,Str "5"]
-,Header 6 ("level-6",[],[]) [Str "Level",Space,Str "6"]
-,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "Line",Space,Str "breaks",Space,Str "are",Space,Str "preserved",Space,Str "in",Space,Str "textile,",Space,Str "so",Space,Str "you",Space,Str "can",Space,Str "not",Space,Str "wrap",Space,Str "your",Space,Str "very",LineBreak,Str "long",Space,Str "paragraph",Space,Str "with",Space,Str "your",Space,Str "favourite",Space,Str "text",Space,Str "editor",Space,Str "and",Space,Str "have",Space,Str "it",Space,Str "rendered",LineBreak,Str "with",Space,Str "no",Space,Str "break."]
-,Para [Str "Here\8217s",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet."]
-,BulletList
- [[Plain [Str "criminey."]]]
-,Para [Str "There",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "paragraph",Space,Str "break",Space,Str "between",Space,Str "here"]
-,Para [Str "and",Space,Str "here."]
-,Para [Str "pandoc",Space,Str "converts",Space,Str "textile."]
-,Header 1 ("block-quotes",[],[]) [Str "Block",Space,Str "Quotes"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "famous",Space,Str "quote",Space,Str "from",Space,Str "somebody.",Space,Str "He",Space,Str "had",Space,Str "a",Space,Str "lot",Space,Str "of",Space,Str "things",Space,Str "to",LineBreak,Str "say,",Space,Str "so",Space,Str "the",Space,Str "text",Space,Str "is",Space,Str "really",Space,Str "really",Space,Str "long",Space,Str "and",Space,Str "spans",Space,Str "on",Space,Str "multiple",Space,Str "lines."]]
-,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
-,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "    ---- (should be four hyphens)\n\n    sub status {\n        print \"working\";\n    }\n\n    this code block is indented by one tab"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "        this code block is indented by two tabs\n\n    These should not be escaped:  \\$ \\\\ \\> \\[ \\{"
-,CodeBlock ("",[],[]) "Code block with .bc\n        continued\n    @</\\"
-,CodeBlock ("",[],[]) "extended code block\n\n        continued"
-,Para [Str "ended",Space,Str "by",Space,Str "paragraph"]
-,Para [Str "Inline",Space,Str "code:",Space,Code ("",[],[]) "<tt>",Str ",",Space,Code ("",[],[]) "@",Str "."]
-,Header 1 ("notextile",[],[]) [Str "Notextile"]
-,Para [Str "A",Space,Str "block",Space,Str "of",Space,Str "text",Space,Str "can",Space,Str "be",Space,Str "protected",Space,Str "with",Space,Str "notextile",Space,Str ":"]
-,Para [Str "\nNo *bold* and\n* no bullet\n"]
-,Para [Str "and",Space,Str "inlines",Space,Str "can",Space,Str "be",Space,Str "protected",Space,Str "with",Space,Str "double *equals (=)* markup."]
-,Header 1 ("lists",[],[]) [Str "Lists"]
-,Header 2 ("unordered",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "asterisk",Space,Str "1"]]
- ,[Plain [Str "asterisk",Space,Str "2"]]
- ,[Plain [Str "asterisk",Space,Str "3"]]]
-,Para [Str "With",Space,Str "line",Space,Str "breaks:"]
-,BulletList
- [[Plain [Str "asterisk",Space,Str "1",LineBreak,Str "newline"]]
- ,[Plain [Str "asterisk",Space,Str "2"]]]
-,Header 2 ("ordered",[],[]) [Str "Ordered"]
-,Para [Str "Tight:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second"]]
- ,[Plain [Str "Third"]]]
-,Header 2 ("nested",[],[]) [Str "Nested"]
-,BulletList
- [[Plain [Str "ui",Space,Str "1"]
-  ,BulletList
-   [[Plain [Str "ui",Space,Str "1.1"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "oi",Space,Str "1.1.1"]]
-     ,[Plain [Str "oi",Space,Str "1.1.2"]]]]
-   ,[Plain [Str "ui",Space,Str "1.2"]]]]
- ,[Plain [Str "ui",Space,Str "2"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "oi",Space,Str "2.1"]
-    ,BulletList
-     [[Plain [Str "ui",Space,Str "2.1.1"]]
-     ,[Plain [Str "ui",Space,Str "2.1.2"]]]]]]]
-,Header 2 ("issue-1500",[],[]) [Str "Issue",Space,Str "#1500"]
-,BulletList
- [[Plain [Str "one"]]
- ,[Plain [Str "two",LineBreak,Str "->",Space,Str "and",Space,Str "more"]]]
-,Header 2 ("issue-1513",[],[]) [Str "Issue",Space,Str "#1513"]
-,Para [Str "List:"]
-,BulletList
- [[Plain [Str "one"]]
- ,[Plain [Str "two"]]]
-,Header 2 ("definition-list",[],[]) [Str "Definition",Space,Str "List"]
-,DefinitionList
- [([Str "coffee"],
-   [[Plain [Str "Hot",Space,Str "and",Space,Str "black"]]])
- ,([Str "tea"],
-   [[Plain [Str "Also",Space,Str "hot,",Space,Str "but",Space,Str "a",Space,Str "little",Space,Str "less",Space,Str "black"]]])
- ,([Str "milk"],
-   [[Para [Str "Nourishing",Space,Str "beverage",Space,Str "for",Space,Str "baby",Space,Str "cows."]
-    ,Para [Str "Cold",Space,Str "drink",Space,Str "that",Space,Str "goes",Space,Str "great",Space,Str "with",Space,Str "cookies."]]])
- ,([Str "beer"],
-   [[Plain [Str "fresh",Space,Str "and",Space,Str "bitter"]]])]
-,Header 1 ("inline-markup",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ",",Space,Str "and",Space,Str "so",Space,Emph [Str "is",Space,Str "this"],Str ".",LineBreak,Str "This",Space,Str "is",Space,Strong [Str "strong"],Str ",",Space,Str "and",Space,Str "so",Space,Strong [Str "is",Space,Str "this"],Str ".",LineBreak,Str "This",Space,Str "is",Space,Underline [Str "inserted"],Str ",",Space,Str "and",Space,Str "this",Space,Str "is",Space,Strikeout [Str "deleted"],Str ".",LineBreak,Str "Hyphenated-words-are-ok,",Space,Str "as",Space,Str "well",Space,Str "as",Space,Str "strange_underscore_notation.",LineBreak,Str "A",Space,Link ("",[],[]) [Strong [Str "strong",Space,Str "link"]] ("http://www.foobar.com",""),Str "."]
-,Para [Emph [Strong [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]],LineBreak,Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word",Space,Str "and",Space,Emph [Strong [Str "that",Space,Str "one"]],Str ".",LineBreak,Strikeout [Str "This",Space,Str "is",Space,Str "strikeout",Space,Str "and",Space,Strong [Str "strong"]]]
-,Para [Str "Superscripts:",Space,Str "a",Superscript [Str "bc"],Str "d",Space,Str "a",Space,Superscript [Strong [Str "hello"]],Space,Str "a",Superscript [Str "hello",Space,Str "there"],Str ".",LineBreak,Str "Subscripts:",Space,Subscript [Str "here"],Space,Str "H",Space,Subscript [Str "2"],Str "O,",Space,Str "H",Space,Subscript [Str "23"],Str "O,",Space,Str "H",Space,Subscript [Str "many",Space,Str "of",Space,Str "them"],Str "O."]
-,Para [Str "Dashes",Space,Str ":",Space,Str "How",Space,Str "cool",Space,Str "\8212",Space,Str "automatic",Space,Str "dashes."]
-,Para [Str "Ellipses",Space,Str ":",Space,Str "He",Space,Str "thought",Space,Str "and",Space,Str "thought",Space,Str "\8230",Space,Str "and",Space,Str "then",Space,Str "thought",Space,Str "some",Space,Str "more."]
-,Para [Str "Quotes",Space,Str "and",Space,Str "apostrophes",Space,Str ":",Space,Quoted DoubleQuote [Str "I\8217d",Space,Str "like",Space,Str "to",Space,Str "thank",Space,Str "you"],Space,Str "for",Space,Str "example."]
-,Header 1 ("links",[],[]) [Str "Links"]
-,Header 2 ("explicit",[],[]) [Str "Explicit"]
-,Para [Str "Just",Space,Str "a",Space,Link ("",[],[]) [Str "url"] ("http://www.url.com","")]
-,Para [Link ("",[],[]) [Str "Email",Space,Str "link"] ("mailto:nobody@nowhere.net","")]
-,Para [Quoted DoubleQuote [Str "not",Space,Str "a",Space,Str "link"],Str ":",Space,Str "foo"]
-,Para [Str "Automatic",Space,Str "linking",Space,Str "to",Space,Link ("",[],[]) [Str "http://www.example.com"] ("http://www.example.com",""),Str "."]
-,Para [Link ("",[],[]) [Str "Example"] ("http://www.example.com/",""),Str ":",Space,Str "Example",Space,Str "of",Space,Str "a",Space,Str "link",Space,Str "followed",Space,Str "by",Space,Str "a",Space,Str "colon."]
-,Para [Str "A",Space,Str "link",Link ("",[],[]) [Str "with",Space,Str "brackets"] ("http://www.example.com",""),Str "and",Space,Str "no",Space,Str "spaces."]
-,Header 1 ("tables",[],[]) [Str "Tables"]
-,Para [Str "Textile",Space,Str "allows",Space,Str "tables",Space,Str "with",Space,Str "and",Space,Str "without",Space,Str "headers",Space,Str ":"]
-,Header 2 ("without-headers",[],[]) [Str "Without",Space,Str "headers"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "name"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "age"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "sex"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "joan"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "24"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "archie"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "29"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "m"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "bella"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "45"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "and",Space,Str "some",Space,Str "text",Space,Str "following",Space,Str "\8230"]
-,Header 2 ("with-headers",[],[]) [Str "With",Space,Str "headers"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "name"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "age"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "sex"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "joan"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "24"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "archie"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "29"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "m"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "bella"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "45"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 1 ("images",[],[]) [Str "Images"]
-,Para [Str "Textile",Space,Str "inline",Space,Str "image",Space,Str "syntax,",Space,Str "like",LineBreak,Str "here",Space,Image ("",[],[]) [Str "this is the alt text"] ("this_is_an_image.png","this is the alt text"),LineBreak,Str "and",Space,Str "here",Space,Image ("",[],[]) [Str ""] ("this_is_an_image.png",""),Str "."]
-,Header 1 ("attributes",[],[]) [Str "Attributes"]
-,Header 2 ("ident",["bar","foo"],[("style","color:red;"),("lang","en")]) [Str "HTML",Space,Str "and",Space,Str "CSS",Space,Str "attributes",Space,Str "are",Space,Str "parsed",Space,Str "in",Space,Str "headers."]
-,Header 2 ("centered",[],[("style","text-align:center;")]) [Str "Centered"]
-,Header 2 ("right",[],[("style","text-align:right;")]) [Str "Right"]
-,Header 2 ("justified",[],[("lang","en"),("style","color:blue;text-align:justify;")]) [Str "Justified"]
-,Para [Str "as",Space,Str "well",Space,Str "as",Space,Strong [Span ("",["foo"],[]) [Str "inline",Space,Str "attributes"]],Space,Str "of",Space,Span ("",[],[("style","color:red;")]) [Str "all",Space,Str "kind"]]
-,Para [Str "and",Space,Str "paragraph",Space,Str "attributes,",Space,Str "and",Space,Str "table",Space,Str "attributes."]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "name"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "age"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "sex"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "joan"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "24"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Emph [Str "(class#id)",Space,Str "emph"]]
-,Para [Emph [Str "(no",Space,Str "class#id)",Space,Str "emph"]]
-,Header 1 ("entities",[],[]) [Str "Entities"]
-,Para [Str "*",LineBreak,Str "&"]
-,Header 1 ("raw-html",[],[]) [Str "Raw",Space,Str "HTML"]
-,Para [Str "However,",Space,RawInline (Format "html") "<strong>",Space,Str "raw",Space,Str "HTML",Space,Str "inlines",Space,RawInline (Format "html") "</strong>",Space,Str "are",Space,Str "accepted,",Space,Str "as",Space,Str "well",Space,Str "as",Space,Str ":"]
-,RawBlock (Format "html") "<div class=\"foobar\">"
-,Para [Str "any",Space,Strong [Str "Raw",Space,Str "HTML",Space,Str "Block"],Space,Str "with",Space,Str "bold"]
-,RawBlock (Format "html") "</div>"
-,Para [Str "Html",Space,Str "blocks",Space,Str "can"]
-,RawBlock (Format "html") "<div>"
-,Para [Str "interrupt",Space,Str "paragraphs"]
-,RawBlock (Format "html") "</div>"
-,Para [Str "as",Space,Str "well."]
-,Para [Str "Can",Space,Str "you",Space,Str "prove",Space,Str "that",Space,Str "2",Space,Str "<",Space,Str "3",Space,Str "?"]
-,Header 1 ("acronyms-and-marks",[],[]) [Str "Acronyms",Space,Str "and",Space,Str "marks"]
-,Para [Str "PBS (Public Broadcasting System)"]
-,Para [Str "Hi\8482"]
-,Para [Str "Hi",Space,Str "\8482"]
-,Para [Str "\174",Space,Str "Hi\174"]
-,Para [Str "Hi\169\&2008",Space,Str "\169",Space,Str "2008"]
-,Header 1 ("footnotes",[],[]) [Str "Footnotes"]
-,Para [Str "A",Space,Str "note.",Note [Para [Str "The",Space,Str "note",LineBreak,Str "is",Space,Str "here!"]],Space,Str "Another",Space,Str "note",Note [Para [Str "Other",Space,Str "note."]],Str "."]
-,Header 1 ("comment-blocks",[],[]) [Str "Comment",Space,Str "blocks"]
-,Para [Str "not",Space,Str "a",Space,Str "comment."]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc"
+    , Space
+    , Str "Textile"
+    , Space
+    , Str "Reader."
+    , Space
+    , Str "Part"
+    , Space
+    , Str "of"
+    , Space
+    , Str "it"
+    , Space
+    , Str "comes"
+    , LineBreak
+    , Str "from"
+    , Space
+    , Str "John"
+    , Space
+    , Str "Gruber\8217s"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "test"
+    , Space
+    , Str "suite."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "headers", [], [] )
+    [ Str "Headers" ]
+  , Header 2
+    ( "level-2-with-an-embedded-link", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "link" ]
+      ( "http://www.example.com", "" )
+    ]
+  , Header 3
+    ( "level-3-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "3"
+    , Space
+    , Str "with"
+    , Space
+    , Strong
+      [ Str "emphasis" ]
+    ]
+  , Header 4
+    ( "level-4", [], [] )
+    [ Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "level-5", [], [] )
+    [ Str "Level", Space, Str "5" ]
+  , Header 6
+    ( "level-6", [], [] )
+    [ Str "Level", Space, Str "6" ]
+  , Header 1
+    ( "paragraphs", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "Line"
+    , Space
+    , Str "breaks"
+    , Space
+    , Str "are"
+    , Space
+    , Str "preserved"
+    , Space
+    , Str "in"
+    , Space
+    , Str "textile,"
+    , Space
+    , Str "so"
+    , Space
+    , Str "you"
+    , Space
+    , Str "can"
+    , Space
+    , Str "not"
+    , Space
+    , Str "wrap"
+    , Space
+    , Str "your"
+    , Space
+    , Str "very"
+    , LineBreak
+    , Str "long"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "with"
+    , Space
+    , Str "your"
+    , Space
+    , Str "favourite"
+    , Space
+    , Str "text"
+    , Space
+    , Str "editor"
+    , Space
+    , Str "and"
+    , Space
+    , Str "have"
+    , Space
+    , Str "it"
+    , Space
+    , Str "rendered"
+    , LineBreak
+    , Str "with"
+    , Space
+    , Str "no"
+    , Space
+    , Str "break."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    ]
+  , BulletList
+    [ [ Plain [ Str "criminey." ] ] ]
+  , Para
+    [ Str "There"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "break"
+    , Space
+    , Str "between"
+    , Space
+    , Str "here"
+    ]
+  , Para
+    [ Str "and", Space, Str "here." ]
+  , Para
+    [ Str "pandoc", Space, Str "converts", Space, Str "textile." ]
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "famous"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "from"
+      , Space
+      , Str "somebody."
+      , Space
+      , Str "He"
+      , Space
+      , Str "had"
+      , Space
+      , Str "a"
+      , Space
+      , Str "lot"
+      , Space
+      , Str "of"
+      , Space
+      , Str "things"
+      , Space
+      , Str "to"
+      , LineBreak
+      , Str "say,"
+      , Space
+      , Str "so"
+      , Space
+      , Str "the"
+      , Space
+      , Str "text"
+      , Space
+      , Str "is"
+      , Space
+      , Str "really"
+      , Space
+      , Str "really"
+      , Space
+      , Str "long"
+      , Space
+      , Str "and"
+      , Space
+      , Str "spans"
+      , Space
+      , Str "on"
+      , Space
+      , Str "multiple"
+      , Space
+      , Str "lines."
+      ]
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "a"
+    , Space
+    , Str "following"
+    , Space
+    , Str "paragraph."
+    ]
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "    ---- (should be four hyphens)\n\n    sub status {\n        print \"working\";\n    }\n\n    this code block is indented by one tab"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "        this code block is indented by two tabs\n\n    These should not be escaped:  \\$ \\\\ \\> \\[ \\{"
+  , CodeBlock
+    ( "", [], [] ) "Code block with .bc\n        continued\n    @</\\"
+  , CodeBlock
+    ( "", [], [] ) "extended code block\n\n        continued"
+  , Para
+    [ Str "ended", Space, Str "by", Space, Str "paragraph" ]
+  , Para
+    [ Str "Inline"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) "<tt>"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "@"
+    , Str "."
+    ]
+  , Header 1
+    ( "notextile", [], [] )
+    [ Str "Notextile" ]
+  , Para
+    [ Str "A"
+    , Space
+    , Str "block"
+    , Space
+    , Str "of"
+    , Space
+    , Str "text"
+    , Space
+    , Str "can"
+    , Space
+    , Str "be"
+    , Space
+    , Str "protected"
+    , Space
+    , Str "with"
+    , Space
+    , Str "notextile"
+    , Space
+    , Str ":"
+    ]
+  , Para
+    [ Str "\nNo *bold* and\n* no bullet\n" ]
+  , Para
+    [ Str "and"
+    , Space
+    , Str "inlines"
+    , Space
+    , Str "can"
+    , Space
+    , Str "be"
+    , Space
+    , Str "protected"
+    , Space
+    , Str "with"
+    , Space
+    , Str "double *equals (=)* markup."
+    ]
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "unordered", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "With", Space, Str "line", Space, Str "breaks:" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "asterisk", Space, Str "1", LineBreak, Str "newline" ]
+      ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "2" ] ]
+    ]
+  , Header 2
+    ( "ordered", [], [] )
+    [ Str "Ordered" ]
+  , Para
+    [ Str "Tight:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain [ Str "Second" ] ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "nested", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "ui", Space, Str "1" ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "ui", Space, Str "1.1" ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain [ Str "oi", Space, Str "1.1.1" ] ]
+            ,
+              [ Plain [ Str "oi", Space, Str "1.1.2" ] ]
+            ]
+          ]
+        ,
+          [ Plain [ Str "ui", Space, Str "1.2" ] ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "ui", Space, Str "2" ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "oi", Space, Str "2.1" ]
+          , BulletList
+            [
+              [ Plain [ Str "ui", Space, Str "2.1.1" ] ]
+            ,
+              [ Plain [ Str "ui", Space, Str "2.1.2" ] ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "issue-1500", [], [] )
+    [ Str "Issue", Space, Str "#1500" ]
+  , BulletList
+    [
+      [ Plain [ Str "one" ] ]
+    ,
+      [ Plain
+        [ Str "two"
+        , LineBreak
+        , Str "->"
+        , Space
+        , Str "and"
+        , Space
+        , Str "more"
+        ]
+      ]
+    ]
+  , Header 2
+    ( "issue-1513", [], [] )
+    [ Str "Issue", Space, Str "#1513" ]
+  , Para
+    [ Str "List:" ]
+  , BulletList
+    [ [ Plain [ Str "one" ] ], [ Plain [ Str "two" ] ] ]
+  , Header 2
+    ( "definition-list", [], [] )
+    [ Str "Definition", Space, Str "List" ]
+  , DefinitionList
+    [
+      (
+        [ Str "coffee" ]
+      ,
+        [
+          [ Plain [ Str "Hot", Space, Str "and", Space, Str "black" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "tea" ]
+      ,
+        [
+          [ Plain
+            [ Str "Also"
+            , Space
+            , Str "hot,"
+            , Space
+            , Str "but"
+            , Space
+            , Str "a"
+            , Space
+            , Str "little"
+            , Space
+            , Str "less"
+            , Space
+            , Str "black"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Str "milk" ]
+      ,
+        [
+          [ Para
+            [ Str "Nourishing"
+            , Space
+            , Str "beverage"
+            , Space
+            , Str "for"
+            , Space
+            , Str "baby"
+            , Space
+            , Str "cows."
+            ]
+          , Para
+            [ Str "Cold"
+            , Space
+            , Str "drink"
+            , Space
+            , Str "that"
+            , Space
+            , Str "goes"
+            , Space
+            , Str "great"
+            , Space
+            , Str "with"
+            , Space
+            , Str "cookies."
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Str "beer" ]
+      ,
+        [
+          [ Plain
+            [ Str "fresh", Space, Str "and", Space, Str "bitter" ]
+          ]
+        ]
+      )
+    ]
+  , Header 1
+    ( "inline-markup", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Emph
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    , LineBreak
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Strong
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    , LineBreak
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Underline
+      [ Str "inserted" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Strikeout
+      [ Str "deleted" ]
+    , Str "."
+    , LineBreak
+    , Str "Hyphenated-words-are-ok,"
+    , Space
+    , Str "as"
+    , Space
+    , Str "well"
+    , Space
+    , Str "as"
+    , Space
+    , Str "strange_underscore_notation."
+    , LineBreak
+    , Str "A"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Strong [ Str "strong", Space, Str "link" ] ]
+      ( "http://www.foobar.com", "" )
+    , Str "."
+    ]
+  , Para
+    [ Emph
+      [ Strong
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    , LineBreak
+    , Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word"
+    , Space
+    , Str "and"
+    , Space
+    , Emph
+      [ Strong [ Str "that", Space, Str "one" ] ]
+    , Str "."
+    , LineBreak
+    , Strikeout
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "strikeout"
+      , Space
+      , Str "and"
+      , Space
+      , Strong
+        [ Str "strong" ]
+      ]
+    ]
+  , Para
+    [ Str "Superscripts:"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "bc" ]
+    , Str "d"
+    , Space
+    , Str "a"
+    , Space
+    , Superscript
+      [ Strong [ Str "hello" ] ]
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "hello", Space, Str "there" ]
+    , Str "."
+    , LineBreak
+    , Str "Subscripts:"
+    , Space
+    , Subscript
+      [ Str "here" ]
+    , Space
+    , Str "H"
+    , Space
+    , Subscript
+      [ Str "2" ]
+    , Str "O,"
+    , Space
+    , Str "H"
+    , Space
+    , Subscript
+      [ Str "23" ]
+    , Str "O,"
+    , Space
+    , Str "H"
+    , Space
+    , Subscript
+      [ Str "many", Space, Str "of", Space, Str "them" ]
+    , Str "O."
+    ]
+  , Para
+    [ Str "Dashes"
+    , Space
+    , Str ":"
+    , Space
+    , Str "How"
+    , Space
+    , Str "cool"
+    , Space
+    , Str "\8212"
+    , Space
+    , Str "automatic"
+    , Space
+    , Str "dashes."
+    ]
+  , Para
+    [ Str "Ellipses"
+    , Space
+    , Str ":"
+    , Space
+    , Str "He"
+    , Space
+    , Str "thought"
+    , Space
+    , Str "and"
+    , Space
+    , Str "thought"
+    , Space
+    , Str "\8230"
+    , Space
+    , Str "and"
+    , Space
+    , Str "then"
+    , Space
+    , Str "thought"
+    , Space
+    , Str "some"
+    , Space
+    , Str "more."
+    ]
+  , Para
+    [ Str "Quotes"
+    , Space
+    , Str "and"
+    , Space
+    , Str "apostrophes"
+    , Space
+    , Str ":"
+    , Space
+    , Quoted DoubleQuote
+      [ Str "I\8217d"
+      , Space
+      , Str "like"
+      , Space
+      , Str "to"
+      , Space
+      , Str "thank"
+      , Space
+      , Str "you"
+      ]
+    , Space
+    , Str "for"
+    , Space
+    , Str "example."
+    ]
+  , Header 1
+    ( "links", [], [] )
+    [ Str "Links" ]
+  , Header 2
+    ( "explicit", [], [] )
+    [ Str "Explicit" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "url" ]
+      ( "http://www.url.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Email", Space, Str "link" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , Para
+    [ Quoted DoubleQuote
+      [ Str "not", Space, Str "a", Space, Str "link" ]
+    , Str ":"
+    , Space
+    , Str "foo"
+    ]
+  , Para
+    [ Str "Automatic"
+    , Space
+    , Str "linking"
+    , Space
+    , Str "to"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.example.com" ]
+      ( "http://www.example.com", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Example" ]
+      ( "http://www.example.com/", "" )
+    , Str ":"
+    , Space
+    , Str "Example"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "followed"
+    , Space
+    , Str "by"
+    , Space
+    , Str "a"
+    , Space
+    , Str "colon."
+    ]
+  , Para
+    [ Str "A"
+    , Space
+    , Str "link"
+    , Link
+      ( "", [], [] )
+      [ Str "with", Space, Str "brackets" ]
+      ( "http://www.example.com", "" )
+    , Str "and"
+    , Space
+    , Str "no"
+    , Space
+    , Str "spaces."
+    ]
+  , Header 1
+    ( "tables", [], [] )
+    [ Str "Tables" ]
+  , Para
+    [ Str "Textile"
+    , Space
+    , Str "allows"
+    , Space
+    , Str "tables"
+    , Space
+    , Str "with"
+    , Space
+    , Str "and"
+    , Space
+    , Str "without"
+    , Space
+    , Str "headers"
+    , Space
+    , Str ":"
+    ]
+  , Header 2
+    ( "without-headers", [], [] )
+    [ Str "Without", Space, Str "headers" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "name" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "age" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "sex" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "joan" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "24" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "archie" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "29" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "m" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "bella" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "45" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "and"
+    , Space
+    , Str "some"
+    , Space
+    , Str "text"
+    , Space
+    , Str "following"
+    , Space
+    , Str "\8230"
+    ]
+  , Header 2
+    ( "with-headers", [], [] )
+    [ Str "With", Space, Str "headers" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "name" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "age" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "sex" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "joan" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "24" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "archie" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "29" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "m" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "bella" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "45" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 1
+    ( "images", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "Textile"
+    , Space
+    , Str "inline"
+    , Space
+    , Str "image"
+    , Space
+    , Str "syntax,"
+    , Space
+    , Str "like"
+    , LineBreak
+    , Str "here"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "this is the alt text" ]
+      ( "this_is_an_image.png", "this is the alt text" )
+    , LineBreak
+    , Str "and"
+    , Space
+    , Str "here"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "" ]
+      ( "this_is_an_image.png", "" )
+    , Str "."
+    ]
+  , Header 1
+    ( "attributes", [], [] )
+    [ Str "Attributes" ]
+  , Header 2
+    ( "ident"
+    ,
+      [ "bar", "foo" ]
+    ,
+      [ ( "style", "color:red;" ), ( "lang", "en" ) ]
+    )
+    [ Str "HTML"
+    , Space
+    , Str "and"
+    , Space
+    , Str "CSS"
+    , Space
+    , Str "attributes"
+    , Space
+    , Str "are"
+    , Space
+    , Str "parsed"
+    , Space
+    , Str "in"
+    , Space
+    , Str "headers."
+    ]
+  , Header 2
+    ( "centered", [], [ ( "style", "text-align:center;" ) ] )
+    [ Str "Centered" ]
+  , Header 2
+    ( "right", [], [ ( "style", "text-align:right;" ) ] )
+    [ Str "Right" ]
+  , Header 2
+    ( "justified"
+    , []
+    ,
+      [
+        ( "lang", "en" )
+      ,
+        ( "style", "color:blue;text-align:justify;" )
+      ]
+    )
+    [ Str "Justified" ]
+  , Para
+    [ Str "as"
+    , Space
+    , Str "well"
+    , Space
+    , Str "as"
+    , Space
+    , Strong
+      [ Span
+        ( "", [ "foo" ], [] )
+        [ Str "inline", Space, Str "attributes" ]
+      ]
+    , Space
+    , Str "of"
+    , Space
+    , Span
+      ( "", [], [ ( "style", "color:red;" ) ] )
+      [ Str "all", Space, Str "kind" ]
+    ]
+  , Para
+    [ Str "and"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "attributes,"
+    , Space
+    , Str "and"
+    , Space
+    , Str "table"
+    , Space
+    , Str "attributes."
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "name" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "age" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "sex" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "joan" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "24" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Emph [ Str "(class#id)", Space, Str "emph" ] ]
+  , Para
+    [ Emph [ Str "(no", Space, Str "class#id)", Space, Str "emph" ] ]
+  , Header 1
+    ( "entities", [], [] )
+    [ Str "Entities" ]
+  , Para
+    [ Str "*", LineBreak, Str "&" ]
+  , Header 1
+    ( "raw-html", [], [] )
+    [ Str "Raw", Space, Str "HTML" ]
+  , Para
+    [ Str "However,"
+    , Space
+    , RawInline
+      ( Format "html" ) "<strong>"
+    , Space
+    , Str "raw"
+    , Space
+    , Str "HTML"
+    , Space
+    , Str "inlines"
+    , Space
+    , RawInline
+      ( Format "html" ) "</strong>"
+    , Space
+    , Str "are"
+    , Space
+    , Str "accepted,"
+    , Space
+    , Str "as"
+    , Space
+    , Str "well"
+    , Space
+    , Str "as"
+    , Space
+    , Str ":"
+    ]
+  , RawBlock
+    ( Format "html" ) "<div class=\"foobar\">"
+  , Para
+    [ Str "any"
+    , Space
+    , Strong
+      [ Str "Raw", Space, Str "HTML", Space, Str "Block" ]
+    , Space
+    , Str "with"
+    , Space
+    , Str "bold"
+    ]
+  , RawBlock
+    ( Format "html" ) "</div>"
+  , Para
+    [ Str "Html", Space, Str "blocks", Space, Str "can" ]
+  , RawBlock
+    ( Format "html" ) "<div>"
+  , Para
+    [ Str "interrupt", Space, Str "paragraphs" ]
+  , RawBlock
+    ( Format "html" ) "</div>"
+  , Para
+    [ Str "as", Space, Str "well." ]
+  , Para
+    [ Str "Can"
+    , Space
+    , Str "you"
+    , Space
+    , Str "prove"
+    , Space
+    , Str "that"
+    , Space
+    , Str "2"
+    , Space
+    , Str "<"
+    , Space
+    , Str "3"
+    , Space
+    , Str "?"
+    ]
+  , Header 1
+    ( "acronyms-and-marks", [], [] )
+    [ Str "Acronyms", Space, Str "and", Space, Str "marks" ]
+  , Para
+    [ Str "PBS (Public Broadcasting System)" ]
+  , Para
+    [ Str "Hi\8482" ]
+  , Para
+    [ Str "Hi", Space, Str "\8482" ]
+  , Para
+    [ Str "\174", Space, Str "Hi\174" ]
+  , Para
+    [ Str "Hi\169\&2008", Space, Str "\169", Space, Str "2008" ]
+  , Header 1
+    ( "footnotes", [], [] )
+    [ Str "Footnotes" ]
+  , Para
+    [ Str "A"
+    , Space
+    , Str "note."
+    , Note
+      [ Para
+        [ Str "The"
+        , Space
+        , Str "note"
+        , LineBreak
+        , Str "is"
+        , Space
+        , Str "here!"
+        ]
+      ]
+    , Space
+    , Str "Another"
+    , Space
+    , Str "note"
+    , Note
+      [ Para [ Str "Other", Space, Str "note." ] ]
+    , Str "."
+    ]
+  , Header 1
+    ( "comment-blocks", [], [] )
+    [ Str "Comment", Space, Str "blocks" ]
+  , Para
+    [ Str "not", Space, Str "a", Space, Str "comment." ]
+  ]

--- a/test/tikiwiki-reader.native
+++ b/test/tikiwiki-reader.native
@@ -1,212 +1,761 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("header",[],[]) [Str "header"]
-,Header 2 ("header-level-two",[],[]) [Str "header",Space,Str "level",Space,Str "two"]
-,Header 3 ("header-level-3",[],[]) [Str "header",Space,Str "level",Space,Str "3"]
-,Header 4 ("header-_level_-four",[],[]) [Str "header",Space,Str "_level_",Space,Str "four"]
-,Header 5 ("header-level-5",[],[]) [Str "header",Space,Str "level",Space,Str "5"]
-,Header 6 ("header-level-6",[],[]) [Str "header",Space,Str "level",Space,Str "6"]
-,Para [Str "!!!!!!!",Space,Str "not",Space,Str "a",Space,Str "header"]
-,Para [Str "--++",Space,Str "not",Space,Str "a",Space,Str "header"]
-,Header 1 ("emph-and-strong",[],[]) [Str "emph",Space,Str "and",Space,Str "strong"]
-,Para [Emph [Str "emph"],Space,Strong [Str "strong"]]
-,Para [Emph [Strong [Str "strong",Space,Str "and",Space,Str "emph",Space,Str "1"]]]
-,Para [Strong [Emph [Str "strong",Space,Str "and",Space,Str "emph",Space,Str "2"]]]
-,Para [Strong [Emph [Str "emph",Space,Str "inside"],Space,Str "strong"]]
-,Para [Strong [Str "strong",Space,Str "with",Space,Emph [Str "emph"]]]
-,Para [Emph [Strong [Str "strong",Space,Str "inside"],Space,Str "emph"]]
-,Header 1 ("horizontal-rule",[],[]) [Str "horizontal",Space,Str "rule"]
-,Para [Str "top"]
-,HorizontalRule
-,Para [Str "bottom"]
-,HorizontalRule
-,Header 1 ("nop",[],[]) [Str "nop"]
-,Para [Str "__not emph__"]
-,Header 1 ("entities",[],[]) [Str "entities"]
-,Para [Str "hi",Space,Str "&",Space,Str "low"]
-,Para [Str "hi",Space,Str "&",Space,Str "low"]
-,Para [Str "G\246del"]
-,Para [Str "\777\2730"]
-,Header 1 ("linebreaks",[],[]) [Str "linebreaks"]
-,Para [Str "hi",LineBreak,Str "there"]
-,Para [Str "hi",LineBreak,Str "there"]
-,Header 1 ("inline-code",[],[]) [Str "inline",Space,Str "code"]
-,Para [Code ("",[],[]) "*\8594*",Space,Code ("",[],[]) "typed",Space,Code ("",[],[]) ">>="]
-,Header 1 ("code-blocks",[],[]) [Str "code",Space,Str "blocks"]
-,CodeBlock ("",[],[]) "\ncase xs of\n     (_:_) -> reverse xs\n     []    -> ['*']\n"
-,CodeBlock ("",["haskell"],[("colors","haskell"),("ln","0")]) "\ncase xs of\n     (_:_) -> reverse xs\n     []    -> ['*']\n"
-,Header 1 ("external-links",[],[]) [Str "external",Space,Str "links"]
-,Para [Link ("",[],[]) [Emph [Str "Google"],Space,Str "search",Space,Str "engine"] ("http://google.com","")]
-,Para [Link ("",[],[]) [Str "http://pandoc.org"] ("http://pandoc.org","")]
-,Para [Link ("",[],[]) [Str "http://google.com"] ("http://google.com",""),Space,Link ("",[],[]) [Str "http://yahoo.com"] ("http://yahoo.com","")]
-,Para [Link ("",[],[]) [Str "email",Space,Str "me"] ("mailto:info@example.org","")]
-,Para [Str "http://google.com"]
-,Para [Str "info@example.org"]
-,Header 1 ("lists",[],[]) [Str "lists"]
-,BulletList
- [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]
- ,[Plain [Str "with",Space,Str "an",Space,Str "asterisk",Space,Str "(*)."]
-  ,BulletList
-   [[Plain [Str "More",Space,Str "asterisks",Space,Str "gives",Space,Str "deeper"]
-    ,BulletList
-     [[Plain [Str "and",Space,Str "deeper",Space,Str "levels."]]]]]]
- ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels."]]
- ,[Plain [Str "Continuations",Space,Str "are",Space,Str "also",Space,Str "possible"]
-  ,BulletList
-   [[Plain [Str "and",Space,Str "do",Space,Str "not",Space,Str "break",Space,Str "the",Space,Str "list",Space,Str "flow"]]]]
- ,[Plain [Str "Level",Space,Str "one"]]]
-,Para [Str "Any",Space,Str "other",Space,Str "start",Space,Str "ends",Space,Str "the",Space,Str "list."]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]
- ,[Plain [Str "with",Space,Str "a",Space,Str "number",Space,Str "(1.)."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "More",Space,Str "number",Space,Str "signs",Space,Str "gives",Space,Str "deeper"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "and",Space,Str "deeper"]]
-     ,[Plain [Str "levels."]]]]]]
- ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels."]]
- ,[Plain [Str "Blank",Space,Str "lines"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "end",Space,Str "the",Space,Str "list",Space,Str "and",Space,Str "start",Space,Str "another."]]]
-,Para [Str "Any",Space,Str "other",Space,Str "start",Space,Str "also",Space,Str "ends",Space,Str "the",Space,Str "list."]
-,DefinitionList
- [([Str "item",Space,Str "1"],
-   [[Plain [Str "definition",Space,Str "1"]]])
- ,([Str "item",Space,Str "2"],
-   [[Plain [Str "definition",Space,Str "2-1",Space,Str "definition",Space,Str "2-2"]]])
- ,([Str "item",Space,Emph [Str "3"]],
-   [[Plain [Str "definition",Space,Emph [Str "3"]]]])]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "one"]]
- ,[Plain [Str "two"]
-  ,BulletList
-   [[Plain [Str "two",Space,Str "point",Space,Str "one"]]
-   ,[Plain [Str "two",Space,Str "point",Space,Str "two"]]]]
- ,[Plain [Str "three"]]
- ,[Plain [Str "four"]]
- ,[Plain [Str "five"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "five",Space,Str "sub",Space,Str "1"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "five",Space,Str "sub",Space,Str "1",Space,Str "sub",Space,Str "1"]]]]
-   ,[Plain [Str "five",Space,Str "sub",Space,Str "2"]]]]]
-,Header 1 ("tables",[],[]) [Str "tables"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Apple"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Pie"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Butter"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Ice",Space,Str "cream"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Apple"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Pie"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Strong [Str "Butter"]]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Ice",Space,Str "cream"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Apple"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Bread",LineBreak,LineBreak,Str "and",Space,Str "cheese"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Pie",LineBreak,LineBreak,Strong [Str "apple"],Space,Str "and",Space,Emph [Str "carrot"],Space]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str ""]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "Orange",Space]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "Apple",Space]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "more"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "Bread",Space]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "Pie",Space]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "more"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "Butter",Space]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "Ice",Space,Str "cream",Space]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Space,Str "and",Space,Str "more",Space]]]])]
- (TableFoot ("",[],[])
- [])]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "header", [], [] )
+    [ Str "header" ]
+  , Header 2
+    ( "header-level-two", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "two" ]
+  , Header 3
+    ( "header-level-3", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "3" ]
+  , Header 4
+    ( "header-_level_-four", [], [] )
+    [ Str "header", Space, Str "_level_", Space, Str "four" ]
+  , Header 5
+    ( "header-level-5", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "5" ]
+  , Header 6
+    ( "header-level-6", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "6" ]
+  , Para
+    [ Str "!!!!!!!"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    ]
+  , Para
+    [ Str "--++"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    ]
+  , Header 1
+    ( "emph-and-strong", [], [] )
+    [ Str "emph", Space, Str "and", Space, Str "strong" ]
+  , Para
+    [ Emph [ Str "emph" ], Space, Strong [ Str "strong" ] ]
+  , Para
+    [ Emph
+      [ Strong
+        [ Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "emph"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "emph"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ]
+  , Para
+    [ Strong
+      [ Emph [ Str "emph", Space, Str "inside" ], Space, Str "strong" ]
+    ]
+  , Para
+    [ Strong
+      [ Str "strong", Space, Str "with", Space, Emph [ Str "emph" ] ]
+    ]
+  , Para
+    [ Emph
+      [ Strong
+        [ Str "strong", Space, Str "inside" ]
+      , Space
+      , Str "emph"
+      ]
+    ]
+  , Header 1
+    ( "horizontal-rule", [], [] )
+    [ Str "horizontal", Space, Str "rule" ]
+  , Para
+    [ Str "top" ]
+  , HorizontalRule
+  , Para
+    [ Str "bottom" ]
+  , HorizontalRule
+  , Header 1
+    ( "nop", [], [] )
+    [ Str "nop" ]
+  , Para
+    [ Str "__not emph__" ]
+  , Header 1
+    ( "entities", [], [] )
+    [ Str "entities" ]
+  , Para
+    [ Str "hi", Space, Str "&", Space, Str "low" ]
+  , Para
+    [ Str "hi", Space, Str "&", Space, Str "low" ]
+  , Para
+    [ Str "G\246del" ]
+  , Para
+    [ Str "\777\2730" ]
+  , Header 1
+    ( "linebreaks", [], [] )
+    [ Str "linebreaks" ]
+  , Para
+    [ Str "hi", LineBreak, Str "there" ]
+  , Para
+    [ Str "hi", LineBreak, Str "there" ]
+  , Header 1
+    ( "inline-code", [], [] )
+    [ Str "inline", Space, Str "code" ]
+  , Para
+    [ Code
+      ( "", [], [] ) "*\8594*"
+    , Space
+    , Code
+      ( "", [], [] ) "typed"
+    , Space
+    , Code
+      ( "", [], [] ) ">>="
+    ]
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "code", Space, Str "blocks" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "\ncase xs of\n     (_:_) -> reverse xs\n     []    -> ['*']\n"
+  , CodeBlock
+    ( ""
+    , [ "haskell" ]
+    ,
+      [ ( "colors", "haskell" ), ( "ln", "0" ) ]
+    ) "\ncase xs of\n     (_:_) -> reverse xs\n     []    -> ['*']\n"
+  , Header 1
+    ( "external-links", [], [] )
+    [ Str "external", Space, Str "links" ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Emph
+        [ Str "Google" ]
+      , Space
+      , Str "search"
+      , Space
+      , Str "engine"
+      ]
+      ( "http://google.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "http://pandoc.org" ]
+      ( "http://pandoc.org", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "http://google.com" ]
+      ( "http://google.com", "" )
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://yahoo.com" ]
+      ( "http://yahoo.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "email", Space, Str "me" ]
+      ( "mailto:info@example.org", "" )
+    ]
+  , Para
+    [ Str "http://google.com" ]
+  , Para
+    [ Str "info@example.org" ]
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "lists" ]
+  , BulletList
+    [
+      [ Plain [ Str "Start", Space, Str "each", Space, Str "line" ] ]
+    ,
+      [ Plain
+        [ Str "with"
+        , Space
+        , Str "an"
+        , Space
+        , Str "asterisk"
+        , Space
+        , Str "(*)."
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "More"
+            , Space
+            , Str "asterisks"
+            , Space
+            , Str "gives"
+            , Space
+            , Str "deeper"
+            ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "and", Space, Str "deeper", Space, Str "levels." ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Line"
+        , Space
+        , Str "breaks"
+        , LineBreak
+        , Str "don't"
+        , Space
+        , Str "break"
+        , Space
+        , Str "levels."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Continuations"
+        , Space
+        , Str "are"
+        , Space
+        , Str "also"
+        , Space
+        , Str "possible"
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "and"
+            , Space
+            , Str "do"
+            , Space
+            , Str "not"
+            , Space
+            , Str "break"
+            , Space
+            , Str "the"
+            , Space
+            , Str "list"
+            , Space
+            , Str "flow"
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain [ Str "Level", Space, Str "one" ] ]
+    ]
+  , Para
+    [ Str "Any"
+    , Space
+    , Str "other"
+    , Space
+    , Str "start"
+    , Space
+    , Str "ends"
+    , Space
+    , Str "the"
+    , Space
+    , Str "list."
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "Start", Space, Str "each", Space, Str "line" ] ]
+    ,
+      [ Plain
+        [ Str "with"
+        , Space
+        , Str "a"
+        , Space
+        , Str "number"
+        , Space
+        , Str "(1.)."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "More"
+            , Space
+            , Str "number"
+            , Space
+            , Str "signs"
+            , Space
+            , Str "gives"
+            , Space
+            , Str "deeper"
+            ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain [ Str "and", Space, Str "deeper" ] ]
+            ,
+              [ Plain [ Str "levels." ] ]
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Line"
+        , Space
+        , Str "breaks"
+        , LineBreak
+        , Str "don't"
+        , Space
+        , Str "break"
+        , Space
+        , Str "levels."
+        ]
+      ]
+    ,
+      [ Plain [ Str "Blank", Space, Str "lines" ] ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "end"
+        , Space
+        , Str "the"
+        , Space
+        , Str "list"
+        , Space
+        , Str "and"
+        , Space
+        , Str "start"
+        , Space
+        , Str "another."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Any"
+    , Space
+    , Str "other"
+    , Space
+    , Str "start"
+    , Space
+    , Str "also"
+    , Space
+    , Str "ends"
+    , Space
+    , Str "the"
+    , Space
+    , Str "list."
+    ]
+  , DefinitionList
+    [
+      (
+        [ Str "item", Space, Str "1" ]
+      ,
+        [ [ Plain [ Str "definition", Space, Str "1" ] ] ]
+      )
+    ,
+      (
+        [ Str "item", Space, Str "2" ]
+      ,
+        [
+          [ Plain
+            [ Str "definition"
+            , Space
+            , Str "2-1"
+            , Space
+            , Str "definition"
+            , Space
+            , Str "2-2"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Str "item", Space, Emph [ Str "3" ] ]
+      ,
+        [ [ Plain [ Str "definition", Space, Emph [ Str "3" ] ] ] ]
+      )
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "one" ] ]
+    ,
+      [ Plain
+        [ Str "two" ]
+      , BulletList
+        [
+          [ Plain [ Str "two", Space, Str "point", Space, Str "one" ] ]
+        ,
+          [ Plain [ Str "two", Space, Str "point", Space, Str "two" ] ]
+        ]
+      ]
+    ,
+      [ Plain [ Str "three" ] ]
+    ,
+      [ Plain [ Str "four" ] ]
+    ,
+      [ Plain
+        [ Str "five" ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "five", Space, Str "sub", Space, Str "1" ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain
+                [ Str "five"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "1"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "1"
+                ]
+              ]
+            ]
+          ]
+        ,
+          [ Plain [ Str "five", Space, Str "sub", Space, Str "2" ] ]
+        ]
+      ]
+    ]
+  , Header 1
+    ( "tables", [], [] )
+    [ Str "tables" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Apple" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Pie" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Butter" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Ice", Space, Str "cream" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Apple" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Pie" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Strong [ Str "Butter" ] ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Ice", Space, Str "cream" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Apple" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Bread"
+            , LineBreak
+            , LineBreak
+            , Str "and"
+            , Space
+            , Str "cheese"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Pie"
+            , LineBreak
+            , LineBreak
+            , Strong
+              [ Str "apple" ]
+            , Space
+            , Str "and"
+            , Space
+            , Emph
+              [ Str "carrot" ]
+            , Space
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "Orange", Space ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "Apple", Space ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "more" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "Bread", Space ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "Pie", Space ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "more" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "Butter", Space ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "Ice", Space, Str "cream", Space ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Space, Str "and", Space, Str "more", Space ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  ]

--- a/test/twiki-reader.native
+++ b/test/twiki-reader.native
@@ -1,250 +1,875 @@
-Pandoc (Meta {unMeta = fromList []})
-[Header 1 ("header",[],[]) [Str "header"]
-,Header 2 ("header-level-two",[],[]) [Str "header",Space,Str "level",Space,Str "two"]
-,Header 3 ("header-level-3",[],[]) [Str "header",Space,Str "level",Space,Str "3"]
-,Header 4 ("header-level-four",[],[]) [Str "header",Space,Emph [Str "level"],Space,Str "four"]
-,Header 5 ("header-level-5",[],[]) [Str "header",Space,Str "level",Space,Str "5"]
-,Header 6 ("header-level-6",[],[]) [Str "header",Space,Str "level",Space,Str "6"]
-,Para [Str "---+++++++",Space,Str "not",Space,Str "a",Space,Str "header"]
-,Para [Str "--++",Space,Str "not",Space,Str "a",Space,Str "header"]
-,Header 1 ("emph-and-strong",[],[]) [Str "emph",Space,Str "and",Space,Str "strong"]
-,Para [Emph [Str "emph"],Space,Strong [Str "strong"]]
-,Para [Emph [Strong [Str "strong",Space,Str "and",Space,Str "emph"]]]
-,Para [Strong [Emph [Str "emph",Space,Str "inside"],Space,Str "strong"]]
-,Para [Strong [Str "strong",Space,Str "with",Space,Emph [Str "emph"]]]
-,Para [Emph [Strong [Str "strong",Space,Str "inside"],Space,Str "emph"]]
-,Header 1 ("horizontal-rule",[],[]) [Str "horizontal",Space,Str "rule"]
-,Para [Str "top"]
-,HorizontalRule
-,Para [Str "bottom"]
-,HorizontalRule
-,Header 1 ("nop",[],[]) [Str "nop"]
-,Para [Str "_not",Space,Str "emph_"]
-,Header 1 ("entities",[],[]) [Str "entities"]
-,Para [Str "hi",Space,Str "&",Space,Str "low"]
-,Para [Str "hi",Space,Str "&",Space,Str "low"]
-,Para [Str "G\246del"]
-,Para [Str "\777\2730"]
-,Header 1 ("comments",[],[]) [Str "comments"]
-,Para [Str "inline",Space,Str "comment"]
-,Para [Str "between",Space,Str "blocks"]
-,Header 1 ("linebreaks",[],[]) [Str "linebreaks"]
-,Para [Str "hi",LineBreak,Str "there"]
-,Para [Str "hi",LineBreak,Str "there"]
-,Header 1 ("inline-code",[],[]) [Str "inline",Space,Str "code"]
-,Para [Code ("",[],[]) "*\8594*",Space,Code ("",[],[]) "typed",Space,Code ("",["haskell"],[]) ">>="]
-,Header 1 ("code-blocks",[],[]) [Str "code",Space,Str "blocks"]
-,CodeBlock ("",[],[]) "case xs of\n     (_:_) -> reverse xs\n     []    -> ['*']"
-,CodeBlock ("",["haskell"],[]) "case xs of\n     (_:_) -> reverse xs\n     []    -> ['*']"
-,Header 1 ("block-quotes",[],[]) [Str "block",Space,Str "quotes"]
-,Para [Str "Regular",Space,Str "paragraph"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote."]
- ,Para [Str "With",Space,Str "two",Space,Str "paragraphs."]]
-,Para [Str "Nother",Space,Str "paragraph."]
-,Header 1 ("external-links",[],[]) [Str "external",Space,Str "links"]
-,Para [Link ("",[],[]) [Emph [Str "Google"],Space,Str "search",Space,Str "engine"] ("http://google.com","")]
-,Para [Link ("",[],[]) [Str "http://pandoc.org"] ("http://pandoc.org","")]
-,Para [Link ("",[],[]) [Str "http://google.com"] ("http://google.com",""),Space,Link ("",[],[]) [Str "http://yahoo.com"] ("http://yahoo.com","")]
-,Para [Link ("",[],[]) [Str "email",Space,Str "me"] ("mailto:info@example.org","")]
-,Para [Str "http://google.com"]
-,Para [Str "http://google.com"]
-,Para [Str "http://google.com"]
-,Para [Str "info@example.org"]
-,Para [Str "info@example.org"]
-,Para [Str "info@example.org"]
-,Header 1 ("lists",[],[]) [Str "lists"]
-,BulletList
- [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]
- ,[Plain [Str "with",Space,Str "an",Space,Str "asterisk",Space,Str "(*)."]
-  ,BulletList
-   [[Plain [Str "More",Space,Str "asterisks",Space,Str "gives",Space,Str "deeper"]
-    ,BulletList
-     [[Plain [Str "and",Space,Str "deeper",Space,Str "levels."]]]]]]
- ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels."]]
- ,[Plain [Str "Continuations",Space,Str "are",Space,Str "also",Space,Str "possible"]
-  ,BulletList
-   [[Plain [Str "and",Space,Str "do",Space,Str "not",Space,Str "break",Space,Str "the",Space,Str "list",Space,Str "flow"]]]]
- ,[Plain [Str "Level",Space,Str "one"]]]
-,Para [Str "Any",Space,Str "other",Space,Str "start",Space,Str "ends",Space,Str "the",Space,Str "list."]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Start",Space,Str "each",Space,Str "line"]]
- ,[Plain [Str "with",Space,Str "a",Space,Str "number",Space,Str "(1.)."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "More",Space,Str "number",Space,Str "signs",Space,Str "gives",Space,Str "deeper"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "and",Space,Str "deeper"]]
-     ,[Plain [Str "levels."]]]]]]
- ,[Plain [Str "Line",Space,Str "breaks",LineBreak,Str "don't",Space,Str "break",Space,Str "levels."]]
- ,[Plain [Str "Blank",Space,Str "lines"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "end",Space,Str "the",Space,Str "list",Space,Str "and",Space,Str "start",Space,Str "another."]]]
-,Para [Str "Any",Space,Str "other",Space,Str "start",Space,Str "also",Space,Str "ends",Space,Str "the",Space,Str "list."]
-,DefinitionList
- [([Str "item",Space,Str "1"],
-   [[Plain [Str "definition",Space,Str "1"]]])
- ,([Str "item",Space,Str "2"],
-   [[Plain [Str "definition",Space,Str "2-1",Space,Str "definition",Space,Str "2-2"]]])
- ,([Str "item",Space,Emph [Str "3"]],
-   [[Plain [Str "definition",Space,Emph [Str "3"]]]])]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "one"]]
- ,[Plain [Str "two"]
-  ,BulletList
-   [[Plain [Str "two",Space,Str "point",Space,Str "one"]]
-   ,[Plain [Str "two",Space,Str "point",Space,Str "two"]]]]
- ,[Plain [Str "three"]
-  ,DefinitionList
-   [([Str "three",Space,Str "item",Space,Str "one"],
-     [[Plain [Str "three",Space,Str "def",Space,Str "one"]]])]]
- ,[Plain [Str "four"]
-  ,DefinitionList
-   [([Str "four",Space,Str "def",Space,Str "one"],
-     [[Plain [Str "this",Space,Str "is",Space,Str "a",Space,Str "continuation"]]])]]
- ,[Plain [Str "five"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "five",Space,Str "sub",Space,Str "1"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "five",Space,Str "sub",Space,Str "1",Space,Str "sub",Space,Str "1"]]]]
-   ,[Plain [Str "five",Space,Str "sub",Space,Str "2"]]]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "other"]
-  ,OrderedList (1,UpperRoman,DefaultDelim)
-   [[Plain [Str "list"]]
-   ,[Plain [Str "styles"]]]]
- ,[Plain [Str "are"]
-  ,OrderedList (1,LowerRoman,DefaultDelim)
-   [[Plain [Str "also"]]
-   ,[Plain [Str "possible"]]]]
- ,[Plain [Str "all"]
-  ,OrderedList (1,LowerAlpha,DefaultDelim)
-   [[Plain [Str "the"]]
-   ,[Plain [Str "different"]]
-   ,[Plain [Str "styles"]]]]
- ,[Plain [Str "are"]
-  ,OrderedList (1,UpperAlpha,DefaultDelim)
-   [[Plain [Str "implemented"]]
-   ,[Plain [Str "and"]]
-   ,[Plain [Str "supported"]]]]]
-,Header 1 ("tables",[],[]) [Str "tables"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Apple"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Pie"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Butter"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Ice",Space,Str "cream"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Orange"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Apple"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Pie"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Strong [Str "Butter"]]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Ice",Space,Str "cream"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignLeft,ColWidthDefault)
- ,(AlignLeft,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Orange"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Apple"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Bread",LineBreak,LineBreak,Str "and",Space,Str "cheese"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Pie",LineBreak,LineBreak,Strong [Str "apple"],Space,Str "and",Space,Emph [Str "carrot"]]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Orange"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Apple"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "more"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Bread"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Pie"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "more"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Butter"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Ice",Space,Str "cream"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "and",Space,Str "more"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 1 ("macros",[],[]) [Str "macros"]
-,Para [Span ("",["twiki-macro","TEST"],[]) []]
-,Para [Span ("",["twiki-macro","TEST"],[]) [Str ""]]
-,Para [Span ("",["twiki-macro","TEST"],[]) [Str "content with spaces"]]
-,Para [Span ("",["twiki-macro","TEST"],[]) [Str "content with spaces"]]
-,Para [Span ("",["twiki-macro","TEST"],[("ARG1","test")]) [Str "content with spaces"]]
-,Para [Span ("",["twiki-macro","TEST"],[]) [Str "content with spaces ARG1=test"]]
-,Para [Span ("",["twiki-macro","TEST"],[("ARG1","test")]) [Str "content with spaces"]]
-,Para [Span ("",["twiki-macro","TEST"],[("ARG1","test"),("ARG2","test2")]) [Str ""]]
-,Para [Span ("",["twiki-macro","TEST"],[("ARG1","test"),("ARG2","test2")]) [Str ""]]
-,Para [Span ("",["twiki-macro","TEST"],[("ARG1","test"),("ARG2","test2")]) [Str "multiline\ndoes also work"]]]
+Pandoc
+  ( Meta { unMeta = fromList [] } )
+  [ Header 1
+    ( "header", [], [] )
+    [ Str "header" ]
+  , Header 2
+    ( "header-level-two", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "two" ]
+  , Header 3
+    ( "header-level-3", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "3" ]
+  , Header 4
+    ( "header-level-four", [], [] )
+    [ Str "header", Space, Emph [ Str "level" ], Space, Str "four" ]
+  , Header 5
+    ( "header-level-5", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "5" ]
+  , Header 6
+    ( "header-level-6", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "6" ]
+  , Para
+    [ Str "---+++++++"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    ]
+  , Para
+    [ Str "--++"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    ]
+  , Header 1
+    ( "emph-and-strong", [], [] )
+    [ Str "emph", Space, Str "and", Space, Str "strong" ]
+  , Para
+    [ Emph [ Str "emph" ], Space, Strong [ Str "strong" ] ]
+  , Para
+    [ Emph
+      [ Strong [ Str "strong", Space, Str "and", Space, Str "emph" ] ]
+    ]
+  , Para
+    [ Strong
+      [ Emph [ Str "emph", Space, Str "inside" ], Space, Str "strong" ]
+    ]
+  , Para
+    [ Strong
+      [ Str "strong", Space, Str "with", Space, Emph [ Str "emph" ] ]
+    ]
+  , Para
+    [ Emph
+      [ Strong
+        [ Str "strong", Space, Str "inside" ]
+      , Space
+      , Str "emph"
+      ]
+    ]
+  , Header 1
+    ( "horizontal-rule", [], [] )
+    [ Str "horizontal", Space, Str "rule" ]
+  , Para
+    [ Str "top" ]
+  , HorizontalRule
+  , Para
+    [ Str "bottom" ]
+  , HorizontalRule
+  , Header 1
+    ( "nop", [], [] )
+    [ Str "nop" ]
+  , Para
+    [ Str "_not", Space, Str "emph_" ]
+  , Header 1
+    ( "entities", [], [] )
+    [ Str "entities" ]
+  , Para
+    [ Str "hi", Space, Str "&", Space, Str "low" ]
+  , Para
+    [ Str "hi", Space, Str "&", Space, Str "low" ]
+  , Para
+    [ Str "G\246del" ]
+  , Para
+    [ Str "\777\2730" ]
+  , Header 1
+    ( "comments", [], [] )
+    [ Str "comments" ]
+  , Para
+    [ Str "inline", Space, Str "comment" ]
+  , Para
+    [ Str "between", Space, Str "blocks" ]
+  , Header 1
+    ( "linebreaks", [], [] )
+    [ Str "linebreaks" ]
+  , Para
+    [ Str "hi", LineBreak, Str "there" ]
+  , Para
+    [ Str "hi", LineBreak, Str "there" ]
+  , Header 1
+    ( "inline-code", [], [] )
+    [ Str "inline", Space, Str "code" ]
+  , Para
+    [ Code
+      ( "", [], [] ) "*\8594*"
+    , Space
+    , Code
+      ( "", [], [] ) "typed"
+    , Space
+    , Code
+      ( "", [ "haskell" ], [] ) ">>="
+    ]
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "code", Space, Str "blocks" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "case xs of\n     (_:_) -> reverse xs\n     []    -> ['*']"
+  , CodeBlock
+    ( ""
+    , [ "haskell" ]
+    , []
+    ) "case xs of\n     (_:_) -> reverse xs\n     []    -> ['*']"
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "block", Space, Str "quotes" ]
+  , Para
+    [ Str "Regular", Space, Str "paragraph" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      ]
+    , Para
+      [ Str "With", Space, Str "two", Space, Str "paragraphs." ]
+    ]
+  , Para
+    [ Str "Nother", Space, Str "paragraph." ]
+  , Header 1
+    ( "external-links", [], [] )
+    [ Str "external", Space, Str "links" ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Emph
+        [ Str "Google" ]
+      , Space
+      , Str "search"
+      , Space
+      , Str "engine"
+      ]
+      ( "http://google.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "http://pandoc.org" ]
+      ( "http://pandoc.org", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "http://google.com" ]
+      ( "http://google.com", "" )
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://yahoo.com" ]
+      ( "http://yahoo.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "email", Space, Str "me" ]
+      ( "mailto:info@example.org", "" )
+    ]
+  , Para
+    [ Str "http://google.com" ]
+  , Para
+    [ Str "http://google.com" ]
+  , Para
+    [ Str "http://google.com" ]
+  , Para
+    [ Str "info@example.org" ]
+  , Para
+    [ Str "info@example.org" ]
+  , Para
+    [ Str "info@example.org" ]
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "lists" ]
+  , BulletList
+    [
+      [ Plain [ Str "Start", Space, Str "each", Space, Str "line" ] ]
+    ,
+      [ Plain
+        [ Str "with"
+        , Space
+        , Str "an"
+        , Space
+        , Str "asterisk"
+        , Space
+        , Str "(*)."
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "More"
+            , Space
+            , Str "asterisks"
+            , Space
+            , Str "gives"
+            , Space
+            , Str "deeper"
+            ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "and", Space, Str "deeper", Space, Str "levels." ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Line"
+        , Space
+        , Str "breaks"
+        , LineBreak
+        , Str "don't"
+        , Space
+        , Str "break"
+        , Space
+        , Str "levels."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Continuations"
+        , Space
+        , Str "are"
+        , Space
+        , Str "also"
+        , Space
+        , Str "possible"
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "and"
+            , Space
+            , Str "do"
+            , Space
+            , Str "not"
+            , Space
+            , Str "break"
+            , Space
+            , Str "the"
+            , Space
+            , Str "list"
+            , Space
+            , Str "flow"
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain [ Str "Level", Space, Str "one" ] ]
+    ]
+  , Para
+    [ Str "Any"
+    , Space
+    , Str "other"
+    , Space
+    , Str "start"
+    , Space
+    , Str "ends"
+    , Space
+    , Str "the"
+    , Space
+    , Str "list."
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "Start", Space, Str "each", Space, Str "line" ] ]
+    ,
+      [ Plain
+        [ Str "with"
+        , Space
+        , Str "a"
+        , Space
+        , Str "number"
+        , Space
+        , Str "(1.)."
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "More"
+            , Space
+            , Str "number"
+            , Space
+            , Str "signs"
+            , Space
+            , Str "gives"
+            , Space
+            , Str "deeper"
+            ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain [ Str "and", Space, Str "deeper" ] ]
+            ,
+              [ Plain [ Str "levels." ] ]
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Line"
+        , Space
+        , Str "breaks"
+        , LineBreak
+        , Str "don't"
+        , Space
+        , Str "break"
+        , Space
+        , Str "levels."
+        ]
+      ]
+    ,
+      [ Plain [ Str "Blank", Space, Str "lines" ] ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "end"
+        , Space
+        , Str "the"
+        , Space
+        , Str "list"
+        , Space
+        , Str "and"
+        , Space
+        , Str "start"
+        , Space
+        , Str "another."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Any"
+    , Space
+    , Str "other"
+    , Space
+    , Str "start"
+    , Space
+    , Str "also"
+    , Space
+    , Str "ends"
+    , Space
+    , Str "the"
+    , Space
+    , Str "list."
+    ]
+  , DefinitionList
+    [
+      (
+        [ Str "item", Space, Str "1" ]
+      ,
+        [ [ Plain [ Str "definition", Space, Str "1" ] ] ]
+      )
+    ,
+      (
+        [ Str "item", Space, Str "2" ]
+      ,
+        [
+          [ Plain
+            [ Str "definition"
+            , Space
+            , Str "2-1"
+            , Space
+            , Str "definition"
+            , Space
+            , Str "2-2"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Str "item", Space, Emph [ Str "3" ] ]
+      ,
+        [ [ Plain [ Str "definition", Space, Emph [ Str "3" ] ] ] ]
+      )
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "one" ] ]
+    ,
+      [ Plain
+        [ Str "two" ]
+      , BulletList
+        [
+          [ Plain [ Str "two", Space, Str "point", Space, Str "one" ] ]
+        ,
+          [ Plain [ Str "two", Space, Str "point", Space, Str "two" ] ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "three" ]
+      , DefinitionList
+        [
+          (
+            [ Str "three", Space, Str "item", Space, Str "one" ]
+          ,
+            [
+              [ Plain
+                [ Str "three", Space, Str "def", Space, Str "one" ]
+              ]
+            ]
+          )
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "four" ]
+      , DefinitionList
+        [
+          (
+            [ Str "four", Space, Str "def", Space, Str "one" ]
+          ,
+            [
+              [ Plain
+                [ Str "this"
+                , Space
+                , Str "is"
+                , Space
+                , Str "a"
+                , Space
+                , Str "continuation"
+                ]
+              ]
+            ]
+          )
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "five" ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "five", Space, Str "sub", Space, Str "1" ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain
+                [ Str "five"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "1"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "1"
+                ]
+              ]
+            ]
+          ]
+        ,
+          [ Plain [ Str "five", Space, Str "sub", Space, Str "2" ] ]
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "other" ]
+      , OrderedList
+        ( 1, UpperRoman, DefaultDelim )
+        [ [ Plain [ Str "list" ] ], [ Plain [ Str "styles" ] ] ]
+      ]
+    ,
+      [ Plain
+        [ Str "are" ]
+      , OrderedList
+        ( 1, LowerRoman, DefaultDelim )
+        [ [ Plain [ Str "also" ] ], [ Plain [ Str "possible" ] ] ]
+      ]
+    ,
+      [ Plain
+        [ Str "all" ]
+      , OrderedList
+        ( 1, LowerAlpha, DefaultDelim )
+        [
+          [ Plain [ Str "the" ] ]
+        ,
+          [ Plain [ Str "different" ] ]
+        ,
+          [ Plain [ Str "styles" ] ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "are" ]
+      , OrderedList
+        ( 1, UpperAlpha, DefaultDelim )
+        [
+          [ Plain [ Str "implemented" ] ]
+        ,
+          [ Plain [ Str "and" ] ]
+        ,
+          [ Plain [ Str "supported" ] ]
+        ]
+      ]
+    ]
+  , Header 1
+    ( "tables", [], [] )
+    [ Str "tables" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Apple" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Pie" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Butter" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Ice", Space, Str "cream" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [ ( AlignLeft, ColWidthDefault ), ( AlignLeft, ColWidthDefault ) ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Apple" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Pie" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Strong [ Str "Butter" ] ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Ice", Space, Str "cream" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [ ( AlignLeft, ColWidthDefault ), ( AlignLeft, ColWidthDefault ) ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Apple" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Bread"
+            , LineBreak
+            , LineBreak
+            , Str "and"
+            , Space
+            , Str "cheese"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "Pie"
+            , LineBreak
+            , LineBreak
+            , Strong
+              [ Str "apple" ]
+            , Space
+            , Str "and"
+            , Space
+            , Emph
+              [ Str "carrot" ]
+            ]
+          ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Orange" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Apple" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "more" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Bread" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Pie" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "more" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Butter" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Ice", Space, Str "cream" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "and", Space, Str "more" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 1
+    ( "macros", [], [] )
+    [ Str "macros" ]
+  , Para
+    [ Span ( "", [ "twiki-macro", "TEST" ], [] ) [] ]
+  , Para
+    [ Span ( "", [ "twiki-macro", "TEST" ], [] ) [ Str "" ] ]
+  , Para
+    [ Span
+      ( "", [ "twiki-macro", "TEST" ], [] )
+      [ Str "content with spaces" ]
+    ]
+  , Para
+    [ Span
+      ( "", [ "twiki-macro", "TEST" ], [] )
+      [ Str "content with spaces" ]
+    ]
+  , Para
+    [ Span
+      ( "", [ "twiki-macro", "TEST" ], [ ( "ARG1", "test" ) ] )
+      [ Str "content with spaces" ]
+    ]
+  , Para
+    [ Span
+      ( "", [ "twiki-macro", "TEST" ], [] )
+      [ Str "content with spaces ARG1=test" ]
+    ]
+  , Para
+    [ Span
+      ( "", [ "twiki-macro", "TEST" ], [ ( "ARG1", "test" ) ] )
+      [ Str "content with spaces" ]
+    ]
+  , Para
+    [ Span
+      ( ""
+      ,
+        [ "twiki-macro", "TEST" ]
+      ,
+        [ ( "ARG1", "test" ), ( "ARG2", "test2" ) ]
+      )
+      [ Str "" ]
+    ]
+  , Para
+    [ Span
+      ( ""
+      ,
+        [ "twiki-macro", "TEST" ]
+      ,
+        [ ( "ARG1", "test" ), ( "ARG2", "test2" ) ]
+      )
+      [ Str "" ]
+    ]
+  , Para
+    [ Span
+      ( ""
+      ,
+        [ "twiki-macro", "TEST" ]
+      ,
+        [ ( "ARG1", "test" ), ( "ARG2", "test2" ) ]
+      )
+      [ Str "multiline\ndoes also work" ]
+    ]
+  ]

--- a/test/txt2tags.native
+++ b/test/txt2tags.native
@@ -1,968 +1,5200 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "author"]]),("date",MetaInlines [Str "date"]),("includeconf",MetaString "rules.conf"),("title",MetaInlines [Str "Txt2tags",Space,Str "Markup",Space,Str "Rules"])]})
-[Para [Str "This",Space,Str "document",Space,Str "describes",Space,Str "all",Space,Str "the",Space,Str "details",Space,Str "about",Space,Str "each",Space,Str "txt2tags",Space,Str "mark.",SoftBreak,Str "The",Space,Str "target",Space,Str "audience",Space,Str "are",Space,Strong [Str "experienced"],Space,Str "users.",Space,Str "You",Space,Str "may",Space,Str "find",Space,Str "it",SoftBreak,Str "useful",Space,Str "if",Space,Str "you",Space,Str "want",Space,Str "to",Space,Str "master",Space,Str "the",Space,Str "marks",Space,Str "or",Space,Str "solve",Space,Str "a",Space,Str "specific",Space,Str "problem",SoftBreak,Str "about",Space,Str "a",Space,Str "mark."]
-,Para [Str "If",Space,Str "you",Space,Str "are",Space,Str "new",Space,Str "to",Space,Str "txt2tags",Space,Str "or",Space,Str "just",Space,Str "want",Space,Str "to",Space,Str "know",Space,Str "which",Space,Str "are",Space,Str "the",SoftBreak,Str "available",Space,Str "marks,",Space,Str "please",Space,Str "read",Space,Str "the",Space,Link ("",[],[]) [Str "Markup",Space,Str "Demo"] ("MARKUPDEMO",""),Str "."]
-,Para [Str "Note",Space,Str "1:",Space,Str "This",Space,Str "document",Space,Str "is",Space,Str "generated",Space,Str "directly",Space,Str "from",Space,Str "the",Space,Str "txt2tags",SoftBreak,Str "test-suite.",Space,Str "All",Space,Str "the",Space,Str "rules",Space,Str "mentioned",Space,Str "here",Space,Str "are",Space,Str "100%",Space,Str "in",Space,Str "sync",Space,Str "with",Space,Str "the",SoftBreak,Str "current",Space,Str "program",Space,Str "code."]
-,Para [Str "Note",Space,Str "2:",Space,Str "A",Space,Str "good",Space,Str "practice",Space,Str "is",Space,Str "to",Space,Str "consult",Space,Link ("",[],[]) [Str "the",Space,Str "sources"] ("rules.t2t",""),Space,Str "when",SoftBreak,Str "reading,",Space,Str "to",Space,Str "see",Space,Str "how",Space,Str "the",Space,Str "texts",Space,Str "were",Space,Str "made."]
-,Para [Str "Table",Space,Str "of",Space,Str "Contents:"]
-,HorizontalRule
-,Header 1 ("paragraph",[],[]) [Str "Paragraph"]
-,Para [Str "A",Space,Str "paragraph",Space,Str "is",Space,Str "composed",Space,Str "by",Space,Str "one",Space,Str "or",Space,Str "more",Space,Str "lines.",SoftBreak,Str "A",Space,Str "blank",Space,Str "line",Space,Str "(or",Space,Str "a",Space,Str "table,",Space,Str "or",Space,Str "a",Space,Str "list)",Space,Str "ends",Space,Str "the",SoftBreak,Str "current",Space,Str "paragraph."]
-,Para [Str "Leading",Space,Str "and",Space,Str "trailing",Space,Str "spaces",Space,Str "are",Space,Str "ignored."]
-,Para [Str "A",Space,Str "comment",Space,Str "line",Space,Str "can",Space,Str "be",Space,Str "placed",Space,Str "inside",Space,Str "a",Space,Str "paragraph.",SoftBreak,Str "It",Space,Str "will",Space,Str "not",Space,Str "affect",Space,Str "it."]
-,Para [Str "The",Space,Str "end",Space,Str "of",Space,Str "the",Space,Str "file",Space,Str "(EOF)",Space,Str "closes",Space,Str "the",SoftBreak,Str "currently",Space,Str "open",Space,Str "paragraph."]
-,Header 1 ("comment",[],[]) [Str "Comment"]
-,Para [Str "%",Space,Str "not",Space,Str "on",Space,Str "the",Space,Str "line",Space,Str "beginning",Space,Str "(at",Space,Str "column",Space,Str "2)"]
-,Para [Str "some",Space,Str "text",Space,Str "%",Space,Str "half",Space,Str "line",Space,Str "comments",Space,Str "are",Space,Str "not",Space,Str "allowed"]
-,Header 1 ("line",[],[]) [Str "Line"]
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,HorizontalRule
-,Para [Strikeout [Str "-----"],SoftBreak,Strikeout [Str "-------",Space,Str "--------"]]
-,Para [Strikeout [Str "-------+--------"]]
-,Para [Str "(",Space,Strikeout [Str "----------------"],Space,Str ")"]
-,Header 1 ("inline",[],[]) [Str "Inline"]
-,Para [Str "i)",Space,Strong [Str "b"],Space,Emph [Str "i"],Space,Underline [Str "u"],Space,Strikeout [Str "s"],Space,Code ("",[],[]) "m",Space,Str "r",Space,RawInline (Format "html") "t",SoftBreak,Str "i)",Space,Strong [Str "bo"],Space,Emph [Str "it"],Space,Underline [Str "un"],Space,Strikeout [Str "st"],Space,Code ("",[],[]) "mo",Space,Str "ra",Space,RawInline (Format "html") "tg",SoftBreak,Str "i)",Space,Strong [Str "bold"],Space,Emph [Str "ital"],Space,Underline [Str "undr"],Space,Strikeout [Str "strk"],Space,Code ("",[],[]) "mono",Space,Str "raw",Space,RawInline (Format "html") "tggd",SoftBreak,Str "i)",Space,Strong [Str "bo",Space,Str "ld"],Space,Emph [Str "it",Space,Str "al"],Space,Underline [Str "un",Space,Str "dr"],Space,Strikeout [Str "st",Space,Str "rk"],Space,Code ("",[],[]) "mo no",Space,Str "r",Space,Str "aw",Space,RawInline (Format "html") "tg gd",SoftBreak,Str "i)",Space,Strong [Str "bo",Space,Str "*",Space,Str "ld"],Space,Emph [Str "it",Space,Str "/",Space,Str "al"],Space,Underline [Str "un",Space,Str "_",Space,Str "dr"],Space,Strikeout [Str "st",Space,Str "-",Space,Str "rk"],Space,Code ("",[],[]) "mo ` no",Space,Str "r",Space,Str "\"",Space,Str "aw",Space,RawInline (Format "html") "tg ' gd",SoftBreak,Str "i)",Space,Strong [Str "bo",Space,Str "**ld"],Space,Emph [Str "it",Space,Str "//al"],Space,Underline [Str "un",Space,Str "__dr"],Space,Strikeout [Str "st",Space,Str "--rk"],Space,Code ("",[],[]) "mo ``no",Space,Str "r",Space,Str "\"\"aw",Space,RawInline (Format "html") "tg ''gd",SoftBreak,Str "i)",Space,Strong [Str "bo",Space,Str "**",Space,Str "ld"],Space,Emph [Str "it",Space,Str "//",Space,Str "al"],Space,Underline [Str "un",Space,Str "__",Space,Str "dr"],Space,Strikeout [Str "st",Space,Str "--",Space,Str "rk"],Space,Code ("",[],[]) "mo `` no",Space,Str "r",Space,Str "\"\"",Space,Str "aw",Space,RawInline (Format "html") "tg '' gd",SoftBreak,Str "i)",Space,Strong [Str "**bold**"],Space,Emph [Str "//ital//"],Space,Underline [Str "__undr__"],Space,Strikeout [Str "--strk--"],Space,Code ("",[],[]) "``mono``",Space,Str "\"\"raw\"\"",Space,RawInline (Format "html") "''tggd''",SoftBreak,Str "i)",Space,Strong [Str "*bold*"],Space,Emph [Str "/ital/"],Space,Underline [Str "_undr_"],Space,Strikeout [Str "-strk-"],Space,Code ("",[],[]) "`mono`",Space,Str "\"raw\"",Space,RawInline (Format "html") "'tggd'"]
-,Para [Str "i)",Space,Strong [Str "*"],Space,Emph [Str "/"],Space,Underline [Str "_"],Space,Strikeout [Str "-"],Space,Code ("",[],[]) "`",Space,Str "\"",Space,RawInline (Format "html") "'",SoftBreak,Str "i)",Space,Strong [Str "**"],Space,Emph [Str "//"],Space,Underline [Str "__"],Space,Strikeout [Str "--"],Space,Code ("",[],[]) "``",Space,Str "\"\"",Space,RawInline (Format "html") "''",SoftBreak,Str "i)",Space,Strong [Str "***"],Space,Emph [Str "///"],Space,Underline [Str "___"],Space,Strikeout [Str "---"],Space,Code ("",[],[]) "```",Space,Str "\"\"\"",Space,RawInline (Format "html") "'''",SoftBreak,Str "i)",Space,Strong [Str "****"],Space,Emph [Str "////"],Space,Underline [Str "____"],Space,Strikeout [Str "----"],Space,Code ("",[],[]) "````",Space,Str "\"\"\"\"",Space,RawInline (Format "html") "''''",SoftBreak,Str "i)",Space,Strong [Str "*****"],Space,Emph [Str "/////"],Space,Underline [Str "_____"],Space,Strikeout [Str "-----"],Space,Code ("",[],[]) "`````",Space,Str "\"\"\"\"\"",Space,RawInline (Format "html") "'''''",SoftBreak,Str "i)",Space,Strong [Str "******"],Space,Emph [Str "//////"],Space,Underline [Str "______"],Space,Strikeout [Str "------"],Space,Code ("",[],[]) "``````",Space,Str "\"\"\"\"\"\"",Space,RawInline (Format "html") "''''''"]
-,Para [Str "i)",Space,Str "****",Space,Str "////",Space,Str "____",Space,Str "----",Space,Str "````",Space,Str "\"\"\"\"",Space,Str "''''",SoftBreak,Str "i)",Space,Str "**",Space,Str "**",Space,Str "//",Space,Str "//",Space,Str "__",Space,Str "__",Space,Str "--",Space,Str "--",Space,Str "``",Space,Str "``",Space,Str "\"\"",Space,Str "\"\"",Space,Str "''",Space,Str "''"]
-,Para [Str "i)",Space,Str "**",Space,Str "bold**",Space,Str "//",Space,Str "ital//",Space,Str "__",Space,Str "undr__",Space,Str "--",Space,Str "strk--",Space,Str "``",Space,Str "mono``",Space,Str "\"\"",Space,Str "raw\"\"",Space,Str "''",Space,Str "tggd''",SoftBreak,Str "i)",Space,Str "**bold",Space,Str "**",Space,Str "//ital",Space,Str "//",Space,Str "__undr",Space,Str "__",Space,Str "--strk",Space,Str "--",Space,Str "``mono",Space,Str "``",Space,Str "\"\"raw",Space,Str "\"\"",Space,Str "''tggd",Space,Str "''",SoftBreak,Str "i)",Space,Str "**",Space,Str "bold",Space,Str "**",Space,Str "//",Space,Str "ital",Space,Str "//",Space,Str "__",Space,Str "undr",Space,Str "__",Space,Str "--",Space,Str "strk",Space,Str "--",Space,Str "``",Space,Str "mono",Space,Str "``",Space,Str "\"\"",Space,Str "raw",Space,Str "\"\"",Space,Str "''",Space,Str "tggd",Space,Str "''"]
-,Header 1 ("link",[],[]) [Str "Link"]
-,Para [Link ("",[],[]) [Str "mailto:user@domain.com"] ("user@domain.com",""),SoftBreak,Link ("",[],[]) [Str "mailto:user@domain.com"] ("user@domain.com",""),Str ".",SoftBreak,Link ("",[],[]) [Str "mailto:user@domain.com"] ("user@domain.com",""),Str ".",Space,Str "any",Space,Str "text.",SoftBreak,Str "any",Space,Str "text:",Space,Link ("",[],[]) [Str "mailto:user@domain.com"] ("user@domain.com",""),Str ".",Space,Str "any",Space,Str "text.",SoftBreak,Link ("",[],[]) [Str "label"] ("user@domain.com",""),SoftBreak,Link ("",[],[]) [Str "mailto:user@domain.com?subject=bla"] ("user@domain.com?subject=bla",""),SoftBreak,Link ("",[],[]) [Str "mailto:user@domain.com?subject=bla"] ("user@domain.com?subject=bla",""),Str ".",SoftBreak,Link ("",[],[]) [Str "mailto:user@domain.com?subject=bla"] ("user@domain.com?subject=bla",""),Str ",",SoftBreak,Link ("",[],[]) [Str "mailto:user@domain.com?subject=bla&cc=otheruser@domain.com"] ("user@domain.com?subject=bla&cc=otheruser@domain.com",""),SoftBreak,Link ("",[],[]) [Str "mailto:user@domain.com?subject=bla&cc=otheruser@domain.com"] ("user@domain.com?subject=bla&cc=otheruser@domain.com",""),Str ".",SoftBreak,Link ("",[],[]) [Str "mailto:user@domain.com?subject=bla&cc=otheruser@domain.com"] ("user@domain.com?subject=bla&cc=otheruser@domain.com",""),Str ",",SoftBreak,Link ("",[],[]) [Str "label"] ("user@domain.com?subject=bla&cc=otheruser@domain.com",""),Str ".",SoftBreak,Link ("",[],[]) [Str "label"] ("user@domain.com?subject=bla&cc=otheruser@domain.com.",""),Str ".",SoftBreak,Link ("",[],[]) [Str "http://www.domain.com"] ("http://www.domain.com",""),SoftBreak,Link ("",[],[]) [Str "http://www.domain.com/dir/"] ("http://www.domain.com/dir/",""),SoftBreak,Link ("",[],[]) [Str "http://www.domain.com/dir///"] ("http://www.domain.com/dir///",""),SoftBreak,Link ("",[],[]) [Str "http://www.domain.com."] ("http://www.domain.com.",""),SoftBreak,Link ("",[],[]) [Str "http://www.domain.com,"] ("http://www.domain.com,",""),SoftBreak,Link ("",[],[]) [Str "http://www.domain.com."] ("http://www.domain.com.",""),Space,Str "any",Space,Str "text.",SoftBreak,Link ("",[],[]) [Str "http://www.domain.com,"] ("http://www.domain.com,",""),Space,Str "any",Space,Str "text.",SoftBreak,Link ("",[],[]) [Str "http://www.domain.com/dir/."] ("http://www.domain.com/dir/.",""),Space,Str "any",Space,Str "text.",SoftBreak,Str "any",Space,Str "text:",Space,Link ("",[],[]) [Str "http://www.domain.com."] ("http://www.domain.com.",""),Space,Str "any",Space,Str "text.",SoftBreak,Str "any",Space,Str "text:",Space,Link ("",[],[]) [Str "http://www.domain.com/dir/."] ("http://www.domain.com/dir/.",""),Space,Str "any",Space,Str "text.",SoftBreak,Str "any",Space,Str "text:",Space,Link ("",[],[]) [Str "http://www.domain.com/dir/index.html."] ("http://www.domain.com/dir/index.html.",""),Space,Str "any",Space,Str "text.",SoftBreak,Str "any",Space,Str "text:",Space,Link ("",[],[]) [Str "http://www.domain.com/dir/index.html,"] ("http://www.domain.com/dir/index.html,",""),Space,Str "any",Space,Str "text.",SoftBreak,Link ("",[],[]) [Str "http://www.domain.com/dir/#anchor"] ("http://www.domain.com/dir/#anchor",""),SoftBreak,Link ("",[],[]) [Str "http://www.domain.com/dir/index.html#anchor"] ("http://www.domain.com/dir/index.html#anchor",""),SoftBreak,Link ("",[],[]) [Str "http://www.domain.com/dir/index.html#anchor."] ("http://www.domain.com/dir/index.html#anchor.",""),SoftBreak,Link ("",[],[]) [Str "http://www.domain.com/dir/#anchor."] ("http://www.domain.com/dir/#anchor.",""),Space,Str "any",Space,Str "text.",SoftBreak,Link ("",[],[]) [Str "http://www.domain.com/dir/index.html#anchor."] ("http://www.domain.com/dir/index.html#anchor.",""),Space,Str "any",Space,Str "text.",SoftBreak,Str "any",Space,Str "text:",Space,Link ("",[],[]) [Str "http://www.domain.com/dir/#anchor."] ("http://www.domain.com/dir/#anchor.",""),Space,Str "any",Space,Str "text.",SoftBreak,Str "any",Space,Str "text:",Space,Link ("",[],[]) [Str "http://www.domain.com/dir/index.html#anchor."] ("http://www.domain.com/dir/index.html#anchor.",""),Space,Str "any",Space,Str "text.",SoftBreak,Link ("",[],[]) [Str "http://domain.com?a=a@a.a&b=a+b+c."] ("http://domain.com?a=a@a.a&b=a+b+c.",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com?a=a@a.a&b=a+b+c,"] ("http://domain.com?a=a@a.a&b=a+b+c,",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c."] ("http://domain.com/bla.cgi?a=a@a.a&b=a+b+c.",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c@."] ("http://domain.com/bla.cgi?a=a@a.a&b=a+b+c@.",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com?a=a@a.a&b=a+b+c.#anchor"] ("http://domain.com?a=a@a.a&b=a+b+c.#anchor",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor"] ("http://domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c@.#anchor"] ("http://domain.com/bla.cgi?a=a@a.a&b=a+b+c@.#anchor",""),SoftBreak,Link ("",[],[]) [Str "http://user:password@domain.com/bla.html."] ("http://user:password@domain.com/bla.html.",""),SoftBreak,Link ("",[],[]) [Str "http://user:password@domain.com/dir/."] ("http://user:password@domain.com/dir/.",""),SoftBreak,Link ("",[],[]) [Str "http://user:password@domain.com."] ("http://user:password@domain.com.",""),SoftBreak,Link ("",[],[]) [Str "http://user:@domain.com."] ("http://user:@domain.com.",""),SoftBreak,Link ("",[],[]) [Str "http://user@domain.com."] ("http://user@domain.com.",""),SoftBreak,Link ("",[],[]) [Str "http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor"] ("http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor",""),SoftBreak,Link ("",[],[]) [Str "http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c@#anchor"] ("http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c@#anchor",""),SoftBreak,Link ("",[],[]) [Str "label"] ("www.domain.com",""),SoftBreak,Str "[",Space,Str "label",Space,Link ("",[],[]) [Str "www.domain.com"] ("www.domain.com",""),Str "]",SoftBreak,Link ("",[],[]) [Str "label",Space] ("www.domain.com",""),SoftBreak,Link ("",[],[]) [Str "anchor",Space] ("http://www.domain.com/dir/index.html#anchor.",""),SoftBreak,Link ("",[],[]) [Str "login",Space] ("http://user:password@domain.com/bla.html",""),SoftBreak,Link ("",[],[]) [Str "form",Space] ("http://www.domain.com/bla.cgi?a=a@a.a&b=a+b+c.",""),SoftBreak,Link ("",[],[]) [Str "form",Space,Str "&",Space,Str "anchor"] ("http://www.domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor",""),SoftBreak,Link ("",[],[]) [Str "login",Space,Str "&",Space,Str "form",Space] ("http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c.",""),SoftBreak,Link ("",[],[]) [Str "local",Space,Str "link",Space,Str "up",Space] ("..",""),SoftBreak,Link ("",[],[]) [Str "local",Space,Str "link",Space,Str "file",Space] ("bla.html",""),SoftBreak,Link ("",[],[]) [Str "local",Space,Str "link",Space,Str "anchor",Space] ("#anchor",""),SoftBreak,Link ("",[],[]) [Str "local",Space,Str "link",Space,Str "file/anchor"] ("bla.html#anchor",""),SoftBreak,Link ("",[],[]) [Str "local",Space,Str "link",Space,Str "file/anchor"] ("bla.html#anchor.",""),SoftBreak,Link ("",[],[]) [Str "local",Space,Str "link",Space,Str "img",Space] ("abc.gif",""),SoftBreak,Link ("",[],[]) [Str "www.fake.com"] ("www.domain.com",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm"] ("http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-"] ("http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-",""),SoftBreak,Link ("",[],[]) [Str "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-#anchor_"] ("http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-#anchor_",""),Str "-1%.",SoftBreak,Link ("",[],[]) [Str "http://foo._user-9:pass!#$%&*()+word@domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-#anchor_"] ("http://foo._user-9:pass!#$%&*()+word@domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-#anchor_",""),Str "-1%.",SoftBreak,Link ("",[],[]) [Str "http://L1.com"] ("http://L1.com",""),Space,Str "!",Space,Link ("",[],[]) [Str "mailto:L2@www.com"] ("L2@www.com",""),Space,Str "!",Space,Link ("",[],[]) [Str "L3"] ("www.com",""),Space,Str "!",Space,Link ("",[],[]) [Str "L4"] ("w@ww.com",""),Space,Str "!",Space,Link ("",[],[]) [Str "www.L5.com"] ("www.L5.com",""),SoftBreak,Link ("",[],[]) [Str "www.domain.com"] ("www.domain.com",""),SoftBreak,Link ("",[],[]) [Str "www2.domain.com"] ("www2.domain.com",""),SoftBreak,Link ("",[],[]) [Str "ftp.domain.com"] ("ftp.domain.com",""),SoftBreak,Link ("",[],[]) [Str "WWW.DOMAIN.COM"] ("WWW.DOMAIN.COM",""),SoftBreak,Link ("",[],[]) [Str "FTP.DOMAIN.COM"] ("FTP.DOMAIN.COM",""),SoftBreak,Link ("",[],[]) [Str "label"] ("www.domain.com",""),SoftBreak,Link ("",[],[]) [Str "label"] ("ftp.domain.com",""),SoftBreak,Link ("",[],[]) [Str "label"] ("WWW.DOMAIN.COM",""),SoftBreak,Link ("",[],[]) [Str "label"] ("FTP.DOMAIN.COM",""),SoftBreak,Str "[label",Space,Link ("",[],[]) [Str "www.domain.com"] ("www.domain.com",""),Space,Str "]",SoftBreak,Str "[label]",Space,Link ("",[],[]) [Str "www.domain.com"] ("www.domain.com",""),Str "]"]
-,Header 1 ("image",[],[]) [Str "Image"]
-,Para [Image ("",[],[]) [] ("img.png","")]
-,Para [Link ("",[],[]) [Image ("",[],[]) [] ("img.png","")] ("https://txt2tags.org","")]
-,Para [Image ("",[],[]) [] ("img.png",""),Space,Str "Image",Space,Str "at",Space,Str "the",Space,Str "line",Space,Str "beginning."]
-,Para [Str "Image",Space,Str "in",Space,Str "the",Space,Str "middle",Space,Image ("",[],[]) [] ("img.png",""),Space,Str "of",Space,Str "the",Space,Str "line."]
-,Para [Str "Image",Space,Str "at",Space,Str "the",Space,Str "line",Space,Str "end.",Space,Image ("",[],[]) [] ("img.png","")]
-,Para [Image ("",[],[]) [] ("img.png",""),SoftBreak,Image ("",[],[]) [] ("img.png",""),SoftBreak,Image ("",[],[]) [] ("img.png","")]
-,Para [Image ("",[],[]) [] ("img.png",""),Image ("",[],[]) [] ("img.png","")]
-,Para [Str "Images",Space,Image ("",[],[]) [] ("img.png",""),Space,Str "mixed",Space,Image ("",[],[]) [] ("img.png",""),Space,Str "with",Space,Image ("",[],[]) [] ("img.png",""),Space,Str "text."]
-,Para [Str "Images",Space,Str "glued",Space,Str "together:",Space,Image ("",[],[]) [] ("img.png",""),Image ("",[],[]) [] ("img.png",""),Image ("",[],[]) [] ("img.png",""),Str "."]
-,Para [Str "[img.png",Space,Str "]"]
-,Para [Str "[",Space,Str "img.png]"]
-,Para [Str "[",Space,Str "img.png",Space,Str "]"]
-,Header 1 ("numtitle",[],[]) [Str "Numbered",Space,Str "Title"]
-,Header 1 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "1"]
-,Header 2 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "2"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 4 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "4"]
-,Header 5 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "5"]
-,Header 1 ("lab_el-1",[],[]) [Str "Title",Space,Str "Level",Space,Str "1"]
-,Header 2 ("lab_el-2",[],[]) [Str "Title",Space,Str "Level",Space,Str "2"]
-,Header 3 ("lab_el-3",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 4 ("lab_el-4",[],[]) [Str "Title",Space,Str "Level",Space,Str "4"]
-,Header 5 ("lab_el-5",[],[]) [Str "Title",Space,Str "Level",Space,Str "5"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("lab_el-9",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Para [Str "+Not",Space,Str "Title"]
-,Para [Str "++Not",Space,Str "Title+"]
-,Para [Str "+++Not",Space,Str "Title++++",SoftBreak,Str "++++++Not",Space,Str "Title",Space,Str "6++++++"]
-,Para [Str "+++++++Not",Space,Str "Title",Space,Str "7+++++++",SoftBreak,Str "+Not",Space,Str "Title+",Space,Str "[label1]",SoftBreak,Str "+Not",Space,Str "Title+[",Space,Str "label",Space,Str "]",SoftBreak,Str "+Not",Space,Str "Title+[la/bel]"]
-,Header 1 ("title",[],[]) [Str "Title"]
-,Header 1 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "1"]
-,Header 2 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "2"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 4 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "4"]
-,Header 5 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "5"]
-,Header 1 ("lab_el-1",[],[]) [Str "Title",Space,Str "Level",Space,Str "1"]
-,Header 2 ("lab_el-2",[],[]) [Str "Title",Space,Str "Level",Space,Str "2"]
-,Header 3 ("lab_el-3",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 4 ("lab_el-4",[],[]) [Str "Title",Space,Str "Level",Space,Str "4"]
-,Header 5 ("lab_el-5",[],[]) [Str "Title",Space,Str "Level",Space,Str "5"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Header 3 ("lab_el-9",[],[]) [Str "Title",Space,Str "Level",Space,Str "3"]
-,Para [Str "=Not",Space,Str "Title"]
-,Para [Str "==Not",Space,Str "Title="]
-,Para [Str "===Not",Space,Str "Title====",SoftBreak,Str "======Not",Space,Str "Title",Space,Str "6======"]
-,Para [Str "=======Not",Space,Str "Title",Space,Str "7=======",SoftBreak,Str "=Not",Space,Str "Title=",Space,Str "[label1]",SoftBreak,Str "=Not",Space,Str "Title=[",Space,Str "label",Space,Str "]",SoftBreak,Str "=Not",Space,Str "Title=[la/bel]"]
-,Header 1 ("quote",[],[]) [Str "Quote"]
-,BlockQuote
- [Para [Str "To",Space,Str "quote",Space,Str "a",Space,Str "paragraph,",Space,Str "just",Space,Str "prefix",Space,Str "it",Space,Str "by",Space,Str "a",Space,Str "TAB",SoftBreak,Str "character.",Space,Str "All",Space,Str "the",Space,Str "lines",Space,Str "of",Space,Str "the",Space,Str "paragraph",Space,Str "must",SoftBreak,Str "begin",Space,Str "with",Space,Str "a",Space,Str "TAB."]]
-,Para [Str "Any",Space,Str "non-tabbed",Space,Str "line",Space,Str "closes",Space,Str "the",Space,Str "quote",Space,Str "block."]
-,BlockQuote
- [Para [Str "The",Space,Str "number",Space,Str "of",Space,Str "leading",Space,Str "TABs",Space,Str "identifies",Space,Str "the",Space,Str "quote",SoftBreak,Str "block",Space,Str "depth.",Space,Str "This",Space,Str "is",Space,Str "quote",Space,Str "level",Space,Str "1."]
- ,BlockQuote
-  [Para [Str "With",Space,Str "two",Space,Str "TABs,",Space,Str "we",Space,Str "are",Space,Str "on",Space,Str "the",Space,Str "quote",SoftBreak,Str "level",Space,Str "2."]
-  ,BlockQuote
-   [Para [Str "The",Space,Str "more",Space,Str "TABs,",Space,Str "more",Space,Str "deep",Space,Str "is",SoftBreak,Str "the",Space,Str "quote",Space,Str "level."]
-   ,BlockQuote
-    [Para [Str "There",Space,Str "isn't",Space,Str "a",Space,Str "limit."]]]]]
-,BlockQuote
- [BlockQuote
-  [BlockQuote
-   [BlockQuote
-    [Para [Str "This",Space,Str "quote",Space,Str "starts",Space,Str "at",SoftBreak,Str "level",Space,Str "4."]]
-   ,Para [Str "Then",Space,Str "its",Space,Str "depth",Space,Str "is",Space,Str "decreased."]]
-  ,Para [Str "Counting",Space,Str "down,",Space,Str "one",Space,Str "by",Space,Str "one."]]
- ,Para [Str "Until",Space,Str "the",Space,Str "level",Space,Str "1."]]
-,BlockQuote
- [BlockQuote
-  [BlockQuote
-   [Para [Str "Unlike",Space,Str "lists,",Space,Str "any",Space,Str "quote",Space,Str "block",Space,Str "is",SoftBreak,Str "independent,",Space,Str "not",Space,Str "part",Space,Str "of",Space,Str "a",Space,Str "tree."]]]
- ,Para [Str "The",Space,Str "TAB",Space,Str "count",Space,Str "don't",Space,Str "need",Space,Str "to",Space,Str "be",Space,Str "incremental",SoftBreak,Str "by",Space,Str "one."]
- ,BlockQuote
-  [BlockQuote
-   [BlockQuote
-    [Para [Str "The",Space,Str "nesting",Space,Str "don't",Space,Str "need",SoftBreak,Str "to",Space,Str "follow",Space,Str "any",Space,Str "rule."]]]
-  ,Para [Str "Quotes",Space,Str "can",Space,Str "be",Space,Str "opened",Space,Str "and",Space,Str "closed",SoftBreak,Str "in",Space,Str "any",Space,Str "way."]
-  ,BlockQuote
-   [BlockQuote
-    [BlockQuote
-     [Para [Str "You",Space,Str "choose."]]]]]]
-,BlockQuote
- [Para [Str "Some",Space,Str "targets",Space,Str "(as",Space,Str "sgml)",Space,Str "don't",Space,Str "support",Space,Str "the",SoftBreak,Str "nesting",Space,Str "of",Space,Str "quotes.",Space,Str "There",Space,Str "is",Space,Str "only",Space,Str "one",Space,Str "quote",SoftBreak,Str "level."]
- ,BlockQuote
-  [Para [Str "In",Space,Str "this",Space,Str "case,",Space,Str "no",Space,Str "matter",Space,Str "how",Space,Str "much",SoftBreak,Str "TABs",Space,Str "are",Space,Str "used",Space,Str "to",Space,Str "define",Space,Str "the",Space,Str "quote",SoftBreak,Str "block,",Space,Str "it",Space,Str "always",Space,Str "will",Space,Str "be",Space,Str "level",Space,Str "1."]]]
-,BlockQuote
- [Para [Str "Spaces",Space,Str "AFTER",Space,Str "the",Space,Str "TAB",Space,Str "character",Space,Str "are",Space,Str "allowed.",SoftBreak,Str "But",Space,Str "be",Space,Str "careful,",Space,Str "it",Space,Str "can",Space,Str "be",Space,Str "confusing."]]
-,Para [Str "Spaces",Space,Str "BEFORE",Space,Str "the",Space,Str "TAB",Space,Str "character",SoftBreak,Str "invalidate",Space,Str "the",Space,Str "mark.",Space,Str "It's",Space,Str "not",Space,Str "quote."]
-,BlockQuote
- [Para [Str "Paragraph",Space,Str "breaks",Space,Str "inside",Space,Str "a",Space,Str "quote",Space,Str "aren't",SoftBreak,Str "possible."]
- ,Para [Str "This",Space,Str "sample",Space,Str "are",Space,Str "two",Space,Str "separated",Space,Str "quoted",SoftBreak,Str "paragraphs,",Space,Str "not",Space,Str "a",Space,Str "quote",Space,Str "block",Space,Str "with",SoftBreak,Str "two",Space,Str "paragraphs",Space,Str "inside."]]
-,BlockQuote
- [Para [Str "The",Space,Str "end",Space,Str "of",Space,Str "the",Space,Str "file",Space,Str "(EOF)",Space,Str "closes",Space,Str "the",SoftBreak,Str "currently",Space,Str "open",Space,Str "quote",Space,Str "block."]]
-,Header 1 ("raw",[],[]) [Str "Raw"]
-,Para [Str "A raw line.\n"]
-,Para [Str "  Another raw line, with leading spaces.\n"]
-,Para [Str "A raw area delimited\n       by lines with marks.\n"]
-,Para [Str "Trailing spaces and TABs after the area marks\nare allowed, but not encouraged nor documented.\n"]
-,Para [Str "\"\"\"Not",Space,Str "a",Space,Str "raw",Space,Str "line,",Space,Str "need",Space,Str "one",Space,Str "space",Space,Str "after",Space,Str "mark."]
-,Para [Str "\"\"\"",SoftBreak,Str "Not",Space,Str "a",Space,Str "raw",Space,Str "area.",SoftBreak,Str "The",Space,Str "marks",Space,Str "must",Space,Str "be",Space,Str "at",Space,Str "the",Space,Str "line",Space,Str "beginning,",SoftBreak,Str "no",Space,Str "leading",Space,Str "spaces.",SoftBreak,Str "\"\"\""]
-,Para [Str "The end of the file (EOF) closes\nthe currently open raw area.\n"]
-,Header 1 ("verbatim",[],[]) [Str "Verbatim"]
-,CodeBlock ("",[],[]) "A verbatim line.\n"
-,CodeBlock ("",[],[]) "  Another verbatim line, with leading spaces.\n"
-,CodeBlock ("",[],[]) "A verbatim area delimited\n       by lines with marks.\n"
-,CodeBlock ("",[],[]) "Trailing spaces and TABs after the area marks\nare allowed, but not encouraged nor documented.\n"
-,Para [Str "```Not",Space,Str "a",Space,Str "verbatim",Space,Str "line,",Space,Str "need",Space,Str "one",Space,Str "space",Space,Str "after",Space,Str "mark."]
-,Para [Str "```",SoftBreak,Str "Not",Space,Str "a",Space,Str "verbatim",Space,Str "area.",SoftBreak,Str "The",Space,Str "marks",Space,Str "must",Space,Str "be",Space,Str "at",Space,Str "the",Space,Str "line",Space,Str "beginning,",SoftBreak,Str "no",Space,Str "leading",Space,Str "spaces.",SoftBreak,Str "```"]
-,CodeBlock ("",[],[]) "The end of the file (EOF) closes\nthe currently open verbatim area.\n"
-,Header 1 ("deflist",[],[]) [Str "Definition",Space,Str "List"]
-,DefinitionList
- [([Str "Definition",Space,Str "list"],
-   [[Plain [Str "A",Space,Str "list",Space,Str "with",Space,Str "terms"]]])
- ,([Str "Start",Space,Str "term",Space,Str "with",Space,Str "colon"],
-   [[Plain [Str "And",Space,Str "its",Space,Str "definition",Space,Str "follows"]]])]
-,Header 1 ("numlist",[],[]) [Str "Numbered",Space,Str "List"]
-,Para [Str "See",Space,Link ("",[],[]) [Str "List"] ("#list",""),Str ",",Space,Str "the",Space,Str "same",Space,Str "rules",Space,Str "apply."]
-,Header 1 ("list",[],[]) [Str "List"]
-,BulletList
- [[Plain [Str "Use",Space,Str "the",Space,Str "hyphen",Space,Str "to",Space,Str "prefix",Space,Str "list",Space,Str "items."]]
- ,[Plain [Str "There",Space,Str "must",Space,Str "be",Space,Str "one",Space,Str "space",Space,Str "after",Space,Str "the",Space,Str "hyphen."]]
- ,[Plain [Str "The",Space,Str "list",Space,Str "is",Space,Str "closed",Space,Str "by",Space,Str "two",Space,Str "consecutive",Space,Str "blank",Space,Str "lines."]]]
-,BulletList
- [[Plain [Str "The",Space,Str "list",Space,Str "can",Space,Str "be",Space,Str "indented",Space,Str "on",Space,Str "the",Space,Str "source",Space,Str "document."]]
- ,[Plain [Str "You",Space,Str "can",Space,Str "use",Space,Str "any",Space,Str "number",Space,Str "of",Space,Str "spaces."]]
- ,[Plain [Str "The",Space,Str "result",Space,Str "will",Space,Str "be",Space,Str "the",Space,Str "same."]]]
-,BulletList
- [[Para [Str "Let",Space,Str "one",Space,Str "blank",Space,Str "line",Space,Str "between",Space,Str "the",Space,Str "list",Space,Str "items."]]
- ,[Para [Str "It",Space,Str "will",Space,Str "be",Space,Str "maintained",Space,Str "on",Space,Str "the",Space,Str "conversion."]]
- ,[Para [Str "Some",Space,Str "targets",Space,Str "don't",Space,Str "support",Space,Str "this",Space,Str "behavior."]]
- ,[Para [Str "This",Space,Str "one",Space,Str "was",Space,Str "separated",Space,Str "by",Space,Str "a",Space,Str "line",Space,Str "with",Space,Str "blanks.",SoftBreak,Str "You",Space,Str "can",Space,Str "also",Space,Str "put",Space,Str "a",Space,Str "blank",Space,Str "line",Space,Str "inside"]
-  ,Para [Str "the",Space,Str "item",Space,Str "contents",Space,Str "and",Space,Str "it",Space,Str "will",Space,Str "be",Space,Str "preserved."]]]
-,Para [Str "-This",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "list",Space,Str "(no",Space,Str "space)"]
-,Para [Str "-",Space,Str "This",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "list",Space,Str "(more",Space,Str "than",Space,Str "one",Space,Str "space)"]
-,Para [Str "-",Space,Str "This",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "list",Space,Str "(a",Space,Str "TAB",Space,Str "instead",Space,Str "the",Space,Str "space)"]
-,BulletList
- [[BulletList
-   [[Plain [Str "This",Space,Str "is",Space,Str "a",Space,Str "list"]]]]
- ,[OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "This",Space,Str "is",Space,Str "a",Space,Str "list"]]]]
- ,[DefinitionList
-   [([Str "This",Space,Str "is",Space,Str "a",Space,Str "list"],
-     [[]])]]]
-,BulletList
- [[Plain [Str "This",Space,Str "is",Space,Str "the",Space,Str "\"mother\"",Space,Str "list",Space,Str "first",Space,Str "item."]]
- ,[Plain [Str "Here",Space,Str "is",Space,Str "the",Space,Str "second,",Space,Str "but",Space,Str "inside",Space,Str "this",Space,Str "item,"]
-  ,BulletList
-   [[Plain [Str "there",Space,Str "is",Space,Str "a",Space,Str "sublist,",Space,Str "with",Space,Str "its",Space,Str "own",Space,Str "items."]]
-   ,[Plain [Str "Note",Space,Str "that",Space,Str "the",Space,Str "items",Space,Str "of",Space,Str "the",Space,Str "same",Space,Str "sublist"]]
-   ,[Plain [Str "must",Space,Str "have",Space,Str "the",Space,Str "same",Space,Str "indentation."]
-    ,BulletList
-     [[Plain [Str "And",Space,Str "this",Space,Str "can",Space,Str "go",Space,Str "on,",Space,Str "opening",Space,Str "sublists."]
-      ,BulletList
-       [[Plain [Str "Just",Space,Str "add",Space,Str "leading",Space,Str "spaces",Space,Str "before",Space,Str "the"]]
-       ,[Plain [Str "hyphen",Space,Str "and",Space,Str "sublists",Space,Str "will",Space,Str "be",Space,Str "opened."]]
-       ,[Plain [Str "The",Space,Str "two",Space,Str "blank",Space,Str "lines",Space,Str "closes",Space,Str "them",Space,Str "all."]]]]]]]]]
-,BulletList
- [[Plain [Str "When",Space,Str "nesting",Space,Str "lists,",Space,Str "the",Space,Str "additional",Space,Str "spaces",Space,Str "are",Space,Str "free."]]
- ,[Plain [Str "You",Space,Str "can",Space,Str "add",Space,Str "just",Space,Str "one,"]
-  ,BulletList
-   [[Plain [Str "or",Space,Str "many."]
-    ,BulletList
-     [[Plain [Str "What",Space,Str "matters",Space,Str "is",Space,Str "to",Space,Str "put",Space,Str "more",Space,Str "than",Space,Str "the",Space,Str "previous."]]
-     ,[Plain [Str "But",Space,Str "remember",Space,Str "that",Space,Str "the",Space,Str "other",Space,Str "items",Space,Str "of",Space,Str "the",Space,Str "same",Space,Str "list"]]
-     ,[Plain [Str "must",Space,Str "use",Space,Str "the",Space,Str "same",Space,Str "indentation."]]]]]]]
-,BulletList
- [[Plain [Str "There",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "depth",Space,Str "limit,"]
-  ,BulletList
-   [[Plain [Str "you",Space,Str "can",Space,Str "go",Space,Str "deeper",Space,Str "and",Space,Str "deeper."]
-    ,BulletList
-     [[Plain [Str "But",Space,Str "some",Space,Str "targets",Space,Str "may",Space,Str "have",Space,Str "restrictions."]
-      ,BulletList
-       [[Plain [Str "The",Space,Str "LaTeX",Space,Str "maximum",Space,Str "is",Space,Str "here,",Space,Str "4",Space,Str "levels."]]]]]]]]]
-,BulletList
- [[Plain [Str "Reverse",Space,Str "nesting",Space,Str "doesn't",Space,Str "work."]]
- ,[Plain [Str "Because",Space,Str "a",Space,Str "sublist",Space,Str "*must*",Space,Str "have",Space,Str "a",Space,Str "mother",Space,Str "list."]]
- ,[Plain [Str "It's",Space,Str "the",Space,Str "list",Space,Str "concept,",Space,Str "not",Space,Str "a",Space,Str "txt2tags",Space,Str "limitation."]]
- ,[Plain [Str "All",Space,Str "this",Space,Str "sublists",Space,Str "will",Space,Str "be",Space,Str "bumped",Space,Str "to",Space,Str "mother",Space,Str "lists."]]
- ,[Plain [Str "At",Space,Str "level",Space,Str "1,",Space,Str "like",Space,Str "this",Space,Str "one."]]]
-,BulletList
- [[Plain [Str "Level",Space,Str "1"]
-  ,BulletList
-   [[Plain [Str "Level",Space,Str "2"]
-    ,BulletList
-     [[Plain [Str "Level",Space,Str "3"]
-      ,BulletList
-       [[Plain [Str "Level",Space,Str "4"]]]]
-     ,[Plain [Str "Level",Space,Str "3",Space,Str "--",Space,Str "(closed",Space,Str "Level",Space,Str "4)"]]]]
-   ,[Plain [Str "Level",Space,Str "2",Space,Str "--",Space,Str "(closed",Space,Str "Level",Space,Str "3)"]]]]
- ,[Plain [Str "Level",Space,Str "1",Space,Str "--",Space,Str "(closed",Space,Str "Level",Space,Str "2)"]]]
-,BulletList
- [[Plain [Str "Level",Space,Str "1"]
-  ,BulletList
-   [[Plain [Str "Level",Space,Str "2"]
-    ,BulletList
-     [[Plain [Str "Level",Space,Str "3"]
-      ,BulletList
-       [[Plain [Str "Level",Space,Str "4"]]]]]]]]
- ,[Plain [Str "Level",Space,Str "1",Space,Str "--",Space,Str "(closed",Space,Str "Level",Space,Str "4,",Space,Str "Level",Space,Str "3",Space,Str "and",Space,Str "Level",Space,Str "2)"]]]
-,BulletList
- [[Para [Str "Level",Space,Str "1"]
-  ,BulletList
-   [[Para [Str "Level",Space,Str "2",Space,Str "--",Space,Str "blank",Space,Str "BEFORE",Space,Str "and",Space,Str "AFTER",Space,Str "(in)"]
-    ,BulletList
-     [[Plain [Str "Level",Space,Str "3"]]]]]]]
-,BulletList
- [[Plain [Str "Level",Space,Str "4"]]]
-,BulletList
- [[Para [Str "Level",Space,Str "3"]]
- ,[Para [Str "Level",Space,Str "2",Space,Str "--",Space,Str "blank",Space,Str "BEFORE",Space,Str "and",Space,Str "AFTER",Space,Str "(out)"]]
- ,[Para [Str "Level",Space,Str "1"]
-  ,BulletList
-   [[Para [Str "Level",Space,Str "2",Space,Str "--",Space,Str "blank",Space,Str "BEFORE",Space,Str "(spaces)",Space,Str "and",Space,Str "AFTER",Space,Str "(TAB)"]
-    ,BulletList
-     [[Plain [Str "Level",Space,Str "3"]]]]]]]
-,BulletList
- [[Plain [Str "Level",Space,Str "1"]
-  ,BulletList
-   [[Plain [Str "Level",Space,Str "2"]
-    ,BulletList
-     [[Plain [Str "Level",Space,Str "3"]
-      ,BulletList
-       [[Plain [Str "Level",Space,Str "4"]]
-       ,[Plain [Str "Level",Space,Str "3.5",Space,Str "???"]]]]
-     ,[Plain [Str "Level",Space,Str "3"]]
-     ,[Plain [Str "Level",Space,Str "2.5",Space,Str "???"]]]]
-   ,[Plain [Str "Level",Space,Str "2"]]
-   ,[Plain [Str "Level",Space,Str "1.5",Space,Str "???"]]]]
- ,[Plain [Str "Level",Space,Str "1"]]]
-,BulletList
- [[Plain [Str "This",Space,Str "list",Space,Str "is",Space,Str "closed",Space,Str "by",Space,Str "a",Space,Str "line",Space,Str "with",Space,Str "spaces",Space,Str "and",Space,Str "other",Space,Str "with",Space,Str "TABs"]]]
-,BulletList
- [[Plain [Str "This",Space,Str "list",Space,Str "is",Space,Str "NOT",Space,Str "closed",Space,Str "by",Space,Str "two",Space,Str "comment",Space,Str "lines"]]]
-,BulletList
- [[Plain [Str "This",Space,Str "list",Space,Str "is",Space,Str "closed",Space,Str "by",Space,Str "a",Space,Str "line",Space,Str "with",Space,Str "spaces",Space,Str "and",Space,Str "TAB,"]]
- ,[Plain [Str "then",Space,Str "a",Space,Str "comment",Space,Str "line,",Space,Str "then",Space,Str "an",Space,Str "empty",Space,Str "line."]]]
-,BulletList
- [[Plain [Str "Level",Space,Str "1"]
-  ,BulletList
-   [[Plain [Str "Level",Space,Str "2"]
-    ,BulletList
-     [[Plain [Str "Level",Space,Str "3"]]]
-    ,Plain [Str "-",SoftBreak,Str "Level",Space,Str "2"]]]
-  ,Plain [Str "-",SoftBreak,Str "Level",Space,Str "1"]]]
-,Para [Str "-"]
-,BulletList
- [[Plain [Str "Empty",Space,Str "item",Space,Str "with",Space,Str "trailing",Space,Str "spaces."]]]
-,Para [Str "-"]
-,BulletList
- [[Plain [Str "Empty",Space,Str "item",Space,Str "with",Space,Str "trailing",Space,Str "TAB."]]]
-,Para [Str "-"]
-,BulletList
- [[Plain [Str "If",Space,Str "the",Space,Str "end",Space,Str "of",Space,Str "the",Space,Str "file",Space,Str "(EOF)",Space,Str "is",Space,Str "hit,"]
-  ,BulletList
-   [[Plain [Str "all",Space,Str "the",Space,Str "currently",Space,Str "opened",Space,Str "list",Space,Str "are",Space,Str "closed,"]
-    ,BulletList
-     [[Plain [Str "just",Space,Str "like",Space,Str "when",Space,Str "using",Space,Str "the",Space,Str "two",Space,Str "blank",Space,Str "lines."]]]]]]]
-,Header 1 ("table",[],[]) [Str "Table"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignRight,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3"]]]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "||",Space,Str "Cell",Space,Str "1",Space,Str "|",Space,Str "Cell",Space,Str "2",Space,Str "|",Space,Str "Cell",Space,Str "3",Space,Str "|"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Cell",Space,Str "3"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Heading"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Heading"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Heading"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "<-"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "--"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "->"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "--"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "--"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "--"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "->"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "--"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "<-"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "1"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "2"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "3+4"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1+2+3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2+3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1+2+3+4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "7"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "8"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "A"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "B"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "D"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "E"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "F"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Jan"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Fev"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Mar"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "Apr"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "May"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "20%"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "40%"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "60%"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "80%"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "100%"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "/"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "/",Space,Str "/",Space,Str "/",Space,Str "/",Space,Str "/"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "/",Space,Str "/",Space,Str "/",Space,Str "/",Space,Str "/",Space,Str "/",Space,Str "/",Space,Str "/",Space,Str "/"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "o"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "o"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "."]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "=",Space,Str "=",Space,Str "=",Space,Str "="]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "01"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "02"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "05"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "07"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "11"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "13"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "16"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "17"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "19"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "20"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "23"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "25"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "26"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "29"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "30"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "32"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "35"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "37"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "39"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "40"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)
- ,(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "7"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "8"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "9"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "A"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "B"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "C"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "D"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "E"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "F"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "0"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "3"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "4"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "5"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "6"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "7"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "8"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "9"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "A"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "B"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "C"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "D"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "E"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "F"]]]])]
- (TableFoot ("",[],[])
- [])
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignCenter,ColWidthDefault)]
- (TableHead ("",[],[])
- [])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]])]
- (TableFoot ("",[],[])
- [])
-,Para [Str "|this|is|not|a|table|"]
-,Para [Str "|this|",Space,Str "is|",Space,Str "not|",Space,Str "a|",Space,Str "table|"]
-,Para [Str "|this",Space,Str "|is",Space,Str "|not",Space,Str "|a",Space,Str "|table",Space,Str "|"]
-,Para [Str "|",Space,Str "this\t|",Space,Str "is\t|",Space,Str "not\t|",Space,Str "a\t|",Space,Str "table\t|"]
-,HorizontalRule
-,Para [Str "The",Space,Str "End."]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author", MetaList [ MetaInlines [ Str "author" ] ] )
+      ,
+        ( "date", MetaInlines [ Str "date" ] )
+      ,
+        ( "includeconf", MetaString "rules.conf" )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Txt2tags", Space, Str "Markup", Space, Str "Rules" ]
+        )
+      ]
+    }
+  )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "document"
+    , Space
+    , Str "describes"
+    , Space
+    , Str "all"
+    , Space
+    , Str "the"
+    , Space
+    , Str "details"
+    , Space
+    , Str "about"
+    , Space
+    , Str "each"
+    , Space
+    , Str "txt2tags"
+    , Space
+    , Str "mark."
+    , SoftBreak
+    , Str "The"
+    , Space
+    , Str "target"
+    , Space
+    , Str "audience"
+    , Space
+    , Str "are"
+    , Space
+    , Strong
+      [ Str "experienced" ]
+    , Space
+    , Str "users."
+    , Space
+    , Str "You"
+    , Space
+    , Str "may"
+    , Space
+    , Str "find"
+    , Space
+    , Str "it"
+    , SoftBreak
+    , Str "useful"
+    , Space
+    , Str "if"
+    , Space
+    , Str "you"
+    , Space
+    , Str "want"
+    , Space
+    , Str "to"
+    , Space
+    , Str "master"
+    , Space
+    , Str "the"
+    , Space
+    , Str "marks"
+    , Space
+    , Str "or"
+    , Space
+    , Str "solve"
+    , Space
+    , Str "a"
+    , Space
+    , Str "specific"
+    , Space
+    , Str "problem"
+    , SoftBreak
+    , Str "about"
+    , Space
+    , Str "a"
+    , Space
+    , Str "mark."
+    ]
+  , Para
+    [ Str "If"
+    , Space
+    , Str "you"
+    , Space
+    , Str "are"
+    , Space
+    , Str "new"
+    , Space
+    , Str "to"
+    , Space
+    , Str "txt2tags"
+    , Space
+    , Str "or"
+    , Space
+    , Str "just"
+    , Space
+    , Str "want"
+    , Space
+    , Str "to"
+    , Space
+    , Str "know"
+    , Space
+    , Str "which"
+    , Space
+    , Str "are"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "available"
+    , Space
+    , Str "marks,"
+    , Space
+    , Str "please"
+    , Space
+    , Str "read"
+    , Space
+    , Str "the"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "Markup", Space, Str "Demo" ]
+      ( "MARKUPDEMO", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Note"
+    , Space
+    , Str "1:"
+    , Space
+    , Str "This"
+    , Space
+    , Str "document"
+    , Space
+    , Str "is"
+    , Space
+    , Str "generated"
+    , Space
+    , Str "directly"
+    , Space
+    , Str "from"
+    , Space
+    , Str "the"
+    , Space
+    , Str "txt2tags"
+    , SoftBreak
+    , Str "test-suite."
+    , Space
+    , Str "All"
+    , Space
+    , Str "the"
+    , Space
+    , Str "rules"
+    , Space
+    , Str "mentioned"
+    , Space
+    , Str "here"
+    , Space
+    , Str "are"
+    , Space
+    , Str "100%"
+    , Space
+    , Str "in"
+    , Space
+    , Str "sync"
+    , Space
+    , Str "with"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "current"
+    , Space
+    , Str "program"
+    , Space
+    , Str "code."
+    ]
+  , Para
+    [ Str "Note"
+    , Space
+    , Str "2:"
+    , Space
+    , Str "A"
+    , Space
+    , Str "good"
+    , Space
+    , Str "practice"
+    , Space
+    , Str "is"
+    , Space
+    , Str "to"
+    , Space
+    , Str "consult"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "the", Space, Str "sources" ]
+      ( "rules.t2t", "" )
+    , Space
+    , Str "when"
+    , SoftBreak
+    , Str "reading,"
+    , Space
+    , Str "to"
+    , Space
+    , Str "see"
+    , Space
+    , Str "how"
+    , Space
+    , Str "the"
+    , Space
+    , Str "texts"
+    , Space
+    , Str "were"
+    , Space
+    , Str "made."
+    ]
+  , Para
+    [ Str "Table", Space, Str "of", Space, Str "Contents:" ]
+  , HorizontalRule
+  , Header 1
+    ( "paragraph", [], [] )
+    [ Str "Paragraph" ]
+  , Para
+    [ Str "A"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "is"
+    , Space
+    , Str "composed"
+    , Space
+    , Str "by"
+    , Space
+    , Str "one"
+    , Space
+    , Str "or"
+    , Space
+    , Str "more"
+    , Space
+    , Str "lines."
+    , SoftBreak
+    , Str "A"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "line"
+    , Space
+    , Str "(or"
+    , Space
+    , Str "a"
+    , Space
+    , Str "table,"
+    , Space
+    , Str "or"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list)"
+    , Space
+    , Str "ends"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "current"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "Leading"
+    , Space
+    , Str "and"
+    , Space
+    , Str "trailing"
+    , Space
+    , Str "spaces"
+    , Space
+    , Str "are"
+    , Space
+    , Str "ignored."
+    ]
+  , Para
+    [ Str "A"
+    , Space
+    , Str "comment"
+    , Space
+    , Str "line"
+    , Space
+    , Str "can"
+    , Space
+    , Str "be"
+    , Space
+    , Str "placed"
+    , Space
+    , Str "inside"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph."
+    , SoftBreak
+    , Str "It"
+    , Space
+    , Str "will"
+    , Space
+    , Str "not"
+    , Space
+    , Str "affect"
+    , Space
+    , Str "it."
+    ]
+  , Para
+    [ Str "The"
+    , Space
+    , Str "end"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "file"
+    , Space
+    , Str "(EOF)"
+    , Space
+    , Str "closes"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "currently"
+    , Space
+    , Str "open"
+    , Space
+    , Str "paragraph."
+    ]
+  , Header 1
+    ( "comment", [], [] )
+    [ Str "Comment" ]
+  , Para
+    [ Str "%"
+    , Space
+    , Str "not"
+    , Space
+    , Str "on"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line"
+    , Space
+    , Str "beginning"
+    , Space
+    , Str "(at"
+    , Space
+    , Str "column"
+    , Space
+    , Str "2)"
+    ]
+  , Para
+    [ Str "some"
+    , Space
+    , Str "text"
+    , Space
+    , Str "%"
+    , Space
+    , Str "half"
+    , Space
+    , Str "line"
+    , Space
+    , Str "comments"
+    , Space
+    , Str "are"
+    , Space
+    , Str "not"
+    , Space
+    , Str "allowed"
+    ]
+  , Header 1
+    ( "line", [], [] )
+    [ Str "Line" ]
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , HorizontalRule
+  , Para
+    [ Strikeout
+      [ Str "-----" ]
+    , SoftBreak
+    , Strikeout
+      [ Str "-------", Space, Str "--------" ]
+    ]
+  , Para
+    [ Strikeout [ Str "-------+--------" ] ]
+  , Para
+    [ Str "("
+    , Space
+    , Strikeout
+      [ Str "----------------" ]
+    , Space
+    , Str ")"
+    ]
+  , Header 1
+    ( "inline", [], [] )
+    [ Str "Inline" ]
+  , Para
+    [ Str "i)"
+    , Space
+    , Strong
+      [ Str "b" ]
+    , Space
+    , Emph
+      [ Str "i" ]
+    , Space
+    , Underline
+      [ Str "u" ]
+    , Space
+    , Strikeout
+      [ Str "s" ]
+    , Space
+    , Code
+      ( "", [], [] ) "m"
+    , Space
+    , Str "r"
+    , Space
+    , RawInline
+      ( Format "html" ) "t"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "bo" ]
+    , Space
+    , Emph
+      [ Str "it" ]
+    , Space
+    , Underline
+      [ Str "un" ]
+    , Space
+    , Strikeout
+      [ Str "st" ]
+    , Space
+    , Code
+      ( "", [], [] ) "mo"
+    , Space
+    , Str "ra"
+    , Space
+    , RawInline
+      ( Format "html" ) "tg"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "bold" ]
+    , Space
+    , Emph
+      [ Str "ital" ]
+    , Space
+    , Underline
+      [ Str "undr" ]
+    , Space
+    , Strikeout
+      [ Str "strk" ]
+    , Space
+    , Code
+      ( "", [], [] ) "mono"
+    , Space
+    , Str "raw"
+    , Space
+    , RawInline
+      ( Format "html" ) "tggd"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "bo", Space, Str "ld" ]
+    , Space
+    , Emph
+      [ Str "it", Space, Str "al" ]
+    , Space
+    , Underline
+      [ Str "un", Space, Str "dr" ]
+    , Space
+    , Strikeout
+      [ Str "st", Space, Str "rk" ]
+    , Space
+    , Code
+      ( "", [], [] ) "mo no"
+    , Space
+    , Str "r"
+    , Space
+    , Str "aw"
+    , Space
+    , RawInline
+      ( Format "html" ) "tg gd"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "bo", Space, Str "*", Space, Str "ld" ]
+    , Space
+    , Emph
+      [ Str "it", Space, Str "/", Space, Str "al" ]
+    , Space
+    , Underline
+      [ Str "un", Space, Str "_", Space, Str "dr" ]
+    , Space
+    , Strikeout
+      [ Str "st", Space, Str "-", Space, Str "rk" ]
+    , Space
+    , Code
+      ( "", [], [] ) "mo ` no"
+    , Space
+    , Str "r"
+    , Space
+    , Str "\""
+    , Space
+    , Str "aw"
+    , Space
+    , RawInline
+      ( Format "html" ) "tg ' gd"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "bo", Space, Str "**ld" ]
+    , Space
+    , Emph
+      [ Str "it", Space, Str "//al" ]
+    , Space
+    , Underline
+      [ Str "un", Space, Str "__dr" ]
+    , Space
+    , Strikeout
+      [ Str "st", Space, Str "--rk" ]
+    , Space
+    , Code
+      ( "", [], [] ) "mo ``no"
+    , Space
+    , Str "r"
+    , Space
+    , Str "\"\"aw"
+    , Space
+    , RawInline
+      ( Format "html" ) "tg ''gd"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "bo", Space, Str "**", Space, Str "ld" ]
+    , Space
+    , Emph
+      [ Str "it", Space, Str "//", Space, Str "al" ]
+    , Space
+    , Underline
+      [ Str "un", Space, Str "__", Space, Str "dr" ]
+    , Space
+    , Strikeout
+      [ Str "st", Space, Str "--", Space, Str "rk" ]
+    , Space
+    , Code
+      ( "", [], [] ) "mo `` no"
+    , Space
+    , Str "r"
+    , Space
+    , Str "\"\""
+    , Space
+    , Str "aw"
+    , Space
+    , RawInline
+      ( Format "html" ) "tg '' gd"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "**bold**" ]
+    , Space
+    , Emph
+      [ Str "//ital//" ]
+    , Space
+    , Underline
+      [ Str "__undr__" ]
+    , Space
+    , Strikeout
+      [ Str "--strk--" ]
+    , Space
+    , Code
+      ( "", [], [] ) "``mono``"
+    , Space
+    , Str "\"\"raw\"\""
+    , Space
+    , RawInline
+      ( Format "html" ) "''tggd''"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "*bold*" ]
+    , Space
+    , Emph
+      [ Str "/ital/" ]
+    , Space
+    , Underline
+      [ Str "_undr_" ]
+    , Space
+    , Strikeout
+      [ Str "-strk-" ]
+    , Space
+    , Code
+      ( "", [], [] ) "`mono`"
+    , Space
+    , Str "\"raw\""
+    , Space
+    , RawInline
+      ( Format "html" ) "'tggd'"
+    ]
+  , Para
+    [ Str "i)"
+    , Space
+    , Strong
+      [ Str "*" ]
+    , Space
+    , Emph
+      [ Str "/" ]
+    , Space
+    , Underline
+      [ Str "_" ]
+    , Space
+    , Strikeout
+      [ Str "-" ]
+    , Space
+    , Code
+      ( "", [], [] ) "`"
+    , Space
+    , Str "\""
+    , Space
+    , RawInline
+      ( Format "html" ) "'"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "**" ]
+    , Space
+    , Emph
+      [ Str "//" ]
+    , Space
+    , Underline
+      [ Str "__" ]
+    , Space
+    , Strikeout
+      [ Str "--" ]
+    , Space
+    , Code
+      ( "", [], [] ) "``"
+    , Space
+    , Str "\"\""
+    , Space
+    , RawInline
+      ( Format "html" ) "''"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "***" ]
+    , Space
+    , Emph
+      [ Str "///" ]
+    , Space
+    , Underline
+      [ Str "___" ]
+    , Space
+    , Strikeout
+      [ Str "---" ]
+    , Space
+    , Code
+      ( "", [], [] ) "```"
+    , Space
+    , Str "\"\"\""
+    , Space
+    , RawInline
+      ( Format "html" ) "'''"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "****" ]
+    , Space
+    , Emph
+      [ Str "////" ]
+    , Space
+    , Underline
+      [ Str "____" ]
+    , Space
+    , Strikeout
+      [ Str "----" ]
+    , Space
+    , Code
+      ( "", [], [] ) "````"
+    , Space
+    , Str "\"\"\"\""
+    , Space
+    , RawInline
+      ( Format "html" ) "''''"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "*****" ]
+    , Space
+    , Emph
+      [ Str "/////" ]
+    , Space
+    , Underline
+      [ Str "_____" ]
+    , Space
+    , Strikeout
+      [ Str "-----" ]
+    , Space
+    , Code
+      ( "", [], [] ) "`````"
+    , Space
+    , Str "\"\"\"\"\""
+    , Space
+    , RawInline
+      ( Format "html" ) "'''''"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Strong
+      [ Str "******" ]
+    , Space
+    , Emph
+      [ Str "//////" ]
+    , Space
+    , Underline
+      [ Str "______" ]
+    , Space
+    , Strikeout
+      [ Str "------" ]
+    , Space
+    , Code
+      ( "", [], [] ) "``````"
+    , Space
+    , Str "\"\"\"\"\"\""
+    , Space
+    , RawInline
+      ( Format "html" ) "''''''"
+    ]
+  , Para
+    [ Str "i)"
+    , Space
+    , Str "****"
+    , Space
+    , Str "////"
+    , Space
+    , Str "____"
+    , Space
+    , Str "----"
+    , Space
+    , Str "````"
+    , Space
+    , Str "\"\"\"\""
+    , Space
+    , Str "''''"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Str "**"
+    , Space
+    , Str "**"
+    , Space
+    , Str "//"
+    , Space
+    , Str "//"
+    , Space
+    , Str "__"
+    , Space
+    , Str "__"
+    , Space
+    , Str "--"
+    , Space
+    , Str "--"
+    , Space
+    , Str "``"
+    , Space
+    , Str "``"
+    , Space
+    , Str "\"\""
+    , Space
+    , Str "\"\""
+    , Space
+    , Str "''"
+    , Space
+    , Str "''"
+    ]
+  , Para
+    [ Str "i)"
+    , Space
+    , Str "**"
+    , Space
+    , Str "bold**"
+    , Space
+    , Str "//"
+    , Space
+    , Str "ital//"
+    , Space
+    , Str "__"
+    , Space
+    , Str "undr__"
+    , Space
+    , Str "--"
+    , Space
+    , Str "strk--"
+    , Space
+    , Str "``"
+    , Space
+    , Str "mono``"
+    , Space
+    , Str "\"\""
+    , Space
+    , Str "raw\"\""
+    , Space
+    , Str "''"
+    , Space
+    , Str "tggd''"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Str "**bold"
+    , Space
+    , Str "**"
+    , Space
+    , Str "//ital"
+    , Space
+    , Str "//"
+    , Space
+    , Str "__undr"
+    , Space
+    , Str "__"
+    , Space
+    , Str "--strk"
+    , Space
+    , Str "--"
+    , Space
+    , Str "``mono"
+    , Space
+    , Str "``"
+    , Space
+    , Str "\"\"raw"
+    , Space
+    , Str "\"\""
+    , Space
+    , Str "''tggd"
+    , Space
+    , Str "''"
+    , SoftBreak
+    , Str "i)"
+    , Space
+    , Str "**"
+    , Space
+    , Str "bold"
+    , Space
+    , Str "**"
+    , Space
+    , Str "//"
+    , Space
+    , Str "ital"
+    , Space
+    , Str "//"
+    , Space
+    , Str "__"
+    , Space
+    , Str "undr"
+    , Space
+    , Str "__"
+    , Space
+    , Str "--"
+    , Space
+    , Str "strk"
+    , Space
+    , Str "--"
+    , Space
+    , Str "``"
+    , Space
+    , Str "mono"
+    , Space
+    , Str "``"
+    , Space
+    , Str "\"\""
+    , Space
+    , Str "raw"
+    , Space
+    , Str "\"\""
+    , Space
+    , Str "''"
+    , Space
+    , Str "tggd"
+    , Space
+    , Str "''"
+    ]
+  , Header 1
+    ( "link", [], [] )
+    [ Str "Link" ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com" ]
+      ( "user@domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com" ]
+      ( "user@domain.com", "" )
+    , Str "."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com" ]
+      ( "user@domain.com", "" )
+    , Str "."
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Str "any"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com" ]
+      ( "user@domain.com", "" )
+    , Str "."
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label" ]
+      ( "user@domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com?subject=bla" ]
+      ( "user@domain.com?subject=bla", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com?subject=bla" ]
+      ( "user@domain.com?subject=bla", "" )
+    , Str "."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com?subject=bla" ]
+      ( "user@domain.com?subject=bla", "" )
+    , Str ","
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com?subject=bla&cc=otheruser@domain.com" ]
+      ( "user@domain.com?subject=bla&cc=otheruser@domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com?subject=bla&cc=otheruser@domain.com" ]
+      ( "user@domain.com?subject=bla&cc=otheruser@domain.com", "" )
+    , Str "."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:user@domain.com?subject=bla&cc=otheruser@domain.com" ]
+      ( "user@domain.com?subject=bla&cc=otheruser@domain.com", "" )
+    , Str ","
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label" ]
+      ( "user@domain.com?subject=bla&cc=otheruser@domain.com", "" )
+    , Str "."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label" ]
+      ( "user@domain.com?subject=bla&cc=otheruser@domain.com.", "" )
+    , Str "."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com" ]
+      ( "http://www.domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/" ]
+      ( "http://www.domain.com/dir/", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir///" ]
+      ( "http://www.domain.com/dir///", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com." ]
+      ( "http://www.domain.com.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com," ]
+      ( "http://www.domain.com,", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com." ]
+      ( "http://www.domain.com.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com," ]
+      ( "http://www.domain.com,", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/." ]
+      ( "http://www.domain.com/dir/.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Str "any"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com." ]
+      ( "http://www.domain.com.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Str "any"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/." ]
+      ( "http://www.domain.com/dir/.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Str "any"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/index.html." ]
+      ( "http://www.domain.com/dir/index.html.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Str "any"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/index.html," ]
+      ( "http://www.domain.com/dir/index.html,", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/#anchor" ]
+      ( "http://www.domain.com/dir/#anchor", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/index.html#anchor" ]
+      ( "http://www.domain.com/dir/index.html#anchor", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/index.html#anchor." ]
+      ( "http://www.domain.com/dir/index.html#anchor.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/#anchor." ]
+      ( "http://www.domain.com/dir/#anchor.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/index.html#anchor." ]
+      ( "http://www.domain.com/dir/index.html#anchor.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Str "any"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/#anchor." ]
+      ( "http://www.domain.com/dir/#anchor.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Str "any"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "http://www.domain.com/dir/index.html#anchor." ]
+      ( "http://www.domain.com/dir/index.html#anchor.", "" )
+    , Space
+    , Str "any"
+    , Space
+    , Str "text."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com?a=a@a.a&b=a+b+c." ]
+      ( "http://domain.com?a=a@a.a&b=a+b+c.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com?a=a@a.a&b=a+b+c," ]
+      ( "http://domain.com?a=a@a.a&b=a+b+c,", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c." ]
+      ( "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c@." ]
+      ( "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c@.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com?a=a@a.a&b=a+b+c.#anchor" ]
+      ( "http://domain.com?a=a@a.a&b=a+b+c.#anchor", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor" ]
+      ( "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c@.#anchor" ]
+      ( "http://domain.com/bla.cgi?a=a@a.a&b=a+b+c@.#anchor", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://user:password@domain.com/bla.html." ]
+      ( "http://user:password@domain.com/bla.html.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://user:password@domain.com/dir/." ]
+      ( "http://user:password@domain.com/dir/.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://user:password@domain.com." ]
+      ( "http://user:password@domain.com.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://user:@domain.com." ]
+      ( "http://user:@domain.com.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://user@domain.com." ]
+      ( "http://user@domain.com.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor" ]
+      ( "http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor"
+      , ""
+      )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c@#anchor" ]
+      ( "http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c@#anchor"
+      , ""
+      )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label" ]
+      ( "www.domain.com", "" )
+    , SoftBreak
+    , Str "["
+    , Space
+    , Str "label"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "www.domain.com" ]
+      ( "www.domain.com", "" )
+    , Str "]"
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label", Space ]
+      ( "www.domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "anchor", Space ]
+      ( "http://www.domain.com/dir/index.html#anchor.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "login", Space ]
+      ( "http://user:password@domain.com/bla.html", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "form", Space ]
+      ( "http://www.domain.com/bla.cgi?a=a@a.a&b=a+b+c.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "form", Space, Str "&", Space, Str "anchor" ]
+      ( "http://www.domain.com/bla.cgi?a=a@a.a&b=a+b+c.#anchor", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "login", Space, Str "&", Space, Str "form", Space ]
+      ( "http://user:password@domain.com/bla.cgi?a=a@a.a&b=a+b+c.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "local", Space, Str "link", Space, Str "up", Space ]
+      ( "..", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "local", Space, Str "link", Space, Str "file", Space ]
+      ( "bla.html", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "local", Space, Str "link", Space, Str "anchor", Space ]
+      ( "#anchor", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "local", Space, Str "link", Space, Str "file/anchor" ]
+      ( "bla.html#anchor", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "local", Space, Str "link", Space, Str "file/anchor" ]
+      ( "bla.html#anchor.", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "local", Space, Str "link", Space, Str "img", Space ]
+      ( "abc.gif", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "www.fake.com" ]
+      ( "www.domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm" ]
+      ( "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm"
+      , ""
+      )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-" ]
+      ( "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-"
+      , ""
+      )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-#anchor_" ]
+      ( "http://domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-#anchor_"
+      , ""
+      )
+    , Str "-1%."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://foo._user-9:pass!#$%&*()+word@domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-#anchor_" ]
+      ( "http://foo._user-9:pass!#$%&*()+word@domain.com:8080/~user/_st-r@a=n$g,e/index%20new.htm?a=/%22&b=+.@*_-#anchor_"
+      , ""
+      )
+    , Str "-1%."
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "http://L1.com" ]
+      ( "http://L1.com", "" )
+    , Space
+    , Str "!"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "mailto:L2@www.com" ]
+      ( "L2@www.com", "" )
+    , Space
+    , Str "!"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "L3" ]
+      ( "www.com", "" )
+    , Space
+    , Str "!"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "L4" ]
+      ( "w@ww.com", "" )
+    , Space
+    , Str "!"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "www.L5.com" ]
+      ( "www.L5.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "www.domain.com" ]
+      ( "www.domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "www2.domain.com" ]
+      ( "www2.domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "ftp.domain.com" ]
+      ( "ftp.domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "WWW.DOMAIN.COM" ]
+      ( "WWW.DOMAIN.COM", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "FTP.DOMAIN.COM" ]
+      ( "FTP.DOMAIN.COM", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label" ]
+      ( "www.domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label" ]
+      ( "ftp.domain.com", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label" ]
+      ( "WWW.DOMAIN.COM", "" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "label" ]
+      ( "FTP.DOMAIN.COM", "" )
+    , SoftBreak
+    , Str "[label"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "www.domain.com" ]
+      ( "www.domain.com", "" )
+    , Space
+    , Str "]"
+    , SoftBreak
+    , Str "[label]"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "www.domain.com" ]
+      ( "www.domain.com", "" )
+    , Str "]"
+    ]
+  , Header 1
+    ( "image", [], [] )
+    [ Str "Image" ]
+  , Para
+    [ Image ( "", [], [] ) [] ( "img.png", "" ) ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Image ( "", [], [] ) [] ( "img.png", "" ) ]
+      ( "https://txt2tags.org", "" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Space
+    , Str "Image"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line"
+    , Space
+    , Str "beginning."
+    ]
+  , Para
+    [ Str "Image"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "middle"
+    , Space
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line."
+    ]
+  , Para
+    [ Str "Image"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line"
+    , Space
+    , Str "end."
+    , Space
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , SoftBreak
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , SoftBreak
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    ]
+  , Para
+    [ Str "Images"
+    , Space
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Space
+    , Str "mixed"
+    , Space
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Space
+    , Str "with"
+    , Space
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Space
+    , Str "text."
+    ]
+  , Para
+    [ Str "Images"
+    , Space
+    , Str "glued"
+    , Space
+    , Str "together:"
+    , Space
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Image
+      ( "", [], [] ) []
+      ( "img.png", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "[img.png", Space, Str "]" ]
+  , Para
+    [ Str "[", Space, Str "img.png]" ]
+  , Para
+    [ Str "[", Space, Str "img.png", Space, Str "]" ]
+  , Header 1
+    ( "numtitle", [], [] )
+    [ Str "Numbered", Space, Str "Title" ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "2" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "5" ]
+  , Header 1
+    ( "lab_el-1", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "lab_el-2", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "2" ]
+  , Header 3
+    ( "lab_el-3", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 4
+    ( "lab_el-4", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "lab_el-5", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "5" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "lab_el-9", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Para
+    [ Str "+Not", Space, Str "Title" ]
+  , Para
+    [ Str "++Not", Space, Str "Title+" ]
+  , Para
+    [ Str "+++Not"
+    , Space
+    , Str "Title++++"
+    , SoftBreak
+    , Str "++++++Not"
+    , Space
+    , Str "Title"
+    , Space
+    , Str "6++++++"
+    ]
+  , Para
+    [ Str "+++++++Not"
+    , Space
+    , Str "Title"
+    , Space
+    , Str "7+++++++"
+    , SoftBreak
+    , Str "+Not"
+    , Space
+    , Str "Title+"
+    , Space
+    , Str "[label1]"
+    , SoftBreak
+    , Str "+Not"
+    , Space
+    , Str "Title+["
+    , Space
+    , Str "label"
+    , Space
+    , Str "]"
+    , SoftBreak
+    , Str "+Not"
+    , Space
+    , Str "Title+[la/bel]"
+    ]
+  , Header 1
+    ( "title", [], [] )
+    [ Str "Title" ]
+  , Header 1
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "2" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 4
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "5" ]
+  , Header 1
+    ( "lab_el-1", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "lab_el-2", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "2" ]
+  , Header 3
+    ( "lab_el-3", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 4
+    ( "lab_el-4", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "lab_el-5", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "5" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Header 3
+    ( "lab_el-9", [], [] )
+    [ Str "Title", Space, Str "Level", Space, Str "3" ]
+  , Para
+    [ Str "=Not", Space, Str "Title" ]
+  , Para
+    [ Str "==Not", Space, Str "Title=" ]
+  , Para
+    [ Str "===Not"
+    , Space
+    , Str "Title===="
+    , SoftBreak
+    , Str "======Not"
+    , Space
+    , Str "Title"
+    , Space
+    , Str "6======"
+    ]
+  , Para
+    [ Str "=======Not"
+    , Space
+    , Str "Title"
+    , Space
+    , Str "7======="
+    , SoftBreak
+    , Str "=Not"
+    , Space
+    , Str "Title="
+    , Space
+    , Str "[label1]"
+    , SoftBreak
+    , Str "=Not"
+    , Space
+    , Str "Title=["
+    , Space
+    , Str "label"
+    , Space
+    , Str "]"
+    , SoftBreak
+    , Str "=Not"
+    , Space
+    , Str "Title=[la/bel]"
+    ]
+  , Header 1
+    ( "quote", [], [] )
+    [ Str "Quote" ]
+  , BlockQuote
+    [ Para
+      [ Str "To"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "a"
+      , Space
+      , Str "paragraph,"
+      , Space
+      , Str "just"
+      , Space
+      , Str "prefix"
+      , Space
+      , Str "it"
+      , Space
+      , Str "by"
+      , Space
+      , Str "a"
+      , Space
+      , Str "TAB"
+      , SoftBreak
+      , Str "character."
+      , Space
+      , Str "All"
+      , Space
+      , Str "the"
+      , Space
+      , Str "lines"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "must"
+      , SoftBreak
+      , Str "begin"
+      , Space
+      , Str "with"
+      , Space
+      , Str "a"
+      , Space
+      , Str "TAB."
+      ]
+    ]
+  , Para
+    [ Str "Any"
+    , Space
+    , Str "non-tabbed"
+    , Space
+    , Str "line"
+    , Space
+    , Str "closes"
+    , Space
+    , Str "the"
+    , Space
+    , Str "quote"
+    , Space
+    , Str "block."
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "The"
+      , Space
+      , Str "number"
+      , Space
+      , Str "of"
+      , Space
+      , Str "leading"
+      , Space
+      , Str "TABs"
+      , Space
+      , Str "identifies"
+      , Space
+      , Str "the"
+      , Space
+      , Str "quote"
+      , SoftBreak
+      , Str "block"
+      , Space
+      , Str "depth."
+      , Space
+      , Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "level"
+      , Space
+      , Str "1."
+      ]
+    , BlockQuote
+      [ Para
+        [ Str "With"
+        , Space
+        , Str "two"
+        , Space
+        , Str "TABs,"
+        , Space
+        , Str "we"
+        , Space
+        , Str "are"
+        , Space
+        , Str "on"
+        , Space
+        , Str "the"
+        , Space
+        , Str "quote"
+        , SoftBreak
+        , Str "level"
+        , Space
+        , Str "2."
+        ]
+      , BlockQuote
+        [ Para
+          [ Str "The"
+          , Space
+          , Str "more"
+          , Space
+          , Str "TABs,"
+          , Space
+          , Str "more"
+          , Space
+          , Str "deep"
+          , Space
+          , Str "is"
+          , SoftBreak
+          , Str "the"
+          , Space
+          , Str "quote"
+          , Space
+          , Str "level."
+          ]
+        , BlockQuote
+          [ Para
+            [ Str "There"
+            , Space
+            , Str "isn't"
+            , Space
+            , Str "a"
+            , Space
+            , Str "limit."
+            ]
+          ]
+        ]
+      ]
+    ]
+  , BlockQuote
+    [ BlockQuote
+      [ BlockQuote
+        [ BlockQuote
+          [ Para
+            [ Str "This"
+            , Space
+            , Str "quote"
+            , Space
+            , Str "starts"
+            , Space
+            , Str "at"
+            , SoftBreak
+            , Str "level"
+            , Space
+            , Str "4."
+            ]
+          ]
+        , Para
+          [ Str "Then"
+          , Space
+          , Str "its"
+          , Space
+          , Str "depth"
+          , Space
+          , Str "is"
+          , Space
+          , Str "decreased."
+          ]
+        ]
+      , Para
+        [ Str "Counting"
+        , Space
+        , Str "down,"
+        , Space
+        , Str "one"
+        , Space
+        , Str "by"
+        , Space
+        , Str "one."
+        ]
+      ]
+    , Para
+      [ Str "Until"
+      , Space
+      , Str "the"
+      , Space
+      , Str "level"
+      , Space
+      , Str "1."
+      ]
+    ]
+  , BlockQuote
+    [ BlockQuote
+      [ BlockQuote
+        [ Para
+          [ Str "Unlike"
+          , Space
+          , Str "lists,"
+          , Space
+          , Str "any"
+          , Space
+          , Str "quote"
+          , Space
+          , Str "block"
+          , Space
+          , Str "is"
+          , SoftBreak
+          , Str "independent,"
+          , Space
+          , Str "not"
+          , Space
+          , Str "part"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "tree."
+          ]
+        ]
+      ]
+    , Para
+      [ Str "The"
+      , Space
+      , Str "TAB"
+      , Space
+      , Str "count"
+      , Space
+      , Str "don't"
+      , Space
+      , Str "need"
+      , Space
+      , Str "to"
+      , Space
+      , Str "be"
+      , Space
+      , Str "incremental"
+      , SoftBreak
+      , Str "by"
+      , Space
+      , Str "one."
+      ]
+    , BlockQuote
+      [ BlockQuote
+        [ BlockQuote
+          [ Para
+            [ Str "The"
+            , Space
+            , Str "nesting"
+            , Space
+            , Str "don't"
+            , Space
+            , Str "need"
+            , SoftBreak
+            , Str "to"
+            , Space
+            , Str "follow"
+            , Space
+            , Str "any"
+            , Space
+            , Str "rule."
+            ]
+          ]
+        ]
+      , Para
+        [ Str "Quotes"
+        , Space
+        , Str "can"
+        , Space
+        , Str "be"
+        , Space
+        , Str "opened"
+        , Space
+        , Str "and"
+        , Space
+        , Str "closed"
+        , SoftBreak
+        , Str "in"
+        , Space
+        , Str "any"
+        , Space
+        , Str "way."
+        ]
+      , BlockQuote
+        [ BlockQuote
+          [ BlockQuote [ Para [ Str "You", Space, Str "choose." ] ] ]
+        ]
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Some"
+      , Space
+      , Str "targets"
+      , Space
+      , Str "(as"
+      , Space
+      , Str "sgml)"
+      , Space
+      , Str "don't"
+      , Space
+      , Str "support"
+      , Space
+      , Str "the"
+      , SoftBreak
+      , Str "nesting"
+      , Space
+      , Str "of"
+      , Space
+      , Str "quotes."
+      , Space
+      , Str "There"
+      , Space
+      , Str "is"
+      , Space
+      , Str "only"
+      , Space
+      , Str "one"
+      , Space
+      , Str "quote"
+      , SoftBreak
+      , Str "level."
+      ]
+    , BlockQuote
+      [ Para
+        [ Str "In"
+        , Space
+        , Str "this"
+        , Space
+        , Str "case,"
+        , Space
+        , Str "no"
+        , Space
+        , Str "matter"
+        , Space
+        , Str "how"
+        , Space
+        , Str "much"
+        , SoftBreak
+        , Str "TABs"
+        , Space
+        , Str "are"
+        , Space
+        , Str "used"
+        , Space
+        , Str "to"
+        , Space
+        , Str "define"
+        , Space
+        , Str "the"
+        , Space
+        , Str "quote"
+        , SoftBreak
+        , Str "block,"
+        , Space
+        , Str "it"
+        , Space
+        , Str "always"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "level"
+        , Space
+        , Str "1."
+        ]
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Spaces"
+      , Space
+      , Str "AFTER"
+      , Space
+      , Str "the"
+      , Space
+      , Str "TAB"
+      , Space
+      , Str "character"
+      , Space
+      , Str "are"
+      , Space
+      , Str "allowed."
+      , SoftBreak
+      , Str "But"
+      , Space
+      , Str "be"
+      , Space
+      , Str "careful,"
+      , Space
+      , Str "it"
+      , Space
+      , Str "can"
+      , Space
+      , Str "be"
+      , Space
+      , Str "confusing."
+      ]
+    ]
+  , Para
+    [ Str "Spaces"
+    , Space
+    , Str "BEFORE"
+    , Space
+    , Str "the"
+    , Space
+    , Str "TAB"
+    , Space
+    , Str "character"
+    , SoftBreak
+    , Str "invalidate"
+    , Space
+    , Str "the"
+    , Space
+    , Str "mark."
+    , Space
+    , Str "It's"
+    , Space
+    , Str "not"
+    , Space
+    , Str "quote."
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Paragraph"
+      , Space
+      , Str "breaks"
+      , Space
+      , Str "inside"
+      , Space
+      , Str "a"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "aren't"
+      , SoftBreak
+      , Str "possible."
+      ]
+    , Para
+      [ Str "This"
+      , Space
+      , Str "sample"
+      , Space
+      , Str "are"
+      , Space
+      , Str "two"
+      , Space
+      , Str "separated"
+      , Space
+      , Str "quoted"
+      , SoftBreak
+      , Str "paragraphs,"
+      , Space
+      , Str "not"
+      , Space
+      , Str "a"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "block"
+      , Space
+      , Str "with"
+      , SoftBreak
+      , Str "two"
+      , Space
+      , Str "paragraphs"
+      , Space
+      , Str "inside."
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "The"
+      , Space
+      , Str "end"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "file"
+      , Space
+      , Str "(EOF)"
+      , Space
+      , Str "closes"
+      , Space
+      , Str "the"
+      , SoftBreak
+      , Str "currently"
+      , Space
+      , Str "open"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "block."
+      ]
+    ]
+  , Header 1
+    ( "raw", [], [] )
+    [ Str "Raw" ]
+  , Para
+    [ Str "A raw line.\n" ]
+  , Para
+    [ Str "  Another raw line, with leading spaces.\n" ]
+  , Para
+    [ Str "A raw area delimited\n       by lines with marks.\n" ]
+  , Para
+    [ Str "Trailing spaces and TABs after the area marks\nare allowed, but not encouraged nor documented.\n" ]
+  , Para
+    [ Str "\"\"\"Not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "raw"
+    , Space
+    , Str "line,"
+    , Space
+    , Str "need"
+    , Space
+    , Str "one"
+    , Space
+    , Str "space"
+    , Space
+    , Str "after"
+    , Space
+    , Str "mark."
+    ]
+  , Para
+    [ Str "\"\"\""
+    , SoftBreak
+    , Str "Not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "raw"
+    , Space
+    , Str "area."
+    , SoftBreak
+    , Str "The"
+    , Space
+    , Str "marks"
+    , Space
+    , Str "must"
+    , Space
+    , Str "be"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line"
+    , Space
+    , Str "beginning,"
+    , SoftBreak
+    , Str "no"
+    , Space
+    , Str "leading"
+    , Space
+    , Str "spaces."
+    , SoftBreak
+    , Str "\"\"\""
+    ]
+  , Para
+    [ Str "The end of the file (EOF) closes\nthe currently open raw area.\n" ]
+  , Header 1
+    ( "verbatim", [], [] )
+    [ Str "Verbatim" ]
+  , CodeBlock
+    ( "", [], [] ) "A verbatim line.\n"
+  , CodeBlock
+    ( "", [], [] ) "  Another verbatim line, with leading spaces.\n"
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "A verbatim area delimited\n       by lines with marks.\n"
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "Trailing spaces and TABs after the area marks\nare allowed, but not encouraged nor documented.\n"
+  , Para
+    [ Str "```Not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "verbatim"
+    , Space
+    , Str "line,"
+    , Space
+    , Str "need"
+    , Space
+    , Str "one"
+    , Space
+    , Str "space"
+    , Space
+    , Str "after"
+    , Space
+    , Str "mark."
+    ]
+  , Para
+    [ Str "```"
+    , SoftBreak
+    , Str "Not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "verbatim"
+    , Space
+    , Str "area."
+    , SoftBreak
+    , Str "The"
+    , Space
+    , Str "marks"
+    , Space
+    , Str "must"
+    , Space
+    , Str "be"
+    , Space
+    , Str "at"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line"
+    , Space
+    , Str "beginning,"
+    , SoftBreak
+    , Str "no"
+    , Space
+    , Str "leading"
+    , Space
+    , Str "spaces."
+    , SoftBreak
+    , Str "```"
+    ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "The end of the file (EOF) closes\nthe currently open verbatim area.\n"
+  , Header 1
+    ( "deflist", [], [] )
+    [ Str "Definition", Space, Str "List" ]
+  , DefinitionList
+    [
+      (
+        [ Str "Definition", Space, Str "list" ]
+      ,
+        [
+          [ Plain
+            [ Str "A"
+            , Space
+            , Str "list"
+            , Space
+            , Str "with"
+            , Space
+            , Str "terms"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Str "Start"
+        , Space
+        , Str "term"
+        , Space
+        , Str "with"
+        , Space
+        , Str "colon"
+        ]
+      ,
+        [
+          [ Plain
+            [ Str "And"
+            , Space
+            , Str "its"
+            , Space
+            , Str "definition"
+            , Space
+            , Str "follows"
+            ]
+          ]
+        ]
+      )
+    ]
+  , Header 1
+    ( "numlist", [], [] )
+    [ Str "Numbered", Space, Str "List" ]
+  , Para
+    [ Str "See"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "List" ]
+      ( "#list", "" )
+    , Str ","
+    , Space
+    , Str "the"
+    , Space
+    , Str "same"
+    , Space
+    , Str "rules"
+    , Space
+    , Str "apply."
+    ]
+  , Header 1
+    ( "list", [], [] )
+    [ Str "List" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Use"
+        , Space
+        , Str "the"
+        , Space
+        , Str "hyphen"
+        , Space
+        , Str "to"
+        , Space
+        , Str "prefix"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "There"
+        , Space
+        , Str "must"
+        , Space
+        , Str "be"
+        , Space
+        , Str "one"
+        , Space
+        , Str "space"
+        , Space
+        , Str "after"
+        , Space
+        , Str "the"
+        , Space
+        , Str "hyphen."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "The"
+        , Space
+        , Str "list"
+        , Space
+        , Str "is"
+        , Space
+        , Str "closed"
+        , Space
+        , Str "by"
+        , Space
+        , Str "two"
+        , Space
+        , Str "consecutive"
+        , Space
+        , Str "blank"
+        , Space
+        , Str "lines."
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "The"
+        , Space
+        , Str "list"
+        , Space
+        , Str "can"
+        , Space
+        , Str "be"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "on"
+        , Space
+        , Str "the"
+        , Space
+        , Str "source"
+        , Space
+        , Str "document."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "You"
+        , Space
+        , Str "can"
+        , Space
+        , Str "use"
+        , Space
+        , Str "any"
+        , Space
+        , Str "number"
+        , Space
+        , Str "of"
+        , Space
+        , Str "spaces."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "The"
+        , Space
+        , Str "result"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "the"
+        , Space
+        , Str "same."
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Para
+        [ Str "Let"
+        , Space
+        , Str "one"
+        , Space
+        , Str "blank"
+        , Space
+        , Str "line"
+        , Space
+        , Str "between"
+        , Space
+        , Str "the"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "It"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "maintained"
+        , Space
+        , Str "on"
+        , Space
+        , Str "the"
+        , Space
+        , Str "conversion."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "Some"
+        , Space
+        , Str "targets"
+        , Space
+        , Str "don't"
+        , Space
+        , Str "support"
+        , Space
+        , Str "this"
+        , Space
+        , Str "behavior."
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "This"
+        , Space
+        , Str "one"
+        , Space
+        , Str "was"
+        , Space
+        , Str "separated"
+        , Space
+        , Str "by"
+        , Space
+        , Str "a"
+        , Space
+        , Str "line"
+        , Space
+        , Str "with"
+        , Space
+        , Str "blanks."
+        , SoftBreak
+        , Str "You"
+        , Space
+        , Str "can"
+        , Space
+        , Str "also"
+        , Space
+        , Str "put"
+        , Space
+        , Str "a"
+        , Space
+        , Str "blank"
+        , Space
+        , Str "line"
+        , Space
+        , Str "inside"
+        ]
+      , Para
+        [ Str "the"
+        , Space
+        , Str "item"
+        , Space
+        , Str "contents"
+        , Space
+        , Str "and"
+        , Space
+        , Str "it"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "preserved."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "-This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "(no"
+    , Space
+    , Str "space)"
+    ]
+  , Para
+    [ Str "-"
+    , Space
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "(more"
+    , Space
+    , Str "than"
+    , Space
+    , Str "one"
+    , Space
+    , Str "space)"
+    ]
+  , Para
+    [ Str "-"
+    , Space
+    , Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "(a"
+    , Space
+    , Str "TAB"
+    , Space
+    , Str "instead"
+    , Space
+    , Str "the"
+    , Space
+    , Str "space)"
+    ]
+  , BulletList
+    [
+      [ BulletList
+        [
+          [ Plain
+            [ Str "This"
+            , Space
+            , Str "is"
+            , Space
+            , Str "a"
+            , Space
+            , Str "list"
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "This"
+            , Space
+            , Str "is"
+            , Space
+            , Str "a"
+            , Space
+            , Str "list"
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ DefinitionList
+        [
+          (
+            [ Str "This"
+            , Space
+            , Str "is"
+            , Space
+            , Str "a"
+            , Space
+            , Str "list"
+            ]
+          , [ [] ]
+          )
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "the"
+        , Space
+        , Str "\"mother\""
+        , Space
+        , Str "list"
+        , Space
+        , Str "first"
+        , Space
+        , Str "item."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Here"
+        , Space
+        , Str "is"
+        , Space
+        , Str "the"
+        , Space
+        , Str "second,"
+        , Space
+        , Str "but"
+        , Space
+        , Str "inside"
+        , Space
+        , Str "this"
+        , Space
+        , Str "item,"
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "there"
+            , Space
+            , Str "is"
+            , Space
+            , Str "a"
+            , Space
+            , Str "sublist,"
+            , Space
+            , Str "with"
+            , Space
+            , Str "its"
+            , Space
+            , Str "own"
+            , Space
+            , Str "items."
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Note"
+            , Space
+            , Str "that"
+            , Space
+            , Str "the"
+            , Space
+            , Str "items"
+            , Space
+            , Str "of"
+            , Space
+            , Str "the"
+            , Space
+            , Str "same"
+            , Space
+            , Str "sublist"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "must"
+            , Space
+            , Str "have"
+            , Space
+            , Str "the"
+            , Space
+            , Str "same"
+            , Space
+            , Str "indentation."
+            ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "And"
+                , Space
+                , Str "this"
+                , Space
+                , Str "can"
+                , Space
+                , Str "go"
+                , Space
+                , Str "on,"
+                , Space
+                , Str "opening"
+                , Space
+                , Str "sublists."
+                ]
+              , BulletList
+                [
+                  [ Plain
+                    [ Str "Just"
+                    , Space
+                    , Str "add"
+                    , Space
+                    , Str "leading"
+                    , Space
+                    , Str "spaces"
+                    , Space
+                    , Str "before"
+                    , Space
+                    , Str "the"
+                    ]
+                  ]
+                ,
+                  [ Plain
+                    [ Str "hyphen"
+                    , Space
+                    , Str "and"
+                    , Space
+                    , Str "sublists"
+                    , Space
+                    , Str "will"
+                    , Space
+                    , Str "be"
+                    , Space
+                    , Str "opened."
+                    ]
+                  ]
+                ,
+                  [ Plain
+                    [ Str "The"
+                    , Space
+                    , Str "two"
+                    , Space
+                    , Str "blank"
+                    , Space
+                    , Str "lines"
+                    , Space
+                    , Str "closes"
+                    , Space
+                    , Str "them"
+                    , Space
+                    , Str "all."
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "When"
+        , Space
+        , Str "nesting"
+        , Space
+        , Str "lists,"
+        , Space
+        , Str "the"
+        , Space
+        , Str "additional"
+        , Space
+        , Str "spaces"
+        , Space
+        , Str "are"
+        , Space
+        , Str "free."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "You"
+        , Space
+        , Str "can"
+        , Space
+        , Str "add"
+        , Space
+        , Str "just"
+        , Space
+        , Str "one,"
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "or", Space, Str "many." ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "What"
+                , Space
+                , Str "matters"
+                , Space
+                , Str "is"
+                , Space
+                , Str "to"
+                , Space
+                , Str "put"
+                , Space
+                , Str "more"
+                , Space
+                , Str "than"
+                , Space
+                , Str "the"
+                , Space
+                , Str "previous."
+                ]
+              ]
+            ,
+              [ Plain
+                [ Str "But"
+                , Space
+                , Str "remember"
+                , Space
+                , Str "that"
+                , Space
+                , Str "the"
+                , Space
+                , Str "other"
+                , Space
+                , Str "items"
+                , Space
+                , Str "of"
+                , Space
+                , Str "the"
+                , Space
+                , Str "same"
+                , Space
+                , Str "list"
+                ]
+              ]
+            ,
+              [ Plain
+                [ Str "must"
+                , Space
+                , Str "use"
+                , Space
+                , Str "the"
+                , Space
+                , Str "same"
+                , Space
+                , Str "indentation."
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "There"
+        , Space
+        , Str "is"
+        , Space
+        , Str "not"
+        , Space
+        , Str "a"
+        , Space
+        , Str "depth"
+        , Space
+        , Str "limit,"
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "you"
+            , Space
+            , Str "can"
+            , Space
+            , Str "go"
+            , Space
+            , Str "deeper"
+            , Space
+            , Str "and"
+            , Space
+            , Str "deeper."
+            ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "But"
+                , Space
+                , Str "some"
+                , Space
+                , Str "targets"
+                , Space
+                , Str "may"
+                , Space
+                , Str "have"
+                , Space
+                , Str "restrictions."
+                ]
+              , BulletList
+                [
+                  [ Plain
+                    [ Str "The"
+                    , Space
+                    , Str "LaTeX"
+                    , Space
+                    , Str "maximum"
+                    , Space
+                    , Str "is"
+                    , Space
+                    , Str "here,"
+                    , Space
+                    , Str "4"
+                    , Space
+                    , Str "levels."
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Reverse"
+        , Space
+        , Str "nesting"
+        , Space
+        , Str "doesn't"
+        , Space
+        , Str "work."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Because"
+        , Space
+        , Str "a"
+        , Space
+        , Str "sublist"
+        , Space
+        , Str "*must*"
+        , Space
+        , Str "have"
+        , Space
+        , Str "a"
+        , Space
+        , Str "mother"
+        , Space
+        , Str "list."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "It's"
+        , Space
+        , Str "the"
+        , Space
+        , Str "list"
+        , Space
+        , Str "concept,"
+        , Space
+        , Str "not"
+        , Space
+        , Str "a"
+        , Space
+        , Str "txt2tags"
+        , Space
+        , Str "limitation."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "All"
+        , Space
+        , Str "this"
+        , Space
+        , Str "sublists"
+        , Space
+        , Str "will"
+        , Space
+        , Str "be"
+        , Space
+        , Str "bumped"
+        , Space
+        , Str "to"
+        , Space
+        , Str "mother"
+        , Space
+        , Str "lists."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "At"
+        , Space
+        , Str "level"
+        , Space
+        , Str "1,"
+        , Space
+        , Str "like"
+        , Space
+        , Str "this"
+        , Space
+        , Str "one."
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Level", Space, Str "1" ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "Level", Space, Str "2" ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "Level", Space, Str "3" ]
+              , BulletList
+                [ [ Plain [ Str "Level", Space, Str "4" ] ] ]
+              ]
+            ,
+              [ Plain
+                [ Str "Level"
+                , Space
+                , Str "3"
+                , Space
+                , Str "--"
+                , Space
+                , Str "(closed"
+                , Space
+                , Str "Level"
+                , Space
+                , Str "4)"
+                ]
+              ]
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Level"
+            , Space
+            , Str "2"
+            , Space
+            , Str "--"
+            , Space
+            , Str "(closed"
+            , Space
+            , Str "Level"
+            , Space
+            , Str "3)"
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Level"
+        , Space
+        , Str "1"
+        , Space
+        , Str "--"
+        , Space
+        , Str "(closed"
+        , Space
+        , Str "Level"
+        , Space
+        , Str "2)"
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Level", Space, Str "1" ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "Level", Space, Str "2" ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "Level", Space, Str "3" ]
+              , BulletList
+                [ [ Plain [ Str "Level", Space, Str "4" ] ] ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Level"
+        , Space
+        , Str "1"
+        , Space
+        , Str "--"
+        , Space
+        , Str "(closed"
+        , Space
+        , Str "Level"
+        , Space
+        , Str "4,"
+        , Space
+        , Str "Level"
+        , Space
+        , Str "3"
+        , Space
+        , Str "and"
+        , Space
+        , Str "Level"
+        , Space
+        , Str "2)"
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Para
+        [ Str "Level", Space, Str "1" ]
+      , BulletList
+        [
+          [ Para
+            [ Str "Level"
+            , Space
+            , Str "2"
+            , Space
+            , Str "--"
+            , Space
+            , Str "blank"
+            , Space
+            , Str "BEFORE"
+            , Space
+            , Str "and"
+            , Space
+            , Str "AFTER"
+            , Space
+            , Str "(in)"
+            ]
+          , BulletList
+            [ [ Plain [ Str "Level", Space, Str "3" ] ] ]
+          ]
+        ]
+      ]
+    ]
+  , BulletList
+    [ [ Plain [ Str "Level", Space, Str "4" ] ] ]
+  , BulletList
+    [
+      [ Para [ Str "Level", Space, Str "3" ] ]
+    ,
+      [ Para
+        [ Str "Level"
+        , Space
+        , Str "2"
+        , Space
+        , Str "--"
+        , Space
+        , Str "blank"
+        , Space
+        , Str "BEFORE"
+        , Space
+        , Str "and"
+        , Space
+        , Str "AFTER"
+        , Space
+        , Str "(out)"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "Level", Space, Str "1" ]
+      , BulletList
+        [
+          [ Para
+            [ Str "Level"
+            , Space
+            , Str "2"
+            , Space
+            , Str "--"
+            , Space
+            , Str "blank"
+            , Space
+            , Str "BEFORE"
+            , Space
+            , Str "(spaces)"
+            , Space
+            , Str "and"
+            , Space
+            , Str "AFTER"
+            , Space
+            , Str "(TAB)"
+            ]
+          , BulletList
+            [ [ Plain [ Str "Level", Space, Str "3" ] ] ]
+          ]
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Level", Space, Str "1" ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "Level", Space, Str "2" ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "Level", Space, Str "3" ]
+              , BulletList
+                [
+                  [ Plain [ Str "Level", Space, Str "4" ] ]
+                ,
+                  [ Plain
+                    [ Str "Level", Space, Str "3.5", Space, Str "???" ]
+                  ]
+                ]
+              ]
+            ,
+              [ Plain [ Str "Level", Space, Str "3" ] ]
+            ,
+              [ Plain
+                [ Str "Level", Space, Str "2.5", Space, Str "???" ]
+              ]
+            ]
+          ]
+        ,
+          [ Plain [ Str "Level", Space, Str "2" ] ]
+        ,
+          [ Plain [ Str "Level", Space, Str "1.5", Space, Str "???" ] ]
+        ]
+      ]
+    ,
+      [ Plain [ Str "Level", Space, Str "1" ] ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "This"
+        , Space
+        , Str "list"
+        , Space
+        , Str "is"
+        , Space
+        , Str "closed"
+        , Space
+        , Str "by"
+        , Space
+        , Str "a"
+        , Space
+        , Str "line"
+        , Space
+        , Str "with"
+        , Space
+        , Str "spaces"
+        , Space
+        , Str "and"
+        , Space
+        , Str "other"
+        , Space
+        , Str "with"
+        , Space
+        , Str "TABs"
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "This"
+        , Space
+        , Str "list"
+        , Space
+        , Str "is"
+        , Space
+        , Str "NOT"
+        , Space
+        , Str "closed"
+        , Space
+        , Str "by"
+        , Space
+        , Str "two"
+        , Space
+        , Str "comment"
+        , Space
+        , Str "lines"
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "This"
+        , Space
+        , Str "list"
+        , Space
+        , Str "is"
+        , Space
+        , Str "closed"
+        , Space
+        , Str "by"
+        , Space
+        , Str "a"
+        , Space
+        , Str "line"
+        , Space
+        , Str "with"
+        , Space
+        , Str "spaces"
+        , Space
+        , Str "and"
+        , Space
+        , Str "TAB,"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "then"
+        , Space
+        , Str "a"
+        , Space
+        , Str "comment"
+        , Space
+        , Str "line,"
+        , Space
+        , Str "then"
+        , Space
+        , Str "an"
+        , Space
+        , Str "empty"
+        , Space
+        , Str "line."
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Level", Space, Str "1" ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "Level", Space, Str "2" ]
+          , BulletList
+            [ [ Plain [ Str "Level", Space, Str "3" ] ] ]
+          , Plain
+            [ Str "-", SoftBreak, Str "Level", Space, Str "2" ]
+          ]
+        ]
+      , Plain
+        [ Str "-", SoftBreak, Str "Level", Space, Str "1" ]
+      ]
+    ]
+  , Para
+    [ Str "-" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Empty"
+        , Space
+        , Str "item"
+        , Space
+        , Str "with"
+        , Space
+        , Str "trailing"
+        , Space
+        , Str "spaces."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "-" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Empty"
+        , Space
+        , Str "item"
+        , Space
+        , Str "with"
+        , Space
+        , Str "trailing"
+        , Space
+        , Str "TAB."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "-" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "If"
+        , Space
+        , Str "the"
+        , Space
+        , Str "end"
+        , Space
+        , Str "of"
+        , Space
+        , Str "the"
+        , Space
+        , Str "file"
+        , Space
+        , Str "(EOF)"
+        , Space
+        , Str "is"
+        , Space
+        , Str "hit,"
+        ]
+      , BulletList
+        [
+          [ Plain
+            [ Str "all"
+            , Space
+            , Str "the"
+            , Space
+            , Str "currently"
+            , Space
+            , Str "opened"
+            , Space
+            , Str "list"
+            , Space
+            , Str "are"
+            , Space
+            , Str "closed,"
+            ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "just"
+                , Space
+                , Str "like"
+                , Space
+                , Str "when"
+                , Space
+                , Str "using"
+                , Space
+                , Str "the"
+                , Space
+                , Str "two"
+                , Space
+                , Str "blank"
+                , Space
+                , Str "lines."
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 1
+    ( "table", [], [] )
+    [ Str "Table" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [ ( AlignRight, ColWidthDefault ) ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "1" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignRight, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "3" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "3" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "||"
+    , Space
+    , Str "Cell"
+    , Space
+    , Str "1"
+    , Space
+    , Str "|"
+    , Space
+    , Str "Cell"
+    , Space
+    , Str "2"
+    , Space
+    , Str "|"
+    , Space
+    , Str "Cell"
+    , Space
+    , Str "3"
+    , Space
+    , Str "|"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Cell", Space, Str "3" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Heading" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Heading" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Heading" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "<-" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "--" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "->" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "--" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "--" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "--" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "->" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "--" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "<-" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3+4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1+2+3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2+3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1+2+3+4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "7" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "8" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "A" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "B" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "D" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "E" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "F" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Jan" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Fev" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Mar" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Apr" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "May" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "20%" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "40%" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "60%" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "80%" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "100%" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "/" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            , Space
+            , Str "/"
+            ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "o" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "o" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "." ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain
+            [ Str "=", Space, Str "=", Space, Str "=", Space, Str "=" ]
+          ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "01" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "02" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "05" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "07" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "11" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "13" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "16" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "17" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "19" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "20" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "23" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "25" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "26" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "29" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "30" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "32" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "35" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "37" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "39" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "40" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ,
+      ( AlignCenter, ColWidthDefault )
+    ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "7" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "8" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "9" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "A" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "B" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "C" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "D" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "E" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "F" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "0" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "3" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "4" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "5" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "6" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "7" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "8" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "9" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "A" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "B" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "C" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "D" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "E" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "F" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [ ( AlignCenter, ColWidthDefault ) ]
+    ( TableHead ( "", [], [] ) [] )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Para
+    [ Str "|this|is|not|a|table|" ]
+  , Para
+    [ Str "|this|"
+    , Space
+    , Str "is|"
+    , Space
+    , Str "not|"
+    , Space
+    , Str "a|"
+    , Space
+    , Str "table|"
+    ]
+  , Para
+    [ Str "|this"
+    , Space
+    , Str "|is"
+    , Space
+    , Str "|not"
+    , Space
+    , Str "|a"
+    , Space
+    , Str "|table"
+    , Space
+    , Str "|"
+    ]
+  , Para
+    [ Str "|"
+    , Space
+    , Str "this\t|"
+    , Space
+    , Str "is\t|"
+    , Space
+    , Str "not\t|"
+    , Space
+    , Str "a\t|"
+    , Space
+    , Str "table\t|"
+    ]
+  , HorizontalRule
+  , Para
+    [ Str "The", Space, Str "End." ]
+  ]

--- a/test/vimwiki-reader.native
+++ b/test/vimwiki-reader.native
@@ -1,449 +1,2419 @@
-Pandoc (Meta {unMeta = fromList [("date",MetaInlines [Str "2017-05-01"]),("title",MetaInlines [Str "title"])]})
-[Header 1 ("implemented",[],[]) [Emph [Span ("implemented",[],[]) [],Strong [Str "implemented"]]]
-,Header 1 ("header",[],[]) [Str "header"]
-,Header 2 ("header level two",[],[]) [Str "header",Space,Str "level",Space,Str "two"]
-,Header 3 ("header level 3",[],[]) [Str "header",Space,Code ("",[],[]) "level",Space,Str "3"]
-,Header 4 ("header level four",[],[]) [Str "header",Space,Strikeout [Str "level"],Space,Str "four"]
-,Header 5 ("header level 5",[],[]) [Str "header",Space,Emph [Span ("level",[],[]) [],Strong [Str "level"],Space,Str "5"]]
-,Header 6 ("header level 6",[],[]) [Str "header",Space,Str "level",Space,Str "6"]
-,Para [Str "=======",Space,Str "not",Space,Str "a",Space,Str "header",Space,Str "========"]
-,Para [Str "hi==",Space,Str "not",Space,Str "a",Space,Str "header",Space,Str "=="]
-,Para [Str "===",Space,Str "not",Space,Str "a",Space,Str "header",Space,Str "=="]
-,Para [Str "===",Space,Str "not",Space,Str "a",Space,Str "header",Space,Str "===-"]
-,Para [Str "not",Space,Str "a",Space,Str "header:"]
-,Para [Str "=n="]
-,Para [Str "===",Space,Str "not",Space,Str "a",Space,Str "header",Space,Str "===="]
-,Header 2 ("centred header",["justcenter"],[]) [Str "centred",Space,Str "header"]
-,Header 2 ("header with some == in between",[],[]) [Str "header",Space,Str "with",Space,Str "some",Space,Code ("",[],[]) "==",Space,Str "in",Space,Str "between"]
-,Header 2 ("header with some == in between",[],[]) [Str "header",Space,Str "with",Space,Str "some",Space,Str "==",Space,Str "in",Space,Str "between"]
-,Header 2 ("header with some ==in between",[],[]) [Str "header",Space,Str "with",Space,Str "some",Space,Str "==in",Space,Str "between"]
-,Header 2 ("emph strong and strikeout",[],[]) [Str "emph",Space,Str "strong",Space,Str "and",Space,Str "strikeout"]
-,Para [Emph [Str "emph"],Space,Span ("strong",[],[]) [],Strong [Str "strong"]]
-,Para [Span ("strong and emph",[],[]) [],Strong [Emph [Str "strong",Space,Str "and",Space,Str "emph"]]]
-,Para [Emph [Span ("emph and strong",[],[]) [],Strong [Str "emph",Space,Str "and",Space,Str "strong"]]]
-,Para [Span ("emph inside strong",[],[]) [],Strong [Emph [Str "emph",Space,Str "inside"],Space,Str "strong"]]
-,Para [Span ("strong with emph",[],[]) [],Strong [Str "strong",Space,Str "with",Space,Emph [Str "emph"]]]
-,Para [Emph [Span ("strong inside",[],[]) [],Strong [Str "strong",Space,Str "inside"],Space,Str "emph"]]
-,Para [Emph [Strikeout [Str "strikeout"],Space,Str "inside",Space,Str "emph"]]
-,Para [Strikeout [Str "This",Space,Str "is",Space,Emph [Str "struck",Space,Str "out"],Space,Str "with",Space,Str "emph"]]
-,Para [Str "*not",SoftBreak,Str "strong*"]
-,Para [Str "just",Space,Str "two",Space,Str "stars:",Space,Str "**"]
-,Para [Str "just",Space,Str "two",Space,Str "underscores:",Space,Str "__"]
-,Para [Str "just",Space,Str "four",Space,Str "~s:",Space,Str "~~~~"]
-,Para [Str "_not",SoftBreak,Str "emph_"]
-,Para [Str "~~not",SoftBreak,Str "strikeout~~"]
-,Header 2 ("horizontal rule",[],[]) [Str "horizontal",Space,Str "rule"]
-,Para [Str "top"]
-,HorizontalRule
-,Para [Str "middle"]
-,HorizontalRule
-,Para [Str "not",Space,Str "a",Space,Str "rule-----"]
-,Para [Str "not",Space,Str "a",Space,Str "rule",Space,Str "(trailing",Space,Str "spaces):",SoftBreak,Str "-----"]
-,Para [Str "not",Space,Str "a",Space,Str "rule",Space,Str "(leading",Space,Str "spaces):",SoftBreak,Str "----"]
-,Header 2 ("comments",[],[]) [Str "comments"]
-,Para [Str "this",SoftBreak,Str "is",Space,Str "%%",Space,Str "not",Space,Str "secret"]
-,Header 2 ("inline code",[],[]) [Str "inline",Space,Str "code"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Code ("",[],[]) "inline code",Str "."]
-,Para [Str "Just",Space,Str "two",Space,Str "backticks:",Space,Str "``"]
-,Header 2 ("preformatted text",[],[]) [Str "preformatted",Space,Str "text"]
-,CodeBlock ("",[],[]) "  Tyger! Tyger! burning bright\n   In the forests of the night,\n    What immortal hand or eye\n     Could frame thy fearful symmetry?\n  In what distant deeps or skies\n   Burnt the fire of thine eyes?\n    On what wings dare he aspire?\n     What the hand dare sieze the fire?"
-,Header 3 ("preformatted text with attributes",[],[]) [Str "preformatted",Space,Str "text",Space,Str "with",Space,Str "attributes"]
-,CodeBlock ("",[],[("class","python"),("style","color:blue")]) " for i in range(1, 5):\n     print(i)"
-,Header 3 ("preformatted text with nested syntax",[],[]) [Str "preformatted",Space,Str "text",Space,Str "with",Space,Str "nested",Space,Str "syntax"]
-,CodeBlock ("",["sql"],[]) "SELECT * FROM table"
-,Header 3 ("empty preformatted text",[],[]) [Str "empty",Space,Str "preformatted",Space,Str "text"]
-,CodeBlock ("",[],[]) ""
-,Header 2 ("block quotes",[],[]) [Str "block",Space,Str "quotes"]
-,BlockQuote
- [Plain [Str "(indentation",Space,Str "4",Space,Str "spaces)",Space,Str "This",Space,Str "would",Space,Str "be",Space,Str "a",Space,Str "blockquote",Space,Str "in",Space,Str "Vimwiki.",Space,Str "It",Space,Str "is",Space,Str "not",Space,Span ("highlighted",[],[]) [],Strong [Str "highlighted"],Space,Str "in",Space,Str "Vim",Space,Str "but",SoftBreak,Str "(indentation",Space,Str "1",Space,Str "space",Space,Str "followed",Space,Str "by",Space,Str "1",Space,Str "tab",Space,Str "of",Space,Str "width",Space,Str "4)",Space,Str "could",Space,Str "be",Space,Str "styled",Space,Str "by",Space,Str "CSS",Space,Str "in",Space,Str "HTML.",Space,Str "Blockquotes",Space,Str "are",Space,Str "usually",Space,Str "used",Space,Str "to",Space,Str "quote",Space,Str "a",SoftBreak,Str "(indentation",Space,Str "1",Space,Str "tab",Space,Str "of",Space,Str "width",Space,Str "4)",Space,Str "long",Space,Str "piece",Space,Str "of",Space,Str "text",Space,Str "from",Space,Str "another",Space,Str "source.",Space,Strikeout [Str "blah",Space,Str "blah"],Space,Span ("-blockquote",[],[]) [Str ""],Span ("blockquote",["tag"],[]) [Str "blockquote"]]]
-,Header 2 ("external links",[],[]) [Str "external",Space,Str "links"]
-,Para [Link ("",[],[]) [Emph [Str "Google"],Space,Str "search",Space,Str "engine"] ("http://google.com","")]
-,Para [Link ("",[],[]) [Str "http://pandoc.org"] ("http://pandoc.org","")]
-,Para [Link ("",[],[]) [Str "ftp://vim.org"] ("ftp://vim.org","")]
-,Para [Link ("",[],[]) [Str "http://google.com"] ("http://google.com","")]
-,Para [Link ("",[],[]) [Str "email",Space,Str "me"] ("mailto:info@example.org","")]
-,Para [Link ("",[],[]) [Str "mailto:hello@bye.com"] ("mailto:hello@bye.com","")]
-,Header 2 ("internal links",[],[]) [Str "internal",Space,Str "links"]
-,Para [Link ("",[],[]) [Str "This is a link"] ("This is a link","wikilink")]
-,Para [Link ("",[],[]) [Str "Description",Space,Str "of",Space,Str "the",Space,Str "link"] ("This is a link source","wikilink")]
-,Para [Link ("",[],[]) [Str "projects/Important Project 1"] ("projects/Important Project 1","wikilink"),SoftBreak,Link ("",[],[]) [Str "../index"] ("../index","wikilink"),SoftBreak,Link ("",[],[]) [Str "Other",Space,Str "files"] ("a subdirectory/","wikilink")]
-,Para [Link ("",[],[]) [Str "try",Space,Str "me",Space,Str "to",Space,Str "test",Space,Str "tag",Space,Str "anchors"] ("#tag-one","wikilink")]
-,Para [Link ("",[],[]) [Str "try",Space,Str "me",Space,Str "to",Space,Str "test",Space,Str "header",Space,Str "anchors"] ("#block quotes","wikilink")]
-,Para [Link ("",[],[]) [Str "try",Space,Str "me",Space,Str "to",Space,Str "test",Space,Str "strong",Space,Str "anchors"] ("#strong","wikilink")]
-,Para [Link ("",[],[]) [Str "Tasks",Space,Str "for",Space,Str "tomorrow"] ("Todo List#Tomorrow","wikilink")]
-,Para [Link ("",[],[]) [Str "diary:2017-05-01"] ("diary/2017-05-01","wikilink")]
-,Para [Link ("",[],[]) [Str "Important",Space,Str "Data"] ("file:../assets/data.csv","")]
-,Header 3 ("links with thumbnails",[],[]) [Str "links",Space,Str "with",Space,Str "thumbnails"]
-,Para [Link ("",[],[]) [Image ("",[],[]) [Str ""] ("./movie.jpg","")] ("http://www.google.com","")]
-,Header 2 ("images",[],[]) [Str "images"]
-,Para [Image ("",[],[]) [Str ""] ("file:./lalune.jpg","")]
-,Para [Image ("",[],[]) [Str "Vimwiki"] ("http://vimwiki.googlecode.com/hg/images/vimwiki_logo.png",""),SoftBreak,Image ("",[],[]) [Str ""] ("file:./movie.jpg","")]
-,Header 3 ("image with attributes",[],[]) [Str "image",Space,Str "with",Space,Str "attributes"]
-,Para [Image ("",[],[("style","width:150px;height:120px;")]) [Emph [Str "cool",Space,Str "stuff"]] ("lalune.jpg","")]
-,Para [Image ("",[],[("style","font-color:red")]) [Span ("Non-existing",[],[]) [],Strong [Str "Non-existing"],Space,Str "image"] ("nonexist.jpg","")]
-,Para [Image ("",[],[("style","width:150px;height:120px;")]) [Emph [Str "cool",Space,Str "stuff"]] ("lalune.jpg","")]
-,Header 2 ("lists",[],[]) [Str "lists"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "ordered",Space,Str "list",Space,Str "item",Space,Str "1,",Space,Str "and",Space,Str "here",Space,Str "is",Space,Str "some",Space,Str "math",Space,Str "belonging",Space,Str "to",Space,Str "list",Space,Str "item",Space,Str "1"]
-  ,Para [Math DisplayMath "a^2 + b^2 = c^2"]
-  ,Plain [Str "and",Space,Str "some",Space,Str "preformatted",Space,Str "and",Space,Str "tables",Space,Str "belonging",Space,Str "to",Space,Str "item",Space,Str "1",Space,Str "as",Space,Str "well"]
-  ,CodeBlock ("",[],[]) "I'm part of item 1."
-  ,Table ("",[],[]) (Caption Nothing
-   [])
-   [(AlignDefault,ColWidthDefault)
-   ,(AlignDefault,ColWidthDefault)]
-   (TableHead ("",[],[])
-   [Row ("",[],[])
-    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     []
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     []]])
-   [(TableBody ("",[],[]) (RowHeadColumns 0)
-    []
-    [Row ("",[],[])
-     [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-      [Plain [Str "this",Space,Str "table"]]
-     ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-      [Plain [Str "is"]]]
-    ,Row ("",[],[])
-     [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-      [Plain [Str "also",Space,Str "a",Space,Str "part"]]
-     ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-      [Plain [Str "of",Space,Str "item",Space,Str "1"]]]])]
-   (TableFoot ("",[],[])
-   [])
-  ,Plain [Str "and",Space,Str "some",Space,Str "more",Space,Str "text",Space,Str "belonging",Space,Str "to",Space,Str "item",Space,Str "1."]]
- ,[Plain [Str "ordered",Space,Str "list",Space,Str "item",Space,Str "2"]]]
-,BulletList
- [[Plain [Str "Bulleted",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Bulleted",Space,Str "list",Space,Str "item",Space,Str "2"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Bulleted",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "the",Space,Str "#",Space,Str "become",Space,Str "numbers",Space,Str "when",Space,Str "converted",Space,Str "to",Space,Str "HTML"]]]
-,BulletList
- [[Plain [Str "Bulleted",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Bulleted",Space,Str "list",Space,Str "item",Space,Str "2"]]]
-,BulletList
- [[Plain [Str "Item",Space,Str "1"]]
- ,[Plain [Str "Item",Space,Str "2"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "Sub",Space,Str "item",Space,Str "1",Space,Str "(indentation",Space,Str "4",Space,Str "spaces)",SoftBreak,Str "Sub",Space,Str "item",Space,Str "1",Space,Str "continued",Space,Str "line.",SoftBreak,Str "Sub",Space,Str "item",Space,Str "1",Space,Str "next",Space,Str "continued",Space,Str "line."]]
-   ,[Plain [Str "Sub",Space,Str "item",Space,Str "2,",Space,Str "as",Space,Str "an",Space,Str "ordered",Space,Str "list",Space,Str "item",Space,Str "even",Space,Str "though",Space,Str "the",Space,Str "identifier",Space,Str "is",Space,Code ("",[],[]) "*",Space,Str "(indentation",Space,Str "2",Space,Str "spaces",Space,Str "followed",Space,Str "by",Space,Str "one",Space,Str "tab",Space,Str "of",Space,Str "width",Space,Str "4)"]]
-   ,[Plain [Str "etc.",SoftBreak,Str "Continuation",Space,Str "of",Space,Str "Item",Space,Str "2",SoftBreak,Str "Next",Space,Str "continuation",Space,Str "of",Space,Str "Item",Space,Str "2"]]]]]
-,Para [Str "But",Space,Str "this",Space,Str "is",Space,Str "a",Space,Str "new",Space,Str "paragraph."]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "1"]
-  ,BulletList
-   [[Plain [Code ("",[],[]) "1.1"]]]]
- ,[Plain [Str "2"]
-  ,BulletList
-   [[Plain [Str "2.1"]]]]]
-,BulletList
- [[Plain [Str "3"]]]
-,Header 3 ("ordered lists with non-# identifiers",[],[]) [Str "ordered",Space,Str "lists",Space,Str "with",Space,Str "non-#",Space,Str "identifiers"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "2"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "3"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "2"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "3"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "2"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "3"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "2"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "3"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "2"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "3"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "2"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "3"]]]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "2"]]
- ,[Plain [Str "Numbered",Space,Str "list",Space,Str "item",Space,Str "3"]]]
-,BulletList
- [[Plain [Str "Bulleted",Space,Str "list",Space,Str "item",Space,Str "1"]]
- ,[Plain [Str "Bulleted",Space,Str "list",Space,Str "item",Space,Str "2"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "Numbered",Space,Str "list",Space,Str "sub",Space,Str "item",Space,Str "1"]]
-   ,[Plain [Str "more",Space,Str "..."]
-    ,BulletList
-     [[Plain [Str "and",Space,Str "more",Space,Str "..."]]
-     ,[Plain [Str "..."]]]]
-   ,[Plain [Str "Numbered",Space,Str "list",Space,Str "sub",Space,Str "item",Space,Str "3"]
-    ,OrderedList (1,DefaultStyle,DefaultDelim)
-     [[Plain [Str "Numbered",Space,Str "list",Space,Str "sub",Space,Str "sub",Space,Str "item",Space,Str "1"]]
-     ,[Plain [Str "Numbered",Space,Str "list",Space,Str "sub",Space,Str "sub",Space,Str "item",Space,Str "2"]]]]
-   ,[Plain [Str "etc."]]]]
- ,[Plain [Str "Bulleted",Space,Str "list",Space,Str "item",Space,Str "3"]]]
-,Header 2 ("todo lists",[],[]) [Str "todo",Space,Str "lists"]
-,BulletList
- [[Plain [Span ("",["done0"],[]) [],Str "task",Space,Str "1"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Span ("",["done1"],[]) [],Str "5"]]]]
- ,[Plain [Span ("",["done2"],[]) [],Str "3"]]
- ,[Plain [Str "[]",Space,Str "not",Space,Str "a",Space,Str "todo",Space,Str "item"]]
- ,[Plain [Str "[",Space,Str "]not",Space,Str "a",Space,Str "todo",Space,Str "item"]]
- ,[Plain [Str "[r]",Space,Str "not",Space,Str "a",Space,Str "todo",Space,Str "item"]]
- ,[Plain [Str "[",Space,Str "]",Space,Str "not",Space,Str "a",Space,Str "todo",Space,Str "item"]]
- ,[Plain [Span ("",["done2"],[]) [],Str "a",Space,Str "tab",Space,Str "in",Space,Str "the",Space,Str "todo",Space,Str "list",Space,Str "marker",Space,Code ("",[],[]) "[ ]"]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Span ("",["done3"],[]) [],Str "4",SoftBreak,Str "5"]]
-   ,[Plain [Span ("",["done4"],[]) []]
-    ,Table ("",[],[]) (Caption Nothing
-     [])
-     [(AlignDefault,ColWidthDefault)
-     ,(AlignDefault,ColWidthDefault)]
-     (TableHead ("",[],[])
-     [Row ("",[],[])
-      [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-       []
-      ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-       []]])
-     [(TableBody ("",[],[]) (RowHeadColumns 0)
-      []
-      [Row ("",[],[])
-       [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-        [Plain [Str "a"]]
-       ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-        [Plain [Str "b"]]]])]
-     (TableFoot ("",[],[])
-     [])]]]
- ,[Plain [Span ("",["done4"],[]) [],Str "task",Space,Str "2"]]]
-,Header 2 ("math",[],[]) [Str "math"]
-,Para [Math InlineMath " \\sum_i a_i^2 = 1 "]
-,Para [Math DisplayMath "\\sum_i a_i^2\n=\n1"]
-,Para [Math DisplayMath "\\begin{aligned}\n\\sum_i a_i^2 &= 1 + 1 \\\\\n&= 2.\n\\end{aligned}"]
-,Para [Str "edge",Space,Str "case",Space,Str "(the",Space,Code ("",[],[]) "c^2 + ",Space,Str "after",Space,Str "the",Space,Str "multline",Space,Str "tag",Space,Str "is",Space,Str "in",Space,Str "the",Space,Str "equation):"]
-,Para [Math DisplayMath "\\begin{gathered}\nc^2 + \na^2 + b^2\n\\end{gathered}"]
-,Para [Str "edge",Space,Str "case",Space,Str "(the",Space,Str "tag",Space,Str "is",Space,Code ("",[],[]) "hello%bye",Str ")"]
-,Para [Math DisplayMath "\\begin{hello%bye}\n\\int_a^b f(x) dx\n\\end{hello%bye}"]
-,Para [Str "Just",Space,Str "two",Space,Str "dollar",Space,Str "signs:",Space,Str "$$"]
-,Para [Str "[not",Space,Str "math]",Space,Str "You",Space,Str "have",Space,Str "$1",SoftBreak,Str "and",Space,Str "I",Space,Str "have",Space,Str "$1."]
-,Header 2 ("tags",[],[]) [Str "tags"]
-,Para [Span ("-tag-one",[],[]) [Str ""],Span ("tag-one",["tag"],[]) [Str "tag-one"],Space,Span ("-tag-two",[],[]) [Str ""],Span ("tag-two",["tag"],[]) [Str "tag-two"]]
-,Header 2 ("tables",[],[]) [Str "tables"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Year"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Temperature",Space,Str "(low)"]]
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   [Plain [Str "Temperature",Space,Str "(high)"]]]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1900"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "-10"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "25"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1910"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "-15"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "30"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1920"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "-10"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "32"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1930"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Emph [Str "N/A"]]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Emph [Str "N/A"]]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "1940"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "-2"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "40"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 3 ("centered headerless tables",[],[]) [Str "centered",Space,Str "headerless",Space,Str "tables"]
-,Div ("",["center"],[])
- [Table ("",[],[]) (Caption Nothing
-  [])
-  [(AlignDefault,ColWidthDefault)
-  ,(AlignDefault,ColWidthDefault)]
-  (TableHead ("",[],[])
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    []]])
-  [(TableBody ("",[],[]) (RowHeadColumns 0)
-   []
-   [Row ("",[],[])
-    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "a"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "b"]]]
-   ,Row ("",[],[])
-    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "c"]]
-    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-     [Plain [Str "d"]]]])]
-  (TableFoot ("",[],[])
-  [])]
-,Header 2 ("paragraphs",[],[]) [Str "paragraphs"]
-,Para [Str "This",Space,Str "is",Space,Str "first",Space,Str "paragraph",SoftBreak,Str "with",Space,Str "two",Space,Str "lines."]
-,Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "second",Space,Str "paragraph",Space,Str "with",SoftBreak,Str "two",Space,Str "lines",Space,Str "after",Space,Str "many",Space,Str "blank",Space,Str "lines."]
-,Header 2 ("definition list",[],[]) [Str "definition",Space,Str "list"]
-,DefinitionList
- [([Str "Term",Space,Str "1"],
-   [[Plain [Str "Definition",Space,Str "1"]]])
- ,([Str "Term",Space,Str "2"],
-   [[Plain [Str "Definition",Space,Str "2"]]
-   ,[Plain [Str "Definition",Space,Str "3"]]])
- ,([Str "Term",Space,Str "::",Space,Span ("separated",[],[]) [],Strong [Str "separated"],Space,Str "by",Space,Str "::",Space,Emph [Str "double",Space,Str "colons"]],
-   [[Plain [Str "Def1"]]
-   ,[Plain [Str "Def2"]]])
- ,([Str "Term",Space,Str "with",Space,Str "lots",Space,Str "of",Space,Str "trailing",Space,Str "colons:::::::"],
-   [[Plain [Str "Definition"]]])
- ,([Str "::",Space,Str "This",Space,Str "is",Space,Str "::",Space,Str "A",Space,Str "term",Space,Str "(rather",Space,Str "than",Space,Str "a",Space,Str "definition)"],
-   [[Plain [Str "and",Space,Str "this",Space,Str "is",Space,Str "a",Space,Str "definition"]]])
- ,([Str "Term",Space,Str "Without",Space,Str "definitions"],
-   [[]])
- ,([Str "Part",Space,Str "::",Space,Str "of",Space,Str "::",Space,Str "dt"],
-   [[Plain [Str "part",Space,Str "of",Space,Str "::dd"]]])]
-,DefinitionList
- [([],
-   [[Plain [Str "Definition",Space,Str "1",Space,Str "without",Space,Str "a",Space,Str "term"]]
-   ,[Plain [Str "Definition",Space,Str "2",Space,Str "without",Space,Str "a",Space,Str "term"]]])]
-,DefinitionList
- [([Str "T1"],
-   [[Plain [Str "D1"]]])]
-,Para [Str "new",Space,Str "paragraph"]
-,DefinitionList
- [([Str "T1"],
-   [[Plain [Str "D1"]]])]
-,Para [Str "Not::Definition"]
-,Para [Str "Not",Space,Str "::Definition"]
-,Para [Str "::Not",Space,Str "definition"]
-,BlockQuote
- [Plain [Str "::",Space,Str "blockquote"]]
-,BlockQuote
- [Plain [Str "block",Space,Str "::",Space,Str "quote"]]
-,Header 2 ("metadata placeholders",[],[]) [Str "metadata",Space,Str "placeholders"]
-,Para [Str "%this",Space,Str "is",Space,Str "not",Space,Str "a",Space,Str "placeholder"]
-,Para [Str "placeholders",SoftBreak,Str "serves",Space,Str "as",Space,Str "space",Space,Str "/",Space,Str "softbreak",Space,Str "in",Space,Str "paragraphs"]
-,Header 2 ("sup, sub",[],[]) [Str "sup,",Space,Str "sub"]
-,Para [Str "super",Superscript [Str "script"]]
-,Para [Str "sub",Subscript [Str "script"]]
-,Header 2 ("the todo mark",[],[]) [Str "the",Space,Str "todo",Space,Str "mark"]
-,Para [Span ("",["todo"],[]) [Str "TODO:"]]
-,Header 1 ("not implemented yet",[],[]) [Emph [Span ("not implemented yet",[],[]) [],Strong [Str "not",Space,Str "implemented",Space,Str "yet"]]]
-,Header 2 ("tables with spans",[],[]) [Str "tables",Space,Str "with",Space,Str "spans"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "a"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "d"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "\\/"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "e"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str ">"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "f"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "\\/"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "\\/"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str ">"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "g"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "h"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str ">"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str ">"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str ">"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 2 ("tables with multiple lines of headers",[],[]) [Str "tables",Space,Str "with",Space,Str "multiple",Space,Str "lines",Space,Str "of",Space,Str "headers"]
-,Table ("",[],[]) (Caption Nothing
- [])
- [(AlignDefault,ColWidthDefault)
- ,(AlignDefault,ColWidthDefault)]
- (TableHead ("",[],[])
- [Row ("",[],[])
-  [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []
-  ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-   []]])
- [(TableBody ("",[],[]) (RowHeadColumns 0)
-  []
-  [Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "a"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "b"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "c"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "d"]]]
-  ,Row ("",[],[])
-   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "---"]]
-   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
-    [Plain [Str "---"]]]])]
- (TableFoot ("",[],[])
- [])
-,Header 2 ("some other placeholders",[],[]) [Str "some",Space,Str "other",Space,Str "placeholders"]
-,Para [Code ("",[],[]) "template",Space,Str "placeholder",Space,Str "is",Space,Str "ignored."]
-,Para [Code ("",[],[]) "nohtml",Space,Str "placeholder",Space,Str "is",Space,Str "ignored."]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "date", MetaInlines [ Str "2017-05-01" ] )
+      ,
+        ( "title", MetaInlines [ Str "title" ] )
+      ]
+    }
+  )
+  [ Header 1
+    ( "implemented", [], [] )
+    [ Emph
+      [ Span
+        ( "implemented", [], [] ) []
+      , Strong
+        [ Str "implemented" ]
+      ]
+    ]
+  , Header 1
+    ( "header", [], [] )
+    [ Str "header" ]
+  , Header 2
+    ( "header level two", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "two" ]
+  , Header 3
+    ( "header level 3", [], [] )
+    [ Str "header", Space, Code ( "", [], [] ) "level", Space, Str "3" ]
+  , Header 4
+    ( "header level four", [], [] )
+    [ Str "header"
+    , Space
+    , Strikeout
+      [ Str "level" ]
+    , Space
+    , Str "four"
+    ]
+  , Header 5
+    ( "header level 5", [], [] )
+    [ Str "header"
+    , Space
+    , Emph
+      [ Span
+        ( "level", [], [] ) []
+      , Strong
+        [ Str "level" ]
+      , Space
+      , Str "5"
+      ]
+    ]
+  , Header 6
+    ( "header level 6", [], [] )
+    [ Str "header", Space, Str "level", Space, Str "6" ]
+  , Para
+    [ Str "======="
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    , Space
+    , Str "========"
+    ]
+  , Para
+    [ Str "hi=="
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    , Space
+    , Str "=="
+    ]
+  , Para
+    [ Str "==="
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    , Space
+    , Str "=="
+    ]
+  , Para
+    [ Str "==="
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    , Space
+    , Str "===-"
+    ]
+  , Para
+    [ Str "not", Space, Str "a", Space, Str "header:" ]
+  , Para
+    [ Str "=n=" ]
+  , Para
+    [ Str "==="
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "header"
+    , Space
+    , Str "===="
+    ]
+  , Header 2
+    ( "centred header", [ "justcenter" ], [] )
+    [ Str "centred", Space, Str "header" ]
+  , Header 2
+    ( "header with some == in between", [], [] )
+    [ Str "header"
+    , Space
+    , Str "with"
+    , Space
+    , Str "some"
+    , Space
+    , Code
+      ( "", [], [] ) "=="
+    , Space
+    , Str "in"
+    , Space
+    , Str "between"
+    ]
+  , Header 2
+    ( "header with some == in between", [], [] )
+    [ Str "header"
+    , Space
+    , Str "with"
+    , Space
+    , Str "some"
+    , Space
+    , Str "=="
+    , Space
+    , Str "in"
+    , Space
+    , Str "between"
+    ]
+  , Header 2
+    ( "header with some ==in between", [], [] )
+    [ Str "header"
+    , Space
+    , Str "with"
+    , Space
+    , Str "some"
+    , Space
+    , Str "==in"
+    , Space
+    , Str "between"
+    ]
+  , Header 2
+    ( "emph strong and strikeout", [], [] )
+    [ Str "emph"
+    , Space
+    , Str "strong"
+    , Space
+    , Str "and"
+    , Space
+    , Str "strikeout"
+    ]
+  , Para
+    [ Emph
+      [ Str "emph" ]
+    , Space
+    , Span
+      ( "strong", [], [] ) []
+    , Strong
+      [ Str "strong" ]
+    ]
+  , Para
+    [ Span
+      ( "strong and emph", [], [] ) []
+    , Strong
+      [ Emph [ Str "strong", Space, Str "and", Space, Str "emph" ] ]
+    ]
+  , Para
+    [ Emph
+      [ Span
+        ( "emph and strong", [], [] ) []
+      , Strong
+        [ Str "emph", Space, Str "and", Space, Str "strong" ]
+      ]
+    ]
+  , Para
+    [ Span
+      ( "emph inside strong", [], [] ) []
+    , Strong
+      [ Emph [ Str "emph", Space, Str "inside" ], Space, Str "strong" ]
+    ]
+  , Para
+    [ Span
+      ( "strong with emph", [], [] ) []
+    , Strong
+      [ Str "strong", Space, Str "with", Space, Emph [ Str "emph" ] ]
+    ]
+  , Para
+    [ Emph
+      [ Span
+        ( "strong inside", [], [] ) []
+      , Strong
+        [ Str "strong", Space, Str "inside" ]
+      , Space
+      , Str "emph"
+      ]
+    ]
+  , Para
+    [ Emph
+      [ Strikeout
+        [ Str "strikeout" ]
+      , Space
+      , Str "inside"
+      , Space
+      , Str "emph"
+      ]
+    ]
+  , Para
+    [ Strikeout
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Emph
+        [ Str "struck", Space, Str "out" ]
+      , Space
+      , Str "with"
+      , Space
+      , Str "emph"
+      ]
+    ]
+  , Para
+    [ Str "*not", SoftBreak, Str "strong*" ]
+  , Para
+    [ Str "just"
+    , Space
+    , Str "two"
+    , Space
+    , Str "stars:"
+    , Space
+    , Str "**"
+    ]
+  , Para
+    [ Str "just"
+    , Space
+    , Str "two"
+    , Space
+    , Str "underscores:"
+    , Space
+    , Str "__"
+    ]
+  , Para
+    [ Str "just"
+    , Space
+    , Str "four"
+    , Space
+    , Str "~s:"
+    , Space
+    , Str "~~~~"
+    ]
+  , Para
+    [ Str "_not", SoftBreak, Str "emph_" ]
+  , Para
+    [ Str "~~not", SoftBreak, Str "strikeout~~" ]
+  , Header 2
+    ( "horizontal rule", [], [] )
+    [ Str "horizontal", Space, Str "rule" ]
+  , Para
+    [ Str "top" ]
+  , HorizontalRule
+  , Para
+    [ Str "middle" ]
+  , HorizontalRule
+  , Para
+    [ Str "not", Space, Str "a", Space, Str "rule-----" ]
+  , Para
+    [ Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "rule"
+    , Space
+    , Str "(trailing"
+    , Space
+    , Str "spaces):"
+    , SoftBreak
+    , Str "-----"
+    ]
+  , Para
+    [ Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "rule"
+    , Space
+    , Str "(leading"
+    , Space
+    , Str "spaces):"
+    , SoftBreak
+    , Str "----"
+    ]
+  , Header 2
+    ( "comments", [], [] )
+    [ Str "comments" ]
+  , Para
+    [ Str "this"
+    , SoftBreak
+    , Str "is"
+    , Space
+    , Str "%%"
+    , Space
+    , Str "not"
+    , Space
+    , Str "secret"
+    ]
+  , Header 2
+    ( "inline code", [], [] )
+    [ Str "inline", Space, Str "code" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Code
+      ( "", [], [] ) "inline code"
+    , Str "."
+    ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "two"
+    , Space
+    , Str "backticks:"
+    , Space
+    , Str "``"
+    ]
+  , Header 2
+    ( "preformatted text", [], [] )
+    [ Str "preformatted", Space, Str "text" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "  Tyger! Tyger! burning bright\n   In the forests of the night,\n    What immortal hand or eye\n     Could frame thy fearful symmetry?\n  In what distant deeps or skies\n   Burnt the fire of thine eyes?\n    On what wings dare he aspire?\n     What the hand dare sieze the fire?"
+  , Header 3
+    ( "preformatted text with attributes", [], [] )
+    [ Str "preformatted"
+    , Space
+    , Str "text"
+    , Space
+    , Str "with"
+    , Space
+    , Str "attributes"
+    ]
+  , CodeBlock
+    ( ""
+    , []
+    ,
+      [ ( "class", "python" ), ( "style", "color:blue" ) ]
+    ) " for i in range(1, 5):\n     print(i)"
+  , Header 3
+    ( "preformatted text with nested syntax", [], [] )
+    [ Str "preformatted"
+    , Space
+    , Str "text"
+    , Space
+    , Str "with"
+    , Space
+    , Str "nested"
+    , Space
+    , Str "syntax"
+    ]
+  , CodeBlock
+    ( "", [ "sql" ], [] ) "SELECT * FROM table"
+  , Header 3
+    ( "empty preformatted text", [], [] )
+    [ Str "empty", Space, Str "preformatted", Space, Str "text" ]
+  , CodeBlock
+    ( "", [], [] ) ""
+  , Header 2
+    ( "block quotes", [], [] )
+    [ Str "block", Space, Str "quotes" ]
+  , BlockQuote
+    [ Plain
+      [ Str "(indentation"
+      , Space
+      , Str "4"
+      , Space
+      , Str "spaces)"
+      , Space
+      , Str "This"
+      , Space
+      , Str "would"
+      , Space
+      , Str "be"
+      , Space
+      , Str "a"
+      , Space
+      , Str "blockquote"
+      , Space
+      , Str "in"
+      , Space
+      , Str "Vimwiki."
+      , Space
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "not"
+      , Space
+      , Span
+        ( "highlighted", [], [] ) []
+      , Strong
+        [ Str "highlighted" ]
+      , Space
+      , Str "in"
+      , Space
+      , Str "Vim"
+      , Space
+      , Str "but"
+      , SoftBreak
+      , Str "(indentation"
+      , Space
+      , Str "1"
+      , Space
+      , Str "space"
+      , Space
+      , Str "followed"
+      , Space
+      , Str "by"
+      , Space
+      , Str "1"
+      , Space
+      , Str "tab"
+      , Space
+      , Str "of"
+      , Space
+      , Str "width"
+      , Space
+      , Str "4)"
+      , Space
+      , Str "could"
+      , Space
+      , Str "be"
+      , Space
+      , Str "styled"
+      , Space
+      , Str "by"
+      , Space
+      , Str "CSS"
+      , Space
+      , Str "in"
+      , Space
+      , Str "HTML."
+      , Space
+      , Str "Blockquotes"
+      , Space
+      , Str "are"
+      , Space
+      , Str "usually"
+      , Space
+      , Str "used"
+      , Space
+      , Str "to"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "a"
+      , SoftBreak
+      , Str "(indentation"
+      , Space
+      , Str "1"
+      , Space
+      , Str "tab"
+      , Space
+      , Str "of"
+      , Space
+      , Str "width"
+      , Space
+      , Str "4)"
+      , Space
+      , Str "long"
+      , Space
+      , Str "piece"
+      , Space
+      , Str "of"
+      , Space
+      , Str "text"
+      , Space
+      , Str "from"
+      , Space
+      , Str "another"
+      , Space
+      , Str "source."
+      , Space
+      , Strikeout
+        [ Str "blah", Space, Str "blah" ]
+      , Space
+      , Span
+        ( "-blockquote", [], [] )
+        [ Str "" ]
+      , Span
+        ( "blockquote", [ "tag" ], [] )
+        [ Str "blockquote" ]
+      ]
+    ]
+  , Header 2
+    ( "external links", [], [] )
+    [ Str "external", Space, Str "links" ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Emph
+        [ Str "Google" ]
+      , Space
+      , Str "search"
+      , Space
+      , Str "engine"
+      ]
+      ( "http://google.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "http://pandoc.org" ]
+      ( "http://pandoc.org", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "ftp://vim.org" ]
+      ( "ftp://vim.org", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "http://google.com" ]
+      ( "http://google.com", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "email", Space, Str "me" ]
+      ( "mailto:info@example.org", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "mailto:hello@bye.com" ]
+      ( "mailto:hello@bye.com", "" )
+    ]
+  , Header 2
+    ( "internal links", [], [] )
+    [ Str "internal", Space, Str "links" ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "This is a link" ]
+      ( "This is a link", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Description"
+      , Space
+      , Str "of"
+      , Space
+      , Str "the"
+      , Space
+      , Str "link"
+      ]
+      ( "This is a link source", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "projects/Important Project 1" ]
+      ( "projects/Important Project 1", "wikilink" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "../index" ]
+      ( "../index", "wikilink" )
+    , SoftBreak
+    , Link
+      ( "", [], [] )
+      [ Str "Other", Space, Str "files" ]
+      ( "a subdirectory/", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "try"
+      , Space
+      , Str "me"
+      , Space
+      , Str "to"
+      , Space
+      , Str "test"
+      , Space
+      , Str "tag"
+      , Space
+      , Str "anchors"
+      ]
+      ( "#tag-one", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "try"
+      , Space
+      , Str "me"
+      , Space
+      , Str "to"
+      , Space
+      , Str "test"
+      , Space
+      , Str "header"
+      , Space
+      , Str "anchors"
+      ]
+      ( "#block quotes", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "try"
+      , Space
+      , Str "me"
+      , Space
+      , Str "to"
+      , Space
+      , Str "test"
+      , Space
+      , Str "strong"
+      , Space
+      , Str "anchors"
+      ]
+      ( "#strong", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Tasks", Space, Str "for", Space, Str "tomorrow" ]
+      ( "Todo List#Tomorrow", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "diary:2017-05-01" ]
+      ( "diary/2017-05-01", "wikilink" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Important", Space, Str "Data" ]
+      ( "file:../assets/data.csv", "" )
+    ]
+  , Header 3
+    ( "links with thumbnails", [], [] )
+    [ Str "links", Space, Str "with", Space, Str "thumbnails" ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Image ( "", [], [] ) [ Str "" ] ( "./movie.jpg", "" ) ]
+      ( "http://www.google.com", "" )
+    ]
+  , Header 2
+    ( "images", [], [] )
+    [ Str "images" ]
+  , Para
+    [ Image ( "", [], [] ) [ Str "" ] ( "file:./lalune.jpg", "" ) ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "Vimwiki" ]
+      ( "http://vimwiki.googlecode.com/hg/images/vimwiki_logo.png", "" )
+    , SoftBreak
+    , Image
+      ( "", [], [] )
+      [ Str "" ]
+      ( "file:./movie.jpg", "" )
+    ]
+  , Header 3
+    ( "image with attributes", [], [] )
+    [ Str "image", Space, Str "with", Space, Str "attributes" ]
+  , Para
+    [ Image
+      ( "", [], [ ( "style", "width:150px;height:120px;" ) ] )
+      [ Emph [ Str "cool", Space, Str "stuff" ] ]
+      ( "lalune.jpg", "" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [ ( "style", "font-color:red" ) ] )
+      [ Span
+        ( "Non-existing", [], [] ) []
+      , Strong
+        [ Str "Non-existing" ]
+      , Space
+      , Str "image"
+      ]
+      ( "nonexist.jpg", "" )
+    ]
+  , Para
+    [ Image
+      ( "", [], [ ( "style", "width:150px;height:120px;" ) ] )
+      [ Emph [ Str "cool", Space, Str "stuff" ] ]
+      ( "lalune.jpg", "" )
+    ]
+  , Header 2
+    ( "lists", [], [] )
+    [ Str "lists" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "ordered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1,"
+        , Space
+        , Str "and"
+        , Space
+        , Str "here"
+        , Space
+        , Str "is"
+        , Space
+        , Str "some"
+        , Space
+        , Str "math"
+        , Space
+        , Str "belonging"
+        , Space
+        , Str "to"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      , Para
+        [ Math DisplayMath "a^2 + b^2 = c^2" ]
+      , Plain
+        [ Str "and"
+        , Space
+        , Str "some"
+        , Space
+        , Str "preformatted"
+        , Space
+        , Str "and"
+        , Space
+        , Str "tables"
+        , Space
+        , Str "belonging"
+        , Space
+        , Str "to"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        , Space
+        , Str "as"
+        , Space
+        , Str "well"
+        ]
+      , CodeBlock
+        ( "", [], [] ) "I'm part of item 1."
+      , Table
+        ( "", [], [] )
+        ( Caption Nothing [] )
+        [
+          ( AlignDefault, ColWidthDefault )
+        ,
+          ( AlignDefault, ColWidthDefault )
+        ]
+        ( TableHead
+          ( "", [], [] )
+          [ Row
+            ( "", [], [] )
+            [ Cell
+              ( "", [], [] ) AlignDefault
+              ( RowSpan 1 )
+              ( ColSpan 1 ) []
+            , Cell
+              ( "", [], [] ) AlignDefault
+              ( RowSpan 1 )
+              ( ColSpan 1 ) []
+            ]
+          ]
+        )
+        [ TableBody
+          ( "", [], [] )
+          ( RowHeadColumns 0 ) []
+          [ Row
+            ( "", [], [] )
+            [ Cell
+              ( "", [], [] ) AlignDefault
+              ( RowSpan 1 )
+              ( ColSpan 1 )
+              [ Plain [ Str "this", Space, Str "table" ] ]
+            , Cell
+              ( "", [], [] ) AlignDefault
+              ( RowSpan 1 )
+              ( ColSpan 1 )
+              [ Plain [ Str "is" ] ]
+            ]
+          , Row
+            ( "", [], [] )
+            [ Cell
+              ( "", [], [] ) AlignDefault
+              ( RowSpan 1 )
+              ( ColSpan 1 )
+              [ Plain
+                [ Str "also", Space, Str "a", Space, Str "part" ]
+              ]
+            , Cell
+              ( "", [], [] ) AlignDefault
+              ( RowSpan 1 )
+              ( ColSpan 1 )
+              [ Plain [ Str "of", Space, Str "item", Space, Str "1" ] ]
+            ]
+          ]
+        ]
+        ( TableFoot ( "", [], [] ) [] )
+      , Plain
+        [ Str "and"
+        , Space
+        , Str "some"
+        , Space
+        , Str "more"
+        , Space
+        , Str "text"
+        , Space
+        , Str "belonging"
+        , Space
+        , Str "to"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "ordered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Bulleted"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Bulleted"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Bulleted"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "the"
+        , Space
+        , Str "#"
+        , Space
+        , Str "become"
+        , Space
+        , Str "numbers"
+        , Space
+        , Str "when"
+        , Space
+        , Str "converted"
+        , Space
+        , Str "to"
+        , Space
+        , Str "HTML"
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Bulleted"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Bulleted"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain [ Str "Item", Space, Str "1" ] ]
+    ,
+      [ Plain
+        [ Str "Item", Space, Str "2" ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "Sub"
+            , Space
+            , Str "item"
+            , Space
+            , Str "1"
+            , Space
+            , Str "(indentation"
+            , Space
+            , Str "4"
+            , Space
+            , Str "spaces)"
+            , SoftBreak
+            , Str "Sub"
+            , Space
+            , Str "item"
+            , Space
+            , Str "1"
+            , Space
+            , Str "continued"
+            , Space
+            , Str "line."
+            , SoftBreak
+            , Str "Sub"
+            , Space
+            , Str "item"
+            , Space
+            , Str "1"
+            , Space
+            , Str "next"
+            , Space
+            , Str "continued"
+            , Space
+            , Str "line."
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Sub"
+            , Space
+            , Str "item"
+            , Space
+            , Str "2,"
+            , Space
+            , Str "as"
+            , Space
+            , Str "an"
+            , Space
+            , Str "ordered"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , Space
+            , Str "even"
+            , Space
+            , Str "though"
+            , Space
+            , Str "the"
+            , Space
+            , Str "identifier"
+            , Space
+            , Str "is"
+            , Space
+            , Code
+              ( "", [], [] ) "*"
+            , Space
+            , Str "(indentation"
+            , Space
+            , Str "2"
+            , Space
+            , Str "spaces"
+            , Space
+            , Str "followed"
+            , Space
+            , Str "by"
+            , Space
+            , Str "one"
+            , Space
+            , Str "tab"
+            , Space
+            , Str "of"
+            , Space
+            , Str "width"
+            , Space
+            , Str "4)"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "etc."
+            , SoftBreak
+            , Str "Continuation"
+            , Space
+            , Str "of"
+            , Space
+            , Str "Item"
+            , Space
+            , Str "2"
+            , SoftBreak
+            , Str "Next"
+            , Space
+            , Str "continuation"
+            , Space
+            , Str "of"
+            , Space
+            , Str "Item"
+            , Space
+            , Str "2"
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "But"
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "new"
+    , Space
+    , Str "paragraph."
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "1" ]
+      , BulletList
+        [ [ Plain [ Code ( "", [], [] ) "1.1" ] ] ]
+      ]
+    ,
+      [ Plain [ Str "2" ], BulletList [ [ Plain [ Str "2.1" ] ] ] ]
+    ]
+  , BulletList
+    [ [ Plain [ Str "3" ] ] ]
+  , Header 3
+    ( "ordered lists with non-# identifiers", [], [] )
+    [ Str "ordered"
+    , Space
+    , Str "lists"
+    , Space
+    , Str "with"
+    , Space
+    , Str "non-#"
+    , Space
+    , Str "identifiers"
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "3"
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "3"
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "3"
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "3"
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "3"
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "3"
+        ]
+      ]
+    ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Numbered"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "3"
+        ]
+      ]
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Bulleted"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "1"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Bulleted"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "2"
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Str "Numbered"
+            , Space
+            , Str "list"
+            , Space
+            , Str "sub"
+            , Space
+            , Str "item"
+            , Space
+            , Str "1"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "more", Space, Str "..." ]
+          , BulletList
+            [
+              [ Plain
+                [ Str "and", Space, Str "more", Space, Str "..." ]
+              ]
+            ,
+              [ Plain [ Str "..." ] ]
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Numbered"
+            , Space
+            , Str "list"
+            , Space
+            , Str "sub"
+            , Space
+            , Str "item"
+            , Space
+            , Str "3"
+            ]
+          , OrderedList
+            ( 1, DefaultStyle, DefaultDelim )
+            [
+              [ Plain
+                [ Str "Numbered"
+                , Space
+                , Str "list"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "item"
+                , Space
+                , Str "1"
+                ]
+              ]
+            ,
+              [ Plain
+                [ Str "Numbered"
+                , Space
+                , Str "list"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "sub"
+                , Space
+                , Str "item"
+                , Space
+                , Str "2"
+                ]
+              ]
+            ]
+          ]
+        ,
+          [ Plain [ Str "etc." ] ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Bulleted"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , Space
+        , Str "3"
+        ]
+      ]
+    ]
+  , Header 2
+    ( "todo lists", [], [] )
+    [ Str "todo", Space, Str "lists" ]
+  , BulletList
+    [
+      [ Plain
+        [ Span ( "", [ "done0" ], [] ) [], Str "task", Space, Str "1" ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [ [ Plain [ Span ( "", [ "done1" ], [] ) [], Str "5" ] ] ]
+      ]
+    ,
+      [ Plain [ Span ( "", [ "done2" ], [] ) [], Str "3" ] ]
+    ,
+      [ Plain
+        [ Str "[]"
+        , Space
+        , Str "not"
+        , Space
+        , Str "a"
+        , Space
+        , Str "todo"
+        , Space
+        , Str "item"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "["
+        , Space
+        , Str "]not"
+        , Space
+        , Str "a"
+        , Space
+        , Str "todo"
+        , Space
+        , Str "item"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "[r]"
+        , Space
+        , Str "not"
+        , Space
+        , Str "a"
+        , Space
+        , Str "todo"
+        , Space
+        , Str "item"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "["
+        , Space
+        , Str "]"
+        , Space
+        , Str "not"
+        , Space
+        , Str "a"
+        , Space
+        , Str "todo"
+        , Space
+        , Str "item"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Span
+          ( "", [ "done2" ], [] ) []
+        , Str "a"
+        , Space
+        , Str "tab"
+        , Space
+        , Str "in"
+        , Space
+        , Str "the"
+        , Space
+        , Str "todo"
+        , Space
+        , Str "list"
+        , Space
+        , Str "marker"
+        , Space
+        , Code
+          ( "", [], [] ) "[ ]"
+        ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [
+          [ Plain
+            [ Span
+              ( "", [ "done3" ], [] ) []
+            , Str "4"
+            , SoftBreak
+            , Str "5"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Span ( "", [ "done4" ], [] ) [] ]
+          , Table
+            ( "", [], [] )
+            ( Caption Nothing [] )
+            [
+              ( AlignDefault, ColWidthDefault )
+            ,
+              ( AlignDefault, ColWidthDefault )
+            ]
+            ( TableHead
+              ( "", [], [] )
+              [ Row
+                ( "", [], [] )
+                [ Cell
+                  ( "", [], [] ) AlignDefault
+                  ( RowSpan 1 )
+                  ( ColSpan 1 ) []
+                , Cell
+                  ( "", [], [] ) AlignDefault
+                  ( RowSpan 1 )
+                  ( ColSpan 1 ) []
+                ]
+              ]
+            )
+            [ TableBody
+              ( "", [], [] )
+              ( RowHeadColumns 0 ) []
+              [ Row
+                ( "", [], [] )
+                [ Cell
+                  ( "", [], [] ) AlignDefault
+                  ( RowSpan 1 )
+                  ( ColSpan 1 )
+                  [ Plain [ Str "a" ] ]
+                , Cell
+                  ( "", [], [] ) AlignDefault
+                  ( RowSpan 1 )
+                  ( ColSpan 1 )
+                  [ Plain [ Str "b" ] ]
+                ]
+              ]
+            ]
+            ( TableFoot ( "", [], [] ) [] )
+          ]
+        ]
+      ]
+    ,
+      [ Plain
+        [ Span ( "", [ "done4" ], [] ) [], Str "task", Space, Str "2" ]
+      ]
+    ]
+  , Header 2
+    ( "math", [], [] )
+    [ Str "math" ]
+  , Para
+    [ Math InlineMath " \\sum_i a_i^2 = 1 " ]
+  , Para
+    [ Math DisplayMath "\\sum_i a_i^2\n=\n1" ]
+  , Para
+    [ Math DisplayMath "\\begin{aligned}\n\\sum_i a_i^2 &= 1 + 1 \\\\\n&= 2.\n\\end{aligned}" ]
+  , Para
+    [ Str "edge"
+    , Space
+    , Str "case"
+    , Space
+    , Str "(the"
+    , Space
+    , Code
+      ( "", [], [] ) "c^2 + "
+    , Space
+    , Str "after"
+    , Space
+    , Str "the"
+    , Space
+    , Str "multline"
+    , Space
+    , Str "tag"
+    , Space
+    , Str "is"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "equation):"
+    ]
+  , Para
+    [ Math DisplayMath "\\begin{gathered}\nc^2 + \na^2 + b^2\n\\end{gathered}" ]
+  , Para
+    [ Str "edge"
+    , Space
+    , Str "case"
+    , Space
+    , Str "(the"
+    , Space
+    , Str "tag"
+    , Space
+    , Str "is"
+    , Space
+    , Code
+      ( "", [], [] ) "hello%bye"
+    , Str ")"
+    ]
+  , Para
+    [ Math DisplayMath "\\begin{hello%bye}\n\\int_a^b f(x) dx\n\\end{hello%bye}" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "two"
+    , Space
+    , Str "dollar"
+    , Space
+    , Str "signs:"
+    , Space
+    , Str "$$"
+    ]
+  , Para
+    [ Str "[not"
+    , Space
+    , Str "math]"
+    , Space
+    , Str "You"
+    , Space
+    , Str "have"
+    , Space
+    , Str "$1"
+    , SoftBreak
+    , Str "and"
+    , Space
+    , Str "I"
+    , Space
+    , Str "have"
+    , Space
+    , Str "$1."
+    ]
+  , Header 2
+    ( "tags", [], [] )
+    [ Str "tags" ]
+  , Para
+    [ Span
+      ( "-tag-one", [], [] )
+      [ Str "" ]
+    , Span
+      ( "tag-one", [ "tag" ], [] )
+      [ Str "tag-one" ]
+    , Space
+    , Span
+      ( "-tag-two", [], [] )
+      [ Str "" ]
+    , Span
+      ( "tag-two", [ "tag" ], [] )
+      [ Str "tag-two" ]
+    ]
+  , Header 2
+    ( "tables", [], [] )
+    [ Str "tables" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Year" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Temperature", Space, Str "(low)" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "Temperature", Space, Str "(high)" ] ]
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1900" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "-10" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "25" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1910" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "-15" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "30" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1920" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "-10" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "32" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1930" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Emph [ Str "N/A" ] ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Emph [ Str "N/A" ] ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "1940" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "-2" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "40" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 3
+    ( "centered headerless tables", [], [] )
+    [ Str "centered", Space, Str "headerless", Space, Str "tables" ]
+  , Div
+    ( "", [ "center" ], [] )
+    [ Table
+      ( "", [], [] )
+      ( Caption Nothing [] )
+      [
+        ( AlignDefault, ColWidthDefault )
+      ,
+        ( AlignDefault, ColWidthDefault )
+      ]
+      ( TableHead
+        ( "", [], [] )
+        [ Row
+          ( "", [], [] )
+          [ Cell
+            ( "", [], [] ) AlignDefault
+            ( RowSpan 1 )
+            ( ColSpan 1 ) []
+          , Cell
+            ( "", [], [] ) AlignDefault
+            ( RowSpan 1 )
+            ( ColSpan 1 ) []
+          ]
+        ]
+      )
+      [ TableBody
+        ( "", [], [] )
+        ( RowHeadColumns 0 ) []
+        [ Row
+          ( "", [], [] )
+          [ Cell
+            ( "", [], [] ) AlignDefault
+            ( RowSpan 1 )
+            ( ColSpan 1 )
+            [ Plain [ Str "a" ] ]
+          , Cell
+            ( "", [], [] ) AlignDefault
+            ( RowSpan 1 )
+            ( ColSpan 1 )
+            [ Plain [ Str "b" ] ]
+          ]
+        , Row
+          ( "", [], [] )
+          [ Cell
+            ( "", [], [] ) AlignDefault
+            ( RowSpan 1 )
+            ( ColSpan 1 )
+            [ Plain [ Str "c" ] ]
+          , Cell
+            ( "", [], [] ) AlignDefault
+            ( RowSpan 1 )
+            ( ColSpan 1 )
+            [ Plain [ Str "d" ] ]
+          ]
+        ]
+      ]
+      ( TableFoot ( "", [], [] ) [] )
+    ]
+  , Header 2
+    ( "paragraphs", [], [] )
+    [ Str "paragraphs" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "first"
+    , Space
+    , Str "paragraph"
+    , SoftBreak
+    , Str "with"
+    , Space
+    , Str "two"
+    , Space
+    , Str "lines."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "second"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "with"
+    , SoftBreak
+    , Str "two"
+    , Space
+    , Str "lines"
+    , Space
+    , Str "after"
+    , Space
+    , Str "many"
+    , Space
+    , Str "blank"
+    , Space
+    , Str "lines."
+    ]
+  , Header 2
+    ( "definition list", [], [] )
+    [ Str "definition", Space, Str "list" ]
+  , DefinitionList
+    [
+      (
+        [ Str "Term", Space, Str "1" ]
+      ,
+        [ [ Plain [ Str "Definition", Space, Str "1" ] ] ]
+      )
+    ,
+      (
+        [ Str "Term", Space, Str "2" ]
+      ,
+        [
+          [ Plain [ Str "Definition", Space, Str "2" ] ]
+        ,
+          [ Plain [ Str "Definition", Space, Str "3" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "Term"
+        , Space
+        , Str "::"
+        , Space
+        , Span
+          ( "separated", [], [] ) []
+        , Strong
+          [ Str "separated" ]
+        , Space
+        , Str "by"
+        , Space
+        , Str "::"
+        , Space
+        , Emph
+          [ Str "double", Space, Str "colons" ]
+        ]
+      ,
+        [ [ Plain [ Str "Def1" ] ], [ Plain [ Str "Def2" ] ] ]
+      )
+    ,
+      (
+        [ Str "Term"
+        , Space
+        , Str "with"
+        , Space
+        , Str "lots"
+        , Space
+        , Str "of"
+        , Space
+        , Str "trailing"
+        , Space
+        , Str "colons:::::::"
+        ]
+      ,
+        [ [ Plain [ Str "Definition" ] ] ]
+      )
+    ,
+      (
+        [ Str "::"
+        , Space
+        , Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "::"
+        , Space
+        , Str "A"
+        , Space
+        , Str "term"
+        , Space
+        , Str "(rather"
+        , Space
+        , Str "than"
+        , Space
+        , Str "a"
+        , Space
+        , Str "definition)"
+        ]
+      ,
+        [
+          [ Plain
+            [ Str "and"
+            , Space
+            , Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "a"
+            , Space
+            , Str "definition"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Str "Term", Space, Str "Without", Space, Str "definitions" ]
+      , [ [] ]
+      )
+    ,
+      (
+        [ Str "Part"
+        , Space
+        , Str "::"
+        , Space
+        , Str "of"
+        , Space
+        , Str "::"
+        , Space
+        , Str "dt"
+        ]
+      ,
+        [ [ Plain [ Str "part", Space, Str "of", Space, Str "::dd" ] ] ]
+      )
+    ]
+  , DefinitionList
+    [
+      ( []
+      ,
+        [
+          [ Plain
+            [ Str "Definition"
+            , Space
+            , Str "1"
+            , Space
+            , Str "without"
+            , Space
+            , Str "a"
+            , Space
+            , Str "term"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "Definition"
+            , Space
+            , Str "2"
+            , Space
+            , Str "without"
+            , Space
+            , Str "a"
+            , Space
+            , Str "term"
+            ]
+          ]
+        ]
+      )
+    ]
+  , DefinitionList
+    [ ( [ Str "T1" ], [ [ Plain [ Str "D1" ] ] ] ) ]
+  , Para
+    [ Str "new", Space, Str "paragraph" ]
+  , DefinitionList
+    [ ( [ Str "T1" ], [ [ Plain [ Str "D1" ] ] ] ) ]
+  , Para
+    [ Str "Not::Definition" ]
+  , Para
+    [ Str "Not", Space, Str "::Definition" ]
+  , Para
+    [ Str "::Not", Space, Str "definition" ]
+  , BlockQuote
+    [ Plain [ Str "::", Space, Str "blockquote" ] ]
+  , BlockQuote
+    [ Plain [ Str "block", Space, Str "::", Space, Str "quote" ] ]
+  , Header 2
+    ( "metadata placeholders", [], [] )
+    [ Str "metadata", Space, Str "placeholders" ]
+  , Para
+    [ Str "%this"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "a"
+    , Space
+    , Str "placeholder"
+    ]
+  , Para
+    [ Str "placeholders"
+    , SoftBreak
+    , Str "serves"
+    , Space
+    , Str "as"
+    , Space
+    , Str "space"
+    , Space
+    , Str "/"
+    , Space
+    , Str "softbreak"
+    , Space
+    , Str "in"
+    , Space
+    , Str "paragraphs"
+    ]
+  , Header 2
+    ( "sup, sub", [], [] )
+    [ Str "sup,", Space, Str "sub" ]
+  , Para
+    [ Str "super", Superscript [ Str "script" ] ]
+  , Para
+    [ Str "sub", Subscript [ Str "script" ] ]
+  , Header 2
+    ( "the todo mark", [], [] )
+    [ Str "the", Space, Str "todo", Space, Str "mark" ]
+  , Para
+    [ Span ( "", [ "todo" ], [] ) [ Str "TODO:" ] ]
+  , Header 1
+    ( "not implemented yet", [], [] )
+    [ Emph
+      [ Span
+        ( "not implemented yet", [], [] ) []
+      , Strong
+        [ Str "not", Space, Str "implemented", Space, Str "yet" ]
+      ]
+    ]
+  , Header 2
+    ( "tables with spans", [], [] )
+    [ Str "tables", Space, Str "with", Space, Str "spans" ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "a" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "d" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\\/" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "e" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str ">" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "f" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\\/" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "\\/" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str ">" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "g" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "h" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str ">" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str ">" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str ">" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 2
+    ( "tables with multiple lines of headers", [], [] )
+    [ Str "tables"
+    , Space
+    , Str "with"
+    , Space
+    , Str "multiple"
+    , Space
+    , Str "lines"
+    , Space
+    , Str "of"
+    , Space
+    , Str "headers"
+    ]
+  , Table
+    ( "", [], [] )
+    ( Caption Nothing [] )
+    [
+      ( AlignDefault, ColWidthDefault )
+    ,
+      ( AlignDefault, ColWidthDefault )
+    ]
+    ( TableHead
+      ( "", [], [] )
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 ) []
+        ]
+      ]
+    )
+    [ TableBody
+      ( "", [], [] )
+      ( RowHeadColumns 0 ) []
+      [ Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "a" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "b" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "c" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "d" ] ]
+        ]
+      , Row
+        ( "", [], [] )
+        [ Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "---" ] ]
+        , Cell
+          ( "", [], [] ) AlignDefault
+          ( RowSpan 1 )
+          ( ColSpan 1 )
+          [ Plain [ Str "---" ] ]
+        ]
+      ]
+    ]
+    ( TableFoot ( "", [], [] ) [] )
+  , Header 2
+    ( "some other placeholders", [], [] )
+    [ Str "some", Space, Str "other", Space, Str "placeholders" ]
+  , Para
+    [ Code
+      ( "", [], [] ) "template"
+    , Space
+    , Str "placeholder"
+    , Space
+    , Str "is"
+    , Space
+    , Str "ignored."
+    ]
+  , Para
+    [ Code
+      ( "", [], [] ) "nohtml"
+    , Space
+    , Str "placeholder"
+    , Space
+    , Str "is"
+    , Space
+    , Str "ignored."
+    ]
+  ]

--- a/test/writer.asciidoc
+++ b/test/writer.asciidoc
@@ -431,8 +431,8 @@ Superscripts: a^bc^d a^_hello_^ a^hello there^.
 
 Subscripts: H~2~O, H~23~O, H~many of them~O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a~b c~d.
 
 '''''
 
@@ -630,10 +630,10 @@ Here is a movie image:movie.jpg[movie] icon.
 
 == Footnotes
 
-Here is a footnote reference,footnote:[Here is the footnote. It can go
-anywhere after the footnote reference. It need not be placed at the end of the
-document.] and another.[multiblock footnote omitted] This should _not_ be a
-footnote reference, because it contains a space.[^my note] Here is an inline
+Here is a footnote reference,footnote:[Here is the footnote. It can go anywhere
+after the footnote reference. It need not be placed at the end of the document.]
+and another.[multiblock footnote omitted] This should _not_ be a footnote
+reference, because it contains a space.[^my note] Here is an inline
 note.footnote:[This is _easier_ to type. Inline notes may contain
 http://google.com[links] and `]` verbatim characters, as well as [bracketed
 text].]

--- a/test/writer.asciidoctor
+++ b/test/writer.asciidoctor
@@ -432,8 +432,8 @@ Superscripts: a^bc^d a^_hello_^ a^hello there^.
 
 Subscripts: H~2~O, H~23~O, H~many of them~O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a~b c~d.
 
 '''''
 
@@ -447,8 +447,8 @@ spaces: a^b c^d, a~b c~d.
 
 '`He said, "`I want to go.`"`' Were you alive in the 70’s?
 
-Here is some quoted '``+code+``' and a
-"`http://example.com/?foo=1&bar=2[quoted link]`".
+Here is some quoted '``+code+``' and a "`http://example.com/?foo=1&bar=2[quoted
+link]`".
 
 Some dashes: one—two — three—four — five.
 
@@ -631,10 +631,10 @@ Here is a movie image:movie.jpg[movie] icon.
 
 == Footnotes
 
-Here is a footnote reference,footnote:[Here is the footnote. It can go
-anywhere after the footnote reference. It need not be placed at the end of the
-document.] and another.[multiblock footnote omitted] This should _not_ be a
-footnote reference, because it contains a space.[^my note] Here is an inline
+Here is a footnote reference,footnote:[Here is the footnote. It can go anywhere
+after the footnote reference. It need not be placed at the end of the document.]
+and another.[multiblock footnote omitted] This should _not_ be a footnote
+reference, because it contains a space.[^my note] Here is an inline
 note.footnote:[This is _easier_ to type. Inline notes may contain
 http://google.com[links] and `+]+` verbatim characters, as well as [bracketed
 text].]

--- a/test/writer.context
+++ b/test/writer.context
@@ -643,8 +643,8 @@ Superscripts: a\high{bc}d a\high{{\em hello}} a\high{hello~there}.
 
 Subscripts: H\low{2}O, H\low{23}O, H\low{many~of~them}O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a\lettertilde{}b c\lettertilde{}d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a\lettertilde{}b c\lettertilde{}d.
 
 \thinrule
 
@@ -878,10 +878,10 @@ Here is a movie {\externalfigure[movie.jpg]} icon.
 
 \section[title={Footnotes},reference={footnotes}]
 
-Here is a footnote reference,\footnote{Here is the footnote. It can go
-  anywhere after the footnote reference. It need not be placed at the end of
-  the document.} and another.\startbuffer Here's the long note. This one
-  contains multiple blocks.
+Here is a footnote reference,\footnote{Here is the footnote. It can go anywhere
+  after the footnote reference. It need not be placed at the end of the
+  document.} and another.\startbuffer Here's the long note. This one contains
+  multiple blocks.
 
   Subsequent blocks are indented to show that they belong to the footnote (as
   with list items).

--- a/test/writer.docbook4
+++ b/test/writer.docbook4
@@ -66,8 +66,8 @@
     </para>
     <para>
       In Markdown 1.0.0 and earlier. Version 8. This line turns into a list
-      item. Because a hard-wrapped line in the middle of a paragraph looked
-      like a list item.
+      item. Because a hard-wrapped line in the middle of a paragraph looked like
+      a list item.
     </para>
     <para>
       Here’s one with a bullet. * criminey.
@@ -1014,19 +1014,19 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
   <sect1 id="smart-quotes-ellipses-dashes">
     <title>Smart quotes, ellipses, dashes</title>
     <para>
-      <quote>Hello,</quote> said the spider. <quote><quote>Shelob</quote> is
-      my name.</quote>
+      <quote>Hello,</quote> said the spider. <quote><quote>Shelob</quote> is my
+      name.</quote>
     </para>
     <para>
       <quote>A</quote>, <quote>B</quote>, and <quote>C</quote> are letters.
     </para>
     <para>
-      <quote>Oak,</quote> <quote>elm,</quote> and <quote>beech</quote> are
-      names of trees. So is <quote>pine.</quote>
+      <quote>Oak,</quote> <quote>elm,</quote> and <quote>beech</quote> are names
+      of trees. So is <quote>pine.</quote>
     </para>
     <para>
-      <quote>He said, <quote>I want to go.</quote></quote> Were you alive in
-      the 70’s?
+      <quote>He said, <quote>I want to go.</quote></quote> Were you alive in the
+      70’s?
     </para>
     <para>
       Here is some quoted <quote><literal>code</literal></quote> and a
@@ -1366,8 +1366,8 @@ or here: &lt;http://example.com/&gt;
     <para>
       Here is a footnote reference,<footnote>
         <para>
-          Here is the footnote. It can go anywhere after the footnote
-          reference. It need not be placed at the end of the document.
+          Here is the footnote. It can go anywhere after the footnote reference.
+          It need not be placed at the end of the document.
         </para>
       </footnote> and another.<footnote>
         <para>
@@ -1384,14 +1384,12 @@ or here: &lt;http://example.com/&gt;
           If you want, you can indent every line, but you can also be lazy and
           just indent the first line of each block.
         </para>
-      </footnote> This should <emphasis>not</emphasis> be a footnote
-      reference, because it contains a space.[^my note] Here is an inline
-      note.<footnote>
+      </footnote> This should <emphasis>not</emphasis> be a footnote reference,
+      because it contains a space.[^my note] Here is an inline note.<footnote>
         <para>
-          This is <emphasis>easier</emphasis> to type. Inline notes may
-          contain <ulink url="http://google.com">links</ulink> and
-          <literal>]</literal> verbatim characters, as well as [bracketed
-          text].
+          This is <emphasis>easier</emphasis> to type. Inline notes may contain
+          <ulink url="http://google.com">links</ulink> and <literal>]</literal>
+          verbatim characters, as well as [bracketed text].
         </para>
       </footnote>
     </para>

--- a/test/writer.docbook5
+++ b/test/writer.docbook5
@@ -68,8 +68,8 @@
     </para>
     <para>
       In Markdown 1.0.0 and earlier. Version 8. This line turns into a list
-      item. Because a hard-wrapped line in the middle of a paragraph looked
-      like a list item.
+      item. Because a hard-wrapped line in the middle of a paragraph looked like
+      a list item.
     </para>
     <para>
       Here’s one with a bullet. * criminey.
@@ -989,19 +989,19 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
   <section xml:id="smart-quotes-ellipses-dashes">
     <title>Smart quotes, ellipses, dashes</title>
     <para>
-      <quote>Hello,</quote> said the spider. <quote><quote>Shelob</quote> is
-      my name.</quote>
+      <quote>Hello,</quote> said the spider. <quote><quote>Shelob</quote> is my
+      name.</quote>
     </para>
     <para>
       <quote>A</quote>, <quote>B</quote>, and <quote>C</quote> are letters.
     </para>
     <para>
-      <quote>Oak,</quote> <quote>elm,</quote> and <quote>beech</quote> are
-      names of trees. So is <quote>pine.</quote>
+      <quote>Oak,</quote> <quote>elm,</quote> and <quote>beech</quote> are names
+      of trees. So is <quote>pine.</quote>
     </para>
     <para>
-      <quote>He said, <quote>I want to go.</quote></quote> Were you alive in
-      the 70’s?
+      <quote>He said, <quote>I want to go.</quote></quote> Were you alive in the
+      70’s?
     </para>
     <para>
       Here is some quoted <quote><literal>code</literal></quote> and a
@@ -1266,8 +1266,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
         <link xlink:href="http://att.com/">AT&amp;T</link>.
       </para>
       <para>
-        Here’s an <link xlink:href="/script?foo=1&amp;bar=2">inline
-        link</link>.
+        Here’s an <link xlink:href="/script?foo=1&amp;bar=2">inline link</link>.
       </para>
       <para>
         Here’s an <link xlink:href="/script?foo=1&amp;bar=2">inline link in
@@ -1342,8 +1341,8 @@ or here: &lt;http://example.com/&gt;
     <para>
       Here is a footnote reference,<footnote>
         <para>
-          Here is the footnote. It can go anywhere after the footnote
-          reference. It need not be placed at the end of the document.
+          Here is the footnote. It can go anywhere after the footnote reference.
+          It need not be placed at the end of the document.
         </para>
       </footnote> and another.<footnote>
         <para>
@@ -1360,14 +1359,12 @@ or here: &lt;http://example.com/&gt;
           If you want, you can indent every line, but you can also be lazy and
           just indent the first line of each block.
         </para>
-      </footnote> This should <emphasis>not</emphasis> be a footnote
-      reference, because it contains a space.[^my note] Here is an inline
-      note.<footnote>
+      </footnote> This should <emphasis>not</emphasis> be a footnote reference,
+      because it contains a space.[^my note] Here is an inline note.<footnote>
         <para>
-          This is <emphasis>easier</emphasis> to type. Inline notes may
-          contain <link xlink:href="http://google.com">links</link> and
-          <literal>]</literal> verbatim characters, as well as [bracketed
-          text].
+          This is <emphasis>easier</emphasis> to type. Inline notes may contain
+          <link xlink:href="http://google.com">links</link> and
+          <literal>]</literal> verbatim characters, as well as [bracketed text].
         </para>
       </footnote>
     </para>

--- a/test/writer.haddock
+++ b/test/writer.haddock
@@ -1,7 +1,7 @@
 This is a set of tests for pandoc. Most of them are adapted from John Gruber’s
 markdown test suite.
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Headers
 #headers#
@@ -34,7 +34,7 @@ with no blank line
 
 with no blank line
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Paragraphs
 #paragraphs#
@@ -50,7 +50,7 @@ Here’s one with a bullet. * criminey.
 There should be a hard line break
 here.
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Block Quotes
 #block-quotes#
@@ -80,7 +80,7 @@ This should not be a block quote: 2 > 1.
 
 And a following paragraph.
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Code Blocks
 #code-blocks#
@@ -101,7 +101,7 @@ And:
 >
 > These should not be escaped:  \$ \\ \> \[ \{
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Lists
 #lists#
@@ -265,7 +265,7 @@ M.A. 2007
 
 B. Williams
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Definition Lists
 #definition-lists#
@@ -398,7 +398,7 @@ Code:
 
 Hr’s:
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Inline Markup
 #inline-markup#
@@ -425,10 +425,10 @@ Superscripts: abcd a/hello/ ahello there.
 
 Subscripts: H2O, H23O, Hmany of themO.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a~b c~d.
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Smart quotes, ellipses, dashes
 #smart-quotes-ellipses-dashes#
@@ -450,7 +450,7 @@ Dashes between numbers: 5–7, 255–66, 1987–1999.
 
 Ellipses…and…and….
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = LaTeX
 #latex#
@@ -475,7 +475,7 @@ These shouldn’t be math:
 
 Here’s a LaTeX table:
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Special Characters
 #special-characters#
@@ -530,7 +530,7 @@ Plus: +
 
 Minus: -
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Links
 #links#
@@ -607,7 +607,7 @@ Auto-links should not occur here: @\<http:\/\/example.com\/>@
 
 > or here: <http://example.com/>
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Images
 #images#
@@ -618,14 +618,14 @@ From “Voyage dans la Lune” by Georges Melies (1902):
 
 Here is a movie <<movie.jpg movie>> icon.
 
-______________________________________________________________________________
+________________________________________________________________________________
 
 = Footnotes
 #footnotes#
 
 Here is a footnote reference,<#notes [1]> and another.<#notes [2]> This should
-/not/ be a footnote reference, because it contains a space.[^my note] Here is
-an inline note.<#notes [3]>
+/not/ be a footnote reference, because it contains a space.[^my note] Here is an
+inline note.<#notes [3]>
 
 Notes can go in quotes.<#notes [4]>
 
@@ -640,17 +640,16 @@ This paragraph should not be part of the note, as it is not indented.
 
 2.  Here’s the long note. This one contains multiple blocks.
 
-    Subsequent blocks are indented to show that they belong to the footnote
-    (as with list items).
+    Subsequent blocks are indented to show that they belong to the footnote (as
+    with list items).
 
     >   { <code> }
 
     If you want, you can indent every line, but you can also be lazy and just
     indent the first line of each block.
 
-3.  This is /easier/ to type. Inline notes may contain
-    <http://google.com links> and @]@ verbatim characters, as well as
-    [bracketed text].
+3.  This is /easier/ to type. Inline notes may contain <http://google.com links>
+    and @]@ verbatim characters, as well as [bracketed text].
 
 4.  In quote.
 

--- a/test/writer.jats_archiving
+++ b/test/writer.jats_archiving
@@ -68,9 +68,9 @@ Gruber’s markdown test suite.</p>
 <sec id="paragraphs">
   <title>Paragraphs</title>
   <p>Here’s a regular paragraph.</p>
-  <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list
-  item. Because a hard-wrapped line in the middle of a paragraph looked like a
-  list item.</p>
+  <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item.
+  Because a hard-wrapped line in the middle of a paragraph looked like a list
+  item.</p>
   <p>Here’s one with a bullet. * criminey.</p>
   <p>There should be a hard line break
   here.</p>
@@ -634,8 +634,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   <p><strike>This is <italic>strikeout</italic>.</strike></p>
   <p>Superscripts: a<sup>bc</sup>d a<sup><italic>hello</italic></sup>
   a<sup>hello there</sup>.</p>
-  <p>Subscripts: H<sub>2</sub>O, H<sub>23</sub>O,
-  H<sub>many of them</sub>O.</p>
+  <p>Subscripts: H<sub>2</sub>O, H<sub>23</sub>O, H<sub>many of them</sub>O.</p>
   <p>These should not be superscripts or subscripts, because of the unescaped
   spaces: a^b c^d, a~b c~d.</p>
 </sec>
@@ -689,8 +688,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mfrac><mml:mi>d</mml:mi><mml:mrow><mml:mi>d</mml:mi><mml:mi>x</mml:mi></mml:mrow></mml:mfrac><mml:mi>f</mml:mi><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:munder><mml:mo>lim</mml:mo><mml:mrow><mml:mi>h</mml:mi><mml:mo>→</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:munder><mml:mfrac><mml:mrow><mml:mi>f</mml:mi><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mi>x</mml:mi><mml:mo>+</mml:mo><mml:mi>h</mml:mi><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>−</mml:mo><mml:mi>f</mml:mi><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow></mml:mrow><mml:mi>h</mml:mi></mml:mfrac></mml:mrow></mml:math></alternatives></disp-formula></p>
     </list-item>
     <list-item>
-      <p>Here’s one that has a line break in it:
-      <inline-formula><alternatives>
+      <p>Here’s one that has a line break in it: <inline-formula><alternatives>
       <tex-math><![CDATA[\alpha + \omega \times x^2]]></tex-math>
       <mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>α</mml:mi><mml:mo>+</mml:mo><mml:mi>ω</mml:mi><mml:mo>×</mml:mo><mml:msup><mml:mi>x</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></alternatives></inline-formula>.</p>
     </list-item>
@@ -780,8 +778,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   </sec>
   <sec id="reference">
     <title>Reference</title>
-    <p>Foo
-    <ext-link ext-link-type="uri" xlink:href="/url/">bar</ext-link>.</p>
+    <p>Foo <ext-link ext-link-type="uri" xlink:href="/url/">bar</ext-link>.</p>
     <p>With <ext-link ext-link-type="uri" xlink:href="/url/">embedded
     [brackets]</ext-link>.</p>
     <p><ext-link ext-link-type="uri" xlink:href="/url/">b</ext-link> by itself
@@ -853,9 +850,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   <title>Footnotes</title>
   <p>Here is a footnote reference,<xref ref-type="fn" rid="fn1">1</xref> and
   another.<xref ref-type="fn" rid="fn2">2</xref> This should
-  <italic>not</italic> be a footnote reference, because it contains a
-  space.[^my note] Here is an inline
-  note.<xref ref-type="fn" rid="fn3">3</xref></p>
+  <italic>not</italic> be a footnote reference, because it contains a space.[^my
+  note] Here is an inline note.<xref ref-type="fn" rid="fn3">3</xref></p>
   <disp-quote>
     <p>Notes can go in quotes.<xref ref-type="fn" rid="fn4">4</xref></p>
   </disp-quote>
@@ -881,12 +877,12 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
     <p specific-use="wrapper">
       <preformat>  { &lt;code&gt; }</preformat>
     </p>
-    <p>If you want, you can indent every line, but you can also be lazy and
-    just indent the first line of each block.</p>
+    <p>If you want, you can indent every line, but you can also be lazy and just
+    indent the first line of each block.</p>
   </fn>
   <fn id="fn3">
-    <label>3</label><p>This is <italic>easier</italic> to type. Inline notes
-    may contain
+    <label>3</label><p>This is <italic>easier</italic> to type. Inline notes may
+    contain
     <ext-link ext-link-type="uri" xlink:href="http://google.com">links</ext-link>
     and <monospace>]</monospace> verbatim characters, as well as [bracketed
     text].</p>

--- a/test/writer.jats_articleauthoring
+++ b/test/writer.jats_articleauthoring
@@ -57,9 +57,9 @@ Gruber’s markdown test suite.</p>
 <sec id="paragraphs">
   <title>Paragraphs</title>
   <p>Here’s a regular paragraph.</p>
-  <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list
-  item. Because a hard-wrapped line in the middle of a paragraph looked like a
-  list item.</p>
+  <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item.
+  Because a hard-wrapped line in the middle of a paragraph looked like a list
+  item.</p>
   <p>Here’s one with a bullet. * criminey.</p>
   <p>There should be a hard line break
   here.</p>
@@ -631,8 +631,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   <p><strike>This is <italic>strikeout</italic>.</strike></p>
   <p>Superscripts: a<sup>bc</sup>d a<sup><italic>hello</italic></sup>
   a<sup>hello there</sup>.</p>
-  <p>Subscripts: H<sub>2</sub>O, H<sub>23</sub>O,
-  H<sub>many of them</sub>O.</p>
+  <p>Subscripts: H<sub>2</sub>O, H<sub>23</sub>O, H<sub>many of them</sub>O.</p>
   <p>These should not be superscripts or subscripts, because of the unescaped
   spaces: a^b c^d, a~b c~d.</p>
 </sec>
@@ -764,8 +763,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   </sec>
   <sec id="reference">
     <title>Reference</title>
-    <p>Foo
-    <ext-link ext-link-type="uri" xlink:href="/url/">bar</ext-link>.</p>
+    <p>Foo <ext-link ext-link-type="uri" xlink:href="/url/">bar</ext-link>.</p>
     <p>With <ext-link ext-link-type="uri" xlink:href="/url/">embedded
     [brackets]</ext-link>.</p>
     <p><ext-link ext-link-type="uri" xlink:href="/url/">b</ext-link> by itself
@@ -836,8 +834,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
 <sec id="footnotes">
   <title>Footnotes</title>
   <p>Here is a footnote reference,<fn>
-    <p>Here is the footnote. It can go anywhere after the footnote reference.
-    It need not be placed at the end of the document.</p>
+    <p>Here is the footnote. It can go anywhere after the footnote reference. It
+    need not be placed at the end of the document.</p>
   </fn> and another.<fn>
     <p>Here’s the long note. This one contains multiple blocks.</p>
     <p>Subsequent blocks are indented to show that they belong to the footnote
@@ -845,8 +843,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
     <p specific-use="wrapper">
       <preformat>  { &lt;code&gt; }</preformat>
     </p>
-    <p>If you want, you can indent every line, but you can also be lazy and
-    just indent the first line of each block.</p>
+    <p>If you want, you can indent every line, but you can also be lazy and just
+    indent the first line of each block.</p>
   </fn> This should <italic>not</italic> be a footnote reference, because it
   contains a space.[^my note] Here is an inline note.<fn>
     <p>This is <italic>easier</italic> to type. Inline notes may contain

--- a/test/writer.jats_publishing
+++ b/test/writer.jats_publishing
@@ -68,9 +68,9 @@ Gruber’s markdown test suite.</p>
 <sec id="paragraphs">
   <title>Paragraphs</title>
   <p>Here’s a regular paragraph.</p>
-  <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list
-  item. Because a hard-wrapped line in the middle of a paragraph looked like a
-  list item.</p>
+  <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item.
+  Because a hard-wrapped line in the middle of a paragraph looked like a list
+  item.</p>
   <p>Here’s one with a bullet. * criminey.</p>
   <p>There should be a hard line break
   here.</p>
@@ -634,8 +634,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   <p><strike>This is <italic>strikeout</italic>.</strike></p>
   <p>Superscripts: a<sup>bc</sup>d a<sup><italic>hello</italic></sup>
   a<sup>hello there</sup>.</p>
-  <p>Subscripts: H<sub>2</sub>O, H<sub>23</sub>O,
-  H<sub>many of them</sub>O.</p>
+  <p>Subscripts: H<sub>2</sub>O, H<sub>23</sub>O, H<sub>many of them</sub>O.</p>
   <p>These should not be superscripts or subscripts, because of the unescaped
   spaces: a^b c^d, a~b c~d.</p>
 </sec>
@@ -689,8 +688,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mfrac><mml:mi>d</mml:mi><mml:mrow><mml:mi>d</mml:mi><mml:mi>x</mml:mi></mml:mrow></mml:mfrac><mml:mi>f</mml:mi><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:munder><mml:mo>lim</mml:mo><mml:mrow><mml:mi>h</mml:mi><mml:mo>→</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:munder><mml:mfrac><mml:mrow><mml:mi>f</mml:mi><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mi>x</mml:mi><mml:mo>+</mml:mo><mml:mi>h</mml:mi><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>−</mml:mo><mml:mi>f</mml:mi><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow></mml:mrow><mml:mi>h</mml:mi></mml:mfrac></mml:mrow></mml:math></alternatives></disp-formula></p>
     </list-item>
     <list-item>
-      <p>Here’s one that has a line break in it:
-      <inline-formula><alternatives>
+      <p>Here’s one that has a line break in it: <inline-formula><alternatives>
       <tex-math><![CDATA[\alpha + \omega \times x^2]]></tex-math>
       <mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>α</mml:mi><mml:mo>+</mml:mo><mml:mi>ω</mml:mi><mml:mo>×</mml:mo><mml:msup><mml:mi>x</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></alternatives></inline-formula>.</p>
     </list-item>
@@ -780,8 +778,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   </sec>
   <sec id="reference">
     <title>Reference</title>
-    <p>Foo
-    <ext-link ext-link-type="uri" xlink:href="/url/">bar</ext-link>.</p>
+    <p>Foo <ext-link ext-link-type="uri" xlink:href="/url/">bar</ext-link>.</p>
     <p>With <ext-link ext-link-type="uri" xlink:href="/url/">embedded
     [brackets]</ext-link>.</p>
     <p><ext-link ext-link-type="uri" xlink:href="/url/">b</ext-link> by itself
@@ -853,9 +850,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   <title>Footnotes</title>
   <p>Here is a footnote reference,<xref ref-type="fn" rid="fn1">1</xref> and
   another.<xref ref-type="fn" rid="fn2">2</xref> This should
-  <italic>not</italic> be a footnote reference, because it contains a
-  space.[^my note] Here is an inline
-  note.<xref ref-type="fn" rid="fn3">3</xref></p>
+  <italic>not</italic> be a footnote reference, because it contains a space.[^my
+  note] Here is an inline note.<xref ref-type="fn" rid="fn3">3</xref></p>
   <disp-quote>
     <p>Notes can go in quotes.<xref ref-type="fn" rid="fn4">4</xref></p>
   </disp-quote>
@@ -881,12 +877,12 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
     <p specific-use="wrapper">
       <preformat>  { &lt;code&gt; }</preformat>
     </p>
-    <p>If you want, you can indent every line, but you can also be lazy and
-    just indent the first line of each block.</p>
+    <p>If you want, you can indent every line, but you can also be lazy and just
+    indent the first line of each block.</p>
   </fn>
   <fn id="fn3">
-    <label>3</label><p>This is <italic>easier</italic> to type. Inline notes
-    may contain
+    <label>3</label><p>This is <italic>easier</italic> to type. Inline notes may
+    contain
     <ext-link ext-link-type="uri" xlink:href="http://google.com">links</ext-link>
     and <monospace>]</monospace> verbatim characters, as well as [bracketed
     text].</p>

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -711,8 +711,8 @@ a\textsuperscript{hello~there}.
 Subscripts: H\textsubscript{2}O, H\textsubscript{23}O,
 H\textsubscript{many~of~them}O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a\^{}b c\^{}d, a\textasciitilde b c\textasciitilde d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a\^{}b c\^{}d, a\textasciitilde b c\textasciitilde d.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 
@@ -905,8 +905,7 @@ Foo \href{/url/}{biz}.
 Here's a \href{http://example.com/?foo=1\&bar=2}{link with an ampersand in the
 URL}.
 
-Here's a link with an amersand in the link text:
-\href{http://att.com/}{AT\&T}.
+Here's a link with an amersand in the link text: \href{http://att.com/}{AT\&T}.
 
 Here's an \href{/script?foo=1\&bar=2}{inline link}.
 
@@ -961,9 +960,9 @@ Here is a movie \includegraphics{movie.jpg} icon.
 \hypertarget{footnotes}{%
 \section{Footnotes}\label{footnotes}}
 
-Here is a footnote reference,\footnote{Here is the footnote. It can go
-  anywhere after the footnote reference. It need not be placed at the end of
-  the document.} and another.\footnote{Here's the long note. This one contains
+Here is a footnote reference,\footnote{Here is the footnote. It can go anywhere
+  after the footnote reference. It need not be placed at the end of the
+  document.} and another.\footnote{Here's the long note. This one contains
   multiple blocks.
 
   Subsequent blocks are indented to show that they belong to the footnote (as
@@ -977,8 +976,8 @@ Here is a footnote reference,\footnote{Here is the footnote. It can go
   indent the first line of each block.} This should \emph{not} be a footnote
 reference, because it contains a space.{[}\^{}my note{]} Here is an inline
 note.\footnote{This is \emph{easier} to type. Inline notes may contain
-  \href{http://google.com}{links} and \texttt{{]}} verbatim characters, as
-  well as {[}bracketed text{]}.}
+  \href{http://google.com}{links} and \texttt{{]}} verbatim characters, as well
+  as {[}bracketed text{]}.}
 
 \begin{quote}
 Notes can go in quotes.\footnote{In quote.}

--- a/test/writer.man
+++ b/test/writer.man
@@ -496,8 +496,8 @@ Superscripts: a^bc^d a^\f[I]hello\f[R]^ a^hello\ there^.
 .PP
 Subscripts: H~2~O, H~23~O, H~many\ of\ them~O.
 .PP
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a\[ha]b c\[ha]d, a\[ti]b c\[ti]d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a\[ha]b c\[ha]d, a\[ti]b c\[ti]d.
 .PP
    *   *   *   *   *
 .SH Smart quotes, ellipses, dashes
@@ -706,9 +706,9 @@ Here is a movie [IMAGE: movie] icon.
    *   *   *   *   *
 .SH Footnotes
 .PP
-Here is a footnote reference,[1] and another.[2] This should \f[I]not\f[R] be
-a footnote reference, because it contains a space.[\[ha]my note] Here is an
-inline note.[3]
+Here is a footnote reference,[1] and another.[2] This should \f[I]not\f[R] be a
+footnote reference, because it contains a space.[\[ha]my note] Here is an inline
+note.[3]
 .RS
 .PP
 Notes can go in quotes.[4]
@@ -728,8 +728,8 @@ It need not be placed at the end of the document.
 Here\[cq]s the long note.
 This one contains multiple blocks.
 .PP
-Subsequent blocks are indented to show that they belong to the footnote (as
-with list items).
+Subsequent blocks are indented to show that they belong to the footnote (as with
+list items).
 .IP
 .nf
 \f[C]
@@ -737,8 +737,8 @@ with list items).
 \f[R]
 .fi
 .PP
-If you want, you can indent every line, but you can also be lazy and just
-indent the first line of each block.
+If you want, you can indent every line, but you can also be lazy and just indent
+the first line of each block.
 .SS [3]
 .PP
 This is \f[I]easier\f[R] to type.

--- a/test/writer.markdown
+++ b/test/writer.markdown
@@ -9,7 +9,7 @@ title: Pandoc Test Suite
 This is a set of tests for pandoc. Most of them are adapted from John Gruber's
 markdown test suite.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Headers
 
@@ -33,7 +33,7 @@ with no blank line
 
 with no blank line
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Paragraphs
 
@@ -48,7 +48,7 @@ Here's one with a bullet. \* criminey.
 There should be a hard line break\
 here.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Block Quotes
 
@@ -77,7 +77,7 @@ This should not be a block quote: 2 \> 1.
 
 And a following paragraph.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Code Blocks
 
@@ -97,7 +97,7 @@ And:
 
     These should not be escaped:  \$ \\ \> \[ \{
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Lists
 
@@ -254,7 +254,7 @@ M.A. 2007
 
 B. Williams
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Definition Lists
 
@@ -507,7 +507,7 @@ Hr's:
 <hr class="foo" id="bar">
 ```
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Inline Markup
 
@@ -533,10 +533,10 @@ Superscripts: a^bc^d a^*hello*^ a^hello there^.
 
 Subscripts: H~2~O, H~23~O, H~many of them~O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a\^b c\^d, a\~b c\~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a\^b c\^d, a\~b c\~d.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Smart quotes, ellipses, dashes
 
@@ -557,7 +557,7 @@ Dashes between numbers: 5--7, 255--66, 1987--1999.
 
 Ellipses...and...and....
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # LaTeX
 
@@ -589,7 +589,7 @@ Cat    & 1      \\ \hline
 \end{tabular}
 ```
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Special Characters
 
@@ -643,7 +643,7 @@ Plus: +
 
 Minus: -
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Links
 
@@ -693,8 +693,7 @@ Foo [biz](/url/ "Title with "quote" inside").
 
 Here's a [link with an ampersand in the URL](http://example.com/?foo=1&bar=2).
 
-Here's a link with an amersand in the link text:
-[AT&T](http://att.com/ "AT&T").
+Here's a link with an amersand in the link text: [AT&T](http://att.com/ "AT&T").
 
 Here's an [inline link](/script?foo=1&bar=2).
 
@@ -716,7 +715,7 @@ Auto-links should not occur here: `<http://example.com/>`
 
     or here: <http://example.com/>
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Images
 
@@ -726,13 +725,13 @@ From "Voyage dans la Lune" by Georges Melies (1902):
 
 Here is a movie ![movie](movie.jpg) icon.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 # Footnotes
 
 Here is a footnote reference,[^1] and another.[^2] This should *not* be a
-footnote reference, because it contains a space.\[\^my note\] Here is an
-inline note.[^3]
+footnote reference, because it contains a space.\[\^my note\] Here is an inline
+note.[^3]
 
 > Notes can go in quotes.[^4]
 
@@ -740,13 +739,13 @@ inline note.[^3]
 
 This paragraph should not be part of the note, as it is not indented.
 
-[^1]: Here is the footnote. It can go anywhere after the footnote reference.
-    It need not be placed at the end of the document.
+[^1]: Here is the footnote. It can go anywhere after the footnote reference. It
+    need not be placed at the end of the document.
 
 [^2]: Here's the long note. This one contains multiple blocks.
 
-    Subsequent blocks are indented to show that they belong to the footnote
-    (as with list items).
+    Subsequent blocks are indented to show that they belong to the footnote (as
+    with list items).
 
           { <code> }
 

--- a/test/writer.ms
+++ b/test/writer.ms
@@ -653,8 +653,8 @@ Superscripts: a\*{bc\*}d a\*{\f[I]hello\f[R]\*} a\*{hello\ there\*}.
 .PP
 Subscripts: H\*<2\*>O, H\*<23\*>O, H\*<many\ of\ them\*>O.
 .PP
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a\[ha]b c\[ha]d, a\[ti]b c\[ti]d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a\[ha]b c\[ha]d, a\[ti]b c\[ti]d.
 .HLINE
 .SH 1
 Smart quotes, ellipses, dashes
@@ -973,8 +973,8 @@ and another.\**
 Here\[cq]s the long note.
 This one contains multiple blocks.
 .PP
-Subsequent blocks are indented to show that they belong to the footnote (as
-with list items).
+Subsequent blocks are indented to show that they belong to the footnote (as with
+list items).
 .IP
 .nf
 \f[C]
@@ -982,8 +982,8 @@ with list items).
 \f[]
 .fi
 .LP
-If you want, you can indent every line, but you can also be lazy and just
-indent the first line of each block.
+If you want, you can indent every line, but you can also be lazy and just indent
+the first line of each block.
 .FE
 This should \f[I]not\f[R] be a footnote reference, because it contains a
 space.[\[ha]my note] Here is an inline note.\**

--- a/test/writer.muse
+++ b/test/writer.muse
@@ -483,8 +483,8 @@ Superscripts: a<sup>bc</sup>d a<sup>*hello*</sup> a<sup>hello there</sup>.
 
 Subscripts: H<sub>2</sub>O, H<sub>23</sub>O, H<sub>many of them</sub>O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a~b c~d.
 
 ----
 
@@ -643,8 +643,7 @@ Foo [[/url/][biz]].
 
 ** With ampersands
 
-Here’s a [[http://example.com/?foo=1&bar=2][link with an ampersand in the
-URL]].
+Here’s a [[http://example.com/?foo=1&bar=2][link with an ampersand in the URL]].
 
 Here’s a link with an amersand in the link text: [[http://att.com/][AT&T]].
 
@@ -686,9 +685,8 @@ Here is a movie [[movie.jpg][movie]] icon.
 
 * Footnotes
 
-Here is a footnote reference,[1] and another.[2] This should *not* be a
-footnote reference, because it contains a space.[^my note] Here is an inline
-note.[3]
+Here is a footnote reference,[1] and another.[2] This should *not* be a footnote
+reference, because it contains a space.[^my note] Here is an inline note.[3]
 
 <quote>
 Notes can go in quotes.[4]
@@ -703,8 +701,8 @@ This paragraph should not be part of the note, as it is not indented.
 
 [2] Here’s the long note. This one contains multiple blocks.
 
-    Subsequent blocks are indented to show that they belong to the footnote
-    (as with list items).
+    Subsequent blocks are indented to show that they belong to the footnote (as
+    with list items).
 
     <example>
       { <code> }

--- a/test/writer.native
+++ b/test/writer.native
@@ -1,409 +1,2385 @@
-Pandoc (Meta {unMeta = fromList [("author",MetaList [MetaInlines [Str "John",Space,Str "MacFarlane"],MetaInlines [Str "Anonymous"]]),("date",MetaInlines [Str "July",Space,Str "17,",Space,Str "2006"]),("title",MetaInlines [Str "Pandoc",Space,Str "Test",Space,Str "Suite"])]})
-[Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "set",Space,Str "of",Space,Str "tests",Space,Str "for",Space,Str "pandoc.",Space,Str "Most",Space,Str "of",Space,Str "them",Space,Str "are",Space,Str "adapted",Space,Str "from",SoftBreak,Str "John",Space,Str "Gruber\8217s",Space,Str "markdown",Space,Str "test",Space,Str "suite."]
-,HorizontalRule
-,Header 1 ("headers",[],[]) [Str "Headers"]
-,Header 2 ("level-2-with-an-embedded-link",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Str "an",Space,Link ("",[],[]) [Str "embedded",Space,Str "link"] ("/url","")]
-,Header 3 ("level-3-with-emphasis",[],[]) [Str "Level",Space,Str "3",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 4 ("level-4",[],[]) [Str "Level",Space,Str "4"]
-,Header 5 ("level-5",[],[]) [Str "Level",Space,Str "5"]
-,Header 1 ("level-1",[],[]) [Str "Level",Space,Str "1"]
-,Header 2 ("level-2-with-emphasis",[],[]) [Str "Level",Space,Str "2",Space,Str "with",Space,Emph [Str "emphasis"]]
-,Header 3 ("level-3",[],[]) [Str "Level",Space,Str "3"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,Header 2 ("level-2",[],[]) [Str "Level",Space,Str "2"]
-,Para [Str "with",Space,Str "no",Space,Str "blank",Space,Str "line"]
-,HorizontalRule
-,Header 1 ("paragraphs",[],[]) [Str "Paragraphs"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "regular",Space,Str "paragraph."]
-,Para [Str "In",Space,Str "Markdown",Space,Str "1.0.0",Space,Str "and",Space,Str "earlier.",Space,Str "Version",SoftBreak,Str "8.",Space,Str "This",Space,Str "line",Space,Str "turns",Space,Str "into",Space,Str "a",Space,Str "list",Space,Str "item.",SoftBreak,Str "Because",Space,Str "a",Space,Str "hard-wrapped",Space,Str "line",Space,Str "in",Space,Str "the",SoftBreak,Str "middle",Space,Str "of",Space,Str "a",Space,Str "paragraph",Space,Str "looked",Space,Str "like",Space,Str "a",SoftBreak,Str "list",Space,Str "item."]
-,Para [Str "Here\8217s",Space,Str "one",Space,Str "with",Space,Str "a",Space,Str "bullet.",SoftBreak,Str "*",Space,Str "criminey."]
-,Para [Str "There",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "hard",Space,Str "line",Space,Str "break",LineBreak,Str "here."]
-,HorizontalRule
-,Header 1 ("block-quotes",[],[]) [Str "Block",Space,Str "Quotes"]
-,Para [Str "E-mail",Space,Str "style:"]
-,BlockQuote
- [Para [Str "This",Space,Str "is",Space,Str "a",Space,Str "block",Space,Str "quote.",SoftBreak,Str "It",Space,Str "is",Space,Str "pretty",Space,Str "short."]]
-,BlockQuote
- [Para [Str "Code",Space,Str "in",Space,Str "a",Space,Str "block",Space,Str "quote:"]
- ,CodeBlock ("",[],[]) "sub status {\n    print \"working\";\n}"
- ,Para [Str "A",Space,Str "list:"]
- ,OrderedList (1,Decimal,Period)
-  [[Plain [Str "item",Space,Str "one"]]
-  ,[Plain [Str "item",Space,Str "two"]]]
- ,Para [Str "Nested",Space,Str "block",Space,Str "quotes:"]
- ,BlockQuote
-  [Para [Str "nested"]]
- ,BlockQuote
-  [Para [Str "nested"]]]
-,Para [Str "This",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "block",Space,Str "quote:",Space,Str "2",SoftBreak,Str ">",Space,Str "1."]
-,Para [Str "And",Space,Str "a",Space,Str "following",Space,Str "paragraph."]
-,HorizontalRule
-,Header 1 ("code-blocks",[],[]) [Str "Code",Space,Str "Blocks"]
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
-,Para [Str "And:"]
-,CodeBlock ("",[],[]) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
-,HorizontalRule
-,Header 1 ("lists",[],[]) [Str "Lists"]
-,Header 2 ("unordered",[],[]) [Str "Unordered"]
-,Para [Str "Asterisks",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "asterisk",Space,Str "1"]]
- ,[Plain [Str "asterisk",Space,Str "2"]]
- ,[Plain [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Asterisks",Space,Str "loose:"]
-,BulletList
- [[Para [Str "asterisk",Space,Str "1"]]
- ,[Para [Str "asterisk",Space,Str "2"]]
- ,[Para [Str "asterisk",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "Plus",Space,Str "1"]]
- ,[Plain [Str "Plus",Space,Str "2"]]
- ,[Plain [Str "Plus",Space,Str "3"]]]
-,Para [Str "Pluses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Plus",Space,Str "1"]]
- ,[Para [Str "Plus",Space,Str "2"]]
- ,[Para [Str "Plus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "tight:"]
-,BulletList
- [[Plain [Str "Minus",Space,Str "1"]]
- ,[Plain [Str "Minus",Space,Str "2"]]
- ,[Plain [Str "Minus",Space,Str "3"]]]
-,Para [Str "Minuses",Space,Str "loose:"]
-,BulletList
- [[Para [Str "Minus",Space,Str "1"]]
- ,[Para [Str "Minus",Space,Str "2"]]
- ,[Para [Str "Minus",Space,Str "3"]]]
-,Header 2 ("ordered",[],[]) [Str "Ordered"]
-,Para [Str "Tight:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second"]]
- ,[Plain [Str "Third"]]]
-,Para [Str "and:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "One"]]
- ,[Plain [Str "Two"]]
- ,[Plain [Str "Three"]]]
-,Para [Str "Loose",Space,Str "using",Space,Str "tabs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second"]]
- ,[Para [Str "Third"]]]
-,Para [Str "and",Space,Str "using",Space,Str "spaces:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "One"]]
- ,[Para [Str "Two"]]
- ,[Para [Str "Three"]]]
-,Para [Str "Multiple",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "Item",Space,Str "1,",Space,Str "graf",Space,Str "one."]
-  ,Para [Str "Item",Space,Str "1.",Space,Str "graf",Space,Str "two.",Space,Str "The",Space,Str "quick",Space,Str "brown",Space,Str "fox",Space,Str "jumped",Space,Str "over",Space,Str "the",Space,Str "lazy",Space,Str "dog\8217s",SoftBreak,Str "back."]]
- ,[Para [Str "Item",Space,Str "2."]]
- ,[Para [Str "Item",Space,Str "3."]]]
-,Header 2 ("nested",[],[]) [Str "Nested"]
-,BulletList
- [[Plain [Str "Tab"]
-  ,BulletList
-   [[Plain [Str "Tab"]
-    ,BulletList
-     [[Plain [Str "Tab"]]]]]]]
-,Para [Str "Here\8217s",Space,Str "another:"]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "First"]]
- ,[Plain [Str "Second:"]
-  ,BulletList
-   [[Plain [Str "Fee"]]
-   ,[Plain [Str "Fie"]]
-   ,[Plain [Str "Foe"]]]]
- ,[Plain [Str "Third"]]]
-,Para [Str "Same",Space,Str "thing",Space,Str "but",Space,Str "with",Space,Str "paragraphs:"]
-,OrderedList (1,Decimal,Period)
- [[Para [Str "First"]]
- ,[Para [Str "Second:"]
-  ,BulletList
-   [[Plain [Str "Fee"]]
-   ,[Plain [Str "Fie"]]
-   ,[Plain [Str "Foe"]]]]
- ,[Para [Str "Third"]]]
-,Header 2 ("tabs-and-spaces",[],[]) [Str "Tabs",Space,Str "and",Space,Str "spaces"]
-,BulletList
- [[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",SoftBreak,Str "indented",Space,Str "with",Space,Str "tabs"]]
- ,[Para [Str "this",Space,Str "is",Space,Str "a",Space,Str "list",Space,Str "item",SoftBreak,Str "indented",Space,Str "with",Space,Str "spaces"]
-  ,BulletList
-   [[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",SoftBreak,Str "indented",Space,Str "with",Space,Str "tabs"]]
-   ,[Para [Str "this",Space,Str "is",Space,Str "an",Space,Str "example",Space,Str "list",Space,Str "item",SoftBreak,Str "indented",Space,Str "with",Space,Str "spaces"]]]]]
-,Header 2 ("fancy-list-markers",[],[]) [Str "Fancy",Space,Str "list",Space,Str "markers"]
-,OrderedList (2,Decimal,TwoParens)
- [[Para [Str "begins",Space,Str "with",Space,Str "2"]]
- ,[Para [Str "and",Space,Str "now",Space,Str "3"]
-  ,Para [Str "with",Space,Str "a",Space,Str "continuation"]
-  ,OrderedList (4,LowerRoman,Period)
-   [[Plain [Str "sublist",Space,Str "with",Space,Str "roman",Space,Str "numerals,",SoftBreak,Str "starting",Space,Str "with",Space,Str "4"]]
-   ,[Plain [Str "more",Space,Str "items"]
-    ,OrderedList (1,UpperAlpha,TwoParens)
-     [[Plain [Str "a",Space,Str "subsublist"]]
-     ,[Plain [Str "a",Space,Str "subsublist"]]]]]]]
-,Para [Str "Nesting:"]
-,OrderedList (1,UpperAlpha,Period)
- [[Plain [Str "Upper",Space,Str "Alpha"]
-  ,OrderedList (1,UpperRoman,Period)
-   [[Plain [Str "Upper",Space,Str "Roman."]
-    ,OrderedList (6,Decimal,TwoParens)
-     [[Plain [Str "Decimal",Space,Str "start",Space,Str "with",Space,Str "6"]
-      ,OrderedList (3,LowerAlpha,OneParen)
-       [[Plain [Str "Lower",Space,Str "alpha",Space,Str "with",Space,Str "paren"]]]]]]]]]
-,Para [Str "Autonumbering:"]
-,OrderedList (1,DefaultStyle,DefaultDelim)
- [[Plain [Str "Autonumber."]]
- ,[Plain [Str "More."]
-  ,OrderedList (1,DefaultStyle,DefaultDelim)
-   [[Plain [Str "Nested."]]]]]
-,Para [Str "Should",Space,Str "not",Space,Str "be",Space,Str "a",Space,Str "list",Space,Str "item:"]
-,Para [Str "M.A.\160\&2007"]
-,Para [Str "B.",Space,Str "Williams"]
-,HorizontalRule
-,Header 1 ("definition-lists",[],[]) [Str "Definition",Space,Str "Lists"]
-,Para [Str "Tight",Space,Str "using",Space,Str "spaces:"]
-,DefinitionList
- [([Str "apple"],
-   [[Plain [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Plain [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Plain [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Tight",Space,Str "using",Space,Str "tabs:"]
-,DefinitionList
- [([Str "apple"],
-   [[Plain [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Plain [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Plain [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Loose:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]])
- ,([Str "banana"],
-   [[Para [Str "yellow",Space,Str "fruit"]]])]
-,Para [Str "Multiple",Space,Str "blocks",Space,Str "with",Space,Str "italics:"]
-,DefinitionList
- [([Emph [Str "apple"]],
-   [[Para [Str "red",Space,Str "fruit"]
-    ,Para [Str "contains",Space,Str "seeds,",SoftBreak,Str "crisp,",Space,Str "pleasant",Space,Str "to",Space,Str "taste"]]])
- ,([Emph [Str "orange"]],
-   [[Para [Str "orange",Space,Str "fruit"]
-    ,CodeBlock ("",[],[]) "{ orange code block }"
-    ,BlockQuote
-     [Para [Str "orange",Space,Str "block",Space,Str "quote"]]]])]
-,Para [Str "Multiple",Space,Str "definitions,",Space,Str "tight:"]
-,DefinitionList
- [([Str "apple"],
-   [[Plain [Str "red",Space,Str "fruit"]]
-   ,[Plain [Str "computer"]]])
- ,([Str "orange"],
-   [[Plain [Str "orange",Space,Str "fruit"]]
-   ,[Plain [Str "bank"]]])]
-,Para [Str "Multiple",Space,Str "definitions,",Space,Str "loose:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]
-   ,[Para [Str "computer"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]]
-   ,[Para [Str "bank"]]])]
-,Para [Str "Blank",Space,Str "line",Space,Str "after",Space,Str "term,",Space,Str "indented",Space,Str "marker,",Space,Str "alternate",Space,Str "markers:"]
-,DefinitionList
- [([Str "apple"],
-   [[Para [Str "red",Space,Str "fruit"]]
-   ,[Para [Str "computer"]]])
- ,([Str "orange"],
-   [[Para [Str "orange",Space,Str "fruit"]
-    ,OrderedList (1,Decimal,Period)
-     [[Plain [Str "sublist"]]
-     ,[Plain [Str "sublist"]]]]])]
-,Header 1 ("html-blocks",[],[]) [Str "HTML",Space,Str "Blocks"]
-,Para [Str "Simple",Space,Str "block",Space,Str "on",Space,Str "one",Space,Str "line:"]
-,Div ("",[],[])
- [Plain [Str "foo"]]
-,Para [Str "And",Space,Str "nested",Space,Str "without",Space,Str "indentation:"]
-,Div ("",[],[])
- [Div ("",[],[])
-  [Div ("",[],[])
-   [Para [Str "foo"]]]
- ,Div ("",[],[])
-  [Plain [Str "bar"]]]
-,Para [Str "Interpreted",Space,Str "markdown",Space,Str "in",Space,Str "a",Space,Str "table:"]
-,RawBlock (Format "html") "<table>"
-,RawBlock (Format "html") "<tr>"
-,RawBlock (Format "html") "<td>"
-,Plain [Str "This",Space,Str "is",Space,Emph [Str "emphasized"]]
-,RawBlock (Format "html") "</td>"
-,RawBlock (Format "html") "<td>"
-,Plain [Str "And",Space,Str "this",Space,Str "is",Space,Strong [Str "strong"]]
-,RawBlock (Format "html") "</td>"
-,RawBlock (Format "html") "</tr>"
-,RawBlock (Format "html") "</table>"
-,RawBlock (Format "html") "<script type=\"text/javascript\">document.write('This *should not* be interpreted as markdown');</script>"
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "simple",Space,Str "block:"]
-,Div ("",[],[])
- [Para [Str "foo"]]
-,Para [Str "This",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "code",Space,Str "block,",Space,Str "though:"]
-,CodeBlock ("",[],[]) "<div>\n    foo\n</div>"
-,Para [Str "As",Space,Str "should",Space,Str "this:"]
-,CodeBlock ("",[],[]) "<div>foo</div>"
-,Para [Str "Now,",Space,Str "nested:"]
-,Div ("",[],[])
- [Div ("",[],[])
-  [Div ("",[],[])
-   [Plain [Str "foo"]]]]
-,Para [Str "This",Space,Str "should",Space,Str "just",Space,Str "be",Space,Str "an",Space,Str "HTML",Space,Str "comment:"]
-,RawBlock (Format "html") "<!-- Comment -->"
-,Para [Str "Multiline:"]
-,RawBlock (Format "html") "<!--\nBlah\nBlah\n-->"
-,RawBlock (Format "html") "<!--\n    This is another comment.\n-->"
-,Para [Str "Code",Space,Str "block:"]
-,CodeBlock ("",[],[]) "<!-- Comment -->"
-,Para [Str "Just",Space,Str "plain",Space,Str "comment,",Space,Str "with",Space,Str "trailing",Space,Str "spaces",Space,Str "on",Space,Str "the",Space,Str "line:"]
-,RawBlock (Format "html") "<!-- foo -->"
-,Para [Str "Code:"]
-,CodeBlock ("",[],[]) "<hr />"
-,Para [Str "Hr\8217s:"]
-,RawBlock (Format "html") "<hr>"
-,RawBlock (Format "html") "<hr />"
-,RawBlock (Format "html") "<hr />"
-,RawBlock (Format "html") "<hr>"
-,RawBlock (Format "html") "<hr />"
-,RawBlock (Format "html") "<hr />"
-,RawBlock (Format "html") "<hr class=\"foo\" id=\"bar\" />"
-,RawBlock (Format "html") "<hr class=\"foo\" id=\"bar\" />"
-,RawBlock (Format "html") "<hr class=\"foo\" id=\"bar\">"
-,HorizontalRule
-,Header 1 ("inline-markup",[],[]) [Str "Inline",Space,Str "Markup"]
-,Para [Str "This",Space,Str "is",Space,Emph [Str "emphasized"],Str ",",Space,Str "and",Space,Str "so",Space,Emph [Str "is",Space,Str "this"],Str "."]
-,Para [Str "This",Space,Str "is",Space,Strong [Str "strong"],Str ",",Space,Str "and",Space,Str "so",Space,Strong [Str "is",Space,Str "this"],Str "."]
-,Para [Str "An",Space,Emph [Link ("",[],[]) [Str "emphasized",Space,Str "link"] ("/url","")],Str "."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Strong [Emph [Str "This",Space,Str "is",Space,Str "strong",Space,Str "and",Space,Str "em."]]]
-,Para [Str "So",Space,Str "is",Space,Strong [Emph [Str "this"]],Space,Str "word."]
-,Para [Str "This",Space,Str "is",Space,Str "code:",Space,Code ("",[],[]) ">",Str ",",Space,Code ("",[],[]) "$",Str ",",Space,Code ("",[],[]) "\\",Str ",",Space,Code ("",[],[]) "\\$",Str ",",Space,Code ("",[],[]) "<html>",Str "."]
-,Para [Strikeout [Str "This",Space,Str "is",Space,Emph [Str "strikeout"],Str "."]]
-,Para [Str "Superscripts:",Space,Str "a",Superscript [Str "bc"],Str "d",Space,Str "a",Superscript [Emph [Str "hello"]],Space,Str "a",Superscript [Str "hello\160there"],Str "."]
-,Para [Str "Subscripts:",Space,Str "H",Subscript [Str "2"],Str "O,",Space,Str "H",Subscript [Str "23"],Str "O,",Space,Str "H",Subscript [Str "many\160of\160them"],Str "O."]
-,Para [Str "These",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "superscripts",Space,Str "or",Space,Str "subscripts,",SoftBreak,Str "because",Space,Str "of",Space,Str "the",Space,Str "unescaped",Space,Str "spaces:",Space,Str "a^b",Space,Str "c^d,",Space,Str "a~b",Space,Str "c~d."]
-,HorizontalRule
-,Header 1 ("smart-quotes-ellipses-dashes",[],[]) [Str "Smart",Space,Str "quotes,",Space,Str "ellipses,",Space,Str "dashes"]
-,Para [Quoted DoubleQuote [Str "Hello,"],Space,Str "said",Space,Str "the",Space,Str "spider.",Space,Quoted DoubleQuote [Quoted SingleQuote [Str "Shelob"],Space,Str "is",Space,Str "my",Space,Str "name."]]
-,Para [Quoted SingleQuote [Str "A"],Str ",",Space,Quoted SingleQuote [Str "B"],Str ",",Space,Str "and",Space,Quoted SingleQuote [Str "C"],Space,Str "are",Space,Str "letters."]
-,Para [Quoted SingleQuote [Str "Oak,"],Space,Quoted SingleQuote [Str "elm,"],Space,Str "and",Space,Quoted SingleQuote [Str "beech"],Space,Str "are",Space,Str "names",Space,Str "of",Space,Str "trees.",SoftBreak,Str "So",Space,Str "is",Space,Quoted SingleQuote [Str "pine."]]
-,Para [Quoted SingleQuote [Str "He",Space,Str "said,",Space,Quoted DoubleQuote [Str "I",Space,Str "want",Space,Str "to",Space,Str "go."]],Space,Str "Were",Space,Str "you",Space,Str "alive",Space,Str "in",Space,Str "the",SoftBreak,Str "70\8217s?"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "quoted",Space,Quoted SingleQuote [Code ("",[],[]) "code"],Space,Str "and",Space,Str "a",Space,Quoted DoubleQuote [Link ("",[],[]) [Str "quoted",Space,Str "link"] ("http://example.com/?foo=1&bar=2","")],Str "."]
-,Para [Str "Some",Space,Str "dashes:",Space,Str "one\8212two",Space,Str "\8212",Space,Str "three\8212four",Space,Str "\8212",Space,Str "five."]
-,Para [Str "Dashes",Space,Str "between",Space,Str "numbers:",Space,Str "5\8211\&7,",Space,Str "255\8211\&66,",Space,Str "1987\8211\&1999."]
-,Para [Str "Ellipses\8230and\8230and\8230."]
-,HorizontalRule
-,Header 1 ("latex",[],[]) [Str "LaTeX"]
-,BulletList
- [[Plain [RawInline (Format "tex") "\\cite[22-23]{smith.1899}"]]
- ,[Plain [Math InlineMath "2+2=4"]]
- ,[Plain [Math InlineMath "x \\in y"]]
- ,[Plain [Math InlineMath "\\alpha \\wedge \\omega"]]
- ,[Plain [Math InlineMath "223"]]
- ,[Plain [Math InlineMath "p",Str "-Tree"]]
- ,[Plain [Str "Here\8217s",Space,Str "some",Space,Str "display",Space,Str "math:",SoftBreak,Math DisplayMath "\\frac{d}{dx}f(x)=\\lim_{h\\to 0}\\frac{f(x+h)-f(x)}{h}"]]
- ,[Plain [Str "Here\8217s",Space,Str "one",Space,Str "that",Space,Str "has",Space,Str "a",Space,Str "line",Space,Str "break",Space,Str "in",Space,Str "it:",Space,Math InlineMath "\\alpha + \\omega \\times x^2",Str "."]]]
-,Para [Str "These",Space,Str "shouldn\8217t",Space,Str "be",Space,Str "math:"]
-,BulletList
- [[Plain [Str "To",Space,Str "get",Space,Str "the",Space,Str "famous",Space,Str "equation,",Space,Str "write",Space,Code ("",[],[]) "$e = mc^2$",Str "."]]
- ,[Plain [Str "$22,000",Space,Str "is",Space,Str "a",Space,Emph [Str "lot"],Space,Str "of",Space,Str "money.",Space,Str "So",Space,Str "is",Space,Str "$34,000.",SoftBreak,Str "(It",Space,Str "worked",Space,Str "if",Space,Quoted DoubleQuote [Str "lot"],Space,Str "is",Space,Str "emphasized.)"]]
- ,[Plain [Str "Shoes",Space,Str "($20)",Space,Str "and",Space,Str "socks",Space,Str "($5)."]]
- ,[Plain [Str "Escaped",Space,Code ("",[],[]) "$",Str ":",Space,Str "$73",Space,Emph [Str "this",Space,Str "should",Space,Str "be",Space,Str "emphasized"],Space,Str "23$."]]]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "LaTeX",Space,Str "table:"]
-,RawBlock (Format "tex") "\\begin{tabular}{|l|l|}\\hline\nAnimal & Number \\\\ \\hline\nDog    & 2      \\\\\nCat    & 1      \\\\ \\hline\n\\end{tabular}"
-,HorizontalRule
-,Header 1 ("special-characters",[],[]) [Str "Special",Space,Str "Characters"]
-,Para [Str "Here",Space,Str "is",Space,Str "some",Space,Str "unicode:"]
-,BulletList
- [[Plain [Str "I",Space,Str "hat:",Space,Str "\206"]]
- ,[Plain [Str "o",Space,Str "umlaut:",Space,Str "\246"]]
- ,[Plain [Str "section:",Space,Str "\167"]]
- ,[Plain [Str "set",Space,Str "membership:",Space,Str "\8712"]]
- ,[Plain [Str "copyright:",Space,Str "\169"]]]
-,Para [Str "AT&T",Space,Str "has",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "their",Space,Str "name."]
-,Para [Str "AT&T",Space,Str "is",Space,Str "another",Space,Str "way",Space,Str "to",Space,Str "write",Space,Str "it."]
-,Para [Str "This",Space,Str "&",Space,Str "that."]
-,Para [Str "4",Space,Str "<",Space,Str "5."]
-,Para [Str "6",Space,Str ">",Space,Str "5."]
-,Para [Str "Backslash:",Space,Str "\\"]
-,Para [Str "Backtick:",Space,Str "`"]
-,Para [Str "Asterisk:",Space,Str "*"]
-,Para [Str "Underscore:",Space,Str "_"]
-,Para [Str "Left",Space,Str "brace:",Space,Str "{"]
-,Para [Str "Right",Space,Str "brace:",Space,Str "}"]
-,Para [Str "Left",Space,Str "bracket:",Space,Str "["]
-,Para [Str "Right",Space,Str "bracket:",Space,Str "]"]
-,Para [Str "Left",Space,Str "paren:",Space,Str "("]
-,Para [Str "Right",Space,Str "paren:",Space,Str ")"]
-,Para [Str "Greater-than:",Space,Str ">"]
-,Para [Str "Hash:",Space,Str "#"]
-,Para [Str "Period:",Space,Str "."]
-,Para [Str "Bang:",Space,Str "!"]
-,Para [Str "Plus:",Space,Str "+"]
-,Para [Str "Minus:",Space,Str "-"]
-,HorizontalRule
-,Header 1 ("links",[],[]) [Str "Links"]
-,Header 2 ("explicit",[],[]) [Str "Explicit"]
-,Para [Str "Just",Space,Str "a",Space,Link ("",[],[]) [Str "URL"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title preceded by two spaces"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title preceded by a tab"),Str "."]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title with \"quotes\" in it")]
-,Para [Link ("",[],[]) [Str "URL",Space,Str "and",Space,Str "title"] ("/url/","title with single quotes")]
-,Para [Link ("",[],[]) [Str "with_underscore"] ("/url/with_underscore","")]
-,Para [Link ("",[],[]) [Str "Email",Space,Str "link"] ("mailto:nobody@nowhere.net","")]
-,Para [Link ("",[],[]) [Str "Empty"] ("",""),Str "."]
-,Header 2 ("reference",[],[]) [Str "Reference"]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/",""),Str "."]
-,Para [Str "With",Space,Link ("",[],[]) [Str "embedded",Space,Str "[brackets]"] ("/url/",""),Str "."]
-,Para [Link ("",[],[]) [Str "b"] ("/url/",""),Space,Str "by",Space,Str "itself",Space,Str "should",Space,Str "be",Space,Str "a",Space,Str "link."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "once"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "twice"] ("/url",""),Str "."]
-,Para [Str "Indented",Space,Link ("",[],[]) [Str "thrice"] ("/url",""),Str "."]
-,Para [Str "This",Space,Str "should",Space,Str "[not][]",Space,Str "be",Space,Str "a",Space,Str "link."]
-,CodeBlock ("",[],[]) "[not]: /url"
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "bar"] ("/url/","Title with \"quotes\" inside"),Str "."]
-,Para [Str "Foo",Space,Link ("",[],[]) [Str "biz"] ("/url/","Title with \"quote\" inside"),Str "."]
-,Header 2 ("with-ampersands",[],[]) [Str "With",Space,Str "ampersands"]
-,Para [Str "Here\8217s",Space,Str "a",Space,Link ("",[],[]) [Str "link",Space,Str "with",Space,Str "an",Space,Str "ampersand",Space,Str "in",Space,Str "the",Space,Str "URL"] ("http://example.com/?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "a",Space,Str "link",Space,Str "with",Space,Str "an",Space,Str "amersand",Space,Str "in",Space,Str "the",Space,Str "link",Space,Str "text:",Space,Link ("",[],[]) [Str "AT&T"] ("http://att.com/","AT&T"),Str "."]
-,Para [Str "Here\8217s",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link"] ("/script?foo=1&bar=2",""),Str "."]
-,Para [Str "Here\8217s",Space,Str "an",Space,Link ("",[],[]) [Str "inline",Space,Str "link",Space,Str "in",Space,Str "pointy",Space,Str "braces"] ("/script?foo=1&bar=2",""),Str "."]
-,Header 2 ("autolinks",[],[]) [Str "Autolinks"]
-,Para [Str "With",Space,Str "an",Space,Str "ampersand:",Space,Link ("",["uri"],[]) [Str "http://example.com/?foo=1&bar=2"] ("http://example.com/?foo=1&bar=2","")]
-,BulletList
- [[Plain [Str "In",Space,Str "a",Space,Str "list?"]]
- ,[Plain [Link ("",["uri"],[]) [Str "http://example.com/"] ("http://example.com/","")]]
- ,[Plain [Str "It",Space,Str "should."]]]
-,Para [Str "An",Space,Str "e-mail",Space,Str "address:",Space,Link ("",["email"],[]) [Str "nobody@nowhere.net"] ("mailto:nobody@nowhere.net","")]
-,BlockQuote
- [Para [Str "Blockquoted:",Space,Link ("",["uri"],[]) [Str "http://example.com/"] ("http://example.com/","")]]
-,Para [Str "Auto-links",Space,Str "should",Space,Str "not",Space,Str "occur",Space,Str "here:",Space,Code ("",[],[]) "<http://example.com/>"]
-,CodeBlock ("",[],[]) "or here: <http://example.com/>"
-,HorizontalRule
-,Header 1 ("images",[],[]) [Str "Images"]
-,Para [Str "From",Space,Quoted DoubleQuote [Str "Voyage",Space,Str "dans",Space,Str "la",Space,Str "Lune"],Space,Str "by",Space,Str "Georges",Space,Str "Melies",Space,Str "(1902):"]
-,Para [Image ("",[],[]) [Str "lalune"] ("lalune.jpg","fig:Voyage dans la Lune")]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "movie",Space,Image ("",[],[]) [Str "movie"] ("movie.jpg",""),Space,Str "icon."]
-,HorizontalRule
-,Header 1 ("footnotes",[],[]) [Str "Footnotes"]
-,Para [Str "Here",Space,Str "is",Space,Str "a",Space,Str "footnote",Space,Str "reference,",Note [Para [Str "Here",Space,Str "is",Space,Str "the",Space,Str "footnote.",Space,Str "It",Space,Str "can",Space,Str "go",Space,Str "anywhere",Space,Str "after",Space,Str "the",Space,Str "footnote",SoftBreak,Str "reference.",Space,Str "It",Space,Str "need",Space,Str "not",Space,Str "be",Space,Str "placed",Space,Str "at",Space,Str "the",Space,Str "end",Space,Str "of",Space,Str "the",Space,Str "document."]],Space,Str "and",Space,Str "another.",Note [Para [Str "Here\8217s",Space,Str "the",Space,Str "long",Space,Str "note.",Space,Str "This",Space,Str "one",Space,Str "contains",Space,Str "multiple",SoftBreak,Str "blocks."],Para [Str "Subsequent",Space,Str "blocks",Space,Str "are",Space,Str "indented",Space,Str "to",Space,Str "show",Space,Str "that",Space,Str "they",Space,Str "belong",Space,Str "to",Space,Str "the",SoftBreak,Str "footnote",Space,Str "(as",Space,Str "with",Space,Str "list",Space,Str "items)."],CodeBlock ("",[],[]) "  { <code> }",Para [Str "If",Space,Str "you",Space,Str "want,",Space,Str "you",Space,Str "can",Space,Str "indent",Space,Str "every",Space,Str "line,",Space,Str "but",Space,Str "you",Space,Str "can",Space,Str "also",Space,Str "be",SoftBreak,Str "lazy",Space,Str "and",Space,Str "just",Space,Str "indent",Space,Str "the",Space,Str "first",Space,Str "line",Space,Str "of",Space,Str "each",Space,Str "block."]],SoftBreak,Str "This",Space,Str "should",Space,Emph [Str "not"],Space,Str "be",Space,Str "a",Space,Str "footnote",Space,Str "reference,",Space,Str "because",Space,Str "it",SoftBreak,Str "contains",Space,Str "a",Space,Str "space.[^my",Space,Str "note]",Space,Str "Here",Space,Str "is",Space,Str "an",Space,Str "inline",Space,Str "note.",Note [Para [Str "This",SoftBreak,Str "is",Space,Emph [Str "easier"],Space,Str "to",Space,Str "type.",Space,Str "Inline",Space,Str "notes",Space,Str "may",Space,Str "contain",SoftBreak,Link ("",[],[]) [Str "links"] ("http://google.com",""),Space,Str "and",Space,Code ("",[],[]) "]",Space,Str "verbatim",Space,Str "characters,",SoftBreak,Str "as",Space,Str "well",Space,Str "as",Space,Str "[bracketed",Space,Str "text]."]]]
-,BlockQuote
- [Para [Str "Notes",Space,Str "can",Space,Str "go",Space,Str "in",Space,Str "quotes.",Note [Para [Str "In",Space,Str "quote."]]]]
-,OrderedList (1,Decimal,Period)
- [[Plain [Str "And",Space,Str "in",Space,Str "list",Space,Str "items.",Note [Para [Str "In",Space,Str "list."]]]]]
-,Para [Str "This",Space,Str "paragraph",Space,Str "should",Space,Str "not",Space,Str "be",Space,Str "part",Space,Str "of",Space,Str "the",Space,Str "note,",Space,Str "as",Space,Str "it",Space,Str "is",Space,Str "not",Space,Str "indented."]]
+Pandoc
+  ( Meta
+    { unMeta = fromList
+      [
+        ( "author"
+        , MetaList
+          [ MetaInlines
+            [ Str "John", Space, Str "MacFarlane" ]
+          , MetaInlines
+            [ Str "Anonymous" ]
+          ]
+        )
+      ,
+        ( "date"
+        , MetaInlines
+          [ Str "July", Space, Str "17,", Space, Str "2006" ]
+        )
+      ,
+        ( "title"
+        , MetaInlines
+          [ Str "Pandoc", Space, Str "Test", Space, Str "Suite" ]
+        )
+      ]
+    }
+  )
+  [ Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "set"
+    , Space
+    , Str "of"
+    , Space
+    , Str "tests"
+    , Space
+    , Str "for"
+    , Space
+    , Str "pandoc."
+    , Space
+    , Str "Most"
+    , Space
+    , Str "of"
+    , Space
+    , Str "them"
+    , Space
+    , Str "are"
+    , Space
+    , Str "adapted"
+    , Space
+    , Str "from"
+    , SoftBreak
+    , Str "John"
+    , Space
+    , Str "Gruber\8217s"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "test"
+    , Space
+    , Str "suite."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "headers", [], [] )
+    [ Str "Headers" ]
+  , Header 2
+    ( "level-2-with-an-embedded-link", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "link" ]
+      ( "/url", "" )
+    ]
+  , Header 3
+    ( "level-3-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "3"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 4
+    ( "level-4", [], [] )
+    [ Str "Level", Space, Str "4" ]
+  , Header 5
+    ( "level-5", [], [] )
+    [ Str "Level", Space, Str "5" ]
+  , Header 1
+    ( "level-1", [], [] )
+    [ Str "Level", Space, Str "1" ]
+  , Header 2
+    ( "level-2-with-emphasis", [], [] )
+    [ Str "Level"
+    , Space
+    , Str "2"
+    , Space
+    , Str "with"
+    , Space
+    , Emph
+      [ Str "emphasis" ]
+    ]
+  , Header 3
+    ( "level-3", [], [] )
+    [ Str "Level", Space, Str "3" ]
+  , Para
+    [ Str "with", Space, Str "no", Space, Str "blank", Space, Str "line" ]
+  , Header 2
+    ( "level-2", [], [] )
+    [ Str "Level", Space, Str "2" ]
+  , Para
+    [ Str "with", Space, Str "no", Space, Str "blank", Space, Str "line" ]
+  , HorizontalRule
+  , Header 1
+    ( "paragraphs", [], [] )
+    [ Str "Paragraphs" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "regular"
+    , Space
+    , Str "paragraph."
+    ]
+  , Para
+    [ Str "In"
+    , Space
+    , Str "Markdown"
+    , Space
+    , Str "1.0.0"
+    , Space
+    , Str "and"
+    , Space
+    , Str "earlier."
+    , Space
+    , Str "Version"
+    , SoftBreak
+    , Str "8."
+    , Space
+    , Str "This"
+    , Space
+    , Str "line"
+    , Space
+    , Str "turns"
+    , Space
+    , Str "into"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item."
+    , SoftBreak
+    , Str "Because"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard-wrapped"
+    , Space
+    , Str "line"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "middle"
+    , Space
+    , Str "of"
+    , Space
+    , Str "a"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "looked"
+    , Space
+    , Str "like"
+    , Space
+    , Str "a"
+    , SoftBreak
+    , Str "list"
+    , Space
+    , Str "item."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "one"
+    , Space
+    , Str "with"
+    , Space
+    , Str "a"
+    , Space
+    , Str "bullet."
+    , SoftBreak
+    , Str "*"
+    , Space
+    , Str "criminey."
+    ]
+  , Para
+    [ Str "There"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "hard"
+    , Space
+    , Str "line"
+    , Space
+    , Str "break"
+    , LineBreak
+    , Str "here."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "block-quotes", [], [] )
+    [ Str "Block", Space, Str "Quotes" ]
+  , Para
+    [ Str "E-mail", Space, Str "style:" ]
+  , BlockQuote
+    [ Para
+      [ Str "This"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote."
+      , SoftBreak
+      , Str "It"
+      , Space
+      , Str "is"
+      , Space
+      , Str "pretty"
+      , Space
+      , Str "short."
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Code"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote:"
+      ]
+    , CodeBlock
+      ( "", [], [] ) "sub status {\n    print \"working\";\n}"
+    , Para
+      [ Str "A", Space, Str "list:" ]
+    , OrderedList
+      ( 1, Decimal, Period )
+      [
+        [ Plain [ Str "item", Space, Str "one" ] ]
+      ,
+        [ Plain [ Str "item", Space, Str "two" ] ]
+      ]
+    , Para
+      [ Str "Nested", Space, Str "block", Space, Str "quotes:" ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    , BlockQuote
+      [ Para [ Str "nested" ] ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "block"
+    , Space
+    , Str "quote:"
+    , Space
+    , Str "2"
+    , SoftBreak
+    , Str ">"
+    , Space
+    , Str "1."
+    ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "a"
+    , Space
+    , Str "following"
+    , Space
+    , Str "paragraph."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "code-blocks", [], [] )
+    [ Str "Code", Space, Str "Blocks" ]
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "---- (should be four hyphens)\n\nsub status {\n    print \"working\";\n}\n\nthis code block is indented by one tab"
+  , Para
+    [ Str "And:" ]
+  , CodeBlock
+    ( ""
+    , []
+    , []
+    ) "    this code block is indented by two tabs\n\nThese should not be escaped:  \\$ \\\\ \\> \\[ \\{"
+  , HorizontalRule
+  , Header 1
+    ( "lists", [], [] )
+    [ Str "Lists" ]
+  , Header 2
+    ( "unordered", [], [] )
+    [ Str "Unordered" ]
+  , Para
+    [ Str "Asterisks", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Asterisks", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "asterisk", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "asterisk", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Pluses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Plus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Plus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "tight:" ]
+  , BulletList
+    [
+      [ Plain [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Plain [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Para
+    [ Str "Minuses", Space, Str "loose:" ]
+  , BulletList
+    [
+      [ Para [ Str "Minus", Space, Str "1" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "2" ] ]
+    ,
+      [ Para [ Str "Minus", Space, Str "3" ] ]
+    ]
+  , Header 2
+    ( "ordered", [], [] )
+    [ Str "Ordered" ]
+  , Para
+    [ Str "Tight:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain [ Str "Second" ] ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "One" ] ]
+    ,
+      [ Plain [ Str "Two" ] ]
+    ,
+      [ Plain [ Str "Three" ] ]
+    ]
+  , Para
+    [ Str "Loose", Space, Str "using", Space, Str "tabs:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para [ Str "Second" ] ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "and", Space, Str "using", Space, Str "spaces:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [ [ Para [ Str "One" ] ], [ Para [ Str "Two" ] ], [ Para [ Str "Three" ] ] ]
+  , Para
+    [ Str "Multiple", Space, Str "paragraphs:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para
+        [ Str "Item", Space, Str "1,", Space, Str "graf", Space, Str "one." ]
+      , Para
+        [ Str "Item"
+        , Space
+        , Str "1."
+        , Space
+        , Str "graf"
+        , Space
+        , Str "two."
+        , Space
+        , Str "The"
+        , Space
+        , Str "quick"
+        , Space
+        , Str "brown"
+        , Space
+        , Str "fox"
+        , Space
+        , Str "jumped"
+        , Space
+        , Str "over"
+        , Space
+        , Str "the"
+        , Space
+        , Str "lazy"
+        , Space
+        , Str "dog\8217s"
+        , SoftBreak
+        , Str "back."
+        ]
+      ]
+    ,
+      [ Para [ Str "Item", Space, Str "2." ] ]
+    ,
+      [ Para [ Str "Item", Space, Str "3." ] ]
+    ]
+  , Header 2
+    ( "nested", [], [] )
+    [ Str "Nested" ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "Tab" ]
+      , BulletList
+        [ [ Plain [ Str "Tab" ], BulletList [ [ Plain [ Str "Tab" ] ] ] ] ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s", Space, Str "another:" ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain [ Str "First" ] ]
+    ,
+      [ Plain
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Plain [ Str "Fee" ] ]
+        ,
+          [ Plain [ Str "Fie" ] ]
+        ,
+          [ Plain [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Plain [ Str "Third" ] ]
+    ]
+  , Para
+    [ Str "Same"
+    , Space
+    , Str "thing"
+    , Space
+    , Str "but"
+    , Space
+    , Str "with"
+    , Space
+    , Str "paragraphs:"
+    ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Para [ Str "First" ] ]
+    ,
+      [ Para
+        [ Str "Second:" ]
+      , BulletList
+        [
+          [ Plain [ Str "Fee" ] ]
+        ,
+          [ Plain [ Str "Fie" ] ]
+        ,
+          [ Plain [ Str "Foe" ] ]
+        ]
+      ]
+    ,
+      [ Para [ Str "Third" ] ]
+    ]
+  , Header 2
+    ( "tabs-and-spaces", [], [] )
+    [ Str "Tabs", Space, Str "and", Space, Str "spaces" ]
+  , BulletList
+    [
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , SoftBreak
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "tabs"
+        ]
+      ]
+    ,
+      [ Para
+        [ Str "this"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Str "list"
+        , Space
+        , Str "item"
+        , SoftBreak
+        , Str "indented"
+        , Space
+        , Str "with"
+        , Space
+        , Str "spaces"
+        ]
+      , BulletList
+        [
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , SoftBreak
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "tabs"
+            ]
+          ]
+        ,
+          [ Para
+            [ Str "this"
+            , Space
+            , Str "is"
+            , Space
+            , Str "an"
+            , Space
+            , Str "example"
+            , Space
+            , Str "list"
+            , Space
+            , Str "item"
+            , SoftBreak
+            , Str "indented"
+            , Space
+            , Str "with"
+            , Space
+            , Str "spaces"
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Header 2
+    ( "fancy-list-markers", [], [] )
+    [ Str "Fancy", Space, Str "list", Space, Str "markers" ]
+  , OrderedList
+    ( 2, Decimal, TwoParens )
+    [
+      [ Para [ Str "begins", Space, Str "with", Space, Str "2" ] ]
+    ,
+      [ Para
+        [ Str "and", Space, Str "now", Space, Str "3" ]
+      , Para
+        [ Str "with", Space, Str "a", Space, Str "continuation" ]
+      , OrderedList
+        ( 4, LowerRoman, Period )
+        [
+          [ Plain
+            [ Str "sublist"
+            , Space
+            , Str "with"
+            , Space
+            , Str "roman"
+            , Space
+            , Str "numerals,"
+            , SoftBreak
+            , Str "starting"
+            , Space
+            , Str "with"
+            , Space
+            , Str "4"
+            ]
+          ]
+        ,
+          [ Plain
+            [ Str "more", Space, Str "items" ]
+          , OrderedList
+            ( 1, UpperAlpha, TwoParens )
+            [
+              [ Plain [ Str "a", Space, Str "subsublist" ] ]
+            ,
+              [ Plain [ Str "a", Space, Str "subsublist" ] ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Nesting:" ]
+  , OrderedList
+    ( 1, UpperAlpha, Period )
+    [
+      [ Plain
+        [ Str "Upper", Space, Str "Alpha" ]
+      , OrderedList
+        ( 1, UpperRoman, Period )
+        [
+          [ Plain
+            [ Str "Upper", Space, Str "Roman." ]
+          , OrderedList
+            ( 6, Decimal, TwoParens )
+            [
+              [ Plain
+                [ Str "Decimal"
+                , Space
+                , Str "start"
+                , Space
+                , Str "with"
+                , Space
+                , Str "6"
+                ]
+              , OrderedList
+                ( 3, LowerAlpha, OneParen )
+                [
+                  [ Plain
+                    [ Str "Lower"
+                    , Space
+                    , Str "alpha"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "paren"
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Autonumbering:" ]
+  , OrderedList
+    ( 1, DefaultStyle, DefaultDelim )
+    [
+      [ Plain [ Str "Autonumber." ] ]
+    ,
+      [ Plain
+        [ Str "More." ]
+      , OrderedList
+        ( 1, DefaultStyle, DefaultDelim )
+        [ [ Plain [ Str "Nested." ] ] ]
+      ]
+    ]
+  , Para
+    [ Str "Should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "list"
+    , Space
+    , Str "item:"
+    ]
+  , Para
+    [ Str "M.A.\160\&2007" ]
+  , Para
+    [ Str "B.", Space, Str "Williams" ]
+  , HorizontalRule
+  , Header 1
+    ( "definition-lists", [], [] )
+    [ Str "Definition", Space, Str "Lists" ]
+  , Para
+    [ Str "Tight", Space, Str "using", Space, Str "spaces:" ]
+  , DefinitionList
+    [
+      ( [ Str "apple" ], [ [ Plain [ Str "red", Space, Str "fruit" ] ] ] )
+    ,
+      ( [ Str "orange" ], [ [ Plain [ Str "orange", Space, Str "fruit" ] ] ] )
+    ,
+      ( [ Str "banana" ], [ [ Plain [ Str "yellow", Space, Str "fruit" ] ] ] )
+    ]
+  , Para
+    [ Str "Tight", Space, Str "using", Space, Str "tabs:" ]
+  , DefinitionList
+    [
+      ( [ Str "apple" ], [ [ Plain [ Str "red", Space, Str "fruit" ] ] ] )
+    ,
+      ( [ Str "orange" ], [ [ Plain [ Str "orange", Space, Str "fruit" ] ] ] )
+    ,
+      ( [ Str "banana" ], [ [ Plain [ Str "yellow", Space, Str "fruit" ] ] ] )
+    ]
+  , Para
+    [ Str "Loose:" ]
+  , DefinitionList
+    [
+      ( [ Str "apple" ], [ [ Para [ Str "red", Space, Str "fruit" ] ] ] )
+    ,
+      ( [ Str "orange" ], [ [ Para [ Str "orange", Space, Str "fruit" ] ] ] )
+    ,
+      ( [ Str "banana" ], [ [ Para [ Str "yellow", Space, Str "fruit" ] ] ] )
+    ]
+  , Para
+    [ Str "Multiple"
+    , Space
+    , Str "blocks"
+    , Space
+    , Str "with"
+    , Space
+    , Str "italics:"
+    ]
+  , DefinitionList
+    [
+      (
+        [ Emph [ Str "apple" ] ]
+      ,
+        [
+          [ Para
+            [ Str "red", Space, Str "fruit" ]
+          , Para
+            [ Str "contains"
+            , Space
+            , Str "seeds,"
+            , SoftBreak
+            , Str "crisp,"
+            , Space
+            , Str "pleasant"
+            , Space
+            , Str "to"
+            , Space
+            , Str "taste"
+            ]
+          ]
+        ]
+      )
+    ,
+      (
+        [ Emph [ Str "orange" ] ]
+      ,
+        [
+          [ Para
+            [ Str "orange", Space, Str "fruit" ]
+          , CodeBlock
+            ( "", [], [] ) "{ orange code block }"
+          , BlockQuote
+            [ Para [ Str "orange", Space, Str "block", Space, Str "quote" ] ]
+          ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "definitions,", Space, Str "tight:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [
+          [ Plain [ Str "red", Space, Str "fruit" ] ]
+        ,
+          [ Plain [ Str "computer" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [
+          [ Plain [ Str "orange", Space, Str "fruit" ] ]
+        ,
+          [ Plain [ Str "bank" ] ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Multiple", Space, Str "definitions,", Space, Str "loose:" ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [
+          [ Para [ Str "red", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "computer" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [
+          [ Para [ Str "orange", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "bank" ] ]
+        ]
+      )
+    ]
+  , Para
+    [ Str "Blank"
+    , Space
+    , Str "line"
+    , Space
+    , Str "after"
+    , Space
+    , Str "term,"
+    , Space
+    , Str "indented"
+    , Space
+    , Str "marker,"
+    , Space
+    , Str "alternate"
+    , Space
+    , Str "markers:"
+    ]
+  , DefinitionList
+    [
+      (
+        [ Str "apple" ]
+      ,
+        [
+          [ Para [ Str "red", Space, Str "fruit" ] ]
+        ,
+          [ Para [ Str "computer" ] ]
+        ]
+      )
+    ,
+      (
+        [ Str "orange" ]
+      ,
+        [
+          [ Para
+            [ Str "orange", Space, Str "fruit" ]
+          , OrderedList
+            ( 1, Decimal, Period )
+            [ [ Plain [ Str "sublist" ] ], [ Plain [ Str "sublist" ] ] ]
+          ]
+        ]
+      )
+    ]
+  , Header 1
+    ( "html-blocks", [], [] )
+    [ Str "HTML", Space, Str "Blocks" ]
+  , Para
+    [ Str "Simple"
+    , Space
+    , Str "block"
+    , Space
+    , Str "on"
+    , Space
+    , Str "one"
+    , Space
+    , Str "line:"
+    ]
+  , Div
+    ( "", [], [] )
+    [ Plain [ Str "foo" ] ]
+  , Para
+    [ Str "And"
+    , Space
+    , Str "nested"
+    , Space
+    , Str "without"
+    , Space
+    , Str "indentation:"
+    ]
+  , Div
+    ( "", [], [] )
+    [ Div
+      ( "", [], [] )
+      [ Div ( "", [], [] ) [ Para [ Str "foo" ] ] ]
+    , Div
+      ( "", [], [] )
+      [ Plain [ Str "bar" ] ]
+    ]
+  , Para
+    [ Str "Interpreted"
+    , Space
+    , Str "markdown"
+    , Space
+    , Str "in"
+    , Space
+    , Str "a"
+    , Space
+    , Str "table:"
+    ]
+  , RawBlock
+    ( Format "html" ) "<table>"
+  , RawBlock
+    ( Format "html" ) "<tr>"
+  , RawBlock
+    ( Format "html" ) "<td>"
+  , Plain
+    [ Str "This", Space, Str "is", Space, Emph [ Str "emphasized" ] ]
+  , RawBlock
+    ( Format "html" ) "</td>"
+  , RawBlock
+    ( Format "html" ) "<td>"
+  , Plain
+    [ Str "And"
+    , Space
+    , Str "this"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    ]
+  , RawBlock
+    ( Format "html" ) "</td>"
+  , RawBlock
+    ( Format "html" ) "</tr>"
+  , RawBlock
+    ( Format "html" ) "</table>"
+  , RawBlock
+    ( Format "html" ) "<script type=\"text/javascript\">document.write('This *should not* be interpreted as markdown');</script>"
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "simple"
+    , Space
+    , Str "block:"
+    ]
+  , Div
+    ( "", [], [] )
+    [ Para [ Str "foo" ] ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "code"
+    , Space
+    , Str "block,"
+    , Space
+    , Str "though:"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "<div>\n    foo\n</div>"
+  , Para
+    [ Str "As", Space, Str "should", Space, Str "this:" ]
+  , CodeBlock
+    ( "", [], [] ) "<div>foo</div>"
+  , Para
+    [ Str "Now,", Space, Str "nested:" ]
+  , Div
+    ( "", [], [] )
+    [ Div ( "", [], [] ) [ Div ( "", [], [] ) [ Plain [ Str "foo" ] ] ] ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "just"
+    , Space
+    , Str "be"
+    , Space
+    , Str "an"
+    , Space
+    , Str "HTML"
+    , Space
+    , Str "comment:"
+    ]
+  , RawBlock
+    ( Format "html" ) "<!-- Comment -->"
+  , Para
+    [ Str "Multiline:" ]
+  , RawBlock
+    ( Format "html" ) "<!--\nBlah\nBlah\n-->"
+  , RawBlock
+    ( Format "html" ) "<!--\n    This is another comment.\n-->"
+  , Para
+    [ Str "Code", Space, Str "block:" ]
+  , CodeBlock
+    ( "", [], [] ) "<!-- Comment -->"
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "plain"
+    , Space
+    , Str "comment,"
+    , Space
+    , Str "with"
+    , Space
+    , Str "trailing"
+    , Space
+    , Str "spaces"
+    , Space
+    , Str "on"
+    , Space
+    , Str "the"
+    , Space
+    , Str "line:"
+    ]
+  , RawBlock
+    ( Format "html" ) "<!-- foo -->"
+  , Para
+    [ Str "Code:" ]
+  , CodeBlock
+    ( "", [], [] ) "<hr />"
+  , Para
+    [ Str "Hr\8217s:" ]
+  , RawBlock
+    ( Format "html" ) "<hr>"
+  , RawBlock
+    ( Format "html" ) "<hr />"
+  , RawBlock
+    ( Format "html" ) "<hr />"
+  , RawBlock
+    ( Format "html" ) "<hr>"
+  , RawBlock
+    ( Format "html" ) "<hr />"
+  , RawBlock
+    ( Format "html" ) "<hr />"
+  , RawBlock
+    ( Format "html" ) "<hr class=\"foo\" id=\"bar\" />"
+  , RawBlock
+    ( Format "html" ) "<hr class=\"foo\" id=\"bar\" />"
+  , RawBlock
+    ( Format "html" ) "<hr class=\"foo\" id=\"bar\">"
+  , HorizontalRule
+  , Header 1
+    ( "inline-markup", [], [] )
+    [ Str "Inline", Space, Str "Markup" ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Emph
+      [ Str "emphasized" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Emph
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Str "strong" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Str "so"
+    , Space
+    , Strong
+      [ Str "is", Space, Str "this" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Emph
+      [ Link
+        ( "", [], [] )
+        [ Str "emphasized", Space, Str "link" ]
+        ( "/url", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Strong
+      [ Emph
+        [ Str "This"
+        , Space
+        , Str "is"
+        , Space
+        , Str "strong"
+        , Space
+        , Str "and"
+        , Space
+        , Str "em."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Strong
+      [ Emph [ Str "this" ] ]
+    , Space
+    , Str "word."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "is"
+    , Space
+    , Str "code:"
+    , Space
+    , Code
+      ( "", [], [] ) ">"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "\\$"
+    , Str ","
+    , Space
+    , Code
+      ( "", [], [] ) "<html>"
+    , Str "."
+    ]
+  , Para
+    [ Strikeout
+      [ Str "This", Space, Str "is", Space, Emph [ Str "strikeout" ], Str "." ]
+    ]
+  , Para
+    [ Str "Superscripts:"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "bc" ]
+    , Str "d"
+    , Space
+    , Str "a"
+    , Superscript
+      [ Emph [ Str "hello" ] ]
+    , Space
+    , Str "a"
+    , Superscript
+      [ Str "hello\160there" ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Subscripts:"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "2" ]
+    , Str "O,"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "23" ]
+    , Str "O,"
+    , Space
+    , Str "H"
+    , Subscript
+      [ Str "many\160of\160them" ]
+    , Str "O."
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "superscripts"
+    , Space
+    , Str "or"
+    , Space
+    , Str "subscripts,"
+    , SoftBreak
+    , Str "because"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "unescaped"
+    , Space
+    , Str "spaces:"
+    , Space
+    , Str "a^b"
+    , Space
+    , Str "c^d,"
+    , Space
+    , Str "a~b"
+    , Space
+    , Str "c~d."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "smart-quotes-ellipses-dashes", [], [] )
+    [ Str "Smart"
+    , Space
+    , Str "quotes,"
+    , Space
+    , Str "ellipses,"
+    , Space
+    , Str "dashes"
+    ]
+  , Para
+    [ Quoted DoubleQuote
+      [ Str "Hello," ]
+    , Space
+    , Str "said"
+    , Space
+    , Str "the"
+    , Space
+    , Str "spider."
+    , Space
+    , Quoted DoubleQuote
+      [ Quoted SingleQuote
+        [ Str "Shelob" ]
+      , Space
+      , Str "is"
+      , Space
+      , Str "my"
+      , Space
+      , Str "name."
+      ]
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "A" ]
+    , Str ","
+    , Space
+    , Quoted SingleQuote
+      [ Str "B" ]
+    , Str ","
+    , Space
+    , Str "and"
+    , Space
+    , Quoted SingleQuote
+      [ Str "C" ]
+    , Space
+    , Str "are"
+    , Space
+    , Str "letters."
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "Oak," ]
+    , Space
+    , Quoted SingleQuote
+      [ Str "elm," ]
+    , Space
+    , Str "and"
+    , Space
+    , Quoted SingleQuote
+      [ Str "beech" ]
+    , Space
+    , Str "are"
+    , Space
+    , Str "names"
+    , Space
+    , Str "of"
+    , Space
+    , Str "trees."
+    , SoftBreak
+    , Str "So"
+    , Space
+    , Str "is"
+    , Space
+    , Quoted SingleQuote
+      [ Str "pine." ]
+    ]
+  , Para
+    [ Quoted SingleQuote
+      [ Str "He"
+      , Space
+      , Str "said,"
+      , Space
+      , Quoted DoubleQuote
+        [ Str "I", Space, Str "want", Space, Str "to", Space, Str "go." ]
+      ]
+    , Space
+    , Str "Were"
+    , Space
+    , Str "you"
+    , Space
+    , Str "alive"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , SoftBreak
+    , Str "70\8217s?"
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "some"
+    , Space
+    , Str "quoted"
+    , Space
+    , Quoted SingleQuote
+      [ Code ( "", [], [] ) "code" ]
+    , Space
+    , Str "and"
+    , Space
+    , Str "a"
+    , Space
+    , Quoted DoubleQuote
+      [ Link
+        ( "", [], [] )
+        [ Str "quoted", Space, Str "link" ]
+        ( "http://example.com/?foo=1&bar=2", "" )
+      ]
+    , Str "."
+    ]
+  , Para
+    [ Str "Some"
+    , Space
+    , Str "dashes:"
+    , Space
+    , Str "one\8212two"
+    , Space
+    , Str "\8212"
+    , Space
+    , Str "three\8212four"
+    , Space
+    , Str "\8212"
+    , Space
+    , Str "five."
+    ]
+  , Para
+    [ Str "Dashes"
+    , Space
+    , Str "between"
+    , Space
+    , Str "numbers:"
+    , Space
+    , Str "5\8211\&7,"
+    , Space
+    , Str "255\8211\&66,"
+    , Space
+    , Str "1987\8211\&1999."
+    ]
+  , Para
+    [ Str "Ellipses\8230and\8230and\8230." ]
+  , HorizontalRule
+  , Header 1
+    ( "latex", [], [] )
+    [ Str "LaTeX" ]
+  , BulletList
+    [
+      [ Plain [ RawInline ( Format "tex" ) "\\cite[22-23]{smith.1899}" ] ]
+    ,
+      [ Plain [ Math InlineMath "2+2=4" ] ]
+    ,
+      [ Plain [ Math InlineMath "x \\in y" ] ]
+    ,
+      [ Plain [ Math InlineMath "\\alpha \\wedge \\omega" ] ]
+    ,
+      [ Plain [ Math InlineMath "223" ] ]
+    ,
+      [ Plain [ Math InlineMath "p", Str "-Tree" ] ]
+    ,
+      [ Plain
+        [ Str "Here\8217s"
+        , Space
+        , Str "some"
+        , Space
+        , Str "display"
+        , Space
+        , Str "math:"
+        , SoftBreak
+        , Math DisplayMath "\\frac{d}{dx}f(x)=\\lim_{h\\to 0}\\frac{f(x+h)-f(x)}{h}"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Here\8217s"
+        , Space
+        , Str "one"
+        , Space
+        , Str "that"
+        , Space
+        , Str "has"
+        , Space
+        , Str "a"
+        , Space
+        , Str "line"
+        , Space
+        , Str "break"
+        , Space
+        , Str "in"
+        , Space
+        , Str "it:"
+        , Space
+        , Math InlineMath "\\alpha + \\omega \\times x^2"
+        , Str "."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "These"
+    , Space
+    , Str "shouldn\8217t"
+    , Space
+    , Str "be"
+    , Space
+    , Str "math:"
+    ]
+  , BulletList
+    [
+      [ Plain
+        [ Str "To"
+        , Space
+        , Str "get"
+        , Space
+        , Str "the"
+        , Space
+        , Str "famous"
+        , Space
+        , Str "equation,"
+        , Space
+        , Str "write"
+        , Space
+        , Code
+          ( "", [], [] ) "$e = mc^2$"
+        , Str "."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "$22,000"
+        , Space
+        , Str "is"
+        , Space
+        , Str "a"
+        , Space
+        , Emph
+          [ Str "lot" ]
+        , Space
+        , Str "of"
+        , Space
+        , Str "money."
+        , Space
+        , Str "So"
+        , Space
+        , Str "is"
+        , Space
+        , Str "$34,000."
+        , SoftBreak
+        , Str "(It"
+        , Space
+        , Str "worked"
+        , Space
+        , Str "if"
+        , Space
+        , Quoted DoubleQuote
+          [ Str "lot" ]
+        , Space
+        , Str "is"
+        , Space
+        , Str "emphasized.)"
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Shoes"
+        , Space
+        , Str "($20)"
+        , Space
+        , Str "and"
+        , Space
+        , Str "socks"
+        , Space
+        , Str "($5)."
+        ]
+      ]
+    ,
+      [ Plain
+        [ Str "Escaped"
+        , Space
+        , Code
+          ( "", [], [] ) "$"
+        , Str ":"
+        , Space
+        , Str "$73"
+        , Space
+        , Emph
+          [ Str "this"
+          , Space
+          , Str "should"
+          , Space
+          , Str "be"
+          , Space
+          , Str "emphasized"
+          ]
+        , Space
+        , Str "23$."
+        ]
+      ]
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "LaTeX"
+    , Space
+    , Str "table:"
+    ]
+  , RawBlock
+    ( Format "tex" ) "\\begin{tabular}{|l|l|}\\hline\nAnimal & Number \\\\ \\hline\nDog    & 2      \\\\\nCat    & 1      \\\\ \\hline\n\\end{tabular}"
+  , HorizontalRule
+  , Header 1
+    ( "special-characters", [], [] )
+    [ Str "Special", Space, Str "Characters" ]
+  , Para
+    [ Str "Here", Space, Str "is", Space, Str "some", Space, Str "unicode:" ]
+  , BulletList
+    [
+      [ Plain [ Str "I", Space, Str "hat:", Space, Str "\206" ] ]
+    ,
+      [ Plain [ Str "o", Space, Str "umlaut:", Space, Str "\246" ] ]
+    ,
+      [ Plain [ Str "section:", Space, Str "\167" ] ]
+    ,
+      [ Plain [ Str "set", Space, Str "membership:", Space, Str "\8712" ] ]
+    ,
+      [ Plain [ Str "copyright:", Space, Str "\169" ] ]
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "has"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "their"
+    , Space
+    , Str "name."
+    ]
+  , Para
+    [ Str "AT&T"
+    , Space
+    , Str "is"
+    , Space
+    , Str "another"
+    , Space
+    , Str "way"
+    , Space
+    , Str "to"
+    , Space
+    , Str "write"
+    , Space
+    , Str "it."
+    ]
+  , Para
+    [ Str "This", Space, Str "&", Space, Str "that." ]
+  , Para
+    [ Str "4", Space, Str "<", Space, Str "5." ]
+  , Para
+    [ Str "6", Space, Str ">", Space, Str "5." ]
+  , Para
+    [ Str "Backslash:", Space, Str "\\" ]
+  , Para
+    [ Str "Backtick:", Space, Str "`" ]
+  , Para
+    [ Str "Asterisk:", Space, Str "*" ]
+  , Para
+    [ Str "Underscore:", Space, Str "_" ]
+  , Para
+    [ Str "Left", Space, Str "brace:", Space, Str "{" ]
+  , Para
+    [ Str "Right", Space, Str "brace:", Space, Str "}" ]
+  , Para
+    [ Str "Left", Space, Str "bracket:", Space, Str "[" ]
+  , Para
+    [ Str "Right", Space, Str "bracket:", Space, Str "]" ]
+  , Para
+    [ Str "Left", Space, Str "paren:", Space, Str "(" ]
+  , Para
+    [ Str "Right", Space, Str "paren:", Space, Str ")" ]
+  , Para
+    [ Str "Greater-than:", Space, Str ">" ]
+  , Para
+    [ Str "Hash:", Space, Str "#" ]
+  , Para
+    [ Str "Period:", Space, Str "." ]
+  , Para
+    [ Str "Bang:", Space, Str "!" ]
+  , Para
+    [ Str "Plus:", Space, Str "+" ]
+  , Para
+    [ Str "Minus:", Space, Str "-" ]
+  , HorizontalRule
+  , Header 1
+    ( "links", [], [] )
+    [ Str "Links" ]
+  , Header 2
+    ( "explicit", [], [] )
+    [ Str "Explicit" ]
+  , Para
+    [ Str "Just"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "URL" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title preceded by two spaces" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title preceded by a tab" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title with \"quotes\" in it" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "URL", Space, Str "and", Space, Str "title" ]
+      ( "/url/", "title with single quotes" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "with_underscore" ]
+      ( "/url/with_underscore", "" )
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "Email", Space, Str "link" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , Para
+    [ Link ( "", [], [] ) [ Str "Empty" ] ( "", "" ), Str "." ]
+  , Header 2
+    ( "reference", [], [] )
+    [ Str "Reference" ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "With"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "embedded", Space, Str "[brackets]" ]
+      ( "/url/", "" )
+    , Str "."
+    ]
+  , Para
+    [ Link
+      ( "", [], [] )
+      [ Str "b" ]
+      ( "/url/", "" )
+    , Space
+    , Str "by"
+    , Space
+    , Str "itself"
+    , Space
+    , Str "should"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "once" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "twice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Indented"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "thrice" ]
+      ( "/url", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Str "[not][]"
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link."
+    ]
+  , CodeBlock
+    ( "", [], [] ) "[not]: /url"
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "bar" ]
+      ( "/url/", "Title with \"quotes\" inside" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Foo"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "biz" ]
+      ( "/url/", "Title with \"quote\" inside" )
+    , Str "."
+    ]
+  , Header 2
+    ( "with-ampersands", [], [] )
+    [ Str "With", Space, Str "ampersands" ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "link"
+      , Space
+      , Str "with"
+      , Space
+      , Str "an"
+      , Space
+      , Str "ampersand"
+      , Space
+      , Str "in"
+      , Space
+      , Str "the"
+      , Space
+      , Str "URL"
+      ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "a"
+    , Space
+    , Str "link"
+    , Space
+    , Str "with"
+    , Space
+    , Str "an"
+    , Space
+    , Str "amersand"
+    , Space
+    , Str "in"
+    , Space
+    , Str "the"
+    , Space
+    , Str "link"
+    , Space
+    , Str "text:"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "AT&T" ]
+      ( "http://att.com/", "AT&T" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline", Space, Str "link" ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Para
+    [ Str "Here\8217s"
+    , Space
+    , Str "an"
+    , Space
+    , Link
+      ( "", [], [] )
+      [ Str "inline"
+      , Space
+      , Str "link"
+      , Space
+      , Str "in"
+      , Space
+      , Str "pointy"
+      , Space
+      , Str "braces"
+      ]
+      ( "/script?foo=1&bar=2", "" )
+    , Str "."
+    ]
+  , Header 2
+    ( "autolinks", [], [] )
+    [ Str "Autolinks" ]
+  , Para
+    [ Str "With"
+    , Space
+    , Str "an"
+    , Space
+    , Str "ampersand:"
+    , Space
+    , Link
+      ( "", [ "uri" ], [] )
+      [ Str "http://example.com/?foo=1&bar=2" ]
+      ( "http://example.com/?foo=1&bar=2", "" )
+    ]
+  , BulletList
+    [
+      [ Plain [ Str "In", Space, Str "a", Space, Str "list?" ] ]
+    ,
+      [ Plain
+        [ Link
+          ( "", [ "uri" ], [] )
+          [ Str "http://example.com/" ]
+          ( "http://example.com/", "" )
+        ]
+      ]
+    ,
+      [ Plain [ Str "It", Space, Str "should." ] ]
+    ]
+  , Para
+    [ Str "An"
+    , Space
+    , Str "e-mail"
+    , Space
+    , Str "address:"
+    , Space
+    , Link
+      ( "", [ "email" ], [] )
+      [ Str "nobody@nowhere.net" ]
+      ( "mailto:nobody@nowhere.net", "" )
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Blockquoted:"
+      , Space
+      , Link
+        ( "", [ "uri" ], [] )
+        [ Str "http://example.com/" ]
+        ( "http://example.com/", "" )
+      ]
+    ]
+  , Para
+    [ Str "Auto-links"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "occur"
+    , Space
+    , Str "here:"
+    , Space
+    , Code
+      ( "", [], [] ) "<http://example.com/>"
+    ]
+  , CodeBlock
+    ( "", [], [] ) "or here: <http://example.com/>"
+  , HorizontalRule
+  , Header 1
+    ( "images", [], [] )
+    [ Str "Images" ]
+  , Para
+    [ Str "From"
+    , Space
+    , Quoted DoubleQuote
+      [ Str "Voyage", Space, Str "dans", Space, Str "la", Space, Str "Lune" ]
+    , Space
+    , Str "by"
+    , Space
+    , Str "Georges"
+    , Space
+    , Str "Melies"
+    , Space
+    , Str "(1902):"
+    ]
+  , Para
+    [ Image
+      ( "", [], [] )
+      [ Str "lalune" ]
+      ( "lalune.jpg", "fig:Voyage dans la Lune" )
+    ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "movie"
+    , Space
+    , Image
+      ( "", [], [] )
+      [ Str "movie" ]
+      ( "movie.jpg", "" )
+    , Space
+    , Str "icon."
+    ]
+  , HorizontalRule
+  , Header 1
+    ( "footnotes", [], [] )
+    [ Str "Footnotes" ]
+  , Para
+    [ Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , Note
+      [ Para
+        [ Str "Here"
+        , Space
+        , Str "is"
+        , Space
+        , Str "the"
+        , Space
+        , Str "footnote."
+        , Space
+        , Str "It"
+        , Space
+        , Str "can"
+        , Space
+        , Str "go"
+        , Space
+        , Str "anywhere"
+        , Space
+        , Str "after"
+        , Space
+        , Str "the"
+        , Space
+        , Str "footnote"
+        , SoftBreak
+        , Str "reference."
+        , Space
+        , Str "It"
+        , Space
+        , Str "need"
+        , Space
+        , Str "not"
+        , Space
+        , Str "be"
+        , Space
+        , Str "placed"
+        , Space
+        , Str "at"
+        , Space
+        , Str "the"
+        , Space
+        , Str "end"
+        , Space
+        , Str "of"
+        , Space
+        , Str "the"
+        , Space
+        , Str "document."
+        ]
+      ]
+    , Space
+    , Str "and"
+    , Space
+    , Str "another."
+    , Note
+      [ Para
+        [ Str "Here\8217s"
+        , Space
+        , Str "the"
+        , Space
+        , Str "long"
+        , Space
+        , Str "note."
+        , Space
+        , Str "This"
+        , Space
+        , Str "one"
+        , Space
+        , Str "contains"
+        , Space
+        , Str "multiple"
+        , SoftBreak
+        , Str "blocks."
+        ]
+      , Para
+        [ Str "Subsequent"
+        , Space
+        , Str "blocks"
+        , Space
+        , Str "are"
+        , Space
+        , Str "indented"
+        , Space
+        , Str "to"
+        , Space
+        , Str "show"
+        , Space
+        , Str "that"
+        , Space
+        , Str "they"
+        , Space
+        , Str "belong"
+        , Space
+        , Str "to"
+        , Space
+        , Str "the"
+        , SoftBreak
+        , Str "footnote"
+        , Space
+        , Str "(as"
+        , Space
+        , Str "with"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items)."
+        ]
+      , CodeBlock
+        ( "", [], [] ) "  { <code> }"
+      , Para
+        [ Str "If"
+        , Space
+        , Str "you"
+        , Space
+        , Str "want,"
+        , Space
+        , Str "you"
+        , Space
+        , Str "can"
+        , Space
+        , Str "indent"
+        , Space
+        , Str "every"
+        , Space
+        , Str "line,"
+        , Space
+        , Str "but"
+        , Space
+        , Str "you"
+        , Space
+        , Str "can"
+        , Space
+        , Str "also"
+        , Space
+        , Str "be"
+        , SoftBreak
+        , Str "lazy"
+        , Space
+        , Str "and"
+        , Space
+        , Str "just"
+        , Space
+        , Str "indent"
+        , Space
+        , Str "the"
+        , Space
+        , Str "first"
+        , Space
+        , Str "line"
+        , Space
+        , Str "of"
+        , Space
+        , Str "each"
+        , Space
+        , Str "block."
+        ]
+      ]
+    , SoftBreak
+    , Str "This"
+    , Space
+    , Str "should"
+    , Space
+    , Emph
+      [ Str "not" ]
+    , Space
+    , Str "be"
+    , Space
+    , Str "a"
+    , Space
+    , Str "footnote"
+    , Space
+    , Str "reference,"
+    , Space
+    , Str "because"
+    , Space
+    , Str "it"
+    , SoftBreak
+    , Str "contains"
+    , Space
+    , Str "a"
+    , Space
+    , Str "space.[^my"
+    , Space
+    , Str "note]"
+    , Space
+    , Str "Here"
+    , Space
+    , Str "is"
+    , Space
+    , Str "an"
+    , Space
+    , Str "inline"
+    , Space
+    , Str "note."
+    , Note
+      [ Para
+        [ Str "This"
+        , SoftBreak
+        , Str "is"
+        , Space
+        , Emph
+          [ Str "easier" ]
+        , Space
+        , Str "to"
+        , Space
+        , Str "type."
+        , Space
+        , Str "Inline"
+        , Space
+        , Str "notes"
+        , Space
+        , Str "may"
+        , Space
+        , Str "contain"
+        , SoftBreak
+        , Link
+          ( "", [], [] )
+          [ Str "links" ]
+          ( "http://google.com", "" )
+        , Space
+        , Str "and"
+        , Space
+        , Code
+          ( "", [], [] ) "]"
+        , Space
+        , Str "verbatim"
+        , Space
+        , Str "characters,"
+        , SoftBreak
+        , Str "as"
+        , Space
+        , Str "well"
+        , Space
+        , Str "as"
+        , Space
+        , Str "[bracketed"
+        , Space
+        , Str "text]."
+        ]
+      ]
+    ]
+  , BlockQuote
+    [ Para
+      [ Str "Notes"
+      , Space
+      , Str "can"
+      , Space
+      , Str "go"
+      , Space
+      , Str "in"
+      , Space
+      , Str "quotes."
+      , Note
+        [ Para [ Str "In", Space, Str "quote." ] ]
+      ]
+    ]
+  , OrderedList
+    ( 1, Decimal, Period )
+    [
+      [ Plain
+        [ Str "And"
+        , Space
+        , Str "in"
+        , Space
+        , Str "list"
+        , Space
+        , Str "items."
+        , Note
+          [ Para [ Str "In", Space, Str "list." ] ]
+        ]
+      ]
+    ]
+  , Para
+    [ Str "This"
+    , Space
+    , Str "paragraph"
+    , Space
+    , Str "should"
+    , Space
+    , Str "not"
+    , Space
+    , Str "be"
+    , Space
+    , Str "part"
+    , Space
+    , Str "of"
+    , Space
+    , Str "the"
+    , Space
+    , Str "note,"
+    , Space
+    , Str "as"
+    , Space
+    , Str "it"
+    , Space
+    , Str "is"
+    , Space
+    , Str "not"
+    , Space
+    , Str "indented."
+    ]
+  ]

--- a/test/writer.opendocument
+++ b/test/writer.opendocument
@@ -1207,9 +1207,9 @@ link</text:span></text:a><text:bookmark-end text:name="level-2-with-an-embedded-
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="paragraphs" />Paragraphs<text:bookmark-end text:name="paragraphs" /></text:h>
 <text:p text:style-name="First_20_paragraph">Here’s a regular
 paragraph.</text:p>
-<text:p text:style-name="Text_20_body">In Markdown 1.0.0 and earlier. Version
-8. This line turns into a list item. Because a hard-wrapped line in the middle
-of a paragraph looked like a list item.</text:p>
+<text:p text:style-name="Text_20_body">In Markdown 1.0.0 and earlier. Version 8.
+This line turns into a list item. Because a hard-wrapped line in the middle of a
+paragraph looked like a list item.</text:p>
 <text:p text:style-name="Text_20_body">Here’s one with a bullet. *
 criminey.</text:p>
 <text:p text:style-name="Text_20_body">There should be a hard line
@@ -1218,8 +1218,7 @@ break<text:line-break />here.</text:p>
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="block-quotes" />Block
 Quotes<text:bookmark-end text:name="block-quotes" /></text:h>
 <text:p text:style-name="First_20_paragraph">E-mail style:</text:p>
-<text:p text:style-name="P1">This is a block quote. It is pretty
-short.</text:p>
+<text:p text:style-name="P1">This is a block quote. It is pretty short.</text:p>
 <text:p text:style-name="P2">Code in a block quote:</text:p>
 <text:p text:style-name="P3">sub status {</text:p>
 <text:p text:style-name="P4"><text:s text:c="4" />print &quot;working&quot;;</text:p>
@@ -1236,8 +1235,8 @@ short.</text:p>
 <text:p text:style-name="P2">Nested block quotes:</text:p>
 <text:p text:style-name="P7">nested</text:p>
 <text:p text:style-name="P8">nested</text:p>
-<text:p text:style-name="First_20_paragraph">This should not be a block quote:
-2 &gt; 1.</text:p>
+<text:p text:style-name="First_20_paragraph">This should not be a block quote: 2
+&gt; 1.</text:p>
 <text:p text:style-name="Text_20_body">And a following paragraph.</text:p>
 <text:p text:style-name="Horizontal_20_Line" />
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="code-blocks" />Code
@@ -1464,12 +1463,12 @@ and spaces<text:bookmark-end text:name="tabs-and-spaces" /></text:h>
     <text:p text:style-name="P37">this is a list item indented with
     spaces</text:p><text:list text:style-name="L21">
       <text:list-item>
-        <text:p text:style-name="P38">this is an example list item indented
-        with tabs</text:p>
+        <text:p text:style-name="P38">this is an example list item indented with
+        tabs</text:p>
       </text:list-item>
       <text:list-item>
-        <text:p text:style-name="P38">this is an example list item indented
-        with spaces</text:p>
+        <text:p text:style-name="P38">this is an example list item indented with
+        spaces</text:p>
       </text:list-item>
     </text:list>
   </text:list-item>
@@ -1485,8 +1484,8 @@ list markers<text:bookmark-end text:name="fancy-list-markers" /></text:h>
     <text:p text:style-name="P39">with a continuation</text:p>
     <text:list>
       <text:list-item>
-        <text:p text:style-name="P39">sublist with roman numerals, starting
-        with 4</text:p>
+        <text:p text:style-name="P39">sublist with roman numerals, starting with
+        4</text:p>
       </text:list-item>
       <text:list-item>
         <text:p text:style-name="P39">more items</text:p>
@@ -1537,8 +1536,7 @@ list markers<text:bookmark-end text:name="fancy-list-markers" /></text:h>
     </text:list>
   </text:list-item>
 </text:list>
-<text:p text:style-name="First_20_paragraph">Should not be a list
-item:</text:p>
+<text:p text:style-name="First_20_paragraph">Should not be a list item:</text:p>
 <text:p text:style-name="Text_20_body">M.A. 2007</text:p>
 <text:p text:style-name="Text_20_body">B. Williams</text:p>
 <text:p text:style-name="Horizontal_20_Line" />
@@ -1573,8 +1571,8 @@ fruit</text:p>
 italics:</text:p>
 <text:p text:style-name="Definition_20_Term"><text:span text:style-name="T1">apple</text:span></text:p>
 <text:p text:style-name="Definition_20_Definition">red
-fruit</text:p><text:p text:style-name="Definition_20_Definition">contains
-seeds, crisp, pleasant to taste</text:p>
+fruit</text:p><text:p text:style-name="Definition_20_Definition">contains seeds,
+crisp, pleasant to taste</text:p>
 <text:p text:style-name="Definition_20_Term"><text:span text:style-name="T1">orange</text:span></text:p>
 <text:p text:style-name="Definition_20_Definition">orange
 fruit</text:p><text:p text:style-name="P42">{ orange code block }</text:p><text:p text:style-name="P43">orange
@@ -1613,15 +1611,12 @@ fruit</text:p><text:list text:style-name="L25">
 </text:list>
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="html-blocks" />HTML
 Blocks<text:bookmark-end text:name="html-blocks" /></text:h>
-<text:p text:style-name="First_20_paragraph">Simple block on one
-line:</text:p>
+<text:p text:style-name="First_20_paragraph">Simple block on one line:</text:p>
 <text:p text:style-name="Text_20_body">foo</text:p>
-<text:p text:style-name="Text_20_body">And nested without
-indentation:</text:p>
+<text:p text:style-name="Text_20_body">And nested without indentation:</text:p>
 <text:p text:style-name="Text_20_body">foo</text:p>
 <text:p text:style-name="Text_20_body">bar</text:p>
-<text:p text:style-name="Text_20_body">Interpreted markdown in a
-table:</text:p>
+<text:p text:style-name="Text_20_body">Interpreted markdown in a table:</text:p>
 <text:p text:style-name="Text_20_body">This is
 <text:span text:style-name="T1">emphasized</text:span></text:p>
 <text:p text:style-name="Text_20_body">And this is
@@ -1689,13 +1684,13 @@ subscripts, because of the unescaped spaces: a^b c^d, a~b c~d.</text:p>
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="smart-quotes-ellipses-dashes" />Smart
 quotes, ellipses,
 dashes<text:bookmark-end text:name="smart-quotes-ellipses-dashes" /></text:h>
-<text:p text:style-name="First_20_paragraph">“Hello,” said the spider.
-“‘Shelob’ is my name.”</text:p>
+<text:p text:style-name="First_20_paragraph">“Hello,” said the spider. “‘Shelob’
+is my name.”</text:p>
 <text:p text:style-name="Text_20_body">‘A’, ‘B’, and ‘C’ are letters.</text:p>
 <text:p text:style-name="Text_20_body">‘Oak,’ ‘elm,’ and ‘beech’ are names of
 trees. So is ‘pine.’</text:p>
-<text:p text:style-name="Text_20_body">‘He said, “I want to go.”’ Were you
-alive in the 70’s?</text:p>
+<text:p text:style-name="Text_20_body">‘He said, “I want to go.”’ Were you alive
+in the 70’s?</text:p>
 <text:p text:style-name="Text_20_body">Here is some quoted
 ‘<text:span text:style-name="Source_Text">code</text:span>’ and a
 “<text:a xlink:type="simple" xlink:href="http://example.com/?foo=1&amp;bar=2" office:name=""><text:span text:style-name="Definition">quoted
@@ -1743,8 +1738,8 @@ five.</text:p>
   </text:list-item>
   <text:list-item>
     <text:p text:style-name="P52">$22,000 is a
-    <text:span text:style-name="T1">lot</text:span> of money. So is $34,000.
-    (It worked if “lot” is emphasized.)</text:p>
+    <text:span text:style-name="T1">lot</text:span> of money. So is $34,000. (It
+    worked if “lot” is emphasized.)</text:p>
   </text:list-item>
   <text:list-item>
     <text:p text:style-name="P52">Shoes ($20) and socks ($5).</text:p>
@@ -1778,8 +1773,8 @@ Characters<text:bookmark-end text:name="special-characters" /></text:h>
     <text:p text:style-name="P53">copyright: ©</text:p>
   </text:list-item>
 </text:list>
-<text:p text:style-name="First_20_paragraph">AT&amp;T has an ampersand in
-their name.</text:p>
+<text:p text:style-name="First_20_paragraph">AT&amp;T has an ampersand in their
+name.</text:p>
 <text:p text:style-name="Text_20_body">AT&amp;T is another way to write
 it.</text:p>
 <text:p text:style-name="Text_20_body">This &amp; that.</text:p>
@@ -1888,25 +1883,23 @@ icon.</text:p>
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="footnotes" />Footnotes<text:bookmark-end text:name="footnotes" /></text:h>
 <text:p text:style-name="First_20_paragraph">Here is a footnote
 reference,<text:note text:id="ftn0" text:note-class="footnote"><text:note-citation>1</text:note-citation><text:note-body><text:p text:style-name="Footnote">Here
-is the footnote. It can go anywhere after the footnote reference. It need not
-be placed at the end of the document.</text:p></text:note-body></text:note>
-and
+is the footnote. It can go anywhere after the footnote reference. It need not be
+placed at the end of the document.</text:p></text:note-body></text:note> and
 another.<text:note text:id="ftn1" text:note-class="footnote"><text:note-citation>2</text:note-citation><text:note-body><text:p text:style-name="Footnote">Here’s
 the long note. This one contains multiple
 blocks.</text:p><text:p text:style-name="Footnote">Subsequent blocks are
 indented to show that they belong to the footnote (as with list
 items).</text:p><text:p text:style-name="P58"><text:s text:c="2" />{ &lt;code&gt; }</text:p><text:p text:style-name="Footnote">If
 you want, you can indent every line, but you can also be lazy and just indent
-the first line of each block.</text:p></text:note-body></text:note> This
-should <text:span text:style-name="T1">not</text:span> be a footnote
-reference, because it contains a space.[^my note] Here is an inline
+the first line of each block.</text:p></text:note-body></text:note> This should
+<text:span text:style-name="T1">not</text:span> be a footnote reference, because
+it contains a space.[^my note] Here is an inline
 note.<text:note text:id="ftn2" text:note-class="footnote"><text:note-citation>3</text:note-citation><text:note-body><text:p text:style-name="Footnote">This
-is <text:span text:style-name="T1">easier</text:span> to type. Inline notes
-may contain
+is <text:span text:style-name="T1">easier</text:span> to type. Inline notes may
+contain
 <text:a xlink:type="simple" xlink:href="http://google.com" office:name=""><text:span text:style-name="Definition">links</text:span></text:a>
-and <text:span text:style-name="Source_Text">]</text:span> verbatim
-characters, as well as [bracketed
-text].</text:p></text:note-body></text:note></text:p>
+and <text:span text:style-name="Source_Text">]</text:span> verbatim characters,
+as well as [bracketed text].</text:p></text:note-body></text:note></text:p>
 <text:p text:style-name="P59">Notes can go in
 quotes.<text:note text:id="ftn3" text:note-class="footnote"><text:note-citation>4</text:note-citation><text:note-body><text:p text:style-name="Footnote">In
 quote.</text:p></text:note-body></text:note></text:p>

--- a/test/writer.org
+++ b/test/writer.org
@@ -566,8 +566,8 @@ Superscripts: a^{bc}d a^{/hello/} a^{hello there}.
 
 Subscripts: H_{2}O, H_{23}O, H_{many of them}O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a~b c~d.
 
 --------------
 
@@ -739,8 +739,7 @@ Foo [[/url/][biz]].
    :PROPERTIES:
    :CUSTOM_ID: with-ampersands
    :END:
-Here's a [[http://example.com/?foo=1&bar=2][link with an ampersand in the
-URL]].
+Here's a [[http://example.com/?foo=1&bar=2][link with an ampersand in the URL]].
 
 Here's a link with an amersand in the link text: [[http://att.com/][AT&T]].
 
@@ -801,8 +800,8 @@ note.[fn:3]
 
 This paragraph should not be part of the note, as it is not indented.
 
-[fn:1] Here is the footnote. It can go anywhere after the footnote reference.
-       It need not be placed at the end of the document.
+[fn:1] Here is the footnote. It can go anywhere after the footnote reference. It
+       need not be placed at the end of the document.
 
 [fn:2] Here's the long note. This one contains multiple blocks.
 
@@ -813,8 +812,8 @@ This paragraph should not be part of the note, as it is not indented.
          { <code> }
        #+end_example
 
-       If you want, you can indent every line, but you can also be lazy and
-       just indent the first line of each block.
+       If you want, you can indent every line, but you can also be lazy and just
+       indent the first line of each block.
 
 [fn:3] This is /easier/ to type. Inline notes may contain
        [[http://google.com][links]] and =]= verbatim characters, as well as

--- a/test/writer.plain
+++ b/test/writer.plain
@@ -5,7 +5,7 @@ July 17, 2006
 This is a set of tests for pandoc. Most of them are adapted from John Gruber’s
 markdown test suite.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Headers
 
@@ -29,7 +29,7 @@ Level 2
 
 with no blank line
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Paragraphs
 
@@ -44,7 +44,7 @@ Here’s one with a bullet. * criminey.
 There should be a hard line break
 here.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Block Quotes
 
@@ -73,7 +73,7 @@ This should not be a block quote: 2 > 1.
 
 And a following paragraph.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Code Blocks
 
@@ -93,7 +93,7 @@ And:
 
     These should not be escaped:  \$ \\ \> \[ \{
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Lists
 
@@ -250,7 +250,7 @@ M.A. 2007
 
 B. Williams
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Definition Lists
 
@@ -395,7 +395,7 @@ Code:
 
 Hr’s:
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Inline Markup
 
@@ -421,10 +421,10 @@ Superscripts: a^(bc)d a^(hello) a^(hello there).
 
 Subscripts: H₂O, H₂₃O, H_(many of them)O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a~b c~d.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Smart quotes, ellipses, dashes
 
@@ -444,7 +444,7 @@ Dashes between numbers: 5–7, 255–66, 1987–1999.
 
 Ellipses…and…and….
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 LaTeX
 
@@ -468,7 +468,7 @@ These shouldn’t be math:
 
 Here’s a LaTeX table:
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Special Characters
 
@@ -522,7 +522,7 @@ Plus: +
 
 Minus: -
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Links
 
@@ -594,7 +594,7 @@ Auto-links should not occur here: <http://example.com/>
 
     or here: <http://example.com/>
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Images
 
@@ -604,7 +604,7 @@ From “Voyage dans la Lune” by Georges Melies (1902):
 
 Here is a movie [movie] icon.
 
-------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 Footnotes
 
@@ -622,13 +622,13 @@ need not be placed at the end of the document.
 
 [2] Here’s the long note. This one contains multiple blocks.
 
-Subsequent blocks are indented to show that they belong to the footnote (as
-with list items).
+Subsequent blocks are indented to show that they belong to the footnote (as with
+list items).
 
       { <code> }
 
-If you want, you can indent every line, but you can also be lazy and just
-indent the first line of each block.
+If you want, you can indent every line, but you can also be lazy and just indent
+the first line of each block.
 
 [3] This is easier to type. Inline notes may contain links and ] verbatim
 characters, as well as [bracketed text].

--- a/test/writer.rst
+++ b/test/writer.rst
@@ -580,8 +580,8 @@ Superscripts: a\ :sup:`bc`\ d a\ :sup:`hello` a\ :sup:`hello there`.
 
 Subscripts: H\ :sub:`2`\ O, H\ :sub:`23`\ O, H\ :sub:`many of them`\ O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a~b c~d.
 
 --------------
 

--- a/test/writer.tei
+++ b/test/writer.tei
@@ -54,9 +54,9 @@ Gruber’s markdown test suite.</p>
 <div type="level1" xml:id="paragraphs">
   <head>Paragraphs</head>
   <p>Here’s a regular paragraph.</p>
-  <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list
-  item. Because a hard-wrapped line in the middle of a paragraph looked like a
-  list item.</p>
+  <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item.
+  Because a hard-wrapped line in the middle of a paragraph looked like a list
+  item.</p>
   <p>Here’s one with a bullet. * criminey.</p>
   <p>There should be a hard line break<lb />here.</p>
   <milestone unit="undefined" type="separator" rendition="line" />
@@ -630,10 +630,10 @@ These should not be escaped:  \$ \\ \&gt; \[ \{
   <p><quote>Hello,</quote> said the spider. <quote><quote>Shelob</quote> is my
   name.</quote></p>
   <p><quote>A</quote>, <quote>B</quote>, and <quote>C</quote> are letters.</p>
-  <p><quote>Oak,</quote> <quote>elm,</quote> and <quote>beech</quote> are
-  names of trees. So is <quote>pine.</quote></p>
-  <p><quote>He said, <quote>I want to go.</quote></quote> Were you alive in
-  the 70’s?</p>
+  <p><quote>Oak,</quote> <quote>elm,</quote> and <quote>beech</quote> are names
+  of trees. So is <quote>pine.</quote></p>
+  <p><quote>He said, <quote>I want to go.</quote></quote> Were you alive in the
+  70’s?</p>
   <p>Here is some quoted <quote><seg type="code">code</seg></quote> and a
   <quote><ref target="http://example.com/?foo=1&amp;bar=2">quoted
   link</ref></quote>.</p>
@@ -821,8 +821,8 @@ or here: &lt;http://example.com/&gt;
 <div type="level1" xml:id="footnotes">
   <head>Footnotes</head>
   <p>Here is a footnote reference,<note>
-    <p>Here is the footnote. It can go anywhere after the footnote reference.
-    It need not be placed at the end of the document.</p>
+    <p>Here is the footnote. It can go anywhere after the footnote reference. It
+    need not be placed at the end of the document.</p>
   </note> and another.<note>
     <p>Here’s the long note. This one contains multiple blocks.</p>
     <p>Subsequent blocks are indented to show that they belong to the footnote
@@ -830,8 +830,8 @@ or here: &lt;http://example.com/&gt;
     <ab type='codeblock '>
   { &lt;code&gt; }
 </ab>
-    <p>If you want, you can indent every line, but you can also be lazy and
-    just indent the first line of each block.</p>
+    <p>If you want, you can indent every line, but you can also be lazy and just
+    indent the first line of each block.</p>
   </note> This should <hi rendition="simple:italic">not</hi> be a footnote
   reference, because it contains a space.[^my note] Here is an inline
   note.<note>

--- a/test/writer.texinfo
+++ b/test/writer.texinfo
@@ -732,8 +732,8 @@ Superscripts: a@sup{bc}d a@sup{@emph{hello}} a@sup{hello@ there}.
 
 Subscripts: H@sub{2}O, H@sub{23}O, H@sub{many@ of@ them}O.
 
-These should not be superscripts or subscripts, because of the unescaped
-spaces: a^b c^d, a~b c~d.
+These should not be superscripts or subscripts, because of the unescaped spaces:
+a^b c^d, a~b c~d.
 
 @iftex
 @bigskip@hrule@bigskip
@@ -1014,24 +1014,22 @@ Here is a movie @image{movie,,,movie,jpg} icon.
 @node Footnotes
 @chapter Footnotes
 @anchor{#footnotes}
-Here is a footnote reference,@footnote{Here is the footnote. It can go
-anywhere after the footnote reference. It need not be placed at the end of the
-document.} and another.@footnote{Here's the long note. This one contains
-multiple blocks.
+Here is a footnote reference,@footnote{Here is the footnote. It can go anywhere
+after the footnote reference. It need not be placed at the end of the document.}
+and another.@footnote{Here's the long note. This one contains multiple blocks.
 
-Subsequent blocks are indented to show that they belong to the footnote (as
-with list items).
+Subsequent blocks are indented to show that they belong to the footnote (as with
+list items).
 
 @verbatim
   { <code> }
 @end verbatim
 
-If you want, you can indent every line, but you can also be lazy and just
-indent the first line of each block.} This should @emph{not} be a footnote
-reference, because it contains a space.[^my note] Here is an inline
-note.@footnote{This is @emph{easier} to type. Inline notes may contain
-@uref{http://google.com,links} and @code{]} verbatim characters, as well as
-[bracketed text].}
+If you want, you can indent every line, but you can also be lazy and just indent
+the first line of each block.} This should @emph{not} be a footnote reference,
+because it contains a space.[^my note] Here is an inline note.@footnote{This is
+@emph{easier} to type. Inline notes may contain @uref{http://google.com,links}
+and @code{]} verbatim characters, as well as [bracketed text].}
 
 @quotation
 Notes can go in quotes.@footnote{In quote.}


### PR DESCRIPTION
Previously we used our own homespun formatting.
But this produces over-long lines that aren't ideal
for diffs in tests. Easier to use something off-the-shelf
and standard.

Closes #7580. Note that this doesn't help with #7335, since
commas are still used at the beginning of lines in pretty-show's
output. But I'm inclined to think #7335 is just a problem with
hindent; this is perfectly legitimate Haskell syntax.

In a first effort, we used pretty-show for this, but pretty-simple
has more configuration options than pretty-show (e.g. it allows
 2-space indent and configurable line width), and seems to give better 
results.  It is also around 20% faster.

Note that with this change the native writer is considerably
slower than before (by a factor of about 10).  I don't think this is a
problem, since this writer is just used for diagnostics and tests; for
performance sensitive serialization, json should be used.
