### PR TITLE
org reader: recognize {webp,jxl} files as images

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Shared.hs
+++ b/src/Text/Pandoc/Readers/Org/Shared.hs
@@ -30,7 +30,7 @@ isImageFilename fp = hasImageExtension && (isValid (T.unpack fp) || isKnownProto
                        `elem` imageExtensions
    isKnownProtocolUri = any (\x -> (x <> "://") `T.isPrefixOf` fp) protocols
 
-   imageExtensions = [ ".jpeg", ".jpg", ".png", ".gif", ".svg" ]
+   imageExtensions = [ ".jpeg", ".jpg", ".png", ".gif", ".svg", ".webp", ".jxl" ]
    protocols = [ "file", "http", "https" ]
 
 -- | Cleanup and canonicalize a string describing a link.  Return @Nothing@ if


### PR DESCRIPTION
Currently, webp files are not recognized as images. This pr would make `echo "[[file:test.webp]]" | stack run -- -f org -t html -i - -o -` outputs `<p><img src="test.webp" /></p>` instead of `<p><a href="test.webp">file:test.webp</a></p>`.

I also added support for [JPEG XL](https://en.wikipedia.org/wiki/JPEG_XL) images.