### PR TITLE
Manual: add mark / highlight documentation

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4720,18 +4720,6 @@ just part of a word, use `*`:
 
     feas*ible*, not feas*able*.
 
-### Highlighting ###
-
-To highlight text, use the `mark` class:
-
-    [Mark]{.mark}
-
-Or, without the `bracketed_spans` extension (but with `native_spans`):
-
-    <span class="mark">Mark</span>
-
-This will work in html output.
-
 ### Strikeout ###
 
 #### Extension: `strikeout` ####
@@ -4817,6 +4805,18 @@ For compatibility with other Markdown flavors, CSS is also supported:
     <span style="font-variant:small-caps;">Small caps</span>
 
 This will work in all output formats that support small caps.
+
+### Highlighting ###
+
+To highlight text, use the `mark` class:
+
+    [Mark]{.mark}
+
+Or, without the `bracketed_spans` extension (but with `native_spans`):
+
+    <span class="mark">Mark</span>
+
+This will work in all output formats that support highlighting.
 
 
 ## Math

--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -162,6 +162,7 @@ header {
 }
 $endif$
 code{white-space: pre-wrap;}
+span.mark{background-color: yellow; color: black;}
 span.smallcaps{font-variant: small-caps;}
 span.underline{text-decoration: underline;}
 div.column{display: inline-block; vertical-align: top; width: 50%;}


### PR DESCRIPTION
Please see [this "Syntax for \<mark>?" pandoc-discuss thread](https://groups.google.com/g/pandoc-discuss/c/9TqKKHfAZac) for context.
* I've added a new section after (and modeled on) the existing underline and small caps sections
* I've checked that `<span class="mark">Mark</span>` does indeed work (and uses the `mark` element)
* But is it true that this will work in all output formats that support mark / highlight? (I don't know... I'm just asking)

Also note:
* The pandoc-discuss thread points out that the mark class only works when it's the first class (and I've verified that this is also the case for the underline and smallcaps classes). Is this intentional (in which case it should be documented) or is it a bug?

* The default HTML template defines underline and smallcaps classes, but it doesn't define a mark class. This seems a bit inconsistent? My "try pandoc" below illustrates that in the "mark isn't the first class" case the HTML will use the (defined) underline and smallcaps classes and the (undefined) mark class

* I used this ["try pandoc"](https://pandoc.org/try/?text=Span+with+single+class%3A%0A%0A*+%5BThis+uses+the+u+element%5D%7B.underline%7D%0A*+%5BThis+uses+the+smallcaps+class%5D%7B.smallcaps%7D%0A*+%5BThis+uses+the+mark+element%5D%7B.mark%7D%0A%0ASpan+with+%27first%27+as+the+first+class%3A%0A%0A*+%5BThis+uses+the+underline+class%5D%7B.first+.underline%7D%0A*+%5BThis+uses+the+smallcaps+class%5D%7B.first+.smallcaps%7D%0A*+%5BThis+uses+the+mark+class+(not+defined)%5D%7B.first+.mark%7D%0A%0ANative+span+with+single+class%3A%0A%0A*+%3Cspan+class%3D%22underline%22%3EThis+uses+the+u+element%3C%2Fspan%3E%0A*+%3Cspan+class%3D%22smallcaps%22%3EThis+uses+the+smallcaps+class%3C%2Fspan%3E%0A*+%3Cspan+class%3D%22mark%22%3EThis+uses+the+mark+element%3C%2Fspan%3E%0A%0ANative+span+with+%27first%27+as+the+first+class%3A%0A%0A*+%3Cspan+class%3D%22first+underline%22%3EThis+uses+the+underline+class%3C%2Fspan%3E%0A*+%3Cspan+class%3D%22first+smallcaps%22%3EThis+uses+the+smallcaps+class%3C%2Fspan%3E%0A*+%3Cspan+class%3D%22first+mark%22%3EThis+uses+the+mark+class+(not+defined)%3C%2Fspan%3E%0A%0AAnything+that+relies+on+a+class+being+defined+will+only+work+in+standalone+documents.&from=markdown&to=&standalone=0) to check out the various behaviors