### PR TITLE
Create option to adjust table header font style

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -266,6 +266,7 @@ $highlighting-macros$
 $endif$
 $if(tables)$
 \usepackage{longtable,booktabs,array}
+\providecommand{\TableHeaderItemStyle}{}
 $if(multirow)$
 \usepackage{multirow}
 $endif$

--- a/src/Text/Pandoc/Writers/LaTeX/Table.hs
+++ b/src/Text/Pandoc/Writers/LaTeX/Table.hs
@@ -159,9 +159,19 @@ headToLaTeX :: PandocMonad m
             -> Ann.TableHead
             -> LW m (Doc Text)
 headToLaTeX blocksWriter (Ann.TableHead _attr headerRows) = do
-  rowsContents <- mapM (rowToLaTeX blocksWriter HeaderCell . headerRowCells)
+  rowsContents <- mapM (headrowToLaTeX blocksWriter HeaderCell . headerRowCells)
                        headerRows
   return ("\\toprule" $$ vcat rowsContents $$ "\\midrule")
+
+-- | Converts a row of table cells into a LaTeX row.
+headrowToLaTeX :: PandocMonad m
+           => BlocksWriter m
+           -> CellType
+           -> [Ann.Cell]
+           -> LW m (Doc Text)
+headrowToLaTeX blocksWriter celltype row = do
+  cellsDocs <- mapM (cellToLaTeX blocksWriter celltype) (fillRow row)
+  return $ "\\TableHeaderItemStyle " <> hsep (intersperse "& \\TableHeaderItemStyle" cellsDocs) <> " \\\\"
 
 -- | Converts a row of table cells into a LaTeX row.
 rowToLaTeX :: PandocMonad m

--- a/test/command/2378.md
+++ b/test/command/2378.md
@@ -14,11 +14,11 @@ is used.
 \begin{longtable}[]{@{}ll@{}}
 \caption{a table}\tabularnewline
 \toprule
-x & y\footnote{a footnote} \\
+\TableHeaderItemStyle x & \TableHeaderItemStyle y\footnote{a footnote} \\
 \midrule
 \endfirsthead
 \toprule
-x & y{} \\
+\TableHeaderItemStyle x & \TableHeaderItemStyle y{} \\
 \midrule
 \endhead
 1 & 2 \\

--- a/test/command/5367.md
+++ b/test/command/5367.md
@@ -24,13 +24,13 @@ hello\footnote{doc footnote}
   >{\centering\arraybackslash}p{(\columnwidth - 0\tabcolsep) * \real{0.1667}}@{}}
 \caption[Sample table.]{Sample table.\footnote{caption footnote}}\tabularnewline
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Fruit\footnote{header footnote}
 \end{minipage} \\
 \midrule
 \endfirsthead
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Fruit{}
 \end{minipage} \\
 \midrule

--- a/test/tables.latex
+++ b/test/tables.latex
@@ -3,11 +3,13 @@ Simple table with caption:
 \begin{longtable}[]{@{}rlcl@{}}
 \caption{Demonstration of simple table syntax.}\tabularnewline
 \toprule
-Right & Left & Center & Default \\
+\TableHeaderItemStyle Right & \TableHeaderItemStyle Left & \TableHeaderItemStyle
+Center & \TableHeaderItemStyle Default \\
 \midrule
 \endfirsthead
 \toprule
-Right & Left & Center & Default \\
+\TableHeaderItemStyle Right & \TableHeaderItemStyle Left & \TableHeaderItemStyle
+Center & \TableHeaderItemStyle Default \\
 \midrule
 \endhead
 12 & 12 & 12 & 12 \\
@@ -20,7 +22,8 @@ Simple table without caption:
 
 \begin{longtable}[]{@{}rlcl@{}}
 \toprule
-Right & Left & Center & Default \\
+\TableHeaderItemStyle Right & \TableHeaderItemStyle Left & \TableHeaderItemStyle
+Center & \TableHeaderItemStyle Default \\
 \midrule
 \endhead
 12 & 12 & 12 & 12 \\
@@ -34,11 +37,13 @@ Simple table indented two spaces:
 \begin{longtable}[]{@{}rlcl@{}}
 \caption{Demonstration of simple table syntax.}\tabularnewline
 \toprule
-Right & Left & Center & Default \\
+\TableHeaderItemStyle Right & \TableHeaderItemStyle Left & \TableHeaderItemStyle
+Center & \TableHeaderItemStyle Default \\
 \midrule
 \endfirsthead
 \toprule
-Right & Left & Center & Default \\
+\TableHeaderItemStyle Right & \TableHeaderItemStyle Left & \TableHeaderItemStyle
+Center & \TableHeaderItemStyle Default \\
 \midrule
 \endhead
 12 & 12 & 12 & 12 \\
@@ -56,25 +61,31 @@ Multiline table with caption:
   >{\raggedright\arraybackslash}p{(\columnwidth - 6\tabcolsep) * \real{0.3500}}@{}}
 \caption{Here's the caption. It may span multiple lines.}\tabularnewline
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Centered Header
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedright
 Left Aligned
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedleft
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedleft
 Right Aligned
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedright
 Default aligned
 \end{minipage} \\
 \midrule
 \endfirsthead
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Centered Header
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedright
 Left Aligned
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedleft
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedleft
 Right Aligned
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedright
 Default aligned
 \end{minipage} \\
 \midrule
@@ -92,13 +103,16 @@ Multiline table without caption:
   >{\raggedleft\arraybackslash}p{(\columnwidth - 6\tabcolsep) * \real{0.1625}}
   >{\raggedright\arraybackslash}p{(\columnwidth - 6\tabcolsep) * \real{0.3500}}@{}}
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Centered Header
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedright
 Left Aligned
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedleft
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedleft
 Right Aligned
