### PR TITLE
Fix MediaWiki reader on internalLink for JCK languages

### DIFF
--- a/src/Text/Pandoc/Readers/MediaWiki.hs
+++ b/src/Text/Pandoc/Readers/MediaWiki.hs
@@ -664,8 +664,7 @@ internalLink = try $ do
              -- [[Help:Contents|] -> "Contents"
              <|> return (B.text $ T.drop 1 $ T.dropWhile (/=':') pagename) )
   sym "]]"
-  linktrail <- B.text <$> manyChar letter
-  let link = B.link (addUnderscores pagename) "wikilink" (label <> linktrail)
+  let link = B.link (addUnderscores pagename) "wikilink" label
   if "Category:" `T.isPrefixOf` pagename
      then do
        updateState $ \st -> st{ mwCategoryLinks = link : mwCategoryLinks st }

--- a/src/Text/Pandoc/Readers/MediaWiki.hs
+++ b/src/Text/Pandoc/Readers/MediaWiki.hs
@@ -19,7 +19,7 @@ module Text.Pandoc.Readers.MediaWiki ( readMediaWiki ) where
 
 import Control.Monad
 import Control.Monad.Except (throwError)
-import Data.Char (isDigit, isSpace)
+import Data.Char (isAscii, isDigit, isLetter, isSpace)
 import qualified Data.Foldable as F
 import Data.List (intersperse)
 import Data.Maybe (fromMaybe, maybeToList)
@@ -664,7 +664,8 @@ internalLink = try $ do
              -- [[Help:Contents|] -> "Contents"
              <|> return (B.text $ T.drop 1 $ T.dropWhile (/=':') pagename) )
   sym "]]"
-  let link = B.link (addUnderscores pagename) "wikilink" label
+  linktrail <- B.text <$> manyChar (satisfy (\c -> isAscii c && isLetter c)) 
+  let link = B.link (addUnderscores pagename) "wikilink" (label <> linktrail)
   if "Category:" `T.isPrefixOf` pagename
      then do
        updateState $ \st -> st{ mwCategoryLinks = link : mwCategoryLinks st }


### PR DESCRIPTION
This PR would fix wrong link text for Chinese or JCK languages which words are not seperated by blank space. Could anyone share the purpose for this `linktrail` variable?

For example:

`是[[台灣|台式]]的傳統[[月餅]]`

would be parsed as below, which is abviously unreasonable.

```
        {
          "t": "Str",
          "c": "是"
        },
        {
          "t": "Link",
          "c": [
            [
              "",
              [],
              []
            ],
            [
              {
                "t": "Str",
                "c": "台式的傳統"
              }
            ],
            [
              "台灣",
              "wikilink"
            ]
          ]
        },
        {
          "t": "Link",
          "c": [
            [
              "",
              [],
              []
            ],
            [
              {
                "t": "Str",
                "c": "月餅"
              }
            ],
            [
              "月餅",
              "wikilink"
            ]
          ]
        },

```

After this fix, json output would be:

```
        {
          "t": "Str",
          "c": "是"
        },
        {
          "t": "Link",
          "c": [
            [
              "",
              [],
              []
            ],
            [
              {
                "t": "Str",
                "c": "台式"
              }
            ],
            [
              "台灣",
              "wikilink"
            ]
          ]
        },
        {
          "t": "Str",
          "c": "的傳統"
        },
        {
          "t": "Link",
          "c": [
            [
              "",
              [],
              []
            ],
            [
              {
                "t": "Str",
                "c": "月餅"
              }
            ],
            [
              "月餅",
              "wikilink"
            ]
          ]
        },

```

Original data: 
https://github.com/chinapedia/mediawiki-to-gfm/commit/40b17e7232fecc7c3d3e9f8ad066ab2ca2383830

Json output with fix:
https://github.com/chinapedia/mediawiki-to-gfm/commit/63add8cb8680247a581bbdb3be3184aacdad8002