### PR TITLE
PDF: support pagedjs-cli as pdf engine

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1299,16 +1299,18 @@ header when requesting a document from a URL:
 
 :   Use the specified engine when producing PDF output.
     Valid values are `pdflatex`, `lualatex`, `xelatex`, `latexmk`,
-    `tectonic`, `wkhtmltopdf`, `weasyprint`, `prince`, `context`,
-    and `pdfroff`. If the engine is not in your PATH, the full
-    path of the engine may be specified here.  If this option
-    is not specified, pandoc uses the following defaults
-    depending on the output format specified using `-t/--to`:
+    `tectonic`, `wkhtmltopdf`, `weasyprint`, `pagedjs-cli`,
+    `prince`, `context`, and `pdfroff`. If the engine is not in
+    your PATH, the full path of the engine may be specified here.
+    If this option is not specified, pandoc uses the following
+    defaults depending on the output format specified using
+    `-t/--to`:
 
     - `-t latex` or none: `pdflatex` (other options: `xelatex`, `lualatex`,
         `tectonic`, `latexmk`)
     - `-t context`: `context`
-    - `-t html`:  `wkhtmltopdf` (other options: `prince`, `weasyprint`;
+    - `-t html`:  `wkhtmltopdf` (other options: `prince`, `weasyprint`,
+        `pagedjs-cli`;
         see [print-css.rocks](https://print-css.rocks) for a good
         introduction to PDF generation from HTML/CSS.)
     - `-t ms`:  `pdfroff`

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -109,7 +109,7 @@ latexEngines :: [String]
 latexEngines  = ["pdflatex", "lualatex", "xelatex", "latexmk", "tectonic"]
 
 htmlEngines :: [String]
-htmlEngines  = ["wkhtmltopdf", "weasyprint", "prince"]
+htmlEngines  = ["pagedjs-cli", "wkhtmltopdf", "weasyprint", "prince"]
 
 engines :: [(Text, String)]
 engines = map ("html",) htmlEngines ++

--- a/src/Text/Pandoc/PDF.hs
+++ b/src/Text/Pandoc/PDF.hs
@@ -70,7 +70,8 @@ changePathSeparators =
 
 makePDF :: (PandocMonad m, MonadIO m, MonadMask m)
         => String              -- ^ pdf creator (pdflatex, lualatex, xelatex,
-                               -- wkhtmltopdf, weasyprint, prince, context, pdfroff,
+                               -- wkhtmltopdf, weasyprint, prince, context,
+                               -- pdfroff, pagedjs,
                                -- or path to executable)
         -> [String]            -- ^ arguments to pass to pdf creator
         -> (WriterOptions -> Pandoc -> m Text)  -- ^ writer
@@ -80,7 +81,7 @@ makePDF :: (PandocMonad m, MonadIO m, MonadMask m)
 makePDF program pdfargs writer opts doc =
   case takeBaseName program of
     "wkhtmltopdf" -> makeWithWkhtmltopdf program pdfargs writer opts doc
-    prog | prog `elem` ["weasyprint", "prince"] -> do
+    prog | prog `elem` ["pagedjs-cli" ,"weasyprint", "prince"] -> do
       source <- writer opts doc
       verbosity <- getVerbosity
       liftIO $ html2pdf verbosity program pdfargs source
@@ -434,7 +435,8 @@ html2pdf verbosity program args source =
       hClose h1
       hClose h2
       BS.writeFile file $ UTF8.fromText source
-      let pdfFileArgName = ["-o" | takeBaseName program == "prince"]
+      let pdfFileArgName = ["-o" | takeBaseName program `elem`
+                                   ["pagedjs-cli", "prince"]]
       let programArgs = args ++ [file] ++ pdfFileArgName ++ [pdfFile]
       env' <- getEnvironment
       when (verbosity >= INFO) $


### PR DESCRIPTION
PagedJS is a polyfill and supports the Paged Media standards by the W3C.
<https://www.pagedjs.org/>