### PR TITLE
Lua: add function `pandoc.utils.citeproc`

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3589,6 +3589,28 @@ Usage:
     --   pandoc.Emph{ pandoc.Str 'Paragraph2' }
     -- }
 
+### `citeproc (doc)` {#pandoc.utils.citeproc}
+
+Process the citations in the file, replacing them with rendered
+citations and adding a bibliography. See the manual section on
+citation rendering for details.
+
+Parameters:
+
+`doc`
+:   document ([Pandoc](#type-pandoc))
+
+Returns:
+
+-   processed document ([Pandoc](#type-pandoc))
+
+Usage:
+
+    -- Lua filter that behaves like `--citeproc`
+    function Pandoc (doc)
+      return pandoc.utils.citeproc(doc)
+    end
+
 ### `equals (element1, element2)` {#pandoc.utils.equals}
 
 Test equality of AST elements. Elements in Lua are considered

--- a/src/Text/Pandoc/Lua/Module/Utils.hs
+++ b/src/Text/Pandoc/Lua/Module/Utils.hs
@@ -25,7 +25,7 @@ import Data.Maybe (fromMaybe)
 import Data.Version (Version)
 import HsLua as Lua
 import HsLua.Module.Version (peekVersionFuzzy, pushVersion)
-import Text.Pandoc.Citeproc (getReferences)
+import Text.Pandoc.Citeproc (getReferences, processCitations)
 import Text.Pandoc.Definition
 import Text.Pandoc.Error (PandocError)
 import Text.Pandoc.Lua.Marshal.AST
@@ -58,6 +58,16 @@ documentedModule = Module
             "blocks" ""
       <#> opt (parameter (peekList peekInline) "list of inlines" "inline" "")
       =#> functionResult pushInlines "list of inlines" ""
+
+    , defun "citeproc"
+      ### unPandocLua . processCitations
+      <#> parameter peekPandoc "Pandoc" "doc" "document"
+      =#> functionResult pushPandoc "Pandoc" "processed document"
+      #?  T.unwords
+          [ "Process the citations in the file, replacing them with "
+          , "rendered citations and adding a bibliography. "
+          , "See the manual section on citation rendering for details."
+          ]
 
     , defun "equals"
       ### equal


### PR DESCRIPTION
The function runs the *citeproc* processor on a Pandoc document.
Exposing this functionality to Lua allows to make citation processing
part of a filter or writer, simplifies the creation of multiple
bibliographies, and enables the use of varying citation styles in
different parts of a document.