### PR TITLE
epub: Add EPUB3 subject metadata (authority/term)

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2189,7 +2189,7 @@ Currently the following pipes are predefined:
     and AsciiDoc metadata; repeat as for `author`, above
 
 `subject`
-:   document subject, included in ODT, PDF, docx and pptx metadata
+:   document subject, included in ODT, PDF, docx, EPUB, and pptx metadata
 
 `description`
 :   document description, included in ODT, docx and pptx metadata. Some
@@ -6189,7 +6189,12 @@ The following fields are recognized:
     language if nothing is specified.
 
 `subject`
-  ~ A string value or a list of such values.
+  ~ Either a string value, or an object with fields `text`, `authority`,
+    and `term`, or a list of such objects. Valid values for `authority`
+    are either a [reserved authority value] (currently `AAT`, `BIC`,
+    `BISAC`, `CLC`, `DDC`, `CLIL`, `EuroVoc`, `MEDTOP`, `LCSH`, `NDC`,
+    `Thema`, `UDC`, and `WGS`) or an absolute IRI identifying a custom
+    scheme. Valid values for `term` are defined by the scheme.
 
 `description`
   ~ A string value.
@@ -6239,6 +6244,7 @@ The following fields are recognized:
     - `scroll-axis`: `vertical`|`horizontal`|`default`
 
 [MARC relators]: https://loc.gov/marc/relators/relaterm.html
+[reserved authority value]: https://idpf.github.io/epub-registries/authorities/
 [`spine` element]: http://idpf.org/epub/301/spec/epub-publications.html#sec-spine-elem
 
 ## The `epub:type` attribute


### PR DESCRIPTION
This adds the ability to specify EPUB3 specific refinements on the subject tag, specifically `authority` and `term`.

Use of the plain text subject metadata, or use in EPUB2 mode will function as before.