### PR TITLE
doc: use cabal's --package-env more

### DIFF
--- a/doc/filters.md
+++ b/doc/filters.md
@@ -172,7 +172,7 @@ and then
 
 (It is also necessary that `pandoc-types` be installed in the
 local package repository. To do this using cabal-install,
-`cabal v2-update && cabal v2-install --lib pandoc-types`.)
+`cabal v2-update && cabal v2-install --lib pandoc-types --package-env .`.)
 
 Alternatively, we could compile the filter:
 


### PR DESCRIPTION
I noticed that you already use it on the same page and thought that it'd make it more consistent (not to mention, more fail-safe).