### PR TITLE
ConTeXt writer: tag paragraphs

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3579,6 +3579,15 @@ In the `context` output format this enables the use of [Natural Tables
 Natural tables allow more fine-grained global customization but come
 at a performance penalty compared to extreme tables.
 
+#### Extension: `tagging` ####
+
+Enabling this extension with `context` output will produce markup
+suitable for the production of tagged PDFs. This includes
+additional markers for paragraphs and alternative markup for
+emphasized text. The `emphasis-command` template variable is set
+if the extension is enabled. Combine this with the `pdfa` variable
+to generate accessible PDFs.
+
 
 # Pandoc's Markdown
 

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -114,6 +114,9 @@ $endif$
 \setupxtable[foot][]
 \setupxtable[lastrow][bottomframe=on]
 
+$if(emphasis-commands)$
+$emphasis-commands$
+$endif$
 $if(highlighting-commands)$
 $highlighting-commands$
 $endif$

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -129,6 +129,7 @@ data Extension =
     | Ext_subscript           -- ^ Subscript using ~this~ syntax
     | Ext_superscript         -- ^ Superscript using ^this^ syntax
     | Ext_styles              -- ^ Read styles that pandoc doesn't know
+    | Ext_tagging             -- ^ Output optimized for PDF tagging
     | Ext_task_lists          -- ^ Parse certain list items as task list items
     | Ext_table_captions      -- ^ Pandoc-style table captions
     | Ext_tex_math_dollars    -- ^ TeX math between $..$ or $$..$$
@@ -602,6 +603,7 @@ getAllExtensions f = universalExtensions <> getAll f
     [ Ext_smart
     , Ext_raw_tex
     , Ext_ntb
+    , Ext_tagging
     ]
   getAll "textile"         = autoIdExtensions <>
     extensionsFromList

--- a/test/writer.context
+++ b/test/writer.context
@@ -86,8 +86,8 @@ markdown test suite.
 \startsectionlevel[title={Level 2 with an \goto{embedded
 link}[url(/url)]},reference={level-2-with-an-embedded-link}]
 
-\startsectionlevel[title={Level 3 with
-{\em emphasis}},reference={level-3-with-emphasis}]
+\startsectionlevel[title={Level 3 with {\em
+emphasis}},reference={level-3-with-emphasis}]
 
 \startsectionlevel[title={Level 4},reference={level-4}]
 
@@ -105,8 +105,8 @@ link}[url(/url)]},reference={level-2-with-an-embedded-link}]
 
 \startsectionlevel[title={Level 1},reference={level-1}]
 
-\startsectionlevel[title={Level 2 with
-{\em emphasis}},reference={level-2-with-emphasis}]
+\startsectionlevel[title={Level 2 with {\em
+emphasis}},reference={level-2-with-emphasis}]
 
 \startsectionlevel[title={Level 3},reference={level-3}]
 


### PR DESCRIPTION
Paragraphs are enclosed by `\startparagraph` and `\stopparagraph`
commands. This ensures better tagging results in PDF output.