### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -1,6 +1,9 @@
 name: commit-validation
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   check-commit-msg-length:
     runs-on: ubuntu-latest

--- a/.github/workflows/format-validation.yml
+++ b/.github/workflows/format-validation.yml
@@ -26,6 +26,9 @@ on:
       - 'test/tables/planets.jats_archiving'
       - 'test/tables/students.jats_archiving'
 
+permissions:
+  contents: read
+
 jobs:
   jats:
     name: JATS

--- a/.github/workflows/lint.yml.bkp
+++ b/.github/workflows/lint.yml.bkp
@@ -14,6 +14,9 @@ on:
       - stack.yaml
       - .travis.yml
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - 'rc/**'
 
+permissions:
+  contents: read
+
 jobs:
   linux:
 


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
