### PR TITLE
Lua: support topdown traversals

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,11 @@ tests: True
 flags: +embed_data_files
 constraints: aeson >= 2.0.1.0
 
+source-repository-package
+  type: git
+  location: https://github.com/pandoc/pandoc-lua-marshal
+  tag: 98e3de5087bb533fadbb89720f83f7f7cc3be5bf
+
 -- source-repository-package
 --   type: git
 --   location: https://github.com/jgm/texmath.git

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -481,7 +481,7 @@ library
                  mtl                   >= 2.2      && < 2.3,
                  network               >= 2.6,
                  network-uri           >= 2.6      && < 2.8,
-                 pandoc-lua-marshal    >= 0.1.2    && < 0.2,
+                 pandoc-lua-marshal    >= 0.1.3    && < 0.2,
                  pandoc-types          >= 1.22.1   && < 1.23,
                  parsec                >= 3.1      && < 3.2,
                  pretty                >= 1.1      && < 1.2,

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,7 +26,6 @@ extra-deps:
 - lua-2.0.2
 - tasty-hslua-1.0.0
 - tasty-lua-1.0.0
-- pandoc-lua-marshal-0.1.2
 - pandoc-types-1.22.1
 - commonmark-0.2.1.1
 - commonmark-extensions-0.2.2
@@ -37,6 +36,8 @@ extra-deps:
 - unicode-data-0.2.0
 - git: https://github.com/jgm/ipynb.git
   commit: 00246af10885c2ad4413ace4f69a7e6c88297a08
+- git: https://github.com/pandoc/pandoc-lua-marshal
+  commit: 98e3de5087bb533fadbb89720f83f7f7cc3be5bf
 ghc-options:
    "$locals": -fhide-source-paths -Wno-missing-home-modules
 resolver: lts-18.10


### PR DESCRIPTION
The traversal order of filters can now be selected by setting the key
`traverse` of the filter to either `'topdown'` or `'typewise'`; the
default remains `'typewise'`.

Topdown traversals can be cut short by returning `false` as a second
value from the filter function. No child-element of the returned element
is processed in that case.