### PR TITLE
Don't mess with user's font-size or line-height

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -1,8 +1,8 @@
 $if(document-css)$
-html {
-  line-height: $if(linestretch)$$linestretch$$else$1.5$endif$;
-  font-family: $if(mainfont)$$mainfont$$else$Georgia, serif$endif$;
-  font-size: $if(fontsize)$$fontsize$$else$20px$endif$;
+html {$if(linestretch)$
+  line-height: $linestretch$;$endif$
+  font-family: $if(mainfont)$$mainfont$$else$Georgia, serif$endif$;$if(fontsize)$
+  font-size: $fontsize$;$endif$
   color: $if(fontcolor)$$fontcolor$$else$#1a1a1a$endif$;
   background-color: $if(backgroundcolor)$$backgroundcolor$$else$#fdfdfd$endif$;
 }

--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -1,7 +1,9 @@
 $if(document-css)$
-html {$if(linestretch)$
+html {
+$if(linestretch)$
   line-height: $linestretch$;$endif$
-  font-family: $if(mainfont)$$mainfont$$else$Georgia, serif$endif$;$if(fontsize)$
+  font-family: $if(mainfont)$$mainfont$$else$Georgia, serif$endif$;
+$if(fontsize)$
   font-size: $fontsize$;$endif$
   color: $if(fontcolor)$$fontcolor$$else$#1a1a1a$endif$;
   background-color: $if(backgroundcolor)$$backgroundcolor$$else$#fdfdfd$endif$;

--- a/test/lhs-test.html
+++ b/test/lhs-test.html
@@ -7,9 +7,7 @@
   <title>lhs-test</title>
   <style>
     html {
-      line-height: 1.5;
       font-family: Georgia, serif;
-      font-size: 20px;
       color: #1a1a1a;
       background-color: #fdfdfd;
     }

--- a/test/lhs-test.html+lhs
+++ b/test/lhs-test.html+lhs
@@ -7,9 +7,7 @@
   <title>lhs-test</title>
   <style>
     html {
-      line-height: 1.5;
       font-family: Georgia, serif;
-      font-size: 20px;
       color: #1a1a1a;
       background-color: #fdfdfd;
     }

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -10,9 +10,7 @@
   <title>Pandoc Test Suite</title>
   <style type="text/css">
     html {
-      line-height: 1.5;
       font-family: Georgia, serif;
-      font-size: 20px;
       color: #1a1a1a;
       background-color: #fdfdfd;
     }

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -10,9 +10,7 @@
   <title>Pandoc Test Suite</title>
   <style>
     html {
-      line-height: 1.5;
       font-family: Georgia, serif;
-      font-size: 20px;
       color: #1a1a1a;
       background-color: #fdfdfd;
     }


### PR DESCRIPTION
Commit changes the template expansion so that unless fontsize or linestretch are set, browser defaults are used.

I realize that this isn't gonna be an "sure, NP, that's a small fix" automatic merge and that it's gonna see some resistance, and it's an immediately visible change from how the template currently looks, but I think it's ultimately the right call.

I don't think huge letters and enormous leading is necessarily good, readable typography for prose text. Even if you do, there are four places prose text font-size can be set:

1. On the client side, users setting their own preferred font sizes.
2. On the site side, every web page pushing their own preference.
3. On the browser implementation side, browsers deciding on a new default (which users then can change).
4. On the spec / W3C side.

Which of those four places do you think is the absolute worst and most pessimal to mess with this setting? That’s right, 2. On the site side. Making this a site-specific tweak, making the new, partially adopted "de facto default" 20px, is gonna lead to the web becoming even more of a gross hodge-podge of styles.

Even if you disagree with that, the commit still respects the pandoc user's $fontsize and $linestretch variables. (Those settings are not good for the open web but maybe people are generating styled HTML for other things.)