### PR TITLE
Populate mediabag after filters have run.

### DIFF
--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -306,17 +306,16 @@ convertWithOpts opts = do
                                 >>= r readerOpts
              ByteStringReader r ->
                mconcat <$> mapM (r readerOpts . inputToLazyByteString) inputs)
-            >>=
-              (   (if not (optSandbox opts) &&
-                      (isJust (optExtractMedia opts)
-                       || writerNameBase == "docx") -- for fallback pngs
-                      then fillMediaBag
-                      else return)
-              >=> return . adjustMetadata (metadataFromFile <>)
+            >>= ( return . adjustMetadata (metadataFromFile <>)
               >=> return . adjustMetadata (<> optMetadata opts)
               >=> return . adjustMetadata (<> cslMetadata)
               >=> applyTransforms transforms
               >=> applyFilters filterEnv filters [T.unpack format]
+              >=> (if not (optSandbox opts) &&
+                      (isJust (optExtractMedia opts)
+                       || writerNameBase == "docx") -- for fallback pngs
+                   then fillMediaBag
+                   else return)
               >=> maybe return extractMedia (optExtractMedia opts)
               )
 


### PR DESCRIPTION
The mediabag is filled with document resources after the filters have
run. This allows, for example, filter authors to modify image paths
before pandoc tries to fetch the images.

Lua filters that rely on a filled mediabag can use the new
`pandoc.mediabag.fill` function to perform that action in the filter.

Closes: #8099