### PR TITLE
Org reader: support alphabetical (fancy) lists

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3162,6 +3162,15 @@ output format.
 Some aspects of [Pandoc's Markdown citation syntax](#citations)
 are also accepted in `org` input.
 
+#### Extension: `fancy_lists` {#org-fancy-lists}
+
+Some aspects of [Pandoc's Markdown fancy lists](#extension-fancy_lists) are also
+accepted in `org` input, mimicking the option `org-list-allow-alphabetical` in
+Emacs. As in Org Mode, enabling this extension allows lowercase and uppercase
+alphabetical markers for ordered lists to be parsed in addition to arabic ones.
+Note that for Org, this does not include roman numerals or the `#` placeholder
+that are enabled by the extension in Pandoc's Markdown.
+
 #### Extension: `element_citations` ####
 
 In the `jats` output formats, this causes reference items to

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -536,6 +536,7 @@ getAllExtensions f = universalExtensions <> getAll f
     extensionsFromList
     [ Ext_citations
     , Ext_smart
+    , Ext_fancy_lists
     , Ext_task_lists
     ]
   getAll "html"            = autoIdExtensions <>

--- a/src/Text/Pandoc/Readers/Org/Blocks.hs
+++ b/src/Text/Pandoc/Readers/Org/Blocks.hs
@@ -835,8 +835,11 @@ indented indentedMarker minIndent = try $ do
 orderedList :: PandocMonad m => OrgParser m (F Blocks)
 orderedList = try $ do
   (indent, attr) <- lookAhead orderedListStart
-  fmap (B.orderedListWith attr . compactify) . sequence
+  attr' <- option (fst3 attr, DefaultStyle, DefaultDelim) $
+           guardEnabled Ext_fancy_lists $> attr
+  fmap (B.orderedListWith attr' . compactify) . sequence
     <$> many1 (listItem ((fst <$> orderedListStart) `indented` indent))
+  where fst3 (x,_,_) = x
 
 definitionListItem :: PandocMonad m
                    => OrgParser m Int


### PR DESCRIPTION
As discussed in #7806, this adds support for alphabetical lists in org by enabling the extension Ext_fancy_lists, mimicking the behaviour of Org Mode when org-list-allow-alphabetical is enabled.

Enabling Ext_fancy_lists will also make Pandoc differentiate between the delimiters of ordered lists (periods or closing parentheses). Org does this differentiation by default when exporting to some formats (e.g. plain text) but does not in others (e.g. html and latex), so I decided to copy Pandoc's markdown reader behaviour.

One thing I'm unsure: since this is a separate extension, should the tests be moved to a separate file? Or are they fine in List?