### PR TITLE
Org writer: support starting number cookies

### DIFF
--- a/test/Tests/Writers/Org.hs
+++ b/test/Tests/Writers/Org.hs
@@ -50,6 +50,14 @@ tests =
           [ "1. [ ] a"
           , "2. [X] b"
           ]
+    , "ordered task list with starting number"
+      =: orderedListWith
+         (9, DefaultStyle, DefaultDelim)
+         [plain ("☐" <> space <> "a"), plain "☒ b"]
+      =?> T.unlines
+          [ "9. [@9] [ ] a"
+          , "10. [X] b"
+          ]
     , test (orgWithOpts def) "bullet without task_lists" $
       bulletList [plain "☐ a", plain "☒ b"]
       =?> T.unlines

--- a/test/writer.org
+++ b/test/writer.org
@@ -278,13 +278,13 @@ Same thing but with paragraphs:
    :CUSTOM_ID: fancy-list-markers
    :END:
 
-2) begins with 2
+2) [@2] begins with 2
 
 3) and now 3
 
    with a continuation
 
-   4. sublist with roman numerals, starting with 4
+   4. [@4] sublist with roman numerals, starting with 4
    5. more items
 
       1) a subsublist
@@ -296,9 +296,9 @@ Nesting:
 
    1. Upper Roman.
 
-      6) Decimal start with 6
+      6) [@6] Decimal start with 6
 
-         3) Lower alpha with paren
+         3) [@3] Lower alpha with paren
 
 Autonumbering:
 


### PR DESCRIPTION
This complements #7806 by supporting writing Org ordered lists that start at a specific number.

This commit also slightly changes another thing: before, the org writer indented items to match the markers length like so
```
9.  nine
10. ten
```
I was confused about what it should do when a counter cookie was present (should its length be counted as a marker, or ignored as part of the text like checkboxes?). But then I saw that org mode in emacs did not like this indentation anyway, because when you trigger the automatic formatting (`C-c C-c` above the list) emacs removes the extra spaces. So after this commit, the aligment is removed and the last list is written as
```
9. [@9] nine
10. ten
```
Is this ok?

Also, is one test enough? I did wrote another one with an empty item that would not pass for mysterious reasons, only to discover that the issue was not related to this (see #7810) 🙃  