### PR TITLE
Refine tasklist CSS 

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -167,6 +167,7 @@ span.underline{text-decoration: underline;}
 div.column{display: inline-block; vertical-align: top; width: 50%;}
 div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
 ul.task-list{list-style: none;}
+ul.task-list input[type="checkbox"]{margin-left: -1.7em;}
 $if(quotes)$
 q { quotes: "“" "”" "‘" "’"; }
 $endif$

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -502,7 +502,7 @@ listItemToHtml opts bls
       let checkbox  = if checked
                       then checkbox' ! A.checked ""
                       else checkbox'
-          checkbox' = H.input ! A.type_ "checkbox" ! A.disabled ""
+          checkbox' = H.input ! A.type_ "checkbox" ! A.disabled "" >> nl
       isContents <- inlineListToHtml opts is
       bsContents <- blockListToHtml opts bs
       return $ constr (checkbox >> isContents) >> bsContents

--- a/test/command/tasklist.md
+++ b/test/command/tasklist.md
@@ -6,8 +6,10 @@ tests adapted from <https://github.github.com/gfm/#task-list-items-extension->
 - [x] bar
 ^D
 <ul class="task-list">
-<li><input type="checkbox" disabled="" />foo</li>
-<li><input type="checkbox" disabled="" checked="" />bar</li>
+<li><input type="checkbox" disabled="" />
+foo</li>
+<li><input type="checkbox" disabled="" checked="" />
+bar</li>
 </ul>
 ```
 
@@ -20,12 +22,15 @@ tests adapted from <https://github.github.com/gfm/#task-list-items-extension->
 - [ ] bim
 ^D
 <ul class="task-list">
-<li><input type="checkbox" disabled="" checked="" />foo<ul
-class="task-list">
-<li><input type="checkbox" disabled="" />bar</li>
-<li><input type="checkbox" disabled="" checked="" />baz</li>
+<li><input type="checkbox" disabled="" checked="" />
+foo<ul class="task-list">
+<li><input type="checkbox" disabled="" />
+bar</li>
+<li><input type="checkbox" disabled="" checked="" />
+baz</li>
 </ul></li>
-<li><input type="checkbox" disabled="" />bim</li>
+<li><input type="checkbox" disabled="" />
+bim</li>
 </ul>
 ```
 
@@ -53,21 +58,26 @@ paragraph
 - [x] checked
 ^D
 <ul>
-<li><input type="checkbox" disabled="" />unchecked</li>
+<li><input type="checkbox" disabled="" />
+unchecked</li>
 <li>plain item</li>
-<li><input type="checkbox" disabled="" checked="" />checked</li>
+<li><input type="checkbox" disabled="" checked="" />
+checked</li>
 </ul>
 <p>paragraph</p>
 <ol type="1">
-<li><input type="checkbox" disabled="" />ordered unchecked</li>
+<li><input type="checkbox" disabled="" />
+ordered unchecked</li>
 <li>[] plain item</li>
-<li><input type="checkbox" disabled="" checked="" />ordered checked</li>
+<li><input type="checkbox" disabled="" checked="" />
+ordered checked</li>
 </ol>
 <p>paragraph</p>
 <ul class="task-list">
-<li><p><input type="checkbox" disabled="" />list item with
-a</p><p>second paragraph</p></li>
-<li><p><input type="checkbox" disabled="" checked="" />checked</p></li>
+<li><p><input type="checkbox" disabled="" />
+list item with a</p><p>second paragraph</p></li>
+<li><p><input type="checkbox" disabled="" checked="" />
+checked</p></li>
 </ul>
 ```
 


### PR DESCRIPTION
Move checkbox left to where the list marker is
for normal lists.

Closes https://github.com/jgm/pandoc/issues/8151

(If we decide to go with this, I can compile and rerun the tests to auo-fix them.)