### PR TITLE
Lua: allow to control the PandocMonad type used in pandoc.read

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3232,6 +3232,14 @@ Returns: the transformed inline element
 
 Parse the given string into a Pandoc document.
 
+The parser is run in the same environment that was used to read
+the main input files; it has full access to the file-system and
+the mediabag. This means that if the document specifies files to
+be included, as is possible in formats like LaTeX,
+reStructuredText, and Org, then these will be included in the
+resulting document. Any media elements are added to those
+retrieved from the other parsed input files.
+
 Parameters:
 
 `markup`:
@@ -3246,7 +3254,7 @@ Parameters:
     ReaderOptions object; defaults to the default values
     documented in the manual. ([ReaderOptions]|table)
 
-Returns: pandoc document
+Returns: pandoc document ([Pandoc](#type-pandoc))
 
 Usage:
 

--- a/src/Text/Pandoc/Lua/Marshal/ReaderOptions.hs
+++ b/src/Text/Pandoc/Lua/Marshal/ReaderOptions.hs
@@ -127,7 +127,7 @@ peekReaderOptionsTable idx = retrieving "ReaderOptions (table)" $ do
               setFields
     pushnil -- first key
     setFields
-  peekUD typeReaderOptions top
+  peekUD typeReaderOptions top `lastly` pop 1
 
 instance Pushable ReaderOptions where
   push = pushReaderOptions


### PR DESCRIPTION
The default behavior of `pandoc.read` is to run the parser in the IO
environment, meaning that it can access the file-system to include
subfiles, e.g. when reading LaTeX or reStructuredText. However, the
mediabag is always discarded, which can be undesirable when reading
binary input like docx or epub.

A fourth option is added to `pandoc.read` that controls the behavior of
read. It can be one of the strings `'io'`, `'global'`, or `'sandbox'`:

-   'io' is the default and gives the old behavior as described above.
-   'global' uses the same environment that was used to read the input
    files; the parser has full access to the file-system and the
    mediabag.
-   'sandbox' works like 'global', but prohibits file-system access.