### PR TITLE
Add disableLayout variable in revealjs template

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -137,7 +137,7 @@ $endif$
 
         // Disables the default reveal.js slide layout (scaling and centering)
         // so that you can use custom CSS layout
-        disableLayout: false,
+        disableLayout: $disableLayout$,
 
         // Vertical centering of slides
         center: $center$,


### PR DESCRIPTION
This allows to modify it using Pandoc variable. Default value is correctly set to false by Pandoc.

This follows change in 
https://github.com/jgm/pandoc/commit/14b2eb2aeb21b3dee7d07c7348ebd2c586d6a866#diff-ecb2d745902425cf54bfa01ba4522c26288c56cf06be7be034312601f2129b4bR137

where `disableLayout` was added in template but was hard coded to FALSE. 

Unless there is a good reason to do that, I think it should be a variable to allow modify the value. Currently, it requires to patch the template to achieve that. 
