### PR TITLE
RST reader: wrap math in Span to preserve attributes

### DIFF
--- a/test/rst-reader.native
+++ b/test/rst-reader.native
@@ -1556,10 +1556,13 @@ Pandoc
       , Math DisplayMath "\\alpha = \\beta"
       ]
   , Para
-      [ Math
-          DisplayMath
-          "\\begin{aligned}\nE &= mc^2\\\\\nF &= \\pi E\n\\end{aligned}"
-      , Math DisplayMath "F &= \\gamma \\alpha^2"
+      [ Span
+          ( "" , [] , [ ( "label" , "hithere" ) , ( "nowrap" , "" ) ] )
+          [ Math
+              DisplayMath
+              "\\begin{aligned}\nE &= mc^2\\\\\nF &= \\pi E\n\\end{aligned}"
+          , Math DisplayMath "F &= \\gamma \\alpha^2"
+          ]
       ]
   , Para [ Str "All" , Space , Str "done." ]
   , Header 1 ( "default-role" , [] , [] ) [ Str "Default-Role" ]


### PR DESCRIPTION
Math elements with a name, classes, or other fields are wrapped in a
`Span` with these attributes.