### PR TITLE
Org reader: support counter cookies in lists

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Blocks.hs
+++ b/src/Text/Pandoc/Readers/Org/Blocks.hs
@@ -802,7 +802,7 @@ paraOrPlain = try $ do
   -- is directly followed by a list item, in which case the block is read as
   -- plain text.
   try (guard nl
-       *> notFollowedBy (inList *> (orderedListStart <|> bulletListStart))
+       *> notFollowedBy (inList *> (void orderedListStart <|> void bulletListStart))
        $> (B.para <$> ils))
     <|>  return (B.plain <$> ils)
 
@@ -834,9 +834,9 @@ indented indentedMarker minIndent = try $ do
 
 orderedList :: PandocMonad m => OrgParser m (F Blocks)
 orderedList = try $ do
-  indent <- lookAhead orderedListStart
-  fmap (B.orderedList . compactify) . sequence
-    <$> many1 (listItem (orderedListStart `indented` indent))
+  (indent, attr) <- lookAhead orderedListStart
+  fmap (B.orderedListWith attr . compactify) . sequence
+    <$> many1 (listItem ((fst <$> orderedListStart) `indented` indent))
 
 definitionListItem :: PandocMonad m
                    => OrgParser m Int

--- a/test/Tests/Readers/Org/Block/List.hs
+++ b/test/Tests/Readers/Org/Block/List.hs
@@ -27,6 +27,13 @@ tests =
                  , plain "Item2"
                  ]
 
+  , "Simple Bullet List with Ignored Counter Cookie" =:
+      ("- [@4] Item1\n" <>
+       "- Item2\n") =?>
+      bulletList [ plain "Item1"
+                 , plain "Item2"
+                 ]
+
   , "Indented Bullet Lists" =:
       ("   - Item1\n" <>
        "   - Item2\n") =?>
@@ -131,9 +138,51 @@ tests =
                          ]
                ]
 
+  , "Task List with Counter Cookies" =:
+    T.unlines [ "- [ ] nope"
+              , "- [@9] [X] yup"
+              , "- [@a][-] started"
+              , "  1. [@3][X] sure"
+              , "  2. [@b] [ ] nuh-uh"
+              ] =?>
+    bulletList [ plain "☐ nope", plain "☒ yup"
+               , mconcat [ plain "☐ started"
+                         , orderedListWith
+                           (3, DefaultStyle, DefaultDelim)
+                           [plain "☒ sure", plain "☐ nuh-uh"]
+                         ]
+               ]
+
   , "Simple Ordered List" =:
       ("1. Item1\n" <>
        "2. Item2\n") =?>
+      let listStyle = (1, DefaultStyle, DefaultDelim)
+          listStructure = [ plain "Item1"
+                          , plain "Item2"
+                          ]
+      in orderedListWith listStyle listStructure
+
+  , "Simple Ordered List with Counter Cookie" =:
+      ("1. [@1234] Item1\n" <>
+       "2. Item2\n") =?>
+      let listStyle = (1234, DefaultStyle, DefaultDelim)
+          listStructure = [ plain "Item1"
+                          , plain "Item2"
+                          ]
+      in orderedListWith listStyle listStructure
+
+  , "Simple Ordered List with Alphabetical Counter Cookie" =:
+      ("1. [@c] Item1\n" <>
+       "2. Item2\n") =?>
+      let listStyle = (3, DefaultStyle, DefaultDelim)
+          listStructure = [ plain "Item1"
+                          , plain "Item2"
+                          ]
+      in orderedListWith listStyle listStructure
+
+  , "Simple Ordered List with Ignored Counter Cookie" =:
+      ("1. Item1\n" <>
+       "2. [@4] Item2\n") =?>
       let listStyle = (1, DefaultStyle, DefaultDelim)
           listStructure = [ plain "Item1"
                           , plain "Item2"
@@ -163,6 +212,13 @@ tests =
                 , "3. "
                 ] =?>
       orderedList [ plain "", plain "" ]
+
+  , "Empty ordered list item with counter cookie" =:
+      T.unlines [ "1. [@5]"
+                , "3. [@e] "
+                ] =?>
+      let listStyle = (5, DefaultStyle, DefaultDelim)
+      in orderedListWith listStyle [ plain "", plain "" ]
 
   , "Nested Ordered Lists" =:
       ("1. One\n" <>


### PR DESCRIPTION
Hi, this is my first contribution to Pandoc. I'm also somewhat new to Haskell, so even though I followed the guidelines and read similar code from other readers, you may need to revise my code styling.

This adds support for counter cookies in org lists. Such cookies are used to override the item counter in ordered lists. In org it is possible to set the counter at any list item, but since Pandoc AST does not support this, I restricted the usage to setting an offset for the entire ordered list, by using the cookie in the first list item.

Note that even though unordered lists do not have counters, Org Mode still parses such cookies in unordered lists and suppresses them in the output, so in the PR I did the same.

Also, even though org-list-allow-alphabetical is disabled in Emacs by default, for some reason alphabetical cookies are always parsed and used in Org Mode regardlessly of whether this option is enabled or the list style is decimal, so I did the same.

E.g.
```
 2. test
 3. test
```
Is parsed as an ordered list starting at 1, as before. This also conforms to Org Mode behaviour.

```
 1. [@2] test
 2. test
```
Is now parsed as an ordered list starting at 2, so that it conforms to Org Mode behaviour.

Note that when parsing
```
 1. [@2] test
 2. [@9] test
```
the second cookie is silenced and the entire list starts at 2. This is because the current Pandoc AST does not support expressing a change in the counter at a specific item.

The support for alphabetical cookies means that
```
 1. [@c] test
 2. test
```
is parsed as an ordered list starting at 3, since this is what Org Mode does in all exporters I checked (regardless of alphabetical settings).

If there are changes that should be made or more tests that should be written, please let me know 🙂 