### PR TITLE
fillMediaBag: Keep attributes of original image on Span

### DIFF
--- a/src/Text/Pandoc/Class/PandocMonad.hs
+++ b/src/Text/Pandoc/Class/PandocMonad.hs
@@ -688,14 +688,23 @@ fillMediaBag d = walkM handleImage d
                   report $ CouldNotFetchResource src
                             "replacing image with description"
                   -- emit alt text
-                  return $ Span ("",["image"],[]) lab
+                  return $ replacementSpan attr src tit lab
                 PandocHttpError u er -> do
                   report $ CouldNotFetchResource u
                             (T.pack $ show er ++ "\rReplacing image with description.")
                   -- emit alt text
-                  return $ Span ("",["image"],[]) lab
+                  return $ replacementSpan attr src tit lab
                 _ -> throwError e)
         handleImage x = return x
+
+        replacementSpan (ident, classes, attribs) src title descr =
+          Span ( ident
+               , "image":"placeholder":classes
+               , ("original-image-src", src) :
+                 ("original-image-title", title) :
+                 attribs
+               )
+               descr
 
 -- This requires UndecidableInstances.  We could avoid that
 -- by repeating the definitions below for every monad transformer


### PR DESCRIPTION
Images that cannot be fetched are replaced with a Span that contains the
image's description. The span now also retains all original image
attributes and inherits all attributes of the image. Furthermore, the
classes `image` and `placeholder` are added, and path and title are
store in attributes `original-image-src` and `original-image-title`,
respectively.

Closes: #8099