### PR TITLE
Add more class for detecting.

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -87,8 +87,10 @@ pandocToLaTeX options (Pandoc meta blocks) = do
               (fmap chomp . inlineListToLaTeX)
               meta
   let chaptersClasses = ["memoir","book","report","scrreprt","scrreport",
-                        "scrbook","extreport","extbook","tufte-book"]
-  let frontmatterClasses = ["memoir","book","scrbook","extbook","tufte-book"]
+                        "scrbook","extreport","extbook","tufte-book",
+                        "ctexrep","ctexbook","elegantbook"]
+  let frontmatterClasses = ["memoir","book","scrbook","extbook","tufte-book",
+                           "ctexbook","elegantbook"]
   -- these have \frontmatter etc.
   beamer <- gets stBeamer
   let documentClass =


### PR DESCRIPTION
Add ctexrep, ctexbook, and elegantbook document classes to the list for detecting.  These classes are widely used in China.