### PR TITLE
Add support for Textile footnote backlinks

### DIFF
--- a/src/Text/Pandoc/Readers/Textile.hs
+++ b/src/Text/Pandoc/Readers/Textile.hs
@@ -90,7 +90,10 @@ parseTextile = do
   Pandoc nullMeta . B.toList <$> parseBlocks -- FIXME
 
 noteMarker :: PandocMonad m => TextileParser m Text
-noteMarker = skipMany spaceChar >> string "fn" >> T.pack <$> manyTill digit (char '.')
+noteMarker = do
+  skipMany spaceChar
+  string "fn"
+  T.pack <$> manyTill digit (string "." <|> string "^.")
 
 noteBlock :: PandocMonad m => TextileParser m Text
 noteBlock = try $ do

--- a/src/Text/Pandoc/Readers/Textile.hs
+++ b/src/Text/Pandoc/Readers/Textile.hs
@@ -93,7 +93,7 @@ noteMarker :: PandocMonad m => TextileParser m Text
 noteMarker = do
   skipMany spaceChar
   string "fn"
-  T.pack <$> manyTill digit (string "." <|> string "^.")
+  T.pack <$> manyTill digit (string "." <|> try (string "^."))
 
 noteBlock :: PandocMonad m => TextileParser m Text
 noteBlock = try $ do

--- a/test/textile-reader.textile
+++ b/test/textile-reader.textile
@@ -269,7 +269,7 @@ A note.[1]  Another note[2].
 fn1. The note
 is here!
 
-fn2. Other note.
+fn2^. Other note.
 
 h1. Comment blocks
 


### PR DESCRIPTION
Backlinking from footnotes is already the behavior of `Note` values when writing HTML. This adds parsing support for the explicit backlinking syntax in Textile as described here:
https://textile-lang.com/doc/footnotes

Previously, these lines would be interpreted as a new paragraph beginning with "fn2^." in text.