### PR TITLE
URL style in ConTeXt

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1,7 +1,7 @@
 ---
 title: Pandoc User's Guide
 author: John MacFarlane
-date: February 8, 2023
+date: February 12, 2023
 ---
 
 # Synopsis
@@ -2946,7 +2946,7 @@ Pandoc uses these variables when [creating a PDF] with a LaTeX engine.
 :   causes links to be printed as footnotes
 
 `urlstyle`
-:   style for URLs (e.g., tt, same)
+:   style for URLs (e.g., `tt`, `rm`, `sf`, and, the default, `same`)
 
 #### Front matter
 
@@ -3071,6 +3071,10 @@ Pandoc uses these variables when [creating a PDF] with ConTeXt.
 `toc`
 :   include table of contents (can also be set using
     `--toc/--table-of-contents`)
+    
+`urlstyle`
+:   typeface style for links without link text, e.g. `normal`, `bold`, `slanted`, `boldslanted`,
+    `type`, `cap`, `small`
 
 `whitespace`
 :   spacing between paragraphs, e.g. `none`, `small` (using

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -23,7 +23,7 @@ $endif$
   style=$linkstyle$,
   color=$linkcolor$,
   contrastcolor=$linkcontrastcolor$]
-\setupurl[style=]
+\setupurl[style=$urlstyle$]
 
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]

--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -23,6 +23,7 @@ $endif$
   style=$linkstyle$,
   color=$linkcolor$,
   contrastcolor=$linkcontrastcolor$]
+\setupurl[style=]
 
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]

--- a/test/writer.context
+++ b/test/writer.context
@@ -6,6 +6,7 @@
   style=,
   color=,
   contrastcolor=]
+\setupurl[style=]
 
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]

--- a/test/writers-lang-and-dir.context
+++ b/test/writers-lang-and-dir.context
@@ -4,6 +4,7 @@
   style=,
   color=,
   contrastcolor=]
+\setupurl[style=]
 
 % make chapter, section bookmarks visible when opening document
 \placebookmarks[chapter, section, subsection, subsubsection, subsubsubsection, subsubsubsubsection][chapter, section]


### PR DESCRIPTION
I have added `\setupurl[style=]` to the ConTeXt template, and updated the relevant tests. This gives the same default behaviour as the LaTeX template, which is that URLs are the same as the main text.