### PR TITLE
Change default background color of PDFs generated via HTML

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -28,6 +28,9 @@ body {
   }
 }
 @media print {
+  html {
+    background-color: $if(backgroundcolor)$$backgroundcolor$$else$white$endif$;
+  }
   body {
     background-color: transparent;
     color: black;

--- a/test/lhs-test.html
+++ b/test/lhs-test.html
@@ -35,6 +35,9 @@
       }
     }
     @media print {
+      html {
+        background-color: white;
+      }
       body {
         background-color: transparent;
         color: black;

--- a/test/lhs-test.html+lhs
+++ b/test/lhs-test.html+lhs
@@ -35,6 +35,9 @@
       }
     }
     @media print {
+      html {
+        background-color: white;
+      }
       body {
         background-color: transparent;
         color: black;

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -38,6 +38,9 @@
       }
     }
     @media print {
+      html {
+        background-color: white;
+      }
       body {
         background-color: transparent;
         color: black;

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -38,6 +38,9 @@
       }
     }
     @media print {
+      html {
+        background-color: white;
+      }
       body {
         background-color: transparent;
         color: black;


### PR DESCRIPTION
When creating PDF output via HTML the background of `body` element is `transparent`, so it uses the color of `html` which is set to `#fdfdfd` by default. This may potentially lead to wasted printer ink. The introduced fix changes the default color for printing to `white` while respecting the case of user setting a custom background color.

## Steps to reproduce

Run
```sh
$ echo foo | pandoc -o foo.pdf -t html
```

### Before and after
<img alt="before" src="https://user-images.githubusercontent.com/12128106/200075465-a2036bc9-2d6a-4612-bc9e-8b2d5af7944a.png" width='100'> <img alt="after" src="https://user-images.githubusercontent.com/12128106/200075443-35f693c7-7393-4b2f-b2fc-49e8038a431e.png" width='100'>

### The above pictures with increased contrast and lowered brightness
<img alt="before" src="https://user-images.githubusercontent.com/12128106/200075478-42a6466c-f389-4e39-817b-c510a7b33c48.png" width='100'> <img alt="after" src="https://user-images.githubusercontent.com/12128106/200075452-0cfe955e-dbb9-4f18-8e2f-88659c2b1983.png" width='100'>