### PR TITLE
Make org-cite AuthorInText styles apply to all cited authors

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -175,13 +175,12 @@ adjustCiteStyle sty cs = do
   cs' <- cs
   case cs' of
     [] -> return []
-    (d:ds)  -- TODO needs refinement
-      -> case sty of
-         TextStyle -> return $ d{ citationMode = AuthorInText
-                                , citationSuffix = dropWhile (== Space)
-                                    (citationSuffix d)} : ds
-         NoAuthorStyle -> return $ d{ citationMode = SuppressAuthor } : ds
-         _ -> return (d:ds)
+    ds -> case sty of
+         TextStyle -> return $ map (\d -> d{ citationMode = AuthorInText
+                                           , citationSuffix = dropWhile (== Space)
+                                             (citationSuffix d)}) ds
+         NoAuthorStyle -> return $ map (\d -> d{ citationMode = SuppressAuthor }) ds
+         _ -> return ds
 
 addPrefixToFirstItem :: (F Inlines) -> (F [Citation]) -> (F [Citation])
 addPrefixToFirstItem aff cs = do

--- a/test/Tests/Readers/Org/Inline/Citation.hs
+++ b/test/Tests/Readers/Org/Inline/Citation.hs
@@ -65,7 +65,7 @@ tests =
                 { citationId = "item2"
                 , citationPrefix = []
                 , citationSuffix = []
-                , citationMode = NormalCitation
+                , citationMode = AuthorInText
                 , citationNoteNum = 0
                 , citationHash = 0
                 }


### PR DESCRIPTION
This fixes #8509, which only de-parenthesizes the first author in a list. Thus, a `[cite/t:See @Einstein;@Feynman; and @Newton]` list will have no parentheses around any of the authors. Previous behavior was to de-parenthesize the first author, but leave the others in parentheses, which seems strange. 

Before: 

See Einstein, (Feynman, and Newton).

After: 

See Einstein, Feynman, and Newton. 

I also fixed the test so that it's looking for this new behavior. 

I can't really get the nix shell working on this end, or the cabal build to work, so this isn't as well tested as it should be. Was hoping someone with a working build could help test this before merging. 