### PR TITLE
docs(ipynb): documents media related tips & tricks

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -6441,33 +6441,16 @@ soft line breaks in Markdown cells; `--atx-headers` will
 cause ATX-style headings to be used; and `--preserve-tabs` will
 prevent tabs from being turned to spaces.
 
-## Image media
-
-When the ipynb input has media such as svg, png, pdf,
-you may want to use `--self-contained` for any of the supported
-output formats including HTML, or use `--extract-media` in general.
-
-## Javascript media
-
-When converting from ipynb, some Jupyter extensions,
-especially those that uses javascript for visualization,
+Regarding media, `--self-contained`/`--extract-media` can be used
+to include them in the output format,
+whereas some javascript media
 expects the presence of
-[`require.js`](https://github.com/requirejs/requirejs).
-In this case when converting say from ipynb to html,
-you can add the following
-either via `header-includes` in metadata or
-`--include-in-header` on the command line:
+[`require.js`](https://github.com/requirejs/requirejs),
+where you may load this using `header-includes`, such as
 
-```
+```html
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js">
 </script>
-```
-
-such as
-
-```
-pandoc -s -o require.html require.ipynb \
--V header-includes='<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>'
 ```
 
 # Syntax highlighting

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -679,7 +679,7 @@ header when requesting a document from a URL:
     necessary, and adjust the images references in the document
     so they point to the extracted files.  Media are downloaded,
     read from the file system, or extracted from a binary
-    container (e.g. docx), as needed.  The original file paths
+    container (e.g. docx, ipynb), as needed.  The original file paths
     are used if they are relative paths not containing `..`.
     Otherwise filenames are constructed from the SHA1 hash of
     the contents.
@@ -6440,6 +6440,14 @@ notebooks.  For example, `--wrap=preserve` will preserve
 soft line breaks in Markdown cells; `--atx-headers` will
 cause ATX-style headings to be used; and `--preserve-tabs` will
 prevent tabs from being turned to spaces.
+
+## Image media
+
+When the ipynb input has media such as svg, png, pdf,
+you may want to use `--self-contained` for any of the supported
+output formats including HTML, or use `--extract-media` in general.
+
+## Javascript media
 
 When converting from ipynb, some Jupyter extensions,
 especially those that uses javascript for visualization,

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -6441,6 +6441,27 @@ soft line breaks in Markdown cells; `--atx-headers` will
 cause ATX-style headings to be used; and `--preserve-tabs` will
 prevent tabs from being turned to spaces.
 
+When converting from ipynb, some Jupyter extensions,
+especially those that uses javascript for visualization,
+expects the presence of
+[`require.js`](https://github.com/requirejs/requirejs).
+In this case when converting say from ipynb to html,
+you can add the following
+either via `header-includes` in metadata or
+`--include-in-header` on the command line:
+
+```
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js">
+</script>
+```
+
+such as
+
+```
+pandoc -s -o require.html require.ipynb \
+-V header-includes='<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>'
+```
+
 # Syntax highlighting
 
 Pandoc will automatically highlight syntax in [fenced code blocks] that

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -678,7 +678,7 @@ header when requesting a document from a URL:
     the source document to the path *DIR*, creating it if
     necessary, and adjust the images references in the document
     so they point to the extracted files.  Media are downloaded,
-    read from the file system, or extracted from a binary
+    read from the file system, or extracted from a
     container (e.g. docx, ipynb), as needed.  The original file paths
     are used if they are relative paths not containing `..`.
     Otherwise filenames are constructed from the SHA1 hash of


### PR DESCRIPTION
For `require.js`, See discussion in #7745, in particular,

https://github.com/jgm/pandoc/pull/7745#issue-1076570646
https://github.com/jgm/pandoc/pull/7745#issuecomment-991381269

I added a commit to documents the use of `--extract-media` or `--self-contained` too. nbconvert behavior is similar to using `--self-contained` here.