### PR TITLE
correct year in footer for licensing (2022->2023)

### DIFF
--- a/README.template
+++ b/README.template
@@ -83,7 +83,7 @@ new issue.
 License
 -------
 
-© 2006-2022 John MacFarlane (jgm@berkeley.edu). Released under the
+© 2006-2023 John MacFarlane (jgm@berkeley.edu). Released under the
 [GPL], version 2 or greater.  This software carries no warranty of
 any kind.  (See COPYRIGHT for full copyright and warranty notices.)
 


### PR DESCRIPTION
required to correct also in README.md