### PR TITLE
[RFC] Docx writer: allow to supply a template for `word/document.xml`

### DIFF
--- a/data/templates/docx/document.xml
+++ b/data/templates/docx/document.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"
+xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+xmlns:o="urn:schemas-microsoft-com:office:office"
+xmlns:v="urn:schemas-microsoft-com:vml"
+xmlns:w10="urn:schemas-microsoft-com:office:word"
+xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:pStyle w:val="Author" />
+      </w:pPr>
+      $for(author)$
+      ${it}$sep$<w:r><w:t xml:space="preserve">, </w:t></w:r>
+      $endfor$
+    </w:p>
+    $body$
+    <w:p>
+      <w:r><w:t>This paragraph comes after the main text</w:t></w:r>
+    </w:p>
+    $if(sectPr)$
+    $sectPr$
+    $else$
+    <w:sectPr />
+    $endif$
+  </w:body>
+</w:document>


### PR DESCRIPTION
It would be nice if we had Word templates. This PR is the result of an afternoon experiment and a crude attempt to make docx generation easier to customize.

Pandoc checks for a file `templates/docx/document.xml` and uses it as template if it's present.

Pros:
  - simple,
  - based on plain text files,
  - uses the familiar template syntax.

Cons:
  - Completely separate from `reference.docx`,
  - files in nested directories below `data/templates`,
  - unclear how this would be used with `--template` command line option.

Comments welcome.