### PR TITLE
Prepare for liftA2 being exported from Prelude

### DIFF
--- a/src/Text/Pandoc/Parsing/Types.hs
+++ b/src/Text/Pandoc/Parsing/Types.hs
@@ -19,7 +19,8 @@ module Text.Pandoc.Parsing.Types
   )
 where
 
-import Control.Applicative (liftA2)
+import Prelude hiding (Applicative(..))
+import Control.Applicative (Applicative(..))
 import Control.Monad.Reader
   ( asks, runReader, MonadReader(ask), Reader, ReaderT(ReaderT) )
 import Text.Parsec ( Parsec , ParsecT )

--- a/src/Text/Pandoc/Readers/Odt/Arrows/Utils.hs
+++ b/src/Text/Pandoc/Readers/Odt/Arrows/Utils.hs
@@ -21,6 +21,7 @@ with an equivalent return value.
 -- We export everything
 module Text.Pandoc.Readers.Odt.Arrows.Utils where
 
+import Prelude hiding (Applicative(..))
 import Control.Arrow
 import Control.Monad (join)
 

--- a/src/Text/Pandoc/Readers/Odt/ContentReader.hs
+++ b/src/Text/Pandoc/Readers/Odt/ContentReader.hs
@@ -24,6 +24,7 @@ module Text.Pandoc.Readers.Odt.ContentReader
 , read_body
 ) where
 
+import Prelude hiding (Applicative(..))
 import Control.Applicative hiding (liftA, liftA2, liftA3)
 import Control.Arrow
 import Control.Monad ((<=<))

--- a/src/Text/Pandoc/Readers/Odt/Generic/XMLConverter.hs
+++ b/src/Text/Pandoc/Readers/Odt/Generic/XMLConverter.hs
@@ -54,6 +54,7 @@ module Text.Pandoc.Readers.Odt.Generic.XMLConverter
 , matchContent
 ) where
 
+import           Prelude hiding (Applicative(..))
 import           Control.Applicative  hiding ( liftA, liftA2 )
 import           Control.Monad               ( MonadPlus )
 import           Control.Arrow

--- a/src/Text/Pandoc/Readers/Odt/StyleReader.hs
+++ b/src/Text/Pandoc/Readers/Odt/StyleReader.hs
@@ -39,6 +39,7 @@ module Text.Pandoc.Readers.Odt.StyleReader
 , readStylesAt
 ) where
 
+import Prelude hiding (Applicative(..))
 import Control.Applicative hiding (liftA, liftA2, liftA3)
 import Control.Arrow
 


### PR DESCRIPTION
CLC has approved the proposal to export `liftA2` from `Prelude`
(https://github.com/haskell/core-libraries-committee/issues/50).
It means that the entirety of `Applicative` will now be exported from `Prelude`.

The implementation of the proposal is delayed at least to GHC 9.6,
but one can already future-proof code to be
compliant with this change in a backwards-compatible way. No CPP required.

Migration guide and more info:
https://github.com/haskell/core-libraries-committee/blob/main/guides/export-lifta2-prelude.md (not yet merged, draft can be seen [here](https://github.com/googleson78/core-libraries-committee/blob/lifta2-guide/guides/export-lifta2-prelude.md)