### PR TITLE
Rewrite the MediaWiki Writer to use the new tables

### DIFF
--- a/src/Text/Pandoc/Writers/Shared.hs
+++ b/src/Text/Pandoc/Writers/Shared.hs
@@ -172,8 +172,8 @@ getLang opts meta =
                _                                 -> Nothing
 
 -- | Produce an HTML tag with the given pandoc attributes.
-tagWithAttrs :: HasChars a => Text -> Attr -> Doc a
-tagWithAttrs tag attr = "<" <> text (T.unpack tag) <> (htmlAttrs attr) <> ">"
+tagWithAttrs :: HasChars a => a -> Attr -> Doc a
+tagWithAttrs tag attr = "<" <> literal tag <> (htmlAttrs attr) <> ">"
 
 -- | Produce HTML for the given pandoc attributes, to be used in HTML tags
 htmlAttrs :: HasChars a => Attr -> Doc a

--- a/test/Tests/Old.hs
+++ b/test/Tests/Old.hs
@@ -128,7 +128,10 @@ tests pandocPath =
     , fb2WriterTest' "testsuite" [] "testsuite.native" "writer.fb2"
     ]
   , testGroup "mediawiki"
-    [ testGroup "writer" $ writerTests' "mediawiki"
+    [ testGroup "writer" $ mconcat [
+      writerTests' "mediawiki"
+      , extWriterTests' "mediawiki"
+      ]
     , test' "reader" ["-r", "mediawiki", "-w", "native", "-s"]
       "mediawiki-reader.wiki" "mediawiki-reader.native"
     ]

--- a/test/command/4794.md
+++ b/test/command/4794.md
@@ -4,7 +4,8 @@
 | ------- | ------- | ------- |
 | text    |         | text    |
 ^D
-{|
+{| class="wikitable"
+|-
 ! Column1
 ! Column2
 ! Column3

--- a/test/tables.mediawiki
+++ b/test/tables.mediawiki
@@ -1,145 +1,152 @@
 Simple table with caption:
 
-{|
+{| class="wikitable"
 |+ Demonstration of simple table syntax.
-!align="right"| Right
-! Left
-!align="center"| Center
+|-
+! style="text-align: right;"| Right
+! style="text-align: left;"| Left
+! style="text-align: center;"| Center
 ! Default
 |-
-|align="right"| 12
-| 12
-|align="center"| 12
+| style="text-align: right;"| 12
+| style="text-align: left;"| 12
+| style="text-align: center;"| 12
 | 12
 |-
-|align="right"| 123
-| 123
-|align="center"| 123
+| style="text-align: right;"| 123
+| style="text-align: left;"| 123
+| style="text-align: center;"| 123
 | 123
 |-
-|align="right"| 1
-| 1
-|align="center"| 1
+| style="text-align: right;"| 1
+| style="text-align: left;"| 1
+| style="text-align: center;"| 1
 | 1
 |}
 
 Simple table without caption:
 
-{|
-!align="right"| Right
-! Left
-!align="center"| Center
+{| class="wikitable"
+|-
+! style="text-align: right;"| Right
+! style="text-align: left;"| Left
+! style="text-align: center;"| Center
 ! Default
 |-
-|align="right"| 12
-| 12
-|align="center"| 12
+| style="text-align: right;"| 12
+| style="text-align: left;"| 12
+| style="text-align: center;"| 12
 | 12
 |-
-|align="right"| 123
-| 123
-|align="center"| 123
+| style="text-align: right;"| 123
+| style="text-align: left;"| 123
+| style="text-align: center;"| 123
 | 123
 |-
-|align="right"| 1
-| 1
-|align="center"| 1
+| style="text-align: right;"| 1
+| style="text-align: left;"| 1
+| style="text-align: center;"| 1
 | 1
 |}
 
 Simple table indented two spaces:
 
-{|
+{| class="wikitable"
 |+ Demonstration of simple table syntax.
-!align="right"| Right
-! Left
-!align="center"| Center
+|-
+! style="text-align: right;"| Right
+! style="text-align: left;"| Left
+! style="text-align: center;"| Center
 ! Default
 |-
-|align="right"| 12
-| 12
-|align="center"| 12
+| style="text-align: right;"| 12
+| style="text-align: left;"| 12
+| style="text-align: center;"| 12
 | 12
 |-
-|align="right"| 123
-| 123
-|align="center"| 123
+| style="text-align: right;"| 123
+| style="text-align: left;"| 123
+| style="text-align: center;"| 123
 | 123
 |-
-|align="right"| 1
-| 1
-|align="center"| 1
+| style="text-align: right;"| 1
+| style="text-align: left;"| 1
+| style="text-align: center;"| 1
 | 1
 |}
 
 Multiline table with caption:
 
-{|
+{| class="wikitable"
 |+ Here’s the caption. It may span multiple lines.
-!align="center" width="15%"| Centered Header
-!width="13%"| Left Aligned
-!align="right" width="16%"| Right Aligned
-!width="35%"| Default aligned
 |-
-|align="center"| First
-| row
-|align="right"| 12.0
-| Example of a row that spans multiple lines.
+! style="text-align: center;"| Centered Header
+! style="text-align: left;"| Left Aligned
+! style="text-align: right;"| Right Aligned
+! style="text-align: left;"| Default aligned
 |-
-|align="center"| Second
-| row
-|align="right"| 5.0
-| Here’s another one. Note the blank line between rows.
+| style="text-align: center;"| First
+| style="text-align: left;"| row
+| style="text-align: right;"| 12.0
+| style="text-align: left;"| Example of a row that spans multiple lines.
+|-
+| style="text-align: center;"| Second
+| style="text-align: left;"| row
+| style="text-align: right;"| 5.0
+| style="text-align: left;"| Here’s another one. Note the blank line between rows.
 |}
 
 Multiline table without caption:
 
-{|
-!align="center" width="15%"| Centered Header
-!width="13%"| Left Aligned
-!align="right" width="16%"| Right Aligned
-!width="35%"| Default aligned
+{| class="wikitable"
 |-
-|align="center"| First
-| row
-|align="right"| 12.0
-| Example of a row that spans multiple lines.
+! style="text-align: center;"| Centered Header
+! style="text-align: left;"| Left Aligned
+! style="text-align: right;"| Right Aligned
+! style="text-align: left;"| Default aligned
 |-
-|align="center"| Second
-| row
-|align="right"| 5.0
-| Here’s another one. Note the blank line between rows.
+| style="text-align: center;"| First
+| style="text-align: left;"| row
+| style="text-align: right;"| 12.0
+| style="text-align: left;"| Example of a row that spans multiple lines.
+|-
+| style="text-align: center;"| Second
+| style="text-align: left;"| row
+| style="text-align: right;"| 5.0
+| style="text-align: left;"| Here’s another one. Note the blank line between rows.
 |}
 
 Table without column headers:
 
-{|
-|align="right"| 12
-| 12
-|align="center"| 12
-|align="right"| 12
+{| class="wikitable"
 |-
-|align="right"| 123
-| 123
-|align="center"| 123
-|align="right"| 123
+| style="text-align: right;"| 12
+| style="text-align: left;"| 12
+| style="text-align: center;"| 12
+| style="text-align: right;"| 12
 |-
-|align="right"| 1
-| 1
-|align="center"| 1
-|align="right"| 1
+| style="text-align: right;"| 123
+| style="text-align: left;"| 123
+| style="text-align: center;"| 123
+| style="text-align: right;"| 123
+|-
+| style="text-align: right;"| 1
+| style="text-align: left;"| 1
+| style="text-align: center;"| 1
+| style="text-align: right;"| 1
 |}
 
 Multiline table without column headers:
 
-{|
-|align="center" width="15%"| First
-|width="13%"| row
-|align="right" width="16%"| 12.0
-|width="35%"| Example of a row that spans multiple lines.
+{| class="wikitable"
 |-
-|align="center"| Second
-| row
-|align="right"| 5.0
+| style="text-align: center;"| First
+| style="text-align: left;"| row
+| style="text-align: right;"| 12.0
+| Example of a row that spans multiple lines.
+|-
+| style="text-align: center;"| Second
+| style="text-align: left;"| row
+| style="text-align: right;"| 5.0
 | Here’s another one. Note the blank line between rows.
 |}

--- a/test/tables/nordics.mediawiki
+++ b/test/tables/nordics.mediawiki
@@ -1,0 +1,40 @@
+{| id="nordics" class="wikitable" source="wikipedia"
+|+ States belonging to the ''Nordics.''
+|-
+! style="text-align: center;"| Name
+! style="text-align: center;"| Capital
+! style="text-align: center;"| Population<br />
+(in 2018)
+! style="text-align: center;"| Area<br />
+(in km<sup>2</sup>)
+|- class="country"
+! style="text-align: center;"| Denmark
+| style="text-align: left;"| Copenhagen
+| style="text-align: left;"| 5,809,502
+| style="text-align: left;"| 43,094
+|- class="country"
+! style="text-align: center;"| Finland
+| style="text-align: left;"| Helsinki
+| style="text-align: left;"| 5,537,364
+| style="text-align: left;"| 338,145
+|- class="country"
+! style="text-align: center;"| Iceland
+| style="text-align: left;"| Reykjavik
+| style="text-align: left;"| 343,518
+| style="text-align: left;"| 103,000
+|- class="country"
+! style="text-align: center;"| Norway
+| style="text-align: left;"| Oslo
+| style="text-align: left;"| 5,372,191
+| style="text-align: left;"| 323,802
+|- class="country"
+! style="text-align: center;"| Sweden
+| style="text-align: left;"| Stockholm
+| style="text-align: left;"| 10,313,447
+| style="text-align: left;"| 450,295
+|- id="summary"
+! style="text-align: center;"| Total
+! style="text-align: left;"|
+! id="total-population" style="text-align: left;"| 27,376,022
+! id="total-area" style="text-align: left;"| 1,258,336
+|}

--- a/test/tables/planets.mediawiki
+++ b/test/tables/planets.mediawiki
@@ -1,0 +1,119 @@
+{| class="wikitable"
+|+ Data about the planets of our solar system.
+|-
+! colspan="2" style="text-align: center;"|
+! Name
+! style="text-align: right;"| Mass (10^24kg)
+! style="text-align: right;"| Diameter (km)
+! style="text-align: right;"| Density (kg/m^3)
+! style="text-align: right;"| Gravity (m/s^2)
+! style="text-align: right;"| Length of day (hours)
+! style="text-align: right;"| Distance from Sun (10^6km)
+! style="text-align: right;"| Mean temperature (C)
+! style="text-align: right;"| Number of moons
+! Notes
+|-
+! rowspan="4" colspan="2" style="text-align: center;"| Terrestrial planets
+! Mercury
+| style="text-align: right;"| 0.330
+| style="text-align: right;"| 4,879
+| style="text-align: right;"| 5427
+| style="text-align: right;"| 3.7
+| style="text-align: right;"| 4222.6
+| style="text-align: right;"| 57.9
+| style="text-align: right;"| 167
+| style="text-align: right;"| 0
+| Closest to the Sun
+|-
+! Venus
+| style="text-align: right;"| 4.87
+| style="text-align: right;"| 12,104
+| style="text-align: right;"| 5243
+| style="text-align: right;"| 8.9
+| style="text-align: right;"| 2802.0
+| style="text-align: right;"| 108.2
+| style="text-align: right;"| 464
+| style="text-align: right;"| 0
+|
+|-
+! Earth
+| style="text-align: right;"| 5.97
+| style="text-align: right;"| 12,756
+| style="text-align: right;"| 5514
+| style="text-align: right;"| 9.8
+| style="text-align: right;"| 24.0
+| style="text-align: right;"| 149.6
+| style="text-align: right;"| 15
+| style="text-align: right;"| 1
+| Our world
+|-
+! Mars
+| style="text-align: right;"| 0.642
+| style="text-align: right;"| 6,792
+| style="text-align: right;"| 3933
+| style="text-align: right;"| 3.7
+| style="text-align: right;"| 24.7
+| style="text-align: right;"| 227.9
+| style="text-align: right;"| -65
+| style="text-align: right;"| 2
+| The red planet
+|-
+! rowspan="4" style="text-align: center;"| Jovian planets
+! rowspan="2" style="text-align: center;"| Gas giants
+! Jupiter
+| style="text-align: right;"| 1898
+| style="text-align: right;"| 142,984
+| style="text-align: right;"| 1326
+| style="text-align: right;"| 23.1
+| style="text-align: right;"| 9.9
+| style="text-align: right;"| 778.6
+| style="text-align: right;"| -110
+| style="text-align: right;"| 67
+| The largest planet
+|-
+! Saturn
+| style="text-align: right;"| 568
+| style="text-align: right;"| 120,536
+| style="text-align: right;"| 687
+| style="text-align: right;"| 9.0
+| style="text-align: right;"| 10.7
+| style="text-align: right;"| 1433.5
+| style="text-align: right;"| -140
+| style="text-align: right;"| 62
+|
+|-
+! rowspan="2" style="text-align: center;"| Ice giants
+! Uranus
+| style="text-align: right;"| 86.8
+| style="text-align: right;"| 51,118
+| style="text-align: right;"| 1271
+| style="text-align: right;"| 8.7
+| style="text-align: right;"| 17.2
+| style="text-align: right;"| 2872.5
+| style="text-align: right;"| -195
+| style="text-align: right;"| 27
+|
+|-
+! Neptune
+| style="text-align: right;"| 102
+| style="text-align: right;"| 49,528
+| style="text-align: right;"| 1638
+| style="text-align: right;"| 11.0
+| style="text-align: right;"| 16.1
+| style="text-align: right;"| 4495.1
+| style="text-align: right;"| -200
+| style="text-align: right;"| 14
+|
+|-
+! colspan="2" style="text-align: center;"| Dwarf planets
+! Pluto
+| style="text-align: right;"| 0.0146
+| style="text-align: right;"| 2,370
+| style="text-align: right;"| 2095
+| style="text-align: right;"| 0.7
+| style="text-align: right;"| 153.3
+| style="text-align: right;"| 5906.4
+| style="text-align: right;"| -225
+| style="text-align: right;"| 5
+| Declassified as a planet in 2006.
+|}

--- a/test/tables/students.mediawiki
+++ b/test/tables/students.mediawiki
@@ -1,0 +1,30 @@
+{| id="students" class="wikitable" source="mdn"
+|+ List of Students
+|-
+! style="text-align: center;"| Student ID
+! style="text-align: center;"| Name
+|-
+! colspan="2" style="text-align: left;"| Computer Science
+|-
+| style="text-align: left;"| 3741255
+| style="text-align: left;"| Jones, Martha
+|-
+| style="text-align: left;"| 4077830
+| style="text-align: left;"| Pierce, Benjamin
+|-
+| style="text-align: left;"| 5151701
+| style="text-align: left;"| Kirk, James
+|-
+! colspan="2" style="text-align: left;"| Russian Literature
+|-
+| style="text-align: left;"| 3971244
+| style="text-align: left;"| Nim, Victor
+|-
+! colspan="2" style="text-align: left;"| Astrophysics
+|-
+| style="text-align: left;"| 4100332
+| style="text-align: left;"| Petrov, Alexandra
+|-
+| style="text-align: left;"| 4100332
+| style="text-align: left;"| Toyota, Hiroko
+|}


### PR DESCRIPTION
~~Fixes issue #6992~~ (on closer reading, that issue seems to be about the mediawiki reader, this fixes the writer.)

Now the MediaWiki tables can have colspan and rowspan.
The align-attribute has been replaced with a styling option.

See https://www.mediawiki.org/wiki/Help:Tables for more info on formatting mediawiki tables. As can be read there, mw tables do not have the possibility of having `thead`/multiple `tbody`s/`tfoot` or `colgroup`, so I ignored quite a lot of information regarding those.

Most of the code is similar to the html writer, which is why I moved some html-functions to the Shared file, such that it could also be used by mediawiki. 

I am very unexperienced with Haskell, and eager to learn, so please do not hesitate to give codestyle tips or other feedback.


Edit: I also added the `wikitable` class to all tables that are made in this way. It will give the tables the default mediawiki style, which I believe is preferred in most cases. ofc. I could remove that if you prefer the writer to be "pure".