### PR TITLE
Update build files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             prefix: ''
             cabalopts: ''
             testopts: '--test-option=--hide-successes --test-option=--ansi-tricks=false'
-          - ghc: '8.10.4'
+          - ghc: '8.10.7'
             cabal: '3.2'
             prefix: ''
             cabalopts: '-ftrypandoc'
@@ -212,7 +212,7 @@ jobs:
         versions:
           - ghc: '8.8.4'
             cabal: '3.2'
-          - ghc: '8.10.2'
+          - ghc: '8.10.7'
             cabal: '3.2'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install recent cabal/ghc
       uses: haskell/actions/setup@v1
       with:
-        ghc-version: '8.10.3'
+        ghc-version: '8.10.7'
         cabal-version: '3.2'
 
     - name: Install dependencies

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -11,7 +11,7 @@ bug-reports:     https://github.com/jgm/pandoc/issues
 stability:       alpha
 homepage:        https://pandoc.org
 category:        Text
-tested-with:     GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4, GHC == 9.0.1
+tested-with:     GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.1
 synopsis:        Conversion between markup formats
 description:     Pandoc is a Haskell library for converting from one markup
                  format to another, and a command-line tool that uses

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -11,8 +11,7 @@ bug-reports:     https://github.com/jgm/pandoc/issues
 stability:       alpha
 homepage:        https://pandoc.org
 category:        Text
-tested-with:     GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5,
-                 GHC == 8.8.4, GHC == 8.10.2, GHC == 9.0.1
+tested-with:     GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4, GHC == 9.0.1
 synopsis:        Conversion between markup formats
 description:     Pandoc is a Haskell library for converting from one markup
                  format to another, and a command-line tool that uses

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -507,10 +507,6 @@ library
                  yaml                  >= 0.11     && < 0.12,
                  zip-archive           >= 0.2.3.4  && < 0.5,
                  zlib                  >= 0.5      && < 0.7
-  if os(windows) && arch(i386)
-     build-depends: basement >= 0.0.10,
-                    foundation >= 0.0.23
-                    -- basement 0.0.9 won't build on 32-bit windows.
   if !os(windows)
     build-depends:  unix >= 2.4 && < 2.8
   if flag(embed_data_files)


### PR DESCRIPTION
Tested stack update on Linux x86_64 (NixOS Unstable) with:

- `stack test`:

```
All 2940 tests passed (64.06s)

pandoc              > Test suite test-pandoc passed
```

```
    Drop unnecessary windows 32-bit constraints
    Update pandoc.cabal to reflect CI configuration
    Udpate GHC 8.10.{2,4} to GHC 8.10.7 on CI
```