### PR TITLE
workaround for possible pdfroff bug

### DIFF
--- a/haskell.yml
+++ b/haskell.yml
@@ -1,0 +1,40 @@
+name: Haskell CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: '8.10.3'
+        cabal-version: '3.2'
+
+    - name: Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Build
+      run: cabal build --enable-tests --enable-benchmarks all
+    - name: Run tests
+      run: cabal test all

--- a/src/Text/Pandoc/PDF.hs
+++ b/src/Text/Pandoc/PDF.hs
@@ -87,7 +87,7 @@ makePDF program pdfargs writer opts doc =
     "pdfroff" -> do
       source <- writer opts doc
       let args   = ["-ms", "-mpdfmark", "-mspdf",
-                    "-e", "-t", "-k", "-KUTF-8", "-i"] ++ pdfargs
+                    "-e", "-t", "-Dutf8", "--no-toc-relocation", "-i"] ++ pdfargs
       generic2pdf program args source
     baseProg -> do
       withTempDir "tex2pdf." $ \tmpdir' -> do


### PR DESCRIPTION
The `--no-toc-relocation` option avoids a double pass through the intermediate pdfroff files, fixing an empty page at the beginning, and pagination and faulty toc construction. The final output is identical to regular `groff -ms` output.

The `-Dutf8` simplifies the call to `groff` from within `pdfroff`.