### PR TITLE
Add scrreport to the latex writer chaptersClasses. Fixed #6168

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -86,7 +86,8 @@ pandocToLaTeX options (Pandoc meta blocks) = do
               blockListToLaTeX
               (fmap chomp . inlineListToLaTeX)
               meta
-  let chaptersClasses = ["memoir","book","report","scrreprt","scrbook","extreport","extbook","tufte-book"]
+  let chaptersClasses = ["memoir","book","report","scrreprt","scrreport",
+                        "scrbook","extreport","extbook","tufte-book"]
   let frontmatterClasses = ["memoir","book","scrbook","extbook","tufte-book"]
   -- these have \frontmatter etc.
   beamer <- gets stBeamer


### PR DESCRIPTION
If scrreport is now chosen as the latex documentclass chapters will be used instead of sections. This behaviour is intended as scrreport is an alias for scrreprt which already created chapters. Fixes #6168 