### PR TITLE
Add prefixes to identifiers with `--file-scope`.

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -564,6 +564,17 @@ header when requesting a document from a URL:
     footnotes and links will not work across files. Reading binary
     files (docx, odt, epub) implies `--file-scope`.
 
+    If two or more files are processed using `--file-scope`,
+    prefixes based on the filenames will be added to identifiers
+    in order to disambiguate them, and internal links will
+    be adjusted accordingly.  For example, a header with
+    identifier `foo` in `subdir/file1.txt` will have its
+    identifier changed to `subdir__file1.txt__foo`.
+
+    In addition, a Div with an identifier based on the filename
+    will be added around the file's content, so that internal
+    links to the filename will point to this Div's identifier.
+
 `-F` *PROGRAM*, `--filter=`*PROGRAM*
 
 :   Specify an executable to be used as a filter transforming the

--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -216,6 +216,8 @@ extra-source-files:
                  test/command/B.txt
                  test/command/C.txt
                  test/command/D.txt
+                 test/command/file1.txt
+                 test/command/file2.txt
                  test/command/three.txt
                  test/command/01.csv
                  test/command/chap1/spider.png

--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -57,6 +57,7 @@ module Text.Pandoc.Shared (
                      makeSections,
                      uniqueIdent,
                      inlineListToIdentifier,
+                     textToIdentifier,
                      isHeaderBlock,
                      headerShift,
                      stripEmptyParagraphs,
@@ -497,12 +498,10 @@ isPara :: Block -> Bool
 isPara (Para _) = True
 isPara _        = False
 
--- | Convert Pandoc inline list to plain text identifier.  HTML
--- identifiers must start with a letter, and may contain only
--- letters, digits, and the characters _-.
+-- | Convert Pandoc inline list to plain text identifier.
 inlineListToIdentifier :: Extensions -> [Inline] -> T.Text
 inlineListToIdentifier exts =
-  dropNonLetter . filterAscii . toIdent . stringify . walk unEmojify
+  textToIdentifier exts . stringify . walk unEmojify
   where
     unEmojify :: [Inline] -> [Inline]
     unEmojify
@@ -511,6 +510,12 @@ inlineListToIdentifier exts =
       | otherwise = id
     unEmoji (Span ("",["emoji"],[("data-emoji",ename)]) _) = Str ename
     unEmoji x = x
+
+-- | Convert string to plain text identifier.
+textToIdentifier :: Extensions -> T.Text -> T.Text
+textToIdentifier exts =
+  dropNonLetter . filterAscii . toIdent
+  where
     dropNonLetter
       | extensionEnabled Ext_gfm_auto_identifiers exts = id
       | otherwise = T.dropWhile (not . isAlpha)

--- a/test/command/6384.md
+++ b/test/command/6384.md
@@ -1,0 +1,16 @@
+```
+% pandoc --wrap=preserve --file-scope command/file1.txt command/file2.txt
+^D
+<div id="command__file1.txt">
+<h1 id="command__file1.txt__zed">Zed</h1>
+<p><a href="bar">foo</a>
+and <a href="#command__file1.txt__zed">Zed</a>
+and <a href="#command__file2.txt__zed">other Zed</a>
+and <a href="#command__file2.txt">other file</a>
+and <a href="c.md#zed">foreign Zed</a></p>
+</div>
+<div id="command__file2.txt">
+<h2 id="command__file2.txt__zed">Zed</h2>
+<p><a href="baz">foo</a></p>
+</div>
+```

--- a/test/command/file1.txt
+++ b/test/command/file1.txt
@@ -1,0 +1,9 @@
+# Zed
+
+[foo]: bar
+
+[foo]
+and [Zed](#zed)
+and [other Zed](command/file2.txt#zed)
+and [other file](command/file2.txt)
+and [foreign Zed](c.md#zed)

--- a/test/command/file2.txt
+++ b/test/command/file2.txt
@@ -1,0 +1,5 @@
+## Zed
+
+[foo]: baz
+
+[foo]


### PR DESCRIPTION
This change only affects the case where `--file-scope` is used and more than one file is specified on the command line.

In this case, identifiers will be prefixed with a string derived from the file path, to disambiguate them. For example, an identifier `foo` in `contents/file1.txt` will become `contents__file1.txt__foo`.  Links will be adjusted accordingly: if `file2.txt` links to `file1.txt#foo`, then the link will be changed to point to `#file1.txt__foo`.  Similarly, a link to `file1.txt` will point to `#file1.txt`.  A Div with an identifier derived from the file path will be added around each file's content, so that links to files will still work.

Closes #6384.

[API change]: Text.Pandoc.Shared exports `textToIdentifier`.