-\end{minipage} & \begin{minipage}[b]{\linewidth}\raggedright
+\end{minipage} & \TableHeaderItemStyle
+\begin{minipage}[b]{\linewidth}\raggedright
 Default aligned
 \end{minipage} \\
 \midrule

--- a/test/tables/nordics.latex
+++ b/test/tables/nordics.latex
@@ -5,28 +5,28 @@
   >{\raggedright\arraybackslash}p{(\columnwidth - 6\tabcolsep) * \real{0.2000}}@{}}
 \caption{States belonging to the \emph{Nordics.}}\tabularnewline
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Name
-\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\end{minipage} & \TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Capital
-\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\end{minipage} & \TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Population\\
 (in 2018)\strut
-\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\end{minipage} & \TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Area\\
 (in km\textsuperscript{2})\strut
 \end{minipage} \\
 \midrule
 \endfirsthead
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Name
-\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\end{minipage} & \TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Capital
-\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\end{minipage} & \TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Population\\
 (in 2018)\strut
-\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\end{minipage} & \TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Area\\
 (in km\textsuperscript{2})\strut
 \end{minipage} \\

--- a/test/tables/planets.latex
+++ b/test/tables/planets.latex
@@ -1,15 +1,21 @@
 \begin{longtable}[]{@{}cclrrrrrrrrl@{}}
 \caption{Data about the planets of our solar system.}\tabularnewline
 \toprule
-\multicolumn{2}{c}{} & Name & Mass (10\^{}24kg) & Diameter (km) & Density
-(kg/m\^{}3) & Gravity (m/s\^{}2) & Length of day (hours) & Distance from Sun
-(10\^{}6km) & Mean temperature (C) & Number of moons & Notes \\
+\TableHeaderItemStyle \multicolumn{2}{c}{} & \TableHeaderItemStyle Name
+& \TableHeaderItemStyle Mass (10\^{}24kg) & \TableHeaderItemStyle Diameter (km)
+& \TableHeaderItemStyle Density (kg/m\^{}3) & \TableHeaderItemStyle Gravity
+(m/s\^{}2) & \TableHeaderItemStyle Length of day (hours) & \TableHeaderItemStyle
+Distance from Sun (10\^{}6km) & \TableHeaderItemStyle Mean temperature (C)
+& \TableHeaderItemStyle Number of moons & \TableHeaderItemStyle Notes \\
 \midrule
 \endfirsthead
 \toprule
-\multicolumn{2}{c}{} & Name & Mass (10\^{}24kg) & Diameter (km) & Density
-(kg/m\^{}3) & Gravity (m/s\^{}2) & Length of day (hours) & Distance from Sun
-(10\^{}6km) & Mean temperature (C) & Number of moons & Notes \\
+\TableHeaderItemStyle \multicolumn{2}{c}{} & \TableHeaderItemStyle Name
+& \TableHeaderItemStyle Mass (10\^{}24kg) & \TableHeaderItemStyle Diameter (km)
+& \TableHeaderItemStyle Density (kg/m\^{}3) & \TableHeaderItemStyle Gravity
+(m/s\^{}2) & \TableHeaderItemStyle Length of day (hours) & \TableHeaderItemStyle
+Distance from Sun (10\^{}6km) & \TableHeaderItemStyle Mean temperature (C)
+& \TableHeaderItemStyle Number of moons & \TableHeaderItemStyle Notes \\
 \midrule
 \endhead
 \multicolumn{2}{c}{\multirow{4}{*}{Terrestrial planets}} & Mercury & 0.330 &

--- a/test/tables/students.latex
+++ b/test/tables/students.latex
@@ -3,17 +3,17 @@
   >{\raggedright\arraybackslash}p{(\columnwidth - 2\tabcolsep) * \real{0.5000}}@{}}
 \caption{List of Students}\tabularnewline
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Student ID
-\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\end{minipage} & \TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Name
 \end{minipage} \\
 \midrule
 \endfirsthead
 \toprule
-\begin{minipage}[b]{\linewidth}\centering
+\TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Student ID
-\end{minipage} & \begin{minipage}[b]{\linewidth}\centering
+\end{minipage} & \TableHeaderItemStyle \begin{minipage}[b]{\linewidth}\centering
 Name
 \end{minipage} \\
 \midrule


### PR DESCRIPTION
Add option to allow changing font style of the table headers.

Subtract from https://github.com/jgm/pandoc/pull/7716 and https://github.com/jgm/pandoc/pull/3935

As proposed in https://github.com/jgm/pandoc/pull/7716 tables layout can be adjusted by extending the table rules as in:

```latex
\AtBeginEnvironment{longtable}{\rowcolors{2}{White}{Grey}}
\apptocmd{\toprule}{\rowcolor{Green}}{}{}
\apptocmd{\endhead}{\showrowcolors}{}{}
\apptocmd{\endfirsthead}{\showrowcolors}{}{}
```

But unfortunately this does not work for changing the fontstyle as it gets reset after each cell and as such has to be repeated in the Latex.

Therefor I'm proposing to add an optional `\TableHeaderItemStyle{}` command which would allow to adjust table header text style. The name is up for discussion of course.

All together my stylesheet would have:

```latex
\AtBeginEnvironment{longtable}{\rowcolors{2}{White}{Grey}}
\apptocmd{\toprule}{\rowcolor{Green}}{}{}
\apptocmd{\endhead}{\showrowcolors}{}{}
\apptocmd{\endfirsthead}{\showrowcolors}{}{}

\renewcommand{\TableHeaderItemStyle}{
  \bfseries\color{white}}
```

Doing some Googling shows there is more people struggling with this, for ex https://tex.stackexchange.com/questions/524382/template-options-to-change-the-background-colour-and-text-colour-of-all-tables/630827