### PR TITLE
Document math support in PowerPoint

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4871,7 +4871,7 @@ DocBook
     in an `inlineequation` or `informalequation` tag.  Otherwise it
     will be rendered, if possible, using Unicode characters.
 
-Docx
+Docx and PowerPoint
   ~ It will be rendered using OMML math markup.
 
 FictionBook2


### PR DESCRIPTION
In the manual, there is an indication that Math is rendered in all output formats, yet there is no mention of PowerPoint below, when specifying how it is rendered.