### PR TITLE
rST writer: list tables rendering, closes #4564

### DIFF
--- a/test/command/4564.md
+++ b/test/command/4564.md
@@ -1,0 +1,65 @@
+```
+% pandoc -f native -t rst
+[BlockQuote
+ [Table ("",["list-table"],[]) (Caption Nothing
+  [])
+  [(AlignDefault,ColWidth 0.1527777777777778)
+  ,(AlignDefault,ColWidth 0.1388888888888889)
+  ,(AlignDefault,ColWidth 0.16666666666666666)
+  ,(AlignDefault,ColWidth 0.375)]
+  (TableHead ("",[],[])
+  [Row ("",[],[])
+   [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+    [Plain [Str "Centered",SoftBreak,Str "Header"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+    [Plain [Str "Left",SoftBreak,Str "Aligned"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+    [Plain [Str "Right",SoftBreak,Str "Aligned"]]
+   ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+    [Plain [Str "Default",Space,Str "aligned"]]]])
+  [(TableBody ("",[],[]) (RowHeadColumns 0)
+   []
+   [Row ("",[],[])
+    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "First"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "row"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "12.0"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "Example",Space,Str "of",Space,Str "a",Space,Str "row",Space,Str "that",SoftBreak,Str "spans",Space,Str "multiple",Space,Str "lines."]]]
+   ,Row ("",[],[])
+    [Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "Second"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "row"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "5.0"]]
+    ,Cell ("",[],[]) AlignDefault (RowSpan 1) (ColSpan 1)
+     [Plain [Str "Here\8217s",Space,Str "another",Space,Str "one.",Space,Str "Note",SoftBreak,Str "the",Space,Str "blank",Space,Str "line",Space,Str "between",SoftBreak,Str "rows."]]]])]
+  (TableFoot ("",[],[])
+  [])]]
+^D
+   .. list-table::
+      :widths: 11 10 12 27
+      :header-rows: 1
+
+      - 
+
+         - Centered Header
+         - Left Aligned
+         - Right Aligned
+         - Default aligned
+      - 
+
+         - First
+         - row
+         - 12.0
+         - Example of a row that spans multiple lines.
+      - 
+
+         - Second
+         - row
+         - 5.0
+         - Here’s another one. Note the blank line between rows.
+```


### PR DESCRIPTION
When a table is marked with a "list-table" attribute class, it will now be rendered using the list table syntax documented here http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table