### PR TITLE
add required variables template error to Text.Pandoc.Writers.HTML

### DIFF
--- a/src/Text/Pandoc/Templates.hs
+++ b/src/Text/Pandoc/Templates.hs
@@ -19,13 +19,15 @@ module Text.Pandoc.Templates ( Template
                              , WithPartials(..)
                              , compileTemplate
                              , renderTemplate
+                             , renderTemplateM
                              , getTemplate
                              , getDefaultTemplate
                              , compileDefaultTemplate
                              ) where
 
 import System.FilePath ((<.>), (</>), takeFileName)
-import Text.DocTemplates (Template, TemplateMonad(..), compileTemplate, renderTemplate)
+import Text.DocTemplates (Template, TemplateMonad(..), compileTemplate, renderTemplate,
+                          renderTemplateM)
 import Text.Pandoc.Class.CommonState (CommonState(..))
 import Text.Pandoc.Class.PandocMonad (PandocMonad, fetchItem,
                                       getCommonState, modifyCommonState)

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -55,7 +55,7 @@ import Text.Pandoc.ImageSize
 import Text.Pandoc.Options
 import Text.Pandoc.Shared
 import Text.Pandoc.Slides
-import Text.Pandoc.Templates (renderTemplate)
+import Text.Pandoc.Templates (renderTemplateM)
 import Text.Pandoc.Walk
 import Text.Pandoc.Writers.Math
 import Text.Pandoc.Writers.Shared
@@ -249,8 +249,9 @@ writeHtmlString' st opts d = do
                            Just (x:_) -> takeBaseName $ T.unpack x
                    report $ NoTitleElement fallback
                    return $ resetField "pagetitle" (literal fallback) context
-         return $ render colwidth $ renderTemplate tpl
-             (defField "body" (layoutMarkup body) context')
+         document <- either (throwError . PandocTemplateError) pure $
+            renderTemplateM tpl (defField "body" (layoutMarkup body) context')
+         return $ render colwidth document
 
 writeHtml' :: PandocMonad m => WriterState -> WriterOptions -> Pandoc -> m Html
 writeHtml' st opts d =


### PR DESCRIPTION
Allows an error to be thrown if a required variable is missing from the context. This has only been applied to the HTML writer but could be added to all the writers. I do not think this is a breaking change since existing templates do not have required variables. It requires the new features in doctemplates pull request https://github.com/jgm/doctemplates/pull/19

cabal.project with the required variable doctemplate https://github.com/BebeSparkelSparkel/pandoc/blob/required-var-html-my-build/cabal.project