### PR TITLE
CSS in HTML template: adjust #TOC and h1 on mobile

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -23,6 +23,9 @@ body {
     font-size: 0.9em;
     padding: 1em;
   }
+  h1 {
+    font-size: 1.8em;
+  }
 }
 @media print {
   body {
@@ -147,6 +150,12 @@ header {
 }
 #TOC li {
   list-style: none;
+}
+#TOC ul {
+  padding-left: 1.3em;
+}
+#TOC > ul {
+  padding-left: 0;
 }
 #TOC a:not(:hover) {
   text-decoration: none;

--- a/test/lhs-test.html
+++ b/test/lhs-test.html
@@ -30,6 +30,9 @@
         font-size: 0.9em;
         padding: 1em;
       }
+      h1 {
+        font-size: 1.8em;
+      }
     }
     @media print {
       body {
@@ -133,6 +136,12 @@
     }
     #TOC li {
       list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
     }
     #TOC a:not(:hover) {
       text-decoration: none;

--- a/test/lhs-test.html+lhs
+++ b/test/lhs-test.html+lhs
@@ -30,6 +30,9 @@
         font-size: 0.9em;
         padding: 1em;
       }
+      h1 {
+        font-size: 1.8em;
+      }
     }
     @media print {
       body {
@@ -133,6 +136,12 @@
     }
     #TOC li {
       list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
     }
     #TOC a:not(:hover) {
       text-decoration: none;

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -33,6 +33,9 @@
         font-size: 0.9em;
         padding: 1em;
       }
+      h1 {
+        font-size: 1.8em;
+      }
     }
     @media print {
       body {
@@ -136,6 +139,12 @@
     }
     #TOC li {
       list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
     }
     #TOC a:not(:hover) {
       text-decoration: none;

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -33,6 +33,9 @@
         font-size: 0.9em;
         padding: 1em;
       }
+      h1 {
+        font-size: 1.8em;
+      }
     }
     @media print {
       body {
@@ -136,6 +139,12 @@
     }
     #TOC li {
       list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
     }
     #TOC a:not(:hover) {
       text-decoration: none;


### PR DESCRIPTION
I visited https://vmchale.github.io/jacinda/ on mobile, and found we can improve our stylesheet a bit. Repro:

    pandoc https://raw.githubusercontent.com/vmchale/jacinda/main/doc/guide.md -s -o guide.html --toc

Changes:

1. Make all h1 a tiny bit smaller on mobile
2. Since we have no list-markers on the TOC, we should decrease the left paddings a bit to get the same visual effect.

Feedback welcome, then I can update the tests...