### PR TITLE
Org reader: small property drawer tweaks

### DIFF
--- a/src/Text/Pandoc/Readers/Org/DocumentTree.hs
+++ b/src/Text/Pandoc/Readers/Org/DocumentTree.hs
@@ -405,7 +405,8 @@ propertiesDrawer = try $ do
 
    key :: Monad m => OrgParser m PropertyKey
    key = fmap toPropertyKey . try $
-         skipSpaces *> char ':' *> many1TillChar nonspaceChar (char ':')
+         skipSpaces *> char ':' *>
+         many1TillChar nonspaceChar (try $ char ':' *> spaceChar)
 
    value :: Monad m => OrgParser m PropertyValue
    value = fmap toPropertyValue . try $

--- a/src/Text/Pandoc/Readers/Org/DocumentTree.hs
+++ b/src/Text/Pandoc/Readers/Org/DocumentTree.hs
@@ -41,6 +41,7 @@ documentTree :: PandocMonad m
              -> OrgParser m (F Inlines)
              -> OrgParser m (F Headline)
 documentTree blocks inline = do
+  many commentLine
   properties <- option mempty propertiesDrawer
   initialBlocks <- blocks
   headlines <- sequence <$> manyTill (headline blocks inline 1) eof
@@ -59,6 +60,9 @@ documentTree blocks inline = do
       , headlineContents = initialBlocks'
       , headlineChildren = headlines'
       }
+  where
+    commentLine :: Monad m => OrgParser m ()
+    commentLine = commentLineStart <* anyLine
 
 -- | Create a tag containing the given string.
 toTag :: Text -> Tag


### PR DESCRIPTION
I think the commit messages do well in explaining the changes, so I will just copy them here:

### allow ":" in property drawer keys
Any non-space character is allowed as property drawer key, including ":" itself (so it is not really a delimiter). The real delimiter is a space character, so in a drawer like

```
:PROPERTIES:
::k:ey:: value
:END:
```

`:k:ey:` is a key with value `value`.

This usage can be seen in the Org Manual at [orgmode.org/manual/Using-Header-Arguments.html](https://orgmode.org/manual/Using-Header-Arguments.html), where the Org snippet
```
* Heading
  :PROPERTIES:
  :header-args:clojure:    :session *clojure-1*
  :header-args:R:          :session *R*
  :END:
```
is listed as an example.

### allow comments above property drawer
The Org Manual page at [orgmode.org/manual/Property-Syntax.html](https://orgmode.org/manual/Property-Syntax.html) says (as of 2022-02-03):

> "Property blocks defined before first headline needs to be located at
> the top of the buffer, allowing only comments above."

This commit allows comments above such property drawers.