### PR TITLE
Make #+pandoc-emphasis-pre work as expected (#8059)

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -130,7 +130,8 @@ str = return . B.str <$>
       ( many1Char (noneOf $ specialChars ++ "\n\r ") >>= updatePositions' )
       <* updateLastStrPos
   where
-    updatePositions' str' = updatePositions (T.last str') >> return str'
+    updatePositions' str' = str' <$
+      maybe mzero (updatePositions . snd) (T.unsnoc str')
 
 -- | An endline character that can be treated as a space, not a structural
 -- break.  This should reflect the values of the Emacs variable

--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -126,8 +126,11 @@ linebreak :: PandocMonad m => OrgParser m (F Inlines)
 linebreak = try $ pure B.linebreak <$ string "\\\\" <* skipSpaces <* newline
 
 str :: PandocMonad m => OrgParser m (F Inlines)
-str = return . B.str <$> many1Char (noneOf $ specialChars ++ "\n\r ")
+str = return . B.str <$>
+      ( many1Char (noneOf $ specialChars ++ "\n\r ") >>= updatePositions' )
       <* updateLastStrPos
+  where
+    updatePositions' str' = updatePositions (T.last str') >> return str'
 
 -- | An endline character that can be treated as a space, not a structural
 -- break.  This should reflect the values of the Emacs variable
@@ -680,7 +683,6 @@ rawMathBetween s e = try $ textStr s *> manyTillChar anyChar (try $ textStr e)
 emphasisStart :: PandocMonad m => Char -> OrgParser m Char
 emphasisStart c = try $ do
   guard =<< afterEmphasisPreChar
-  guard =<< notAfterString
   char c
   lookAhead (noneOf emphasisForbiddenBorderChars)
   pushToInlineCharStack c

--- a/test/Tests/Readers/Org/Inline.hs
+++ b/test/Tests/Readers/Org/Inline.hs
@@ -104,8 +104,10 @@ tests =
       "[fn::Schreib mir eine E-Mail]" =?>
       para (note $ para "Schreib mir eine E-Mail")
 
-  , "Markup-chars not occurring on word break are symbols" =:
-      T.unlines [ "this+that+ +so+on"
+  , "By default, markup-chars not occurring on word break are symbols" =:
+      T.unlines [ "#+pandoc-emphasis-pre:"
+                , "#+pandoc-emphasis-post:"
+                , "this+that+ +so+on"
                 , "seven*eight* nine*"
                 , "+not+funny+"
                 ] =?>

--- a/test/Tests/Readers/Org/Meta.hs
+++ b/test/Tests/Readers/Org/Meta.hs
@@ -208,12 +208,19 @@ tests =
       ]
 
     , testGroup "emphasis config"
-      [ "Changing pre and post chars for emphasis" =:
-        T.unlines [ "#+pandoc-emphasis-pre: \"[)\""
-                  , "#+pandoc-emphasis-post: \"]\\n\""
-                  , "([/emph/])*foo*"
+      [ "Changing pre chars for emphasis" =:
+        T.unlines [ "#+pandoc-emphasis-pre: \"[)$a1%\""
+                  , "[/emph/.)*strong*.a~code~"
                   ] =?>
-        para ("([" <> emph "emph" <> "])" <> strong "foo")
+        para ("[" <> emph "emph" <> ".)" <> strong "strong" <>
+              ".a" <> code "code")
+
+      , "Changing post chars for emphasis" =:
+        T.unlines [ "#+pandoc-emphasis-post: \"(]$a1%\""
+                  , "/emph/('*strong*]'~code~a"
+                  ] =?>
+        para (emph "emph" <> "('" <> strong "strong" <> "]'" <>
+              code "code" <> "a")
 
       , "setting an invalid value restores the default" =:
         T.unlines [ "#+pandoc-emphasis-pre: \"[\""


### PR DESCRIPTION
The main issue with the original implementation is that it kept the assumption that no emphasis markers may occur directly after most non-whitespace chars, e.g. in the middle of the word (in Pandoc terms: following native `Str`). But with the possibility to modify which chars are allowed around emphasized text, Pandoc should remain indifferent in that respect.

These commits allow it and modify some tests accordingly. This is both:

1. in accordance with Org-mode's behavior when customizing `org-emphasis-regexp-components`.
2. reasonable in many languages[^1] (but rare in English).

Resolves #8059.

[^1]: which is the case in Hebrew and German, both of which I speak.