### PR TITLE
Fix typos

### DIFF
--- a/data/templates/default.rst
+++ b/data/templates/default.rst
@@ -12,7 +12,7 @@ $if(date)$
 :Date: $^$$date$
 $endif$
 $if(address)$
-:Addresss: $^$$address$
+:Address: $^$$address$
 $endif$
 $if(contact)$
 :Contact: $^$$contact$

--- a/doc/jats.md
+++ b/doc/jats.md
@@ -79,7 +79,7 @@ Metadata Values
 
         Furthermore, the [`corresp`][attr:corresp] attribute on
         the author's [`<contrib>`] element is set to `yes` if
-        this attribute is set to a truty.
+        this attribute is set to a truthy.
 
 `affiliation`
 :   the list of organizations with which contributors are

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -4854,7 +4854,7 @@ Parameters
 
 Returns
 
--   doc contatining just the literal string ([Doc])
+-   doc containing just the literal string ([Doc])
 
 ### nest {#pandoc.layout.nest}
 

--- a/doc/short-guide-to-pandocs-sources.md
+++ b/doc/short-guide-to-pandocs-sources.md
@@ -61,7 +61,7 @@ the following points:
    text, others contain "Inline" elements.
 
  * [Inlines][def-Inline] are "running text", with many different
-   types. The most important contstructors are `Str` (a word),
+   types. The most important constructors are `Str` (a word),
    `Space` (a space char), `Emph` (emphasized text), and `Strong`
    (strongly emphasized text). It's worth checking their
    definitions.
@@ -87,7 +87,7 @@ directory, in the `Text.Pandoc` module. The basic flow is:
 
  2. the document AST is modified (optional);
 
- 3. then the internal respresentation is converted into the target
+ 3. then the internal representation is converted into the target
     format by a *writer*.
 
 The [*readers*] can be found in `Text.Pandoc.Readers`, while the

--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -449,7 +449,7 @@ pandocToEPUB version opts doc = do
                       writeHtmlStringForEPUB version o
   metadata <- getEPUBMetadata opts meta
 
-  -- retreive title of document
+  -- retrieve title of document
   let plainTitle :: Text
       plainTitle = case docTitle' meta of
                         [] -> case epubTitle metadata of

--- a/test/Tests/Readers/Creole.hs
+++ b/test/Tests/Readers/Creole.hs
@@ -119,7 +119,7 @@ tests = [
                          , plain "blubb" ]
         , "nested many unordered lists, one separating space" =:
           ("* foo\n** bar\n*** third\n*** third two\n** baz\n*** third again\n"
-           <> "**** fourth\n***** fith\n* blubb")
+           <> "**** fourth\n***** fifth\n* blubb")
           =?> bulletList [ plain "foo"
                            <> bulletList [ plain "bar"
                                            <> bulletList [ plain "third"
@@ -129,7 +129,7 @@ tests = [
                                                          <> bulletList [
                                                              plain "fourth"
                                                              <> bulletList [
-                                                                 plain "fith"
+                                                                 plain "fifth"
                                                                  ]
                                                              ]
                                                          ]
@@ -166,7 +166,7 @@ tests = [
                          , plain "blubb" ]
         , "nested many ordered lists, one separating space" =:
           ("# foo\n## bar\n### third\n### third two\n## baz\n### third again\n"
-           <> "#### fourth\n##### fith\n# blubb")
+           <> "#### fourth\n##### fifth\n# blubb")
           =?> orderedList [ plain "foo"
                            <> orderedList [ plain "bar"
                                            <> orderedList [ plain "third"
@@ -176,7 +176,7 @@ tests = [
                                                          <> orderedList [
                                                              plain "fourth"
                                                              <> orderedList [
-                                                                 plain "fith"
+                                                                 plain "fifth"
                                                                  ]
                                                              ]
                                                          ]
@@ -189,7 +189,7 @@ tests = [
                          , plain "blubb" ]
         , "mixed nested ordered and unordered lists, one separating space" =:
           ("# foo\n** bar\n### third\n### third two\n** baz\n### third again\n"
-           <> "#### fourth\n***** fith\n# blubb")
+           <> "#### fourth\n***** fifth\n# blubb")
           =?> orderedList [ plain "foo"
                            <> bulletList [ plain "bar"
                                            <> orderedList [ plain "third"
@@ -199,7 +199,7 @@ tests = [
                                                          <> orderedList [
                                                              plain "fourth"
                                                              <> bulletList [
-                                                                 plain "fith"
+                                                                 plain "fifth"
                                                                  ]
                                                              ]
                                                          ]

--- a/test/Tests/Readers/Org/Inline.hs
+++ b/test/Tests/Readers/Org/Inline.hs
@@ -186,7 +186,7 @@ tests =
                   , "3" <> subscript "{}"
                   , "4" <> superscript ("(a(" <> strong "b(c" <> ")d))")
                   ])
-  , "Verbatim text can contain equal signes (=)" =:
+  , "Verbatim text can contain equal signs (=)" =:
       "=is_subst = True=" =?>
       para (codeWith ("", ["verbatim"], []) "is_subst = True")
 

--- a/test/command/zeitschrift-fur-kunstgeschichte.csl
+++ b/test/command/zeitschrift-fur-kunstgeschichte.csl
@@ -20,7 +20,7 @@
     <category field="humanities"/>
     <category field="history"/>
     <issn>0044-2992</issn>
-    <summary>From the editors: "Die Herausgeber werden im Falle von Editionen, Lexika und Ausstellungskatalogen dem Titel nachgestellt [use encyclopedia articles with or without container-title for that]. Bei gewöhnlichen Sammelbänden werden die Herausgeber dem Titel vorangestellt [use book for that]." Multilingual style; the information for exhibition catalogues should be entered in the field collection-title; locators may use the word "here" or "hier" in front of the page refering to which must be entered individually (the style outputs the locator as it is entered w/o any label or additional text).</summary>
+    <summary>From the editors: "Die Herausgeber werden im Falle von Editionen, Lexika und Ausstellungskatalogen dem Titel nachgestellt [use encyclopedia articles with or without container-title for that]. Bei gewöhnlichen Sammelbänden werden die Herausgeber dem Titel vorangestellt [use book for that]." Multilingual style; the information for exhibition catalogues should be entered in the field collection-title; locators may use the word "here" or "hier" in front of the page referring to which must be entered individually (the style outputs the locator as it is entered w/o any label or additional text).</summary>
     <updated>2016-02-03T17:41:02+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>


### PR DESCRIPTION
Found via `codespell -q 3 -S changelog.md -L bu,fo,ist,mke,multline,noes,ot,pard,pres,tabl,te,tothe`