### PR TITLE
Follow JATS4R recommendation and PudMed Central

### DIFF
--- a/data/templates/article.jats_publishing
+++ b/data/templates/article.jats_publishing
@@ -189,7 +189,10 @@ $if(copyright.text)$
 </license>
 $endif$
 $for(license)$
-<license$if(it.type)$ license-type="${it.type}"$endif$$if(it.link)$ xlink:href="${it.link}"$endif$>
+<license$if(it.type)$ license-type="${it.type}"$endif$>
+$if(it.link)$
+<ali:license_ref xmlns:ali="http://www.niso.org/schemas/ali/1.0/">${it.link}</ali:license_ref>
+$endif$
 <license-p>$if(it.text)$${it.text}$else$${it}$endif$</license-p>
 </license>
 $endfor$


### PR DESCRIPTION
Using the default jats template of pandoc 2.18, the https://jats4r.org/jats4r-validator/ warns: "The license URI is given in @xlink:href. For JATS 1.1d3 and later, if the license is defined by a canonical URI, then it should be specified in the <ali:license_ref> child element."

I can confirm that what JATS4R recommends here is consistent with the JATS article packages found on the FTP site for the
PubMed Central Open Access Subset <https://www.ncbi.nlm.nih.gov/pmc/tools/openftlist/> (at least with the eLife article I looked at).

This proposed change follows the JATS4R recommendation and an example eLife article on the PubMed Central FTP site.