### PR TITLE
Fix links in manual

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2665,7 +2665,8 @@ math equations flush left using [YAML metadata](#layout) or with
 
 ### Variables for HTML slides
 
-These affect HTML output when [producing slide shows with pandoc].
+These affect HTML output when [producing slide shows with
+pandoc](#slide-shows).
 
 `institute`
 :   author affiliations: can be a list when there are multiple authors

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2687,7 +2687,7 @@ pandoc](#slide-shows).
 
 `title-slide-attributes`
 :   additional attributes for the title slide of reveal.js slide shows.
-    See [background in reveal.js and beamer] for an example.
+    See [background in reveal.js, beamer, and pptx] for an example.
 
 All [reveal.js configuration options] are available as variables.
 To turn off boolean flags that default to true in reveal.js, use `0`.


### PR DESCRIPTION
I've bumped into two links that broke because the section headings they link to have changed.