### PR TITLE
Lua: Allow custom writers to define a default template

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 test/fb2/reader/* -text
 pandoc-lua-engine/test/*.custom		-text
+pandoc-lua-engine/test/*.txt		-text

--- a/doc/custom-writers.md
+++ b/doc/custom-writers.md
@@ -83,6 +83,17 @@ function Writer (doc, opts)
 end
 ```
 
+## Default template
+
+The default template of a custom writer is defined by the return
+value of the global function `Template`. Pandoc uses the default
+template for rendering when the user has not specified a template,
+but invoked with the `-s`/`--standalone` flag.
+
+The `Template` global can be left undefined, in which case pandoc
+will throw an error when it would otherwise use the default
+template.
+
 ## Example: modified Markdown writer
 
 Writers have access to all modules described in the [Lua filters
@@ -105,6 +116,11 @@ function Writer (doc, opts)
     end
   }
   return pandoc.write(doc:walk(filter), 'gfm', opts)
+end
+
+function Template ()
+  local template = pandoc.template
+  return template.compile(template.default 'gfm')
 end
 ```
 

--- a/pandoc-lua-engine/pandoc-lua-engine.cabal
+++ b/pandoc-lua-engine/pandoc-lua-engine.cabal
@@ -32,6 +32,8 @@ extra-source-files:  README.md
                    , test/tables.native
                    , test/testsuite.native
                    , test/writer.custom
+                   , test/writer-template.lua
+                   , test/writer-template.out.txt
 
 source-repository head
   type:                git

--- a/pandoc-lua-engine/test/writer-template.lua
+++ b/pandoc-lua-engine/test/writer-template.lua
@@ -1,0 +1,7 @@
+function Writer (doc, opts)
+  return pandoc.write(doc, 'gfm', opts)
+end
+
+function Template ()
+  return pandoc.template.compile '<!-- start -->\n$body$\n<!-- stop -->\n'
+end

--- a/pandoc-lua-engine/test/writer-template.out.txt
+++ b/pandoc-lua-engine/test/writer-template.out.txt
@@ -1,0 +1,4 @@
+<!-- start -->
+body goes here
+
+<!-- stop -->

--- a/src/Text/Pandoc/Scripting.hs
+++ b/src/Text/Pandoc/Scripting.hs
@@ -23,6 +23,7 @@ import Text.Pandoc.Definition (Pandoc)
 import Text.Pandoc.Error (PandocError (PandocNoScriptingEngine))
 import Text.Pandoc.Filter.Environment (Environment)
 import Text.Pandoc.Format (ExtensionsConfig)
+import Text.Pandoc.Templates (Template)
 import Text.Pandoc.Readers (Reader)
 import Text.Pandoc.Writers (Writer)
 
@@ -40,9 +41,11 @@ data ScriptingEngine = ScriptingEngine
     -- ^ Function to parse input into a 'Pandoc' document.
 
   , engineWriteCustom :: forall m. (PandocMonad m, MonadIO m)
-                      => FilePath -> m (Writer m, ExtensionsConfig)
+                      => FilePath -> m (WriterProperties m)
     -- ^ Invoke the given script file to convert to any custom format.
   }
+
+type WriterProperties m = (Writer m, ExtensionsConfig, m (Template Text))
 
 noEngine :: ScriptingEngine
 noEngine = ScriptingEngine


### PR DESCRIPTION
The template is only used if no template file is found in the *templates* data directory. Custom template files in `data/templates/` are expected to have a `.tmpl` extension.

Example use (using an example from pandoc-discuss):

``` lua
local stringify = pandoc.utils.stringify

function Writer (doc, opts)
  assert(doc.blocks[1] and doc.blocks[1].t == 'Table', 'expected a table')
  local tbl = pandoc.utils.to_simple_table(doc.blocks[1])
  local result = pandoc.List{}
  for _, row in ipairs(tbl.rows) do
    local meta = pandoc.Meta(doc.meta)   -- clone
    for i, cell in ipairs(tbl.header) do
      meta[stringify(cell)] = pandoc.utils.blocks_to_inlines(row[i])
    end
    result:insert(pandoc.write(pandoc.Pandoc({}, meta), 'markdown', opts))
  end
  return table.concat(result, '\f\n') .. '\f\n'
end

Template = pandoc.template.compile [[
${name} ${surname}, born ${date} in ${location}
]]
```

`Template` should probably be a function that's invoked only when pandoc is called with `-s`.

---

I think I like the behavior we get with this. My biggest worry is that I over-engineer custom writers.