### PR TITLE
Support for <indexterm>s when reading DocBook

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -316,7 +316,7 @@ List of all DocBook tags, with [x] indicating implemented,
 [ ] postcode - A postal code in an address
 [x] preface - Introductory matter preceding the first chapter of a book
 [ ] prefaceinfo - Meta-information for a Preface
-[ ] primary - The primary word or phrase under which an index term should be
+[x] primary - The primary word or phrase under which an index term should be
     sorted
 [ ] primaryie - A primary term in an index entry, not in the text
 [ ] printhistory - The printing history of a document
@@ -385,7 +385,7 @@ List of all DocBook tags, with [x] indicating implemented,
 [o] screeninfo - Information about how a screen shot was produced
 [ ] screenshot - A representation of what the user sees or might see on a
     computer screen
-[ ] secondary - A secondary word or phrase in an index term
+[x] secondary - A secondary word or phrase in an index term
 [ ] secondaryie - A secondary term in an index entry, rather than in the text
 [x] sect1 - A top-level section of document
 [x] sect1info - Meta-information for a Sect1
@@ -461,7 +461,7 @@ List of all DocBook tags, with [x] indicating implemented,
 [x] td - A table entry in an HTML table
 [x] term - The word or phrase being defined or described in a variable list
 [ ] termdef - An inline term definition
-[ ] tertiary - A tertiary word or phrase in an index term
+[x] tertiary - A tertiary word or phrase in an index term
 [ ] tertiaryie - A tertiary term in an index entry, rather than in the text
 [ ] textdata - Pointer to external text data
 [ ] textobject - A wrapper for a text description of an object and its

--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -1082,7 +1082,7 @@ elementToStr x = x
 indextermNaryTextAsAttr :: Text -> Element -> Maybe (Text, Text)
 indextermNaryTextAsAttr n e = case findChild q e of
         Nothing -> Nothing
-        Just naryEl -> Just (n, (strContent naryEl))
+        Just naryEl -> Just (n, strContent naryEl)
         where q = QName n (Just "http://docbook.org/ns/docbook") Nothing
 
 attrValueAsOptionalAttr :: Text -> Element -> Maybe (Text, Text)

--- a/test/docbook-reader.docbook
+++ b/test/docbook-reader.docbook
@@ -1598,4 +1598,16 @@ or here: &lt;http://example.com/&gt;
     </step>
   </procedure>
 </sect1>
+<sect1 id="indexterms">
+  <title>Index terms</title>
+  <para>
+    In the simplest case, index terms<indexterm><primary>index term</primary></indexterm> consists of just a <code>&lt;primary&gt;</code> element, but <indexterm><primary>index term</primary><secondary>multi-level</secondary></indexterm> they can also consist of a <code>&lt;primary&gt;</code> <emph>and</emph> <code>&lt;secondary&gt;</code> element, and <indexterm><primary>index term</primary><secondary>multi-level</secondary><tertiary>3-level</tertiary></indexterm> can even include a <code>&lt;tertiary&gt;</code> term.
+  </para>
+  <para>
+    Index terms can also refer to other index terms: <indexterm><primary>index cross referencing</primary></indexterm><indexterm><primary>index term</primary><secondary>cross references</secondary><see>index cross referencing</see></indexterm>exclusively, using the <code>&lt;see&gt;</code> tag; or <indexterm><primary>index cross referencing</primary><seealso>cross referencing</seealso></indexterm> as a reference to related terms, using the <code>&lt;seealso&gt;</code> tag.
+  </para>
+  <para>
+    <indexterm><primary>food</primary><secondary>big <foreignphrase>baguette</foreignphrase> <strong>supreme</strong></secondary></indexterm>Nested content in index term elements is flattened.
+  </para>
+</sect1>
 </article>

--- a/test/docbook-reader.native
+++ b/test/docbook-reader.native
@@ -2927,4 +2927,191 @@ Pandoc
             [ Str "A" , Space , Str "Final" , Space , Str "Step" ]
         ]
       ]
+  , Header
+      1
+      ( "indexterms" , [] , [] )
+      [ Str "Index" , Space , Str "terms" ]
+  , Para
+      [ Str "In"
+      , Space
+      , Str "the"
+      , Space
+      , Str "simplest"
+      , Space
+      , Str "case,"
+      , Space
+      , Str "index"
+      , Space
+      , Str "terms"
+      , Span
+          ( "" , [ "indexterm" ] , [ ( "primary" , "index term" ) ] )
+          []
+      , Space
+      , Str "consists"
+      , Space
+      , Str "of"
+      , Space
+      , Str "just"
+      , Space
+      , Str "a"
+      , Space
+      , Code ( "" , [] , [] ) "<primary>"
+      , Space
+      , Str "element,"
+      , Space
+      , Str "but"
+      , Space
+      , Span
+          ( ""
+          , [ "indexterm" ]
+          , [ ( "primary" , "index term" )
+            , ( "secondary" , "multi-level" )
+            ]
+          )
+          []
+      , Space
+      , Str "they"
+      , Space
+      , Str "can"
+      , Space
+      , Str "also"
+      , Space
+      , Str "consist"
+      , Space
+      , Str "of"
+      , Space
+      , Str "a"
+      , Space
+      , Code ( "" , [] , [] ) "<primary>"
+      , Space
+      , Str "and"
+      , Space
+      , Code ( "" , [] , [] ) "<secondary>"
+      , Space
+      , Str "element,"
+      , Space
+      , Str "and"
+      , Space
+      , Span
+          ( ""
+          , [ "indexterm" ]
+          , [ ( "primary" , "index term" )
+            , ( "secondary" , "multi-level" )
+            , ( "tertiary" , "3-level" )
+            ]
+          )
+          []
+      , Space
+      , Str "can"
+      , Space
+      , Str "even"
+      , Space
+      , Str "include"
+      , Space
+      , Str "a"
+      , Space
+      , Code ( "" , [] , [] ) "<tertiary>"
+      , Space
+      , Str "term."
+      ]
+  , Para
+      [ Str "Index"
+      , Space
+      , Str "terms"
+      , Space
+      , Str "can"
+      , Space
+      , Str "also"
+      , Space
+      , Str "refer"
+      , Space
+      , Str "to"
+      , Space
+      , Str "other"
+      , Space
+      , Str "index"
+      , Space
+      , Str "terms:"
+      , Space
+      , Span
+          ( ""
+          , [ "indexterm" ]
+          , [ ( "primary" , "index cross referencing" ) ]
+          )
+          []
+      , Span
+          ( ""
+          , [ "indexterm" ]
+          , [ ( "primary" , "index term" )
+            , ( "secondary" , "cross references" )
+            , ( "see" , "index cross referencing" )
+            ]
+          )
+          []
+      , Str "exclusively,"
+      , Space
+      , Str "using"
+      , Space
+      , Str "the"
+      , Space
+      , Code ( "" , [] , [] ) "<see>"
+      , Space
+      , Str "tag;"
+      , Space
+      , Str "or"
+      , Space
+      , Span
+          ( ""
+          , [ "indexterm" ]
+          , [ ( "primary" , "index cross referencing" )
+            , ( "seealso" , "cross referencing" )
+            ]
+          )
+          []
+      , Space
+      , Str "as"
+      , Space
+      , Str "a"
+      , Space
+      , Str "reference"
+      , Space
+      , Str "to"
+      , Space
+      , Str "related"
+      , Space
+      , Str "terms,"
+      , Space
+      , Str "using"
+      , Space
+      , Str "the"
+      , Space
+      , Code ( "" , [] , [] ) "<seealso>"
+      , Space
+      , Str "tag."
+      ]
+  , Para
+      [ Span
+          ( ""
+          , [ "indexterm" ]
+          , [ ( "primary" , "food" )
+            , ( "secondary" , "big baguette supreme" )
+            ]
+          )
+          []
+      , Str "Nested"
+      , Space
+      , Str "content"
+      , Space
+      , Str "in"
+      , Space
+      , Str "index"
+      , Space
+      , Str "term"
+      , Space
+      , Str "elements"
+      , Space
+      , Str "is"
+      , Space
+      , Str "flattened."
+      ]
   ]


### PR DESCRIPTION
This PR resolves #7427.  This was my first Haskell patch ever, so I'm sure that my additions, although functional, are an eyesore to seasoned Haskell coders. Please feel even more free than you usually would to correct/criticize my code.