### PR TITLE
Update filter.md Noto Sans CJK TC -> JP

### DIFF
--- a/doc/filters.md
+++ b/doc/filters.md
@@ -411,7 +411,7 @@ Then run it:
 
 Note:  to use this to generate PDFs via LaTeX, you'll need
 to use `--pdf-engine=xelatex`, specify a `mainfont` that has
-the Japanese characters (e.g. "Noto Sans CJK TC"), and add
+the Japanese characters (e.g. "[Noto Sans CJK JP](https://fonts.google.com/noto/specimen/Noto+Sans+JP)"), and add
 `\usepackage{ruby}` to your template or header-includes.
 
 # Exercises


### PR DESCRIPTION
Noto Sans CJK TC, that is suggested as a character set that contains Japanese characters, may not be suitable to properly display Japanese characters. Rather, Noto Sans CJK JP is much more recommendable for that purpose.

Although some characters originated from China are quite similar among countries/regions, most of them have evolved into different shapes in Mainland China, Hong Kong, Taiwan, Japan, Korea, and Vietnam. Therefore, it is best to use a character set that the language of the country/region uses for the readability/recongnizability sake. See also [an webpage that discusses the glyph appearance issue in Chinese, Japanese, Korean, and Vietnamese languages](https://heistak.github.io/your-code-displays-japanese-wrong/).

[README of Noto CJK](https://github.com/googlefonts/noto-cjk/blob/main/README.md) may also be a good resource to know which font should be used to display characters of each language.