### PR TITLE
[API Change] Support binary custom writers.

### DIFF
--- a/data/sample.lua
+++ b/data/sample.lua
@@ -13,19 +13,19 @@
 -- produce informative error messages if your code contains
 -- syntax errors.
 
+function Writer (doc, opts)
+  PANDOC_DOCUMENT = doc
+  PANDOC_WRITER_OPTIONS = opts
+  loadfile(PANDOC_SCRIPT_FILE)()
+  return pandoc.write_classic(doc, opts)
+end
+
 local pipe = pandoc.pipe
 local stringify = (require 'pandoc.utils').stringify
 
--- The global variable PANDOC_DOCUMENT contains the full AST of
--- the document which is going to be written. It can be used to
--- configure the writer.
-local meta = PANDOC_DOCUMENT.meta
-
 -- Choose the image format based on the value of the
--- `image_format` meta value.
-local image_format = meta.image_format
-  and stringify(meta.image_format)
-  or 'png'
+-- `image_format` environment variable.
+local image_format = os.getenv 'image_format' or 'png'
 local image_mime_type = ({
     jpeg = 'image/jpeg',
     jpg = 'image/jpeg',

--- a/doc/custom-writers.md
+++ b/doc/custom-writers.md
@@ -16,16 +16,61 @@ install any additional software to do this.
 [Lua]: https://www.lua.org
 
 A custom writer is a Lua file that defines how to render the
-document. Two styles of custom writers are supported: classic
-custom writers must define rendering functions for each AST
-element. New style writers, available since pandoc 2.17.2, must
-define just a single function `Writer`, which gets passed the
-document and writer options, and then does all rendering.
+document. Writers must define just a single function named
+`Writer`, which gets passed the document and writer options, and
+then handles the conversion of the document, rendering it into a
+string. This interface was introduced in pandoc 2.17.2.
+
+Pandoc also supports "classic" custom writers, where a Lua
+function must be defined for each AST element type. Classic style
+writers are *deprecated* and should be replaced with new-style
+writers if possible.
+
+# Writers
+
+Custom writers using the new style must contain a global function
+named `Writer`. Pandoc calls this function with the document and
+writer options as arguments, and expects the function to return a
+UTF-8 encoded string.
+
+``` lua
+function Writer (doc, opts)
+  -- ...
+end
+```
+
+## Example: modified Markdown writer
+
+Writers have access to all modules described in the [Lua filters
+documentation][]. This includes `pandoc.write`, which can be used
+to render a document in a format already supported by pandoc. The
+document can be modified before this conversion, as demonstrated
+in the following short example. It renders a document as GitHub
+Flavored Markdown, but always uses fenced code blocks, never
+indented code.
+
+``` lua
+function Writer (doc, opts)
+  local filter = {
+    CodeBlock = function (cb)
+      -- only modify if code block has no attributes
+      if cb.attr == pandoc.Attr() then
+        local delimited = '```\n' .. cb.text .. '\n```'
+        return pandoc.RawBlock('markdown', delimited)
+      end
+    end
+  }
+  return pandoc.write(doc:walk(filter), 'gfm', opts)
+end
+```
+
+[Lua filters documentation]: https://pandoc.org/lua-filters.html
 
 # Classic style
 
 A writer using the classic style defines rendering functions for
-each element of the pandoc AST.
+each element of the pandoc AST. Note that this style is
+*deprecated* and may be removed in later versions.
 
 For example,
 
@@ -76,50 +121,19 @@ function Doc (body, meta, vars)
 end
 ```
 
-# New style
+## Changes in pandoc 3.0
 
-Custom writers using the new style must contain a global function
-named `Writer`. Pandoc calls this function with the document and
-writer options as arguments, and expects the function to return a
-UTF-8 encoded string.
-
-``` lua
-function Writer (doc, opts)
-  -- ...
-end
-```
-
-Writers that do not return text but binary data should define a
-function with name `BinaryWriter` instead. The function must still
-return a string, but it does not have to be UTF-8 encoded and can
-contain arbitrary binary data.
-
-If both `Writer` and `BinaryWriter` functions are defined, then
-only the `Writer` function will be used.
-
-## Example: modified Markdown writer
-
-Writers have access to all modules described in the [Lua filters
-documentation][]. This includes `pandoc.write`, which can be used
-to render a document in a format already supported by pandoc. The
-document can be modified before this conversion, as demonstrated
-in the following short example. It renders a document as GitHub
-Flavored Markdown, but always uses fenced code blocks, never
-indented code.
+Custom writers were reworked in pandoc 3.0. For technical reasons,
+the global variables `PANDOC_DOCUMENT` and `PANDOC_WRITER_OPTIONS`
+are set to the empty document and default values, respectively.
+The old behavior can be restored by adding the following snippet,
+which turns a classic into a new style writer.
 
 ``` lua
 function Writer (doc, opts)
-  local filter = {
-    CodeBlock = function (cb)
-      -- only modify if code block has no attributes
-      if cb.attr == pandoc.Attr() then
-        local delimited = '```\n' .. cb.text .. '\n```'
-        return pandoc.RawBlock('markdown', delimited)
-      end
-    end
-  }
-  return pandoc.write(doc:walk(filter), 'gfm', opts)
+  PANDOC_DOCUMENT = doc
+  PANDOC_WRITER_OPTIONS = opts
+  loadfile(PANDOC_SCRIPT_FILE)()
+  return pandoc.write_classic(doc, opts)
 end
 ```
-
-[Lua filters documentation]: https://pandoc.org/lua-filters.html

--- a/doc/custom-writers.md
+++ b/doc/custom-writers.md
@@ -16,10 +16,12 @@ install any additional software to do this.
 [Lua]: https://www.lua.org
 
 A custom writer is a Lua file that defines how to render the
-document. Writers must define just a single function named
-`Writer`, which gets passed the document and writer options, and
-then handles the conversion of the document, rendering it into a
-string. This interface was introduced in pandoc 2.17.2.
+document. Writers must define just a single function, named either
+`Writer` or `ByteStringWriter`, which gets passed the document and
+writer options, and then handles the conversion of the document,
+rendering it into a string. This interface was introduced in
+pandoc 2.17.2, with ByteString writers becoming available in
+pandoc 3.0.
 
 Pandoc also supports "classic" custom writers, where a Lua
 function must be defined for each AST element type. Classic style
@@ -29,15 +31,23 @@ writers if possible.
 # Writers
 
 Custom writers using the new style must contain a global function
-named `Writer`. Pandoc calls this function with the document and
-writer options as arguments, and expects the function to return a
-UTF-8 encoded string.
+named `Writer` or `ByteStringWriter`. Pandoc calls this function
+with the document and writer options as arguments, and expects the
+function to return a UTF-8 encoded string.
 
 ``` lua
 function Writer (doc, opts)
   -- ...
 end
 ```
+
+Writers that do not return text but binary data should define a
+function with name `ByteStringWriter` instead. The function must
+still return a string, but it does not have to be UTF-8 encoded
+and can contain arbitrary binary data.
+
+If both `Writer` and `ByteStringWriter` functions are defined,
+then only the `Writer` function will be used.
 
 ## Example: modified Markdown writer
 

--- a/doc/custom-writers.md
+++ b/doc/custom-writers.md
@@ -81,13 +81,21 @@ end
 Custom writers using the new style must contain a global function
 named `Writer`. Pandoc calls this function with the document and
 writer options as arguments, and expects the function to return a
-string.
+UTF-8 encoded string.
 
 ``` lua
 function Writer (doc, opts)
   -- ...
 end
 ```
+
+Writers that do not return text but binary data should define a
+function with name `BinaryWriter` instead. The function must still
+return a string, but it does not have to be UTF-8 encoded and can
+contain arbitrary binary data.
+
+If both `Writer` and `BinaryWriter` functions are defined, then
+only the `Writer` function will be used.
 
 ## Example: modified Markdown writer
 

--- a/pandoc-lua-engine/pandoc-lua-engine.cabal
+++ b/pandoc-lua-engine/pandoc-lua-engine.cabal
@@ -94,6 +94,9 @@ library
                      , doclayout             >= 0.4     && < 0.5
                      , doctemplates          >= 0.10    && < 0.11
                      , exceptions            >= 0.8     && < 0.11
+                     , hslua                 >= 2.2.1   && < 2.3
+                     , hslua-aeson           >= 2.2.1   && < 2.3
+                     , hslua-core            >= 2.2.1   && < 2.3
                      , hslua-module-doclayout>= 1.0.4   && < 1.1
                      , hslua-module-path     >= 1.0.3   && < 1.1
                      , hslua-module-system   >= 1.0     && < 1.1
@@ -106,12 +109,7 @@ library
                      , pandoc-types          >= 1.22.2  && < 1.23
                      , parsec                >= 3.1     && < 3.2
                      , text                  >= 1.1.1   && < 2.1
-  if flag(lua53)
-    build-depends:       hslua >= 2.1 && < 2.2,
-                         hslua-aeson >= 2.2.1 && < 2.3
-  else
-    build-depends:       hslua >= 2.2.1 && < 2.3
-                       , hslua-aeson >= 2.2.1 && < 2.3
+
 
 test-suite test-pandoc-lua-engine
   import:              common-options

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Pandoc.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Pandoc.hs
@@ -40,6 +40,7 @@ import Text.Pandoc.Lua.Marshal.WriterOptions ( peekWriterOptions
                                              , pushWriterOptions)
 import Text.Pandoc.Lua.Module.Utils (sha1)
 import Text.Pandoc.Lua.PandocLua (PandocLua (unPandocLua), liftPandocLua)
+import Text.Pandoc.Lua.Writer.Classic (runCustom)
 import Text.Pandoc.Options ( ReaderOptions (readerExtensions)
                            , WriterOptions (writerExtensions) )
 import Text.Pandoc.Process (pipeProcess)
@@ -268,6 +269,17 @@ functions =
               "writer options")
     =#> functionResult (either pushLazyByteString pushText) "string"
           "result document"
+
+  , defun "write_classic"
+    ### (\doc mwopts -> runCustom (fromMaybe def mwopts) doc)
+    <#> parameter peekPandoc "Pandoc" "doc" "document to convert"
+    <#> opt (parameter peekWriterOptions "WriterOptions" "writer_options"
+              "writer options")
+    =#> functionResult pushText "string" "rendered document"
+    #? (T.unlines
+       [ "Runs a classic custom Lua writer, using the functions defined"
+       , "in the current environment."
+       ])
   ]
  where
   walkElement x f =

--- a/pandoc-lua-engine/test/Tests/Lua/Writer.hs
+++ b/pandoc-lua-engine/test/Tests/Lua/Writer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase        #-}
 {- |
 Module      : Tests.Lua.Writer
 Copyright   : © 2019-2022 Albert Krewinkel
@@ -15,6 +16,7 @@ import Data.Default (Default (def))
 import Text.Pandoc.Class (runIOorExplode, readFileStrict)
 import Text.Pandoc.Lua (writeCustom)
 import Text.Pandoc.Readers (readNative)
+import Text.Pandoc.Writers (Writer (TextWriter))
 import Test.Tasty (TestTree)
 import Test.Tasty.Golden (goldenVsString)
 
@@ -28,7 +30,9 @@ tests =
     (runIOorExplode $ do
         source <- UTF8.toText <$> readFileStrict "testsuite.native"
         doc <- readNative def source
-        txt <- writeCustom "sample.lua" def doc
+        txt <- writeCustom "sample.lua" >>= \case
+          TextWriter f -> f def doc
+          _            -> error "Expected a text writer"
         pure $ BL.fromStrict (UTF8.fromText txt))
 
   , goldenVsString "tables testsuite"
@@ -36,6 +40,8 @@ tests =
     (runIOorExplode $ do
         source <- UTF8.toText <$> readFileStrict "tables.native"
         doc <- readNative def source
-        txt <- writeCustom "sample.lua" def doc
+        txt <- writeCustom "sample.lua" >>= \case
+          TextWriter f -> f def doc
+          _            -> error "Expected a text writer"
         pure $ BL.fromStrict (UTF8.fromText txt))
   ]

--- a/src/Text/Pandoc/App/OutputSettings.hs
+++ b/src/Text/Pandoc/App/OutputSettings.hs
@@ -102,24 +102,18 @@ optToOutputSettings scriptingEngine opts = do
                       optBibliography opts
            in  case pureWriter of
                  TextWriter w -> TextWriter $ \o d -> sandbox files (w o d)
-                 ByteStringWriter w
-                            -> ByteStringWriter $ \o d -> sandbox files (w o d)
-
+                 ByteStringWriter w ->
+                   ByteStringWriter $ \o d -> sandbox files (w o d)
 
   (writer, writerExts) <-
-            if ".lua" `T.isSuffixOf` format
-               then return ( TextWriter $
-                             engineWriteCustom scriptingEngine
-                                               (T.unpack writerName)
-                           , mempty
-                           )
-               else if optSandbox opts
-                       then
-                         case runPure (getWriter writerName) of
-                           Left e -> throwError e
-                           Right (w, wexts) ->
-                                  return (makeSandboxed w, wexts)
-                       else getWriter (T.toLower writerName)
+    if ".lua" `T.isSuffixOf` format
+    then (,mempty) <$> engineWriteCustom scriptingEngine (T.unpack writerName)
+    else if optSandbox opts
+         then
+           case runPure (getWriter writerName) of
+             Left e -> throwError e
+             Right (w, wexts) ->return (makeSandboxed w, wexts)
+         else getWriter (T.toLower writerName)
 
   let standalone = optStandalone opts || not (isTextFormat format) || pdfOutput
 

--- a/src/Text/Pandoc/Scripting.hs
+++ b/src/Text/Pandoc/Scripting.hs
@@ -22,8 +22,9 @@ import Text.Pandoc.Definition (Pandoc)
 import Text.Pandoc.Class.PandocMonad (PandocMonad)
 import Text.Pandoc.Error (PandocError (PandocNoScriptingEngine))
 import Text.Pandoc.Filter.Environment (Environment)
-import Text.Pandoc.Options (ReaderOptions, WriterOptions)
+import Text.Pandoc.Options (ReaderOptions)
 import Text.Pandoc.Sources (Sources)
+import Text.Pandoc.Writers (Writer)
 
 -- | Structure to define a scripting engine.
 data ScriptingEngine = ScriptingEngine
@@ -39,7 +40,7 @@ data ScriptingEngine = ScriptingEngine
     -- ^ Function to parse input into a 'Pandoc' document.
 
   , engineWriteCustom :: forall m. (PandocMonad m, MonadIO m)
-                      => FilePath -> WriterOptions -> Pandoc -> m Text
+                      => FilePath -> m (Writer m)
     -- ^ Invoke the given script file to convert to any custom format.
   }
 
@@ -50,6 +51,6 @@ noEngine = ScriptingEngine
       throwError PandocNoScriptingEngine
   , engineReadCustom = \_fp _ropts _sources ->
       throwError PandocNoScriptingEngine
-  , engineWriteCustom = \_fp _wopts _doc ->
+  , engineWriteCustom = \_fp ->
       throwError PandocNoScriptingEngine
   }


### PR DESCRIPTION
New-style custom Lua writers can now define an alternative entry function `ByteStringWriter`. If a function with that name is defined, then pandoc will treat the returned string as binary output. This allows to generate formats like docx and odt with custom writers.

`T.P.Lua.writeCustom` function changed to reflect the possibility of a ByteString writer being returned.

Closes: #8313