### PR TITLE
Lua: allow to pass custom reader options to `pandoc.read`

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -2742,7 +2742,33 @@ format, and functions to filter and modify a subtree.
 [`sha1`]{#pandoc.sha1}
 
 :   Alias for [`pandoc.utils.sha1`](#pandoc.utils.sha1)
-    (DEPRECATED).
+    (DEPRECATED, use `pandoc.utils.sha1` instead).
+
+## Other constructors
+
+[`ReaderOptions (opts)`]{#pandoc.readeroptions}
+
+:   Creates a new [ReaderOptions] value.
+
+    Parameters
+
+    `opts`:
+    :   Either a table with a subset of the properties of a
+        [ReaderOptions] object, or another ReaderOptions object.
+        Uses the defaults specified in the manual for all
+        properties that are not explicitly specified. Throws an
+        error if a table contains properties which are not present
+        in a ReaderOptions object. ([ReaderOptions]|table)
+
+    Returns: new [ReaderOptions] object
+
+    Usage:
+
+        -- copy of the reader options that were defined on the command line.
+        local cli_opts = pandoc.ReaderOptions(PANDOC_READER_OPTIONS)
+
+        -- default reader options, but columns set to 66.
+        local short_colums_opts = pandoc.ReaderOptions {columns = 66}
 
 ## Helper functions
 
@@ -2815,17 +2841,23 @@ Returns: the transformed inline element
 
 ### read {#pandoc.read}
 
-`read (markup[, format])`
+`read (markup[, format[, reader_options]])`
 
 Parse the given string into a Pandoc document.
 
 Parameters:
 
 `markup`:
-:   the markup to be parsed
+:   the markup to be parsed (string)
 
 `format`:
-:   format specification, defaults to `"markdown"`.
+:   format specification, defaults to `"markdown"` (string)
+
+`reader_options`:
+:   options passed to the reader; may be a ReaderOptions object or
+    a table with a subset of the keys and values of a
+    ReaderOptions object; defaults to the default values
+    documented in the manual. ([ReaderOptions]|table)
 
 Returns: pandoc document
 
@@ -2837,6 +2869,8 @@ Usage:
     local block = document.blocks[1]
     -- The inline element in that block is an `Emph`
     assert(block.content[1].t == "Emph")
+
+[ReaderOptions]: #type-readeroptions
 
 # Module pandoc.utils
 

--- a/src/Text/Pandoc/Lua/Global.hs
+++ b/src/Text/Pandoc/Lua/Global.hs
@@ -22,7 +22,7 @@ import Text.Pandoc.Definition (Pandoc (Pandoc), pandocTypesVersion)
 import Text.Pandoc.Error (PandocError)
 import Text.Pandoc.Lua.Marshaling ()
 import Text.Pandoc.Lua.Marshaling.CommonState (pushCommonState)
-import Text.Pandoc.Lua.Marshaling.ReaderOptions (pushReaderOptions)
+import Text.Pandoc.Lua.Marshaling.ReaderOptions (pushReaderOptionsReadonly)
 import Text.Pandoc.Options (ReaderOptions)
 
 import qualified Data.Text as Text
@@ -55,7 +55,7 @@ setGlobal global = case global of
     pushUD typePandocLazy  doc
     Lua.setglobal "PANDOC_DOCUMENT"
   PANDOC_READER_OPTIONS ropts -> do
-    pushReaderOptions ropts
+    pushReaderOptionsReadonly ropts
     Lua.setglobal "PANDOC_READER_OPTIONS"
   PANDOC_SCRIPT_FILE filePath -> do
     Lua.push filePath

--- a/test/lua/module/pandoc.lua
+++ b/test/lua/module/pandoc.lua
@@ -809,7 +809,25 @@ return {
         )
         assert.are_same(expected_table, new_table)
       end)
-    }
+    },
+    group 'ReaderOptions' {
+      test('returns a userdata value', function ()
+        local opts = pandoc.ReaderOptions {}
+        assert.are_equal(type(opts), 'userdata')
+      end),
+      test('can construct from table', function ()
+        local opts = pandoc.ReaderOptions {columns = 66}
+        assert.are_equal(opts.columns, 66)
+      end),
+      test('can construct from other ReaderOptions value', function ()
+        local orig = pandoc.ReaderOptions{columns = 65}
+        local copy = pandoc.ReaderOptions(orig)
+        for k, v in pairs(orig) do
+          assert.are_same(copy[k], v)
+        end
+        assert.are_equal(copy.columns, 65)
+      end),
+    },
   },
 
   group 'clone' {
@@ -894,6 +912,16 @@ return {
       assert.error_matches(
         function () pandoc.read('foo', 'gfm+empty_paragraphs') end,
         'Extension empty_paragraphs not supported for gfm'
+      )
+    end),
+    test('read with other indented code classes', function()
+      local indented_code = '    return true'
+      local expected = pandoc.Pandoc({
+          pandoc.CodeBlock('return true', {class='foo'})
+      })
+      assert.are_same(
+        expected,
+        pandoc.read(indented_code, 'markdown', {indented_code_classes={'foo'}})
       )
     end),
     test('failing read', function ()


### PR DESCRIPTION
Reader options can now be passed as an optional third argument to
`pandoc.read`. The object can either be a table or
`PANDOC_READER_OPTIONS`; the latter ensures that the same options used
for main input parsing are re-used to parse the input to `pandoc.read`.

Closes: #7656