### PR TITLE
JATS reader: improve handling of fn-group elements

### DIFF
--- a/test/command/6348.md
+++ b/test/command/6348.md
@@ -1,0 +1,42 @@
+```
+% pandoc -f jats -t native
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" "http://jats.nlm.nih.gov/publishing/1.0/JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" dtd-version="1.0" article-type="research-article">
+  <front>
+    <journal-meta>
+      <journal-title-group>
+        <journal-title>Opinion Research</journal-title>
+      </journal-title-group>
+    </journal-meta>
+    <article-meta>
+      <title-group>
+        <article-title>Example article</article-title>
+      </title-group>
+    </article-meta>
+  </front>
+  <body>
+    <sec sec-type="results">
+      <title>Results</title>
+      <p>A University <xref ref-type="fn" rid="N0001">1</xref></p>
+    </sec>
+  </body>
+  <back>
+    <fn-group>
+      <fn id="N0001">
+        <p>footnote</p>
+      </fn>
+    </fn-group>
+  </back>
+</article>
+^D
+[ Header 1 ( "" , [] , [] ) [ Str "Results" ]
+, Para
+    [ Str "A"
+    , Space
+    , Str "University"
+    , Space
+    , Note [ Para [ Str "footnote" ] ]
+    ]
+]
+```


### PR DESCRIPTION
Footnotes in `<fn-group>` elements are collected and re-inserted into
the document as proper footnotes in the place where they are referenced.

Fixes: #6348