### PR TITLE
Add chromium pdf engine

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1342,7 +1342,7 @@ header when requesting a document from a URL:
 :   Use the specified engine when producing PDF output.
     Valid values are `pdflatex`, `lualatex`, `xelatex`, `latexmk`,
     `tectonic`, `wkhtmltopdf`, `weasyprint`, `pagedjs-cli`,
-    `prince`, `context`, and `pdfroff`. If the engine is not in
+    `prince`, `context`, `pdfroff` and `chromium`. If the engine is not in
     your PATH, the full path of the engine may be specified here.
     If this option is not specified, pandoc uses the following
     defaults depending on the output format specified using

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -215,7 +215,7 @@ latexEngines  = ["pdflatex", "lualatex", "xelatex", "latexmk", "tectonic"]
 -- | Supported HTML PDF engines; the first item is used as default
 -- engine when going through HTML.
 htmlEngines :: [String]
-htmlEngines  = ["wkhtmltopdf", "weasyprint", "pagedjs-cli", "prince"]
+htmlEngines  = ["wkhtmltopdf", "weasyprint", "pagedjs-cli", "prince", "chromium"]
 
 engines :: [(Text, String)]
 engines = map ("html",) htmlEngines ++

--- a/src/Text/Pandoc/PDF.hs
+++ b/src/Text/Pandoc/PDF.hs
@@ -449,11 +449,11 @@ html2pdf verbosity program args source =
       BS.writeFile file $ UTF8.fromText source
       let pdfFileArgName
             | takeBaseName program `elem` ["pagedjs-cli", "prince"] = "-o "
-            | program `elem` ["chromium"]                           = "--print-to-pdf="
+            | takeBaseName program `elem` ["chromium"]              = "--print-to-pdf="
             | otherwise                                             = ""
           args2
-            | program `elem` ["chromium"] = "--headless" : args
-            | otherwise = args
+            | takeBaseName program `elem` ["chromium"] = "--headless" : args
+            | otherwise                                = args
 
           programArgs   = args2 ++ [file] ++ [pdfFileArgName <> pdfFile]
 


### PR DESCRIPTION
Hi. This PR adds Chromium as a supported HTML pdf engine. 
Chromium's headless mode and pdf printing switch is used.

Example usage:
`cabal run pandoc-cli -- --pdf-engine=chromium -o test.pdf test.html`