### PR TITLE
Defines a command in the LaTeX template for Level 6 Markdown headers

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -277,6 +277,7 @@ $endif$
 \setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\subsubparagraph}{} % template for Level 6 Markdown headers
 $if(numbersections)$
 \setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$5$endif$}
 $else$

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -674,6 +674,7 @@ sectionHeader classes ident level lst = do
                           3  -> "subsubsection"
                           4  -> "paragraph"
                           5  -> "subparagraph"
+                          6  -> "subsubparagraph"
                           _  -> ""
   inQuote <- gets stInQuote
   let prefix = if inQuote && level' >= 4
@@ -686,7 +687,7 @@ sectionHeader classes ident level lst = do
   let stuffing = star <> optional <> contents
   stuffing' <- hypertarget True ident $
                   text ('\\':sectionType) <> stuffing <> lab
-  return $ if level' > 5
+  return $ if level' > 6
               then txt
               else prefix $$ stuffing'
                    $$ if unnumbered && not unlisted

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -74,6 +74,7 @@
 \setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\subsubparagraph}{} % template for Level 6 Markdown headers
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 \ifLuaTeX
   \usepackage{selnolig}  % disable illegal ligatures

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -41,6 +41,7 @@
 \setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\subsubparagraph}{} % template for Level 6 Markdown headers
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 \ifLuaTeX
   \usepackage{selnolig}  % disable illegal ligatures

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -51,6 +51,7 @@
 \setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\subsubparagraph}{} % template for Level 6 Markdown headers
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 \ifLuaTeX
   \usepackage{selnolig}  % disable illegal ligatures

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -36,6 +36,7 @@
 \setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\providecommand{\subsubparagraph}{} % template for Level 6 Markdown headers
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 \ifLuaTeX
 \usepackage[bidi=basic]{babel}


### PR DESCRIPTION
Adds a "\subsubparagraph" command definition to the LaTeX template. This command defaults to the current behavior, which compiles level 6 headers (tagged h6 in HTML) to plain text.

Closes #8069.

A potential concern for this change: the command is defined in default.latex, but that's only helpful when the standalone option is used. I am new to this codebase, so I'm not sure if the LaTeX writer has access to the standalone condition. Actually, this is my first pull request on an open source project, so I would love any feedback or advice.