### PR TITLE
Markdown reader: fenced code block shortcuts with attributes (#8174)

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3853,6 +3853,18 @@ This is equivalent to:
     qsort [] = []
     ```
 
+This shortcut form may be combined with attributes:
+
+    ```haskell {.numberLines}
+	qsort [] = []
+	```
+
+Which is equivalent to:
+
+	``` {.haskell .numberLines}
+	qsort [] = []
+	```
+
 If the `fenced_code_attributes` extension is disabled, but
 input contains class attribute(s) for the code block, the first
 class attribute will be printed after the opening fence as a bare

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3856,14 +3856,14 @@ This is equivalent to:
 This shortcut form may be combined with attributes:
 
     ```haskell {.numberLines}
-	qsort [] = []
-	```
+    qsort [] = []
+    ```
 
 Which is equivalent to:
 
-	``` {.haskell .numberLines}
-	qsort [] = []
-	```
+    ``` {.haskell .numberLines}
+    qsort [] = []
+    ```
 
 If the `fenced_code_attributes` extension is disabled, but
 input contains class attribute(s) for the code block, the first

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -694,7 +694,7 @@ codeBlockFenced = try $ do
            maybeAttr <- option Nothing (Just <$> (guardEnabled Ext_fenced_code_attributes >> try attributes))
            return $ case maybeAttr of
               Nothing -> ("", maybeToList languageId, [])
-              Just (_id, classes, _attrs) -> (_id, maybe classes (: classes) languageId, _attrs)))
+              Just (id, classes, attrs) -> (id, maybe classes (: classes) languageId, attrs)))
   blankline
   contents <- T.intercalate "\n" <$>
                  manyTill (gobbleAtMostSpaces indentLevel >> anyLine)

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -694,7 +694,7 @@ codeBlockFenced = try $ do
            maybeAttr <- option Nothing (Just <$> (guardEnabled Ext_fenced_code_attributes >> try attributes))
            return $ case maybeAttr of
               Nothing -> ("", maybeToList languageId, [])
-              Just (id, classes, attrs) -> (id, maybe classes (: classes) languageId, attrs)))
+              Just (elementId, classes, attrs) -> (elementId, maybe classes (: classes) languageId, attrs)))
   blankline
   contents <- T.intercalate "\n" <$>
                  manyTill (gobbleAtMostSpaces indentLevel >> anyLine)

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -689,7 +689,7 @@ codeBlockFenced = try $ do
      (Left <$> (guardEnabled Ext_raw_attribute >> try rawAttribute))
     <|>
      (Right <$> (do
-           languageId <- option Nothing (Just . toLanguageId <$> try (many1Char $ satisfy (\x -> (x /= '{') && not (isSpace x))))
+           languageId <- option Nothing (Just . toLanguageId <$> try (many1Char $ satisfy (\x -> x `notElem` ['`', '{', '}'] && not (isSpace x))))
            skipMany spaceChar
            maybeAttr <- option Nothing (Just <$> (guardEnabled Ext_fenced_code_attributes >> try attributes))
            return $ case maybeAttr of

--- a/test/command/8174.md
+++ b/test/command/8174.md
@@ -17,3 +17,18 @@ some: code
     ( "id" , [ "yaml" , "class" ] , [] ) "some: code"
 ]
 ````
+
+<!-- Inline code sections at the start of the line should not be mistaken for code blocks -->
+````
+% pandoc -t native
+```ab```
+^D
+[ Para [ Code ( "" , [] , [] ) "ab" ] ]
+````
+
+````
+% pandoc -t native
+```ab```{.class}
+^D
+[ Para [ Code ( "" , [ "class"] , [] ) "ab" ] ]
+```

--- a/test/command/8174.md
+++ b/test/command/8174.md
@@ -30,5 +30,15 @@ some: code
 % pandoc -t native
 ```ab```{.class}
 ^D
-[ Para [ Code ( "" , [ "class"] , [] ) "ab" ] ]
+[ Para [ Code ( "" , [ "class" ] , [] ) "ab" ] ]
+````
+
+<!-- Illegal language identifiers should be treated as inline code for now -->
+````
+% pandoc -t native
+``` foo}{.bar}
+test
 ```
+^D
+[ Para [ Code ( "" , [] , [] ) "foo}{.bar} test" ] ]
+````

--- a/test/command/8174.md
+++ b/test/command/8174.md
@@ -1,0 +1,19 @@
+````
+% pandoc -t native
+```yaml {#id}
+some: code
+```
+^D
+[ CodeBlock ( "id" , [ "yaml" ] , [] ) "some: code" ]
+````
+
+````
+% pandoc -t native
+```yaml {.class #id}
+some: code
+```
+^D
+[ CodeBlock
+    ( "id" , [ "yaml" , "class" ] , [] ) "some: code"
+]
+````


### PR DESCRIPTION
This allows the combination of the fenced code block shortcut form with attributes, described in #8174:

````md
```haskell {.lineNumbers #id}
qsort [] = []
```
````

The code syntax class will be combined with the attribute classes, in this case `haskell` and `lineNumbers`.

This syntax allows for more intuitive writing of code blocks and for better compatibility with other Markdown parsers such as GitHub or Codeberg.

Code blocks using the old syntax on GitHub (`{.haskell .lineNumbers}`):

```{.haskell .lineNumbers}
qsort [] = []
```

Using the adapted shortcut form:

```haskell {.lineNumbers}
qsort [] = []
```

---

I'm new to such complex Haskell code, so feel free to suggest stylistic improvements.