### PR TITLE
DocBook reader: honor linenumbering attribute

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -907,6 +907,7 @@ parseBlock (Elem e) =
            let classes' = case attrValue "language" e of
                                 "" -> []
                                 x  -> [x]
+                ++ ["numberLines" | attrValue "linenumbering" e == "numbered"]
            return $ codeBlockWith (attrValue "id" e, classes', [])
                   $ trimNl $ strContentRecursive e
          parseBlockquote = do

--- a/test/docbook-reader.docbook
+++ b/test/docbook-reader.docbook
@@ -102,6 +102,11 @@ sub status {
     print &quot;working&quot;;
 }
 </programlisting>
+    <programlisting linenumbering="numbered">
+sub status {
+    print &quot;working with line numbers&quot;;
+}
+</programlisting>
     <screen>
 % <command>ls</command>
 </screen>

--- a/test/docbook-reader.native
+++ b/test/docbook-reader.native
@@ -266,6 +266,9 @@ Pandoc
           ]
       , CodeBlock
           ( "" , [] , [] ) "sub status {\n    print \"working\";\n}"
+      , CodeBlock
+          ( "" , [ "numberLines" ] , [] )
+          "sub status {\n    print \"working with line numbers\";\n}"
       , CodeBlock ( "" , [] , [] ) "% ls"
       , Para [ Str "A" , Space , Str "list:" ]
       , OrderedList


### PR DESCRIPTION
In DocBook, a `programlisting` node may have a `linenumbering="numbers"` attribute to indicate that the program listing lines should be numbered. This attribute should be mapped to `numberLines` internally so that various writers honor this attribute.