### PR TITLE
Improved reading <xref> elements in DocBook files

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -1342,6 +1342,7 @@ parseInline (Elem e) =
                   "sect5"        -> descendantContent "title" el
                   "cmdsynopsis"  -> descendantContent "command" el
                   "funcsynopsis" -> descendantContent "function" el
+                  "figure"       -> descendantContent "title" el
                   _              -> qName (elName el) <> "_title"
           where
             xrefLabel = attrValue "xreflabel" el

--- a/test/docbook-xref.docbook
+++ b/test/docbook-xref.docbook
@@ -24,6 +24,9 @@ cross-reference text: <xref linkend="ch02"/>.
 <listitem><para>A link to an
 <sgmltag>funcsynopsis</sgmltag> element: <xref linkend="func01"/>.
 </para></listitem>
+<listitem><para>A link to a
+<sgmltag>figure</sgmltag> element: <xref linkend="fig01"/>.
+</para></listitem>
 </itemizedlist>
 </chapter>
 
@@ -65,6 +68,14 @@ cross-reference text: <xref linkend="ch02"/>.
 </funcprototype>
 </funcsynopsis>
 
+<figure id="fig01"><title>The Pythagorean Theorem Illustrated</title>
+<mediaobject>
+  <imageobject>
+    <imagedata fileref="figures/pythag.png"/>
+  </imageobject>
+  <textobject><phrase>An illustration of the Pythagorean Theorem</phrase></textobject>
+</mediaobject>
+</figure>
+
 </chapter>
 </book>
-

--- a/test/docbook-xref.native
+++ b/test/docbook-xref.native
@@ -141,6 +141,33 @@ Pandoc
             , Str "."
             ]
         ]
+      , [ Para
+            [ Str "A"
+            , Space
+            , Str "link"
+            , Space
+            , Str "to"
+            , Space
+            , Str "a"
+            , SoftBreak
+            , Str "figure"
+            , Space
+            , Str "element:"
+            , Space
+            , Link
+                ( "" , [] , [] )
+                [ Str "The"
+                , Space
+                , Str "Pythagorean"
+                , Space
+                , Str "Theorem"
+                , Space
+                , Str "Illustrated"
+                ]
+                ( "#fig01" , "" )
+            , Str "."
+            ]
+        ]
       ]
   , Header
       1
@@ -174,4 +201,17 @@ Pandoc
   , Plain [ Str "int1" ]
   , Plain [ Str "int" ]
   , Plain [ Str "int2" ]
+  , Para
+      [ Image
+          ( "fig01" , [] , [] )
+          [ Str "The"
+          , Space
+          , Str "Pythagorean"
+          , Space
+          , Str "Theorem"
+          , Space
+          , Str "Illustrated"
+          ]
+          ( "figures/pythag.png" , "fig:" )
+      ]
   ]


### PR DESCRIPTION
`<xref>` elements can also be used to link to `<figure>` elements. Alas, the DocBook reader was not aware of this and thus generated a link text which just said 'figure_title'.

https://tdg.docbook.org/tdg/4.5/figure.html explains that `<figure>` elements can contain `<title>` elements, so let's try to use that if it is available.

Technically, this logic could be a _lot_ more sophisticated. The [docbook-xsl project's XSLT stylesheet for handling `<xref>` elements](https://github.com/docbook/xslt10-stylesheets/blob/6ff683948c5a85949e4b7661f302e8b5f12f7bf2/xsl/html/xref.xsl) is a whopping 1300+ lines of code, and a lot of that is dedicated to a comprehensive heuristic which tries to come up with a sensible link text depending on the target element being referenced. However, it took seven years for someone to point out that Pandoc's handling of `<xref>` elements is incomplete, so maybe we don't need to go all the way just yet.

Closes #8064 . 