### PR TITLE
MediaWiki writer: Remove redundant display text for wiki links

### DIFF
--- a/src/Text/Pandoc/Writers/MediaWiki.hs
+++ b/src/Text/Pandoc/Writers/MediaWiki.hs
@@ -449,10 +449,13 @@ inlineToMediaWiki (Link _ txt (src, _)) = do
   case txt of
      [Str s] | isURI src && escapeURI s == src -> return src
      _  -> return $ if isURI src
-              then "[" <> src <> " " <> label <> "]"
-              else "[[" <> src' <> "|" <> label <> "]]"
-                     -- with leading / it's a link to a help page
-                     where src' = fromMaybe src $ T.stripPrefix "/" src
+       then "[" <> src <> " " <> label <> "]"
+       else
+         if src == label
+           then "[[" <> src' <> "]]"
+           else "[[" <> src' <> "|" <> label <> "]]"
+       -- with leading / it's a link to a help page
+       where src' = fromMaybe src $ T.stripPrefix "/" src
 
 inlineToMediaWiki (Image attr alt (source, tit)) = do
   img  <- imageToMediaWiki attr

--- a/test/command/7808.md
+++ b/test/command/7808.md
@@ -1,0 +1,8 @@
+Wiki links should have no display text, if their display text matches
+their target.
+```
+% pandoc -f mediawiki -t mediawiki
+[[Help]] [[Butter|Butter]] [[Bubbles|Everyone loves bubbles]]
+^D
+[[Help]] [[Butter]] [[Bubbles|Everyone loves bubbles]]
+```


### PR DESCRIPTION
Prior to this commit the MediaWiki writer always added the display
text for a wiki link:

    * [[Help|Help]]
    * [[Bubbles|Everyone loves bubbles]]

However the display text in the first example is redundant since
MediaWiki uses the target as the default display text. The result being:

    * [[Help]]
    * [[Bubbles|Everyone loves bubbles]]