### PR TITLE
T.P.Error: Remove PandocParsecError constructor from PandocError.

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1539,7 +1539,6 @@ Nonzero exit codes have the following meanings:
    62 PandocShouldNeverHappenError
    63 PandocSomeError
    64 PandocParseError
-   65 PandocParsecError
    66 PandocMakePDFError
    67 PandocSyntaxMapError
    83 PandocFilterError

--- a/src/Text/Pandoc/Parsing.hs
+++ b/src/Text/Pandoc/Parsing.hs
@@ -47,6 +47,7 @@ module Text.Pandoc.Parsing ( module Text.Pandoc.Sources,
                              mathDisplay,
                              withHorizDisplacement,
                              withRaw,
+                             fromParsecError,
                              escaped,
                              characterReference,
                              upperRoman,
@@ -297,7 +298,8 @@ import Text.Pandoc.Parsing.General
       trimInlinesF,
       uri,
       withHorizDisplacement,
-      withRaw )
+      withRaw,
+      fromParsecError )
 import Text.Pandoc.Parsing.GridTable
     ( gridTableWith,
       gridTableWith',

--- a/src/Text/Pandoc/Readers/BibTeX.hs
+++ b/src/Text/Pandoc/Readers/BibTeX.hs
@@ -23,6 +23,7 @@ where
 import Text.Pandoc.Options
 import Text.Pandoc.Definition
 import Text.Pandoc.Builder (setMeta, cite, str)
+import Text.Pandoc.Parsing (fromParsecError)
 import Citeproc (Lang(..), parseLang)
 import Citeproc.Locale (getLocale)
 import Text.Pandoc.Error (PandocError(..))
@@ -63,7 +64,7 @@ readBibTeX' variant _opts t = do
                    Left _  -> throwError $ PandocCiteprocError e
                Right l -> return l
   case BibTeX.readBibtexString variant locale (const True) t of
-    Left e -> throwError $ PandocParsecError (toSources t) e
+    Left e -> throwError $ fromParsecError (toSources t) e
     Right refs -> return $ setMeta "references"
                               (map referenceToMetaValue refs)
                          . setMeta "nocite"

--- a/src/Text/Pandoc/Readers/CSV.hs
+++ b/src/Text/Pandoc/Readers/CSV.hs
@@ -21,11 +21,11 @@ import Text.Pandoc.CSV (parseCSV, defaultCSVOptions, CSVOptions(..))
 import Text.Pandoc.Definition
 import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Class (PandocMonad)
-import Text.Pandoc.Error
 import Text.Pandoc.Sources (ToSources(..), sourcesToText)
 import Text.Pandoc.Options (ReaderOptions)
 import Control.Monad.Except (throwError)
 import Data.Text (Text)
+import Text.Pandoc.Parsing (fromParsecError)
 
 readCSV :: (PandocMonad m, ToSources a)
         => ReaderOptions -- ^ Reader options
@@ -68,4 +68,4 @@ readCSVWith csvopts txt = do
              aligns = replicate numcols AlignDefault
              widths = replicate numcols ColWidthDefault
     Right []     -> return $ B.doc mempty
-    Left e       -> throwError $ PandocParsecError (toSources [("",txt)]) e
+    Left e       -> throwError $ fromParsecError (toSources [("",txt)]) e

--- a/src/Text/Pandoc/Readers/CommonMark.hs
+++ b/src/Text/Pandoc/Readers/CommonMark.hs
@@ -25,7 +25,6 @@ import Text.Pandoc.Class.PandocMonad (PandocMonad)
 import Text.Pandoc.Definition
 import Text.Pandoc.Builder as B
 import Text.Pandoc.Options
-import Text.Pandoc.Error
 import Text.Pandoc.Readers.Metadata (yamlMetaBlock)
 import Control.Monad.Except
 import Data.Functor.Identity (runIdentity)

--- a/src/Text/Pandoc/Readers/CommonMark.hs
+++ b/src/Text/Pandoc/Readers/CommonMark.hs
@@ -33,7 +33,8 @@ import Data.Typeable
 import Text.Pandoc.Parsing (runParserT, getInput, getPosition,
                             runF, defaultParserState, option, many1, anyChar,
                             Sources(..), ToSources(..), ParsecT, Future,
-                            sourceName, sourceLine, incSourceLine)
+                            sourceName, sourceLine, incSourceLine,
+                            fromParsecError)
 import Text.Pandoc.Walk (walk)
 import qualified Data.Text as T
 import qualified Data.Attoparsec.Text as A
@@ -95,10 +96,10 @@ readCommonMarkBody opts s toks =
       else id) <$>
   if isEnabled Ext_sourcepos opts
      then case runIdentity (parseCommonmarkWith (specFor opts) toks) of
-            Left err -> throwError $ PandocParsecError s err
+            Left err -> throwError $ fromParsecError s err
             Right (Cm bls :: Cm SourceRange Blocks) -> return $ B.doc bls
      else case runIdentity (parseCommonmarkWith (specFor opts) toks) of
-            Left err -> throwError $ PandocParsecError s err
+            Left err -> throwError $ fromParsecError s err
             Right (Cm bls :: Cm () Blocks) -> return $ B.doc bls
 
 stripBlockComments :: Block -> Block

--- a/src/Text/Pandoc/Readers/DokuWiki.hs
+++ b/src/Text/Pandoc/Readers/DokuWiki.hs
@@ -26,7 +26,6 @@ import qualified Data.Text as T
 import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Class.PandocMonad (PandocMonad (..))
 import Text.Pandoc.Definition
-import Text.Pandoc.Error (PandocError (PandocParsecError))
 import Text.Pandoc.Options
 import Text.Pandoc.Parsing hiding (enclosed, nested)
 import Text.Pandoc.Shared (trim, stringify, tshow)
@@ -43,7 +42,7 @@ readDokuWiki opts s = do
   res <- runParserT parseDokuWiki def {stateOptions = opts }
            (initialSourceName sources) sources
   case res of
-       Left e  -> throwError $ PandocParsecError sources e
+       Left e  -> throwError $ fromParsecError sources e
        Right d -> return d
 
 type DWParser = ParsecT Sources ParserState

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -40,7 +40,7 @@ import Text.Pandoc.Class (PandocPure, PandocMonad (..), getResourcePath,
                           readFileFromDirs, report,
                           setResourcePath, getZonedTime)
 import Data.Time (ZonedTime(..), LocalTime(..), showGregorian)
-import Text.Pandoc.Error (PandocError (PandocParseError, PandocParsecError))
+import Text.Pandoc.Error (PandocError (PandocParseError))
 import Text.Pandoc.Highlighting (languagesByExtension)
 import Text.Pandoc.ImageSize (numUnit, showFl)
 import Text.Pandoc.Logging
@@ -87,7 +87,7 @@ readLaTeX opts ltx = do
                (TokStream False (tokenizeSources sources))
   case parsed of
     Right result -> return result
-    Left e       -> throwError $ PandocParsecError sources e
+    Left e       -> throwError $ fromParsecError sources e
 
 parseLaTeX :: PandocMonad m => LP m Pandoc
 parseLaTeX = do
@@ -669,7 +669,7 @@ opt = do
               (TokStream False toks)
   case parsed of
     Right result -> return result
-    Left e       -> throwError $ PandocParsecError (toSources toks) e
+    Left e       -> throwError $ fromParsecError (toSources toks) e
 
 -- block elements:
 

--- a/src/Text/Pandoc/Readers/LaTeX/Citation.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Citation.hs
@@ -15,7 +15,6 @@ import Control.Applicative ((<|>), optional, many)
 import Control.Monad (mzero)
 import Control.Monad.Trans (lift)
 import Control.Monad.Except (throwError)
-import Text.Pandoc.Error (PandocError(PandocParsecError))
 import Text.Pandoc.Parsing hiding (blankline, many, mathDisplay, mathInline,
                             optional, space, spaces, withRaw, (<|>))
 
@@ -121,7 +120,7 @@ simpleCiteArgs inline = try $ do
        (TokStream False toks)
     case parsed of
       Right result -> return result
-      Left e       -> throwError $ PandocParsecError (toSources toks) e
+      Left e       -> throwError $ fromParsecError (toSources toks) e
 
 
 

--- a/src/Text/Pandoc/Readers/Muse.hs
+++ b/src/Text/Pandoc/Readers/Muse.hs
@@ -33,7 +33,6 @@ import Text.Pandoc.Builder (Blocks, Inlines, underline)
 import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Class.PandocMonad (PandocMonad (..))
 import Text.Pandoc.Definition
-import Text.Pandoc.Error (PandocError (PandocParsecError))
 import Text.Pandoc.Logging
 import Text.Pandoc.Options
 import Text.Pandoc.Parsing
@@ -49,7 +48,7 @@ readMuse opts s = do
   res <- flip runReaderT def $ runParserT parseMuse def{ museOptions = opts }
               (initialSourceName sources) sources
   case res of
-       Left e  -> throwError $ PandocParsecError sources e
+       Left e  -> throwError $ fromParsecError sources e
        Right d -> return d
 
 type F = Future MuseState

--- a/src/Text/Pandoc/Readers/RST.hs
+++ b/src/Text/Pandoc/Readers/RST.hs
@@ -871,7 +871,7 @@ csvTableDirective top fields rawcsv = do
   let res = parseCSV opts rawcsv'
   case (<>) <$> header' <*> res of
        Left e  ->
-         throwError $ PandocParsecError "csv table" e
+         throwError $ fromParsecError (toSources rawcsv') e
        Right rawrows -> do
          let singleParaToPlain bs =
                case B.toList bs of


### PR DESCRIPTION
T.P.Parsing now exports `fromParsecError`, which can be used to turn a parsec ParseError into a regular PandocParseError (the appearance to the user should be unchanged in every case).

[API change]

Closes #8382.