### PR TITLE
Lua: add new module `pandoc.format`.

### DIFF
--- a/pandoc-lua-engine/pandoc-lua-engine.cabal
+++ b/pandoc-lua-engine/pandoc-lua-engine.cabal
@@ -73,6 +73,7 @@ library
                      , Text.Pandoc.Lua.Marshal.Sources
                      , Text.Pandoc.Lua.Marshal.Template
                      , Text.Pandoc.Lua.Marshal.WriterOptions
+                     , Text.Pandoc.Lua.Module.Format
                      , Text.Pandoc.Lua.Module.MediaBag
                      , Text.Pandoc.Lua.Module.Pandoc
                      , Text.Pandoc.Lua.Module.System

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Init.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Init.hs
@@ -34,8 +34,9 @@ import qualified HsLua.Aeson
 import qualified HsLua.Module.DocLayout as Module.Layout
 import qualified HsLua.Module.Path as Module.Path
 import qualified HsLua.Module.Text as Module.Text
-import qualified Text.Pandoc.Lua.Module.Pandoc as Module.Pandoc
+import qualified Text.Pandoc.Lua.Module.Format as Pandoc.Format
 import qualified Text.Pandoc.Lua.Module.MediaBag as Pandoc.MediaBag
+import qualified Text.Pandoc.Lua.Module.Pandoc as Module.Pandoc
 import qualified Text.Pandoc.Lua.Module.System as Pandoc.System
 import qualified Text.Pandoc.Lua.Module.Template as Pandoc.Template
 import qualified Text.Pandoc.Lua.Module.Types as Pandoc.Types
@@ -77,7 +78,8 @@ runLuaNoEnv action = do
 -- it must be handled separately.
 loadedModules :: [Module PandocError]
 loadedModules =
-  [ Pandoc.MediaBag.documentedModule
+  [ Pandoc.Format.documentedModule
+  , Pandoc.MediaBag.documentedModule
   , Pandoc.System.documentedModule
   , Pandoc.Template.documentedModule
   , Pandoc.Types.documentedModule

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Format.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Format.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE OverloadedStrings #-}
+{- |
+   Module      : Text.Pandoc.Lua.Module.Format
+   Copyright   : © 2022 Albert Krewinkel
+   License     : GPL-2.0-or-later
+   Maintainer  : Albert Krewinkel <tarleb+pandoc@moltkeplatz.de>
+
+Lua module to handle pandoc templates.
+-}
+module Text.Pandoc.Lua.Module.Format
+  ( documentedModule
+  ) where
+
+import HsLua
+import Text.Pandoc.Error (PandocError)
+import Text.Pandoc.Extensions
+  ( getAllExtensions, getDefaultExtensions )
+import Text.Pandoc.Lua.ErrorConversion ()
+import Text.Pandoc.Lua.Marshal.Extensions (pushExtensions)
+
+import qualified Data.Text as T
+
+-- | The "pandoc.format" module.
+documentedModule :: Module PandocError
+documentedModule = Module
+  { moduleName = "pandoc.format"
+  , moduleDescription = T.unlines
+    [ "Pandoc formats and their extensions."
+    ]
+  , moduleFields = []
+  , moduleOperations = []
+  , moduleFunctions = functions
+  }
+
+-- | Extension module functions.
+functions :: [DocumentedFunction PandocError]
+functions =
+  [ defun "default_extensions"
+     ### liftPure getDefaultExtensions
+     <#> parameter peekText "string" "format" "format name"
+     =#> functionResult pushExtensions "FormatExtensions"
+           "default extensions enabled for `format`"
+     #? T.unlines
+        [ "Returns the list of default extensions of the given format; this"
+        , "function does not check if the format is supported, it will return"
+        , "a fallback list of extensions even for unknown formats."
+        ]
+
+  , defun "all_extensions"
+     ### liftPure getAllExtensions
+     <#> parameter peekText "string" "format" "format name"
+     =#> functionResult pushExtensions "FormatExtensions"
+           "all extensions supported for `format`"
+     #? T.unlines
+        [ "Returns the list of all valid extensions for a format."
+        , "No distinction is made between input and output, and an"
+        , "extension have an effect when reading a format but not when"
+        , "writing it, or *vice versa*."
+        ]
+  ]

--- a/pandoc-lua-engine/test/Tests/Lua/Module.hs
+++ b/pandoc-lua-engine/test/Tests/Lua/Module.hs
@@ -23,6 +23,8 @@ tests =
                   ("lua" </> "module" </> "pandoc.lua")
   , testPandocLua "pandoc.List"
                   ("lua" </> "module" </> "pandoc-list.lua")
+  , testPandocLua "pandoc.format"
+                  ("lua" </> "module" </> "pandoc-format.lua")
   , testPandocLua "pandoc.mediabag"
                   ("lua" </> "module" </> "pandoc-mediabag.lua")
   , testPandocLua "pandoc.path"

--- a/pandoc-lua-engine/test/lua/module/pandoc-format.lua
+++ b/pandoc-lua-engine/test/lua/module/pandoc-format.lua
@@ -1,0 +1,34 @@
+local tasty = require 'tasty'
+
+local test = tasty.test_case
+local group = tasty.test_group
+local assert = tasty.assert
+
+local format = require 'pandoc.format'
+
+return {
+  group 'default_extensions' {
+    test('docx', function ()
+      local docx_default_exts = {
+        'auto_identifiers',
+      }
+      assert.are_same(format.default_extensions('docx'), docx_default_exts)
+    end),
+  },
+
+  group 'all_extensions' {
+    test('docx', function ()
+      local docx_default_exts = {
+        'ascii_identifiers',
+        'auto_identifiers',
+        'citations',
+        'east_asian_line_breaks',
+        'empty_paragraphs',
+        'gfm_auto_identifiers',
+        'native_numbering',
+        'styles',
+      }
+      assert.are_same(format.all_extensions('docx'), docx_default_exts)
+    end),
+  },
+}


### PR DESCRIPTION
The module provides functions to query the set of extensions supported by formats, and the set of extension enabled per default.