### PR TITLE
Remove extra soft break for tasklist

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -502,7 +502,7 @@ listItemToHtml opts bls
       let checkbox  = if checked
                       then checkbox' ! A.checked ""
                       else checkbox'
-          checkbox' = H.input ! A.type_ "checkbox" ! A.disabled "" >> nl
+          checkbox' = H.input ! A.type_ "checkbox" ! A.disabled ""
       isContents <- inlineListToHtml opts is
       bsContents <- blockListToHtml opts bs
       return $ constr (checkbox >> isContents) >> bsContents

--- a/test/command/tasklist.md
+++ b/test/command/tasklist.md
@@ -6,10 +6,8 @@ tests adapted from <https://github.github.com/gfm/#task-list-items-extension->
 - [x] bar
 ^D
 <ul class="task-list">
-<li><input type="checkbox" disabled="" />
-foo</li>
-<li><input type="checkbox" disabled="" checked="" />
-bar</li>
+<li><input type="checkbox" disabled="" />foo</li>
+<li><input type="checkbox" disabled="" checked="" />bar</li>
 </ul>
 ```
 
@@ -22,15 +20,12 @@ bar</li>
 - [ ] bim
 ^D
 <ul class="task-list">
-<li><input type="checkbox" disabled="" checked="" />
-foo<ul class="task-list">
-<li><input type="checkbox" disabled="" />
-bar</li>
-<li><input type="checkbox" disabled="" checked="" />
-baz</li>
+<li><input type="checkbox" disabled="" checked="" />foo<ul
+class="task-list">
+<li><input type="checkbox" disabled="" />bar</li>
+<li><input type="checkbox" disabled="" checked="" />baz</li>
 </ul></li>
-<li><input type="checkbox" disabled="" />
-bim</li>
+<li><input type="checkbox" disabled="" />bim</li>
 </ul>
 ```
 
@@ -58,26 +53,21 @@ paragraph
 - [x] checked
 ^D
 <ul>
-<li><input type="checkbox" disabled="" />
-unchecked</li>
+<li><input type="checkbox" disabled="" />unchecked</li>
 <li>plain item</li>
-<li><input type="checkbox" disabled="" checked="" />
-checked</li>
+<li><input type="checkbox" disabled="" checked="" />checked</li>
 </ul>
 <p>paragraph</p>
 <ol type="1">
-<li><input type="checkbox" disabled="" />
-ordered unchecked</li>
+<li><input type="checkbox" disabled="" />ordered unchecked</li>
 <li>[] plain item</li>
-<li><input type="checkbox" disabled="" checked="" />
-ordered checked</li>
+<li><input type="checkbox" disabled="" checked="" />ordered checked</li>
 </ol>
 <p>paragraph</p>
 <ul class="task-list">
-<li><p><input type="checkbox" disabled="" />
-list item with a</p><p>second paragraph</p></li>
-<li><p><input type="checkbox" disabled="" checked="" />
-checked</p></li>
+<li><p><input type="checkbox" disabled="" />list item with
+a</p><p>second paragraph</p></li>
+<li><p><input type="checkbox" disabled="" checked="" />checked</p></li>
 </ul>
 ```
 


### PR DESCRIPTION
Browser will display the extra newline character between checkbox and
text as a space, which make tasklist items cannot be aligned.

I just remove it.

![图片](https://user-images.githubusercontent.com/29726878/175105768-c8336139-54c1-4609-8f6e-cec10e427075.png)

before:
![图片](https://user-images.githubusercontent.com/29726878/175107397-03cee7a2-e2f2-4920-8fbc-b5a2da64e5b3.png)
after: 
![图片](https://user-images.githubusercontent.com/29726878/175107333-cb1ceb68-3bd3-4ed3-bec6-476eb16f8cd7.png)
