### PR TITLE
Add pandoc-lua-marshal to Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -57,6 +57,7 @@ let
     network
     network
     network-uri
+    pandoc-lua-marshal
     pandoc-types
     parsec
     process


### PR DESCRIPTION
Add missing dependency to Nix shell. `pandoc-lua-marshal` is currently broken in Nixpkgs, so building in the Nix shell still fails (assuming Nixpkgs is used as input). Nevertheless, this is one step closer to a working Nix build.