### PR TITLE
Update Lua filter doc: modify Zerobrane instructions to use Lua 5.4

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -413,16 +413,21 @@ run within the donation-ware Lua editor and IDE,
 REPL console and UI to step-through and view all variables and
 state.
 
-If you already have Lua 5.3 installed, you can add
+Zerobrane doesn't come with Lua 5.4 bundled, but it can debug it, 
+so you should install Lua 5.4, and then add
 [`mobdebug`](https://luarocks.org/modules/paulclinger/mobdebug)
 and its dependency
 [`luasocket`](https://luarocks.org/modules/luasocket/luasocket)
-using [`luarocks`](https://luarocks.org), which should then be
-available on the path. ZeroBrane also includes both of these in
-its package, so if you don't want to install Lua separately, you
-should add/modify your `LUA_PATH` and `LUA_CPATH` to include the
-correct locations; [see detailed instructions
-here](https://studio.zerobrane.com/doc-remote-debugging).
+using [`luarocks`](https://luarocks.org). ZeroBrane can use your 
+lua 5.4 install by adding `path.lua = "/path/to/your/lua"` 
+in your settings file. Open your lua filter in Zerobrane, 
+add `require('mobdebug').start()` at the line where you want 
+your breakpoint.  Then make sure the Project > Lua Intepreter 
+is set to "Lua" and enable "Start Debugger Server" 
+[see detailed instructions
+here](https://studio.zerobrane.com/doc-remote-debugging). 
+Run pandoc as you normally would and Zerobrane should break 
+at the correct line.
 
 ## Common pitfalls
 

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -30,7 +30,7 @@ executable.
 
 Starting with version 2.0, pandoc makes it possible to write
 filters in Lua without any external dependencies at all. A Lua
-interpreter (version 5.3) and a Lua library for creating pandoc
+interpreter (version 5.4) and a Lua library for creating pandoc
 filters is built into the pandoc executable. Pandoc data types
 are marshaled to Lua directly, avoiding the overhead of writing
 JSON to stdout and reading it from stdin.
@@ -413,21 +413,20 @@ run within the donation-ware Lua editor and IDE,
 REPL console and UI to step-through and view all variables and
 state.
 
-Zerobrane doesn't come with Lua 5.4 bundled, but it can debug it, 
-so you should install Lua 5.4, and then add
-[`mobdebug`](https://luarocks.org/modules/paulclinger/mobdebug)
-and its dependency
-[`luasocket`](https://luarocks.org/modules/luasocket/luasocket)
-using [`luarocks`](https://luarocks.org). ZeroBrane can use your 
-lua 5.4 install by adding `path.lua = "/path/to/your/lua"` 
-in your settings file. Open your lua filter in Zerobrane, 
-add `require('mobdebug').start()` at the line where you want 
-your breakpoint.  Then make sure the Project > Lua Intepreter 
-is set to "Lua" and enable "Start Debugger Server" 
-[see detailed instructions
-here](https://studio.zerobrane.com/doc-remote-debugging). 
-Run pandoc as you normally would and Zerobrane should break 
-at the correct line.
+Zerobrane doesn't come with Lua 5.4 bundled, but it can debug it, so
+you should install Lua 5.4, and then add
+[`mobdebug`](https://luarocks.org/modules/paulclinger/mobdebug) and
+its dependency
+[`luasocket`](https://luarocks.org/modules/luasocket/luasocket) using
+[`luarocks`](https://luarocks.org). ZeroBrane can use your Lua 5.4
+install by adding `path.lua = "/path/to/your/lua"` in your Zerobrane
+settings file. Next, open your Lua filter in Zerobrane, and add
+`require('mobdebug').start()` at the line where you want your
+breakpoint. Then make sure the Project > Lua Intepreter is set to the
+"Lua" you added in settings and enable "Start Debugger Server" [see
+detailed instructions
+here](https://studio.zerobrane.com/doc-remote-debugging). Run Pandoc
+as you normally would, and Zerobrane should break at the correct line.
 
 ## Common pitfalls
 
@@ -4194,7 +4193,7 @@ Inserts element `value` at position `pos` in list, shifting
 elements to the next-greater index if necessary.
 
 This function is identical to
-[`table.insert`](https://www.lua.org/manual/5.3/manual.html#6.6).
+[`table.insert`](https://www.lua.org/manual/5.4/manual.html#6.6).
 
 Parameters:
 
@@ -4233,7 +4232,7 @@ Removes the element at position `pos`, returning the value
 of the removed element.
 
 This function is identical to
-[`table.remove`](https://www.lua.org/manual/5.3/manual.html#6.6).
+[`table.remove`](https://www.lua.org/manual/5.4/manual.html#6.6).
 
 Parameters:
 
@@ -4263,7 +4262,7 @@ by the given order may have their relative positions changed
 by the sort.
 
 This function is identical to
-[`table.sort`](https://www.lua.org/manual/5.3/manual.html#6.6).
+[`table.sort`](https://www.lua.org/manual/5.4/manual.html#6.6).
 
 Parameters:
 


### PR DESCRIPTION
Zerobrane IDE does not yet include Lua 5.4. I had tried to get 5.3 working with pandoc debugging but the debugger never triggered. Then I used a 5.4 install (I installed from homebrew) with mobdebug and luasocket installed. Setting this in Zerobrane's settings and configuring it in the IDE and remote debugging worked again. I've modified the instructions. Note I'm not a Lua person so I hope the details are clear...