### PR TITLE
Add diff syntax highlighting language to listings

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -257,6 +257,15 @@ $if(listings)$
 \newcommand{\passthrough}[1]{#1}
 \lstset{defaultdialect=[5.3]Lua}
 \lstset{defaultdialect=[x86masm]Assembler}
+\definecolor{diffstart}{named}{Grey}
+\definecolor{diffincl}{named}{Green}
+\definecolor{diffrem}{named}{OrangeRed}
+\lstdefinelanguage{Diff}{
+  basicstyle=\ttfamily\small,
+  morecomment=[f][\color{diffstart}]{@@},
+  morecomment=[f][\color{diffincl}]{+\ },
+  morecomment=[f][\color{diffrem}]{-\ },
+}
 $endif$
 $if(lhs)$
 \lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}

--- a/src/Text/Pandoc/Highlighting.hs
+++ b/src/Text/Pandoc/Highlighting.hs
@@ -130,6 +130,7 @@ langsList =
   ("comsol","Comsol"),
   ("csh","csh"),
   ("delphi","Delphi"),
+  ("diff","Diff"),
   ("eiffel","Eiffel"),
   ("elan","Elan"),
   ("elisp","elisp"),

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -43,6 +43,15 @@
 \newcommand{\passthrough}[1]{#1}
 \lstset{defaultdialect=[5.3]Lua}
 \lstset{defaultdialect=[x86masm]Assembler}
+\definecolor{diffstart}{named}{Grey}
+\definecolor{diffincl}{named}{Green}
+\definecolor{diffrem}{named}{OrangeRed}
+\lstdefinelanguage{Diff}{
+  basicstyle=\ttfamily\small,
+  morecomment=[f][\color{diffstart}]{@@},
+  morecomment=[f][\color{diffincl}]{+\ },
+  morecomment=[f][\color{diffrem}]{-\ },
+}
 \lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
 \setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%


### PR DESCRIPTION
Add `diff` syntax highlighter to the `listings` module

Idea borrowed from https://tex.stackexchange.com/a/106129