### PR TITLE
Add LaTeX option `urlstyle`

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2910,6 +2910,9 @@ Pandoc uses these variables when [creating a PDF] with a LaTeX engine.
 `links-as-notes`
 :   causes links to be printed as footnotes
 
+`urlstyle`
+:   style for URLs (e.g., tt, same)
+
 #### Front matter
 
 `lof`, `lot`

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -384,7 +384,9 @@ $if(csquotes)$
 $endif$
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
-\urlstyle{same} % disable monospaced font for URLs
+$if(urlstyle)$
+\urlstyle{$urlstyle$}
+$endif$
 $if(links-as-notes)$
 % Make links footnotes instead of hotlinks:
 \DeclareRobustCommand{\href}[2]{#2\footnote{\url{#1}}}

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -384,11 +384,7 @@ $if(csquotes)$
 $endif$
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
-$if(urlstyle)$
-\urlstyle{$urlstyle$}
-$else$
-\urlstyle{same}
-$endif$
+\urlstyle{$if(urlstyle)$$urlstyle$$else$same$endif$}
 $if(links-as-notes)$
 % Make links footnotes instead of hotlinks:
 \DeclareRobustCommand{\href}[2]{#2\footnote{\url{#1}}}

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -386,6 +386,8 @@ $endif$
 \IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
 $if(urlstyle)$
 \urlstyle{$urlstyle$}
+$else$
+\urlstyle{same}
 $endif$
 $if(links-as-notes)$
 % Make links footnotes instead of hotlinks:

--- a/man/pandoc.1
+++ b/man/pandoc.1
@@ -3011,6 +3011,8 @@ and links in table of contents, respectively: uses options allowed by
 .TP
 \f[V]links-as-notes\f[R]
 causes links to be printed as footnotes
+\f[V]urlstyle\f[R]
+style for URLs (e.g., tt, same)
 .SS Front matter
 .TP
 \f[V]lof\f[R], \f[V]lot\f[R]

--- a/test/lhs-test.latex
+++ b/test/lhs-test.latex
@@ -83,7 +83,7 @@
 \fi
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
-\urlstyle{same} % disable monospaced font for URLs
+\urlstyle{same}
 \hypersetup{
   hidelinks,
   pdfcreator={LaTeX via pandoc}}

--- a/test/lhs-test.latex+lhs
+++ b/test/lhs-test.latex+lhs
@@ -50,7 +50,7 @@
 \fi
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
-\urlstyle{same} % disable monospaced font for URLs
+\urlstyle{same}
 \hypersetup{
   hidelinks,
   pdfcreator={LaTeX via pandoc}}

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -60,7 +60,7 @@
 \fi
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
-\urlstyle{same} % disable monospaced font for URLs
+\urlstyle{same}
 \VerbatimFootnotes % allow verbatim text in footnotes
 \hypersetup{
   pdftitle={Pandoc Test Suite},

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -66,7 +66,7 @@
 \fi
 \IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
-\urlstyle{same} % disable monospaced font for URLs
+\urlstyle{same}
 \hypersetup{
   pdflang={en},
   hidelinks,


### PR DESCRIPTION
It would be neat if there was an option to change the URL style for LaTeX documents with an option. By default, Pandoc sets the `urlstyle` to `same` which I do not like because it results in me being unable to differenciate URLs and regular text. If you still want to set the default to `same`, feel free to make that change in my pull request.