### PR TITLE
fix(IpynbOutput)!: rank always favors output format

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -383,9 +383,12 @@ extra-source-files:
                  test/pptx/*.pptx
                  test/pptx/**/*.pptx
                  test/pptx/**/*.native
+                 test/ipynb/*.native
                  test/ipynb/*.in.native
                  test/ipynb/*.out.native
                  test/ipynb/*.ipynb
+                 test/ipynb/*.out.ipynb
+                 test/ipynb/*.out.html
                  test/txt2tags.t2t
                  test/twiki-reader.twiki
                  test/tikiwiki-reader.tikiwiki

--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -727,17 +727,17 @@ filterIpynbOutput mode = walk go
                  where
                   rank (RawBlock (Format "html") _)
                     | fmt == Format "html" = 1 :: Int
-                    | fmt == Format "markdown" = 2
-                    | otherwise = 3
+                    | fmt == Format "markdown" = 3
+                    | otherwise = 4
                   rank (RawBlock (Format "latex") _)
                     | fmt == Format "latex" = 1
-                    | fmt == Format "markdown" = 2
-                    | otherwise = 3
+                    | fmt == Format "markdown" = 3
+                    | otherwise = 4
                   rank (RawBlock f _)
                     | fmt == f = 1
-                    | otherwise = 3
-                  rank (Para [Image{}]) = 1
-                  rank _ = 2
+                    | otherwise = 4
+                  rank (Para [Image{}]) = 2
+                  rank _ = 3
                   removeANSI (CodeBlock attr code) =
                     CodeBlock attr (removeANSIEscapes code)
                   removeANSI x = x

--- a/test/Tests/Old.hs
+++ b/test/Tests/Old.hs
@@ -225,6 +225,8 @@ tests pandocPath =
     , test' "writer" ["-f", "native", "-t", "ipynb",
                       "--wrap=preserve"]
       "ipynb/mime.native" "ipynb/mime.out.ipynb"
+    , test' "reader" ["-f", "ipynb", "-t", "html"]
+      "ipynb/rank.ipynb" "ipynb/rank.out.html"
     ]
   ]
  where

--- a/test/ipynb/rank.ipynb
+++ b/test/ipynb/rank.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5cf8f54d-bf3c-4db2-996d-22662a86ad43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a0228622-9ff8-4392-9ddd-f70a90f0e106",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": "<p><em>you should see this when converting from ipynb to html instead of the image below.</em></p>",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAACdAAAAnQGPcuduAAAASUlEQVR4nGNkYGBgc1HM+/lfkI/hqQ0XAwsDAwPDzSphBi6h/wwlahsgAiJCHxkkBL4zWLA8YGBkYGBgZGBg4GRgYPjDwMDABADgfgxL+wQIRAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 4x4 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(1, 1), dpi=4)\n",
+    "ax.imshow([[0, 1], [2, 3]]);"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test/ipynb/rank.out.html
+++ b/test/ipynb/rank.out.html
@@ -1,0 +1,10 @@
+<div id="5cf8f54d-bf3c-4db2-996d-22662a86ad43" class="cell code" data-execution_count="1">
+<div class="sourceCode" id="cb1"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> matplotlib.pyplot <span class="im">as</span> plt</span></code></pre></div>
+</div>
+<div id="a0228622-9ff8-4392-9ddd-f70a90f0e106" class="cell code" data-execution_count="2">
+<div class="sourceCode" id="cb2"><pre class="sourceCode python"><code class="sourceCode python"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a>fig, ax <span class="op">=</span> plt.subplots(figsize<span class="op">=</span>(<span class="dv">1</span>, <span class="dv">1</span>), dpi<span class="op">=</span><span class="dv">4</span>)</span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>ax.imshow([[<span class="dv">0</span>, <span class="dv">1</span>], [<span class="dv">2</span>, <span class="dv">3</span>]])<span class="op">;</span></span></code></pre></div>
+<div class="output display_data">
+<p><em>you should see this when converting from ipynb to html instead of the image below.</em></p>
+</div>
+</div>


### PR DESCRIPTION
Previously, with fmt == f case and Image have a rank of 1.
In the end, e.g. from ipynb to html conversion, if both html and image exists, it actually prefers the image.
This commit changes this, so that fmt == f is always highest rank, and rank never collides.
This is achieved by keeping fmt == f case having rank 1, and every other rank increased by 1.

# Example

[just-plotly.ipynb.zip](https://github.com/jgm/pandoc/files/7691334/just-plotly.ipynb.zip)

```bash
pandoc -s -o just-plotly-pandoc.html just-plotly.ipynb -V header-includes='<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js" integrity="sha512-c3Nl8+7g4LMSTdrm621y7kf9v3SDPnhxLNhcjFJbKECVnmZHTdo+IRO05sNLTH/D3vA6u1X32ehoLC7WFVdheg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>'    
```

Before this change, (and add the flag `--media=...`), pandoc would pick up the image data from plotly.

After this change, pandoc would pick up the html data, which shows an interactive plot.

Sidenotes:

From
https://github.com/jupyter/nbconvert/blob/6c8d9c8f8374f8785967e0e622ad10826228c193/share/jupyter/nbconvert/templates/lab/index.html.j2#L15-L19
and
https://github.com/jupyter/nbconvert/blob/5d2c5e2b79534c11678b73e707feb74d7827a557/nbconvert/exporters/html.py#L45-L46
nbconvert automatically included `require.min.js` from cdn.

Should we copy it here, namely, when converting from ipynb to html, `require.min.js` is automatically added? (Which is problematic if it is broken into pipes.)

Or perhaps we should just document it in the pandoc manual, what do you think, @jgm?