### PR TITLE
CI: update macos container version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
 
   macos:
 
-    runs-on: macOS-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,7 @@ jobs:
 
   macos:
 
-    runs-on: macOS-10.15
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -87,7 +87,7 @@ jobs:
 
   macos:
 
-    runs-on: macOS-10.15
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30.

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

The PR bumps the `runs-on` from `macos-10.15` to `macos-11`.