### PR TITLE
[#7699] check :class: for custom roles

### DIFF
--- a/test/Tests/Readers/RST.hs
+++ b/test/Tests/Readers/RST.hs
@@ -179,6 +179,15 @@ tests = [ "line block with blank line" =:
           , "custom code role with language field"
             =: ".. role:: lhs(code)\n    :language: haskell\n\n:lhs:`a`"
             =?> para (codeWith ("", ["lhs", "haskell"], []) "a")
+          , "custom role with class field"
+            =: ".. role:: classy\n    :class: myclass\n\n:classy:`a`"
+            =?> para (spanWith ("", ["myclass"], []) "a")
+          , "custom role with class field containing multiple whitespace-separated classes"
+            =: ".. role:: classy\n    :class: myclass1 myclass2\n       myclass3\n\n:classy:`a`"
+            =?> para (spanWith ("", ["myclass1", "myclass2", "myclass3"], []) "a")
+          , "custom role with inherited class field"
+            =: ".. role:: classy\n    :class: myclass1\n.. role:: classier(classy)\n    :class: myclass2\n\n:classier:`a`"
+            =?> para (spanWith ("", ["myclass2", "myclass1"], []) "a")
           , "custom role with unspecified parent role"
             =: ".. role:: classy\n\n:classy:`text`"
             =?> para (spanWith ("", ["classy"], []) "text")


### PR DESCRIPTION
This PR fixes #7699. It includes three new tests:

**Custom role with class field**

Input:

```rst
.. role:: classy
    :class: myclass

:classy:`a`
```

This is expected to create a `Span` with a singleton class list: `["myclass"]`

**Custom role with a class field containing multiple whitespace-separated classes**

Input:

```rst
.. role:: classy
    :class: myclass1 myclass2
       myclass3

:classy:`a`
```

This is expected to create a `Span` with three classes: `["myclass1", "myclass2", "myclass3"]`

**Custom role with an inherited class field**

Input:

```rst
.. role:: classy
    :class: myclass1
.. role:: classier(classy)
    :class: myclass2

:classier:`a`
```

This is expected to create a `Span` with two classes: `["myclass2", "myclass1"]`
