### PR TITLE
Fix link to fedora package site.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -367,7 +367,7 @@ To run just the markdown benchmarks:
 [Arch]: https://www.archlinux.org/packages/community/x86_64/pandoc/
 [Cabal User's Guide]: https://cabal.readthedocs.io/
 [Debian]: https://packages.debian.org/pandoc
-[Fedora]: https://apps.fedoraproject.org/packages/pandoc
+[Fedora]: https://packages.fedoraproject.org/pkgs/pandoc/pandoc/
 [FreeBSD ports]: https://www.freshports.org/textproc/hs-pandoc/
 [GHC]:  https://www.haskell.org/ghc/
 [GitLab CI/CD]: https://about.gitlab.com/stages-devops-lifecycle/continuous-integration/


### PR DESCRIPTION
The current link on @master and on the _pandoc.org_ webpage brings to the site via a redirect: 
https://packages.fedoraproject.org//pandoc
which returns with a 404 site.

This PR fixes the link. I am not sure whether the pandoc.org site uses this very _INSTALL.md_ file or another one which I did not find; if so, please let me know so I could extend the current PR with updating the link there as well.