### PR TITLE
Support HTML Element 'tt'

### DIFF
--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -663,6 +663,7 @@ inline = pTagText <|> do
         "svg" -> pSvg
         "bdo" -> pBdo
         "code" -> pCode
+        "tt" -> pCode
         "samp" -> pCodeWithClass "samp" "sample"
         "var" -> pCodeWithClass "var" "variable"
         "span" -> pSpan

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -98,6 +98,18 @@ tests = [ testGroup "base tag"
           , test htmlNativeDivs "<main> followed by text" $ "<main>main content</main>non-main content" =?>
             doc (divWith ("", [], [("role", "main")]) (plain (text "main content")) <> plain (text "non-main content"))
           ]
+        , testGroup "code"
+          [
+            test html "inline code block" $
+            "<code>Answer is 42</code>" =?>
+            plain (codeWith ("",[],[]) "Answer is 42")
+          ]
+        , testGroup "tt"
+          [
+            test html "inline tt block" $
+            "<tt>Answer is 42</tt>" =?>
+            plain (codeWith ("",[],[]) "Answer is 42")
+          ]
         , testGroup "samp"
           [
             test html "inline samp block" $

--- a/test/Tests/Writers/HTML.hs
+++ b/test/Tests/Writers/HTML.hs
@@ -84,6 +84,11 @@ tests =
       doubleQuoted (spanWith ("", [], [("cite", "http://example.org")]) (str "examples"))
       =?> "<q cite=\"http://example.org\">examples</q>"
     ]
+  , testGroup "code"
+    [ "code should be rendered correctly" =:
+      plain (codeWith ("",[],[]) "Answer is 42") =?>
+      "<code>Answer is 42</code>"
+    ]
   , testGroup "sample"
     [ "sample should be rendered correctly" =:
       plain (codeWith ("",["sample"],[]) "Answer is 42") =?>


### PR DESCRIPTION
My main use-case in this PR is supporting using pandoc to import from inline code elements as exported by JIRA since they seem to still use `<tt>` and for my use-case I only output in `commonmark` but by recognizing the `tt` element as `code` it gets me what I need without having to modify `commonmark`

While here I also added support for the HTML element `kbd`.

I opted to not worry about round-trip on `tt` since it is deprecated, if acceptance requires round-tripping this I'll adjust the PR.

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt
[2] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd