### PR TITLE
Lua: allow to pass Sources to pandoc.read

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3414,7 +3414,7 @@ retrieved from the other parsed input files.
 Parameters:
 
 `markup`
-:   the markup to be parsed (string)
+:   the markup to be parsed (string|Sources)
 
 `format`
 :   format specification, defaults to `"markdown"` (string)


### PR DESCRIPTION
Sources, the data type passed to the `Reader` function in custom
readers, are now accepted as input to `pandoc.read`.