### PR TITLE
Add `<titleabbr>` support to DocBook reader

### DIFF
--- a/test/docbook-reader.docbook
+++ b/test/docbook-reader.docbook
@@ -1615,4 +1615,8 @@ or here: &lt;http://example.com/&gt;
     <indexterm><primary>food</primary><secondary>big <foreignphrase>baguette</foreignphrase> <strong>supreme</strong></secondary></indexterm>Nested content in index term elements is flattened.
   </para>
 </sect1>
+<sect1 id="titleabbrev">
+  <title>Abbreviated title</title>
+  <titleabbrev>Abbr. title</titleabbrev>
+</sect1>
 </article>

--- a/test/docbook-reader.native
+++ b/test/docbook-reader.native
@@ -3117,4 +3117,11 @@ Pandoc
       , Space
       , Str "flattened."
       ]
+  , Header
+      1
+      ( "titleabbrev"
+      , []
+      , [ ( "titleabbrev" , "Abbr. title" ) ]
+      )
+      [ Str "Abbreviated" , Space , Str "title" ]
   ]

--- a/test/docbook-xref.native
+++ b/test/docbook-xref.native
@@ -156,7 +156,7 @@ Pandoc
       [ Str "Some" , Space , Str "content" , Space , Str "here" ]
   , Header
       1
-      ( "ch04" , [] , [] )
+      ( "ch04" , [] , [ ( "titleabbrev" , "Chapter 4" ) ] )
       [ Str "The" , Space , Str "Fourth" , Space , Str "Chapter" ]
   , Para
       [ Str "Some" , Space , Str "content" , Space , Str "here" ]


### PR DESCRIPTION
This goes for everything _below_ the document level. At the document level, the `<titleabbrev>` element doesn't make much semantic sense (in a stand-alone document context), but it _is_ allowed. However, adding support for that requires hooking into `addMetaDataFromElement`, which has itself a bug which I want to address first.
