### PR TITLE
Allow mtl 2.3.1

### DIFF
--- a/pandoc-lua-engine/pandoc-lua-engine.cabal
+++ b/pandoc-lua-engine/pandoc-lua-engine.cabal
@@ -109,7 +109,7 @@ library
                      , hslua-module-version  >= 1.0.3   && < 1.1
                      , hslua-module-zip      >= 1.0.0   && < 1.1
                      , lpeg                  >= 1.0.1   && < 1.1
-                     , mtl                   >= 2.2     && < 2.3
+                     , mtl                   >= 2.2     && < 2.4
                      , pandoc                >= 3.0     && < 3.1
                      , pandoc-lua-marshal    >= 0.1.7   && < 0.2
                      , pandoc-types          >= 1.22.2  && < 1.23


### PR DESCRIPTION
Tested with GHC 9.2.4 by running `for action in build test ; do cabal $action --enable-tests --constrain 'mtl == 2.3.1' --allow-newer=jira-wiki-markup:mtl --allow-newer=servant-server:mtl --allow-newer=servant:mtl || break ; done`.

The bound in jira-wiki-markup will be bumped by https://github.com/tarleb/jira-wiki-markup/pull/21. I couldn't update the Servant code, so perhaps this PR should be blocked until they bumped it themselves.