### PR TITLE
Support passthrough for literate agda

### DIFF
--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -96,6 +96,7 @@ data Extension =
     | Ext_link_attributes         -- ^ link and image attributes
     | Ext_lists_without_preceding_blankline -- ^ Allow lists without preceding blank
     | Ext_literate_haskell    -- ^ Enable literate Haskell conventions
+    | Ext_literate_agda    -- ^ Enable literate Agda conventions
     | Ext_markdown_attribute      -- ^ Interpret text inside HTML as markdown iff
                                   --   container has attribute 'markdown'
     | Ext_markdown_in_html_blocks -- ^ Interpret as markdown inside HTML blocks
@@ -163,6 +164,7 @@ instance ToJSON Extensions where
 -- | Reads a single extension from a string.
 readExtension :: String -> Extension
 readExtension "lhs" = Ext_literate_haskell
+readExtension "lagda" = Ext_literate_agda
 readExtension name =
   case readMaybe ("Ext_" ++ name) of
     Just ext -> ext
@@ -492,6 +494,7 @@ getAllExtensions f = universalExtensions <> getAll f
        , Ext_gutenberg
        , Ext_smart
        , Ext_literate_haskell
+       , Ext_literate_agda
        , Ext_short_subsuperscripts
        , Ext_rebase_relative_paths
        ]
@@ -585,6 +588,7 @@ getAllExtensions f = universalExtensions <> getAll f
     , Ext_raw_tex
     , Ext_task_lists
     , Ext_literate_haskell
+    , Ext_literate_agda
     ]
   getAll "beamer"          = getAll "latex"
   getAll "context"         = autoIdExtensions <>

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -699,7 +699,7 @@ codeBlockFenced = try $ do
               Just (elementId, classes, attrs) -> (elementId, maybe classes (: classes) languageId, attrs)))
   blankline
   contents <- T.intercalate "\n" <$>
-                 manyTill (gobbleAtMostSpaces indentLevel >> anyLine)
+                 manyTill (anyLine)
                           (try $ do
                             blockDelimiter (== c) (Just size)
                             blanklines)

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -405,6 +405,9 @@ blockToLaTeX (CodeBlock (identifier,classes,keyvalAttr) str) = do
   let linkAnchor = if isEmpty linkAnchor'
                       then empty
                       else linkAnchor' <> "%"
+  let lagdaCodeBlock = do
+        return $ flush (linkAnchor $$ "\\begin{code}" $$ literal str $$
+                            "\\end{code}") $$ cr
   let lhsCodeBlock = do
         modify $ \s -> s{ stLHS = True }
         return $ flush (linkAnchor $$ "\\begin{code}" $$ literal str $$
@@ -458,6 +461,8 @@ blockToLaTeX (CodeBlock (identifier,classes,keyvalAttr) str) = do
   case () of
      _ | isEnabled Ext_literate_haskell opts && "haskell" `elem` classes &&
          "literate" `elem` classes           -> lhsCodeBlock
+       | isEnabled Ext_literate_agda opts && "agda" `elem` classes
+                                             -> lagdaCodeBlock
        | writerListings opts                 -> listingsCodeBlock
        | not (null classes) && isJust (writerHighlightStyle opts)
                                              -> highlightedCodeBlock


### PR DESCRIPTION
Agda supports literate markdown and tex files, and is capable of performing semantic syntax highlighting of these literate documents. The result is significantly better highlighting than can be achieved without compiler support.

Unfortunately, Agda can only produce highlighted latex files if the source is literate latex. A nice thought would be to preprocess literate markdown files into literate latex, and then run Agda's latex backend to get the final highlighting. This almost works in pandoc today, except that pandoc transforms agda code fences into `\begin{verbatim}` blocks in the outputted latex.

This is a quick PR that adds a new `Ext_literate_agda` extension which emits `\begin{code}` in the latex writer for agda code blocks. The result is that agda can now happily consume the resulting `latex` file.