### PR TITLE
Lua: allow table structure as format spec.

### DIFF
--- a/doc/custom-readers.md
+++ b/doc/custom-readers.md
@@ -98,10 +98,10 @@ end
 Custom readers can be built such that their behavior is
 controllable through format extensions, such as `smart`,
 `citations`, or `hard-line-breaks`. Supported extensions are those
-that are present as a key in the global `Extensions` table.
-Fields of extensions that are enabled default have the value
-`true`, while those that are supported but disabled have value
-`false`.
+that are present as a key in the global `Extensions` table. Fields
+of extensions that are enabled default have the value `true` or
+`enable`, while those that are supported but disabled have value
+`false` or `disable`.
 
 Example: A writer with the following global table supports the
 extensions `smart`, `citations`, and `foobar`, with `smart` enabled and
@@ -109,9 +109,9 @@ the other two disabled by default:
 
 ``` lua
 Extensions = {
-  smart = true,
-  citations = false,
-  foobar = false
+  smart = 'enable',
+  citations = 'disable',
+  foobar = true
 }
 ```
 

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3495,13 +3495,23 @@ reStructuredText, and Org, then these will be included in the
 resulting document. Any media elements are added to those
 retrieved from the other parsed input files.
 
+The `format` parameter defines the format flavor that will be
+parsed. This can be either a string, using `+` and `-` to enable
+and disable extensions, or a table with fields `format` (string)
+and `extensions` (table). The `extensions` table can be a list of
+all enabled extensions, or a table with extensions as keys and
+their activation status as values (`true` or `'enable'` to enable
+an extension, `false` or `'disable'` to disable it).
+
 Parameters:
 
 `markup`
 :   the markup to be parsed (string|Sources)
 
 `format`
-:   format specification, defaults to `"markdown"` (string)
+:   format specification; defaults to `"markdown"`. See the
+    description above for a complete description of this
+    parameter. (string|table)
 
 `reader_options`
 :   options passed to the reader; may be a ReaderOptions object or
@@ -3532,7 +3542,9 @@ Parameters:
 :   document to convert ([Pandoc](#type-pandoc))
 
 `format`
-:   format specification, defaults to `'html'` (string)
+:   format specification; defaults to `"html"`. See the
+    documentation of [`pandoc.read`](#pandoc.read) for a complete
+    description of this parameter. (string|table)
 
 `writer_options`
 :   options passed to the writer; may be a WriterOptions object

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Marshal/Format.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Marshal/Format.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE OverloadedStrings    #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {- |
    Module      : Text.Pandoc.Lua.Marshaling.Format
@@ -12,11 +14,21 @@ module Text.Pandoc.Lua.Marshal.Format
   ( peekExtensions
   , pushExtensions
   , peekExtensionsConfig
+  , peekFlavoredFormat
   ) where
 
+import Control.Applicative ((<|>))
+import Control.Monad ((<$!>))
+import Data.Maybe (fromMaybe)
 import HsLua
-import Text.Pandoc.Extensions (Extension, Extensions, extensionsFromList, readExtension)
-import Text.Pandoc.Format (ExtensionsConfig (..))
+import Text.Pandoc.Error (PandocError (..))
+import Text.Pandoc.Extensions
+  ( Extension, Extensions, extensionsFromList
+  , getDefaultExtensions, readExtension )
+import Text.Pandoc.Format
+  ( ExtensionsConfig (..), ExtensionsDiff (..), FlavoredFormat (..)
+  , diffExtensions, parseFlavoredFormat)
+import Text.Pandoc.Lua.PandocLua (PandocLua (unPandocLua))
 
 -- | Retrieves an 'Extensions' set from the Lua stack.
 peekExtension :: LuaError e => Peeker e Extension
@@ -27,7 +39,7 @@ peekExtension idx = do
 
 -- | Retrieves an 'Extensions' set from the Lua stack.
 peekExtensions :: LuaError e => Peeker e Extensions
-peekExtensions = peekViaJSON
+peekExtensions = fmap extensionsFromList . peekList peekExtension
 {-# INLINE peekExtensions #-}
 
 -- | Pushes a set of 'Extensions' to the top of the Lua stack.
@@ -44,8 +56,64 @@ instance Pushable Extensions where
 -- | Retrieves an 'ExtensionsConfig' value from the Lua stack.
 peekExtensionsConfig :: LuaError e => Peeker e ExtensionsConfig
 peekExtensionsConfig idx = do
-  exts <- peekKeyValuePairs peekExtension peekBool idx
+  diff <- peekExtensionsDiff idx
   return $ ExtensionsConfig
-    { extsDefault   = extensionsFromList . map fst $ filter snd exts
-    , extsSupported = extensionsFromList . map fst $ exts
+    { extsDefault   = extsToEnable diff
+    , extsSupported = extsToEnable diff <> extsToDisable diff
     }
+
+instance Peekable ExtensionsConfig where
+  safepeek = peekExtensionsConfig
+
+peekExtensionsDiff :: LuaError e => Peeker e ExtensionsDiff
+peekExtensionsDiff = typeChecked "table" istable $ \idx ->
+      (do
+          en <- peekFieldRaw (emptyOr (fmap Just . peekExtensions)) "enable" idx
+          di <- peekFieldRaw (emptyOr (fmap Just . peekExtensions)) "disable" idx
+          if (en, di) == (Nothing, Nothing)
+            then failPeek "At least on of  'enable' and 'disable' must be set"
+            else return $
+                 ExtensionsDiff (fromMaybe mempty en) (fromMaybe mempty di))
+  <|> -- two lists of extensions; the first is list assumed to contain those
+      -- extensions to be enabled
+      (uncurry ExtensionsDiff <$!> peekPair peekExtensions peekExtensions idx)
+  <|> (do
+          let
+          exts <- peekKeyValuePairs peekExtension peekEnabled idx
+          let enabled  = extensionsFromList . map fst $ filter snd exts
+          let disabled = extensionsFromList . map fst $ filter (not . snd) exts
+          return $ ExtensionsDiff enabled disabled)
+
+-- | Retrieves the activation status of an extension. True or the string
+-- @'enable'@ for activated, False or 'disable' for disabled.
+peekEnabled :: LuaError e => Peeker e Bool
+peekEnabled idx' = liftLua (ltype idx') >>= \case
+  TypeBoolean -> peekBool idx'
+  TypeString  -> peekText idx' >>= \case
+                   "disable" -> pure False
+                   "enable"  -> pure True
+                   _         -> failPeek "expected 'disable' or 'enable'"
+  _ -> failPeek "expected boolean or string"
+
+-- | Retrieves a flavored format from the Lua stack.
+peekFlavoredFormat :: Peeker PandocError FlavoredFormat
+peekFlavoredFormat idx = retrieving "flavored format" $
+  liftLua (ltype idx) >>= \case
+  TypeString -> peekText idx >>= liftLua . unPandocLua . parseFlavoredFormat
+  TypeTable -> do
+    let diffFor format idx' = peekExtensionsDiff idx' <|>
+          (getDefaultExtensions format `diffExtensions`) <$>
+          (typeChecked "table" istable peekExtensions idx')
+    format   <- peekFieldRaw peekText "format" idx
+    extsDiff <- peekFieldRaw (emptyOr (diffFor format)) "extensions" idx
+    return (FlavoredFormat format extsDiff)
+  _ -> failPeek =<< typeMismatchMessage "string or table" idx
+
+-- | Returns 'mempty' if the given stack index is @nil@, and the result
+-- of the peeker otherwise.
+emptyOr :: Monoid a => Peeker e a -> Peeker e a
+emptyOr p idx = do
+  nil <- liftLua (isnil idx)
+  if nil
+    then pure mempty
+    else p idx

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Pandoc.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Pandoc.hs
@@ -32,6 +32,7 @@ import Text.Pandoc.Error (PandocError (..))
 import Text.Pandoc.Format (parseFlavoredFormat)
 import Text.Pandoc.Lua.Orphans ()
 import Text.Pandoc.Lua.Marshal.AST
+import Text.Pandoc.Lua.Marshal.Format (peekFlavoredFormat)
 import Text.Pandoc.Lua.Marshal.Filter (peekFilter)
 import Text.Pandoc.Lua.Marshal.ReaderOptions ( peekReaderOptions
                                              , pushReaderOptions)
@@ -200,9 +201,9 @@ functions =
 
   , defun "read"
     ### (\content mformatspec mreaderOptions -> unPandocLua $ do
+            flvrd <- maybe (parseFlavoredFormat "markdown") pure mformatspec
             let readerOpts = fromMaybe def mreaderOptions
-            formatSpec <- parseFlavoredFormat $ fromMaybe "markdown" mformatspec
-            getReader formatSpec >>= \case
+            getReader flvrd >>= \case
               (TextReader r, es)       ->
                  r readerOpts{readerExtensions = es}
                    (case content of
@@ -217,7 +218,8 @@ functions =
     <#> parameter (\idx -> (Left  <$> peekByteString idx)
                        <|> (Right <$> peekSources idx))
           "string|Sources" "content" "text to parse"
-    <#> opt (textParam "formatspec" "format and extensions")
+    <#> opt (parameter peekFlavoredFormat "string|table"
+                       "formatspec" "format and extensions")
     <#> opt (parameter peekReaderOptions "ReaderOptions" "reader_options"
              "reader options")
     =#> functionResult pushPandoc "Pandoc" "result document"
@@ -238,15 +240,16 @@ functions =
 
   , defun "write"
     ### (\doc mformatspec mwriterOpts -> unPandocLua $ do
+            flvrd <- maybe (parseFlavoredFormat "markdown") pure mformatspec
             let writerOpts = fromMaybe def mwriterOpts
-            formatSpec <- parseFlavoredFormat $ fromMaybe "html" mformatspec
-            getWriter formatSpec >>= \case
+            getWriter flvrd >>= \case
               (TextWriter w, es)      -> Right <$>
                 w writerOpts{ writerExtensions = es } doc
               (ByteStringWriter w, es) -> Left <$>
                 w writerOpts{ writerExtensions = es } doc)
     <#> parameter peekPandoc "Pandoc" "doc" "document to convert"
-    <#> opt (textParam "formatspec" "format and extensions")
+    <#> opt (parameter peekFlavoredFormat "string|table"
+                       "formatspec" "format and extensions")
     <#> opt (parameter peekWriterOptions "WriterOptions" "writer_options"
               "writer options")
     =#> functionResult (either pushLazyByteString pushText) "string"

--- a/pandoc-lua-engine/test/Tests/Lua/Writer.hs
+++ b/pandoc-lua-engine/test/Tests/Lua/Writer.hs
@@ -12,7 +12,7 @@ module Tests.Lua.Writer (tests) where
 
 import Data.Default (Default (def))
 import Text.Pandoc.Class (runIOorExplode, readFileStrict)
-import Text.Pandoc.Extensions (Extension (..))
+import Text.Pandoc.Extensions (Extension (..), extensionsFromList)
 import Text.Pandoc.Format (ExtensionsDiff (..), FlavoredFormat (..),
                            applyExtensionsDiff)
 import Text.Pandoc.Lua (writeCustom)
@@ -68,8 +68,7 @@ tests =
         pure $ BL.fromStrict (UTF8.fromText txt))
 
   , testCase "preset extensions" $ do
-      let ediff = ExtensionsDiff{extsToEnable = [], extsToDisable = []}
-      let format = FlavoredFormat "extensions.lua" ediff
+      let format = FlavoredFormat "extensions.lua" mempty
       result <- runIOorExplode $ writeCustom "extensions.lua" >>= \case
           (TextWriter write, extsConf, _) -> do
             exts <- applyExtensionsDiff extsConf format
@@ -78,8 +77,8 @@ tests =
       result @?= "smart extension is enabled;\ncitations extension is disabled\n"
   , testCase "modified extensions" $ do
       let ediff = ExtensionsDiff
-            { extsToEnable = [Ext_citations]
-            , extsToDisable = []
+            { extsToEnable = extensionsFromList [Ext_citations]
+            , extsToDisable = mempty
             }
       let format = FlavoredFormat "extensions.lua" ediff
       result <- runIOorExplode $ writeCustom "extensions.lua" >>= \case

--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -23,6 +23,7 @@ module Text.Pandoc.Extensions ( Extension(..)
                               , extensionEnabled
                               , enableExtension
                               , disableExtension
+                              , disableExtensions
                               , getDefaultExtensions
                               , getAllExtensions
                               , pandocExtensions
@@ -192,6 +193,14 @@ enableExtension x (Extensions exts) = Extensions (Set.insert x exts)
 
 disableExtension :: Extension -> Extensions -> Extensions
 disableExtension x (Extensions exts) = Extensions (Set.delete x exts)
+
+-- | Removes the extensions in the second set from those in the first.
+disableExtensions :: Extensions  -- ^ base set
+                  -> Extensions  -- ^ extensions to remove
+                  -> Extensions
+disableExtensions (Extensions base) (Extensions remove) = Extensions $
+  -- keep only those extensions that are in `base` but not in `remove`.
+  base `Set.difference` remove
 
 -- | Extensions to be used with pandoc-flavored markdown.
 pandocExtensions :: Extensions

--- a/src/Text/Pandoc/Format.hs
+++ b/src/Text/Pandoc/Format.hs
@@ -12,6 +12,7 @@ module Text.Pandoc.Format
   ( FlavoredFormat (..)
   , ExtensionsConfig (..)
   , ExtensionsDiff (..)
+  , diffExtensions
   , parseFlavoredFormat
   , applyExtensionsDiff
   , getExtensionsConfig
@@ -58,6 +59,14 @@ instance Semigroup ExtensionsDiff where
 instance Monoid ExtensionsDiff where
   mempty = ExtensionsDiff mempty mempty
   mappend = (<>)
+
+-- | Calculate the change set to get from one set of extensions to
+-- another.
+diffExtensions :: Extensions -> Extensions -> ExtensionsDiff
+diffExtensions def actual = ExtensionsDiff
+  { extsToEnable = actual `disableExtensions` def
+  , extsToDisable = def `disableExtensions` actual
+  }
 
 -- | Describes the properties of a format.
 data ExtensionsConfig = ExtensionsConfig


### PR DESCRIPTION
This allows to pass structured values as format specifiers to
`pandoc.write` and `pandoc.read`.