### PR TITLE
fix(html-template)!: load header-includes before math for MathJax config

### DIFF
--- a/data/templates/default.html4
+++ b/data/templates/default.html4
@@ -23,12 +23,12 @@ $endif$
 $for(css)$
   <link rel="stylesheet" href="$css$" type="text/css" />
 $endfor$
-$if(math)$
-  $math$
-$endif$
 $for(header-includes)$
   $header-includes$
 $endfor$
+$if(math)$
+  $math$
+$endif$
 </head>
 <body>
 $for(include-before)$

--- a/data/templates/default.html5
+++ b/data/templates/default.html5
@@ -23,15 +23,15 @@ $endif$
 $for(css)$
   <link rel="stylesheet" href="$css$" />
 $endfor$
+$for(header-includes)$
+  $header-includes$
+$endfor$
 $if(math)$
   $math$
 $endif$
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
   <![endif]-->
-$for(header-includes)$
-  $header-includes$
-$endfor$
 </head>
 <body>
 $for(include-before)$


### PR DESCRIPTION
MathJax expect the config comes before loading the MathJax script.
This change of order allows one to config MathJax via header-includes,
which loads before the MathJax script.

This potentially is a breaking change.
However, the only kind math supported by pandoc that is configurable
seems to be katex, and according to
src/Text/Pandoc/Writers/HTML.hs
the way it is configured is hard-coded (katex doesn't seem to offer
MathJax style config that is independent of loading MathJax.)
So it seems it is safe to change this order without breaking
others' documents.

c.f. #2750

Edit: see https://docs.mathjax.org/en/latest/web/configuration.html#configuration-using-an-in-line-script
for the doc to config MathJax.