### PR TITLE
Org reader fix: more flexible LaTeX environments

### DIFF
--- a/src/Text/Pandoc/Readers/Org/BlockStarts.hs
+++ b/src/Text/Pandoc/Readers/Org/BlockStarts.hs
@@ -58,7 +58,6 @@ latexEnvStart = try $
   skipSpaces *> string "\\begin{"
              *> latexEnvName
              <* string "}"
-             <* blankline
  where
    latexEnvName :: Monad m => OrgParser m Text
    latexEnvName = try $ mappend <$> many1Char alphaNum <*> option "" (textStr "*")

--- a/test/Tests/Readers/Org/Block.hs
+++ b/test/Tests/Readers/Org/Block.hs
@@ -186,6 +186,27 @@ tests =
                , "\\end{equation}"
                ])
 
+    , "One-line LaTeX fragment" =:
+      "\\begin{equation} 2 + 3 \\end{equation}" =?>
+      rawBlock "latex" "\\begin{equation} 2 + 3 \\end{equation}\n"
+
+    , "LaTeX fragment with more arguments" =:
+      T.unlines [ "\\begin{tikzcd}[ampersand replacement=\\&]"
+                , "  A \\& B \\\\"
+                , "  C \\& D"
+                , "  \\arrow[from=1-1, to=1-2]"
+                , "  \\arrow[\"f\", from=2-1, to=2-2]"
+                , "\\end{tikzcd}"
+                ] =?>
+      rawBlock "latex"
+      (T.unlines [ "\\begin{tikzcd}[ampersand replacement=\\&]"
+                 , "  A \\& B \\\\"
+                 , "  C \\& D"
+                 , "  \\arrow[from=1-1, to=1-2]"
+                 , "  \\arrow[\"f\", from=2-1, to=2-2]"
+                 , "\\end{tikzcd}"
+                 ])
+
     , "Convert blank lines in blocks to single newlines" =:
       T.unlines [ "#+begin_html"
                 , ""

--- a/test/Tests/Readers/Org/Directive.hs
+++ b/test/Tests/Readers/Org/Directive.hs
@@ -250,7 +250,7 @@ tests =
                     , "\\end{equation}"
                     ] =?>
           para (str "\\begin{equation}" <> softbreak <>
-                str "f(x) = x^2" <> softbreak <>
+                text "f(x) = x^2" <> softbreak <>
                 str "\\end{equation}")
         ]
       ]


### PR DESCRIPTION
Looking at the definition of `org-element-latex-environment-parser`, one sees that Org is more flexible than Pandoc about LaTeX environments. In fact, it parses every char just after `\begin{xxx}` until `\end{xxx}` as content for the environment, so all the following examples are valid environments that did not work before:
```org
\begin{equation} e = mc^2 \end{equations}
```
```org
\begin{tikzcd}[ampersand replacement=\&]
	A \& B \\
	C \& D
	\arrow[from=1-1, to=1-2]
	\arrow["f", from=2-1, to=2-2]
\end{tikzcd}
```
A question: is there any reason why the verbatim case was made to parse a line like `f(x) = x^2` inside environments as `Str "f(x) = x^2"` instead of `[Str "f(x)", Space, Str "=", Space, Str "x^2"]`? If I understood things properly the latter seems more correct to me in respect to what Org does, so this was changed too.