### PR TITLE
Add .yml to Citeproc formatFromExtension

### DIFF
--- a/src/Text/Pandoc/Citeproc.hs
+++ b/src/Text/Pandoc/Citeproc.hs
@@ -357,6 +357,7 @@ formatFromExtension fp = case dropWhile (== '.') $ takeExtension fp of
                            "bib"      -> Just Format_biblatex
                            "json"     -> Just Format_json
                            "yaml"     -> Just Format_yaml
+                           "yml"      -> Just Format_yaml
                            _          -> Nothing
 
 


### PR DESCRIPTION
Make Citeproc recognize files with .yml extension as YAML-bibliography.

This is a shoot at solving #7707.