### PR TITLE
Update bash_completion.tpl

### DIFF
--- a/data/bash_completion.tpl
+++ b/data/bash_completion.tpl
@@ -4,7 +4,7 @@
 
 _pandoc()
 {
-    local cur prev opts lastc informats outformats datafiles
+    local cur prev opts lastc informats outformats highlight_styles datafiles
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -57,8 +57,16 @@ _pandoc()
              COMPREPLY=( $(compgen -W "section chapter part" -- ${cur}) )
              return 0
              ;;
-         --highlight-style)
+         --highlight-style|--print-highlight-style)
              COMPREPLY=( $(compgen -W "${highlight_styles}" -- ${cur}) )
+             return 0
+             ;;
+         --eol)
+             COMPREPLY=( $(compgen -W "crlf lf native" -- ${cur}) )
+             return 0
+             ;;
+         --markdown-headings)
+             COMPREPLY=( $(compgen -W "setext atx" -- ${cur}) )
              return 0
              ;;
          *)


### PR DESCRIPTION
Update bash-completion and fix possible environment pollution

- Declare `highlight_styles` as a function-local scope variable; keeps `highlight_styles` out of the shell session environment when sourcing completion from a file rather than adding `eval "$(pandoc --bash-completion)"` to `.bashrc`
- Add argument completion for `--print-highlight-style`, `--eol`, and `--markdown-headings`