### PR TITLE
Custom reader: pass list of sources instead of concatenated text

### DIFF
--- a/data/creole.lua
+++ b/data/creole.lua
@@ -186,5 +186,5 @@ G = P{ "Doc",
 }
 
 function Reader(input, reader_options)
-  return lpeg.match(G, input)
+  return lpeg.match(G, tostring(input))
 end

--- a/doc/custom-readers.md
+++ b/doc/custom-readers.md
@@ -66,6 +66,13 @@ and fast [lpeg] parsing library, which is automatically in scope.
 You can also use external Lua libraries (for example,
 an XML parser).
 
+A previous pandoc version passed a raw string instead of a list
+of sources to the Reader function. Reader functions that rely on
+this are obsolete, but still supported: Pandoc analyzes any
+script error, detecting when code assumed the old behavior. The
+code is rerun with raw string input in this case, thereby
+ensuring backwards compatibility.
+
 [patterns]: http://lua-users.org/wiki/PatternsTutorial
 [lpeg]: http://www.inf.puc-rio.br/~roberto/lpeg/
 

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -694,6 +694,7 @@ library
                    Text.Pandoc.Lua.Marshal.Context,
                    Text.Pandoc.Lua.Marshal.PandocError,
                    Text.Pandoc.Lua.Marshal.ReaderOptions,
+                   Text.Pandoc.Lua.Marshal.Sources,
                    Text.Pandoc.Lua.Module.MediaBag,
                    Text.Pandoc.Lua.Module.Pandoc,
                    Text.Pandoc.Lua.Module.System,

--- a/src/Text/Pandoc/Lua/Marshal/Sources.hs
+++ b/src/Text/Pandoc/Lua/Marshal/Sources.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{- |
+Module      : Text.Pandoc.Lua.Marshaling.Sources
+Copyright   : © 2021 Albert Krewinkel
+License     : GNU GPL, version 2 or above
+Maintainer  : Albert Krewinkel <tarleb+pandoc@moltkeplatz.de>
+
+Marshal 'Sources'.
+-}
+module Text.Pandoc.Lua.Marshal.Sources
+  ( pushSources
+  ) where
+
+import Data.Text (Text)
+import HsLua as Lua
+import Text.Pandoc.Lua.Marshal.List (newListMetatable)
+import Text.Pandoc.Sources (Sources (..))
+import Text.Parsec (SourcePos, sourceName)
+
+-- | Pushes the 'Sources' as a list of lazy Lua objects.
+pushSources :: LuaError e => Pusher e Sources
+pushSources (Sources srcs) = do
+  pushList (pushUD typeSource) srcs
+  newListMetatable "pandoc Sources" $ do
+    pushName "__tostring"
+    pushHaskellFunction $ do
+      sources <- forcePeek $ peekList (peekUD typeSource) (nthBottom 1)
+      pushText . mconcat $ map snd sources
+      return 1
+    rawset (nth 3)
+  setmetatable (nth 2)
+
+-- | Source object type.
+typeSource :: LuaError e => DocumentedType e (SourcePos, Text)
+typeSource = deftype "pandoc input source"
+  [ operation Tostring $ lambda
+    ### liftPure snd
+    <#> udparam typeSource "srcs" "Source to print in native format"
+    =#> functionResult pushText "string" "Haskell representation"
+  ]
+  [ readonly "name" "source name"
+      (pushString, sourceName . fst)
+  , readonly "text" "source text"
+      (pushText, snd)
+  ]

--- a/src/Text/Pandoc/Lua/Orphans.hs
+++ b/src/Text/Pandoc/Lua/Orphans.hs
@@ -22,7 +22,9 @@ import Text.Pandoc.Lua.Marshal.CommonState ()
 import Text.Pandoc.Lua.Marshal.Context ()
 import Text.Pandoc.Lua.Marshal.PandocError()
 import Text.Pandoc.Lua.Marshal.ReaderOptions ()
+import Text.Pandoc.Lua.Marshal.Sources (pushSources)
 import Text.Pandoc.Lua.ErrorConversion ()
+import Text.Pandoc.Sources (Sources)
 
 instance Pushable Pandoc where
   push = pushPandoc
@@ -109,3 +111,6 @@ instance Peekable Version where
 
 instance {-# OVERLAPPING #-} Peekable Attr where
   peek = forcePeek . peekAttr
+
+instance Pushable Sources where
+  push = pushSources

--- a/src/Text/Pandoc/Lua/Util.hs
+++ b/src/Text/Pandoc/Lua/Util.hs
@@ -13,6 +13,7 @@ Lua utility functions.
 module Text.Pandoc.Lua.Util
   ( addField
   , callWithTraceback
+  , pcallWithTraceback
   , dofileWithTraceback
   ) where
 

--- a/src/Text/Pandoc/Readers/Custom.hs
+++ b/src/Text/Pandoc/Readers/Custom.hs
@@ -17,7 +17,6 @@ Supports custom parsers written in Lua which produce a Pandoc AST.
 module Text.Pandoc.Readers.Custom ( readCustom ) where
 import Control.Exception
 import Control.Monad (when)
-import Data.Text (Text)
 import HsLua as Lua hiding (Operation (Div), render)
 import HsLua.Class.Peekable (PeekError)
 import Control.Monad.IO.Class (MonadIO)
@@ -26,13 +25,13 @@ import Text.Pandoc.Lua (Global (..), runLua, setGlobals)
 import Text.Pandoc.Lua.Util (dofileWithTraceback)
 import Text.Pandoc.Options
 import Text.Pandoc.Class (PandocMonad)
-import Text.Pandoc.Sources (ToSources(..), sourcesToText)
+import Text.Pandoc.Sources (Sources, ToSources(..))
 
 -- | Convert custom markup to Pandoc.
 readCustom :: (PandocMonad m, MonadIO m, ToSources s)
             => FilePath -> ReaderOptions -> s -> m Pandoc
-readCustom luaFile opts sources = do
-  let input = sourcesToText $ toSources sources
+readCustom luaFile opts srcs = do
+  let input = toSources srcs
   let globals = [ PANDOC_SCRIPT_FILE luaFile ]
   res <- runLua $ do
     setGlobals globals
@@ -47,8 +46,7 @@ readCustom luaFile opts sources = do
     Right doc -> return doc
 
 parseCustom :: forall e. PeekError e
-            => Text
+            => Sources
             -> ReaderOptions
             -> LuaE e Pandoc
 parseCustom = invoke @e "Reader"
-


### PR DESCRIPTION
The first argument passed to Lua `Reader` functions is no longer a plain
string but a richer data structure. The structure can easily be
converted to a string by applying `tostring`, but is also a list with
elements that contain each the *text* and *name* of each input source as
a property of the respective name.

A small example is added to the custom reader documentation, showcasing
its use in a reader that creates a syntax-highlighted code block for
each source code file passed as input.

Existing readers must be updated.