### PR TITLE
LaTeX template: treat PARAGRAPH SEPARATOR like a space char

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -195,6 +195,13 @@ $if(zero-width-non-joiner)$
 \fi
 %% End of ZWNJ support
 $endif$
+%% Treat PARAGRAPH SEPARATOR like a space.
+\ifPDFTeX
+  \DeclareUnicodeCharacter{2029}{ }
+\else
+  \catcode`^^^^2029=\active
+  \protected\def ^^^^2029{ }
+\fi
 % Use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
 \IfFileExists{microtype.sty}{% use microtype if available


### PR DESCRIPTION
Pandoc inserts the Unicode char PARAGRAPH SEPARATOR as separator to mark
the end of a block when converting blocks to inlines. That conversion
can happen at various points, but mainly as part of metadata handling.
Therefore, LaTeX must be able to handle the char.

Closes: #8499
