### PR TITLE
Provide a pandoc.json Lua module

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -4513,6 +4513,63 @@ Returns:
 
 -  extensions config
 
+# Module pandoc.json
+
+JSON module to work with JSON; based on the Aeson Haskell package.
+
+## Fields {#pandoc.json-fields}
+
+### null {#pandoc.json.null}
+
+Value used to represent the `null` JSON value. (userdata)
+
+## Functions {#pandoc.json-functions}
+
+### decode {#pandoc.json.decode}
+
+`decode (str[, pandoc_types])`
+
+Creates a Lua object from a JSON string. The function returns an
+[Inline], [Block], [Pandoc], [Inlines], or [Blocks] element if the
+input can be decoded into represent any of those types. Otherwise
+the default decoding is applied, using tables, booleans, numbers,
+and [null](#pandoc.json.null) to represent the JSON value.
+
+The special handling of AST elements can be disabled by setting
+`pandoc_types` to `false`.
+
+Parameters:
+
+`str`
+:   JSON string (string)
+
+`pandoc_types`
+:   whether to use pandoc types when possible. (boolean)
+
+Returns:
+
+-   decoded object (any)
+
+### encode {#pandoc.json.encode}
+
+`encode (object)`
+
+Encodes a Lua object as JSON string.
+
+If the object has a metamethod with name `__tojson`, then the
+result is that of a call to that method with `object` passed as
+the sole argument. The result of that call is expected to be a
+valid JSON string, but this not checked.
+
+Parameters:
+
+`object`
+:   object to convert (any)
+
+Returns:
+
+-   JSON encoding of the given object (string)
+
 
 # Module pandoc.path
 

--- a/pandoc-lua-engine/pandoc-lua-engine.cabal
+++ b/pandoc-lua-engine/pandoc-lua-engine.cabal
@@ -114,7 +114,7 @@ library
                      , lpeg                  >= 1.0.1   && < 1.1
                      , mtl                   >= 2.2     && < 2.4
                      , pandoc                >= 3.1     && < 3.2
-                     , pandoc-lua-marshal    >= 0.2     && < 0.3
+                     , pandoc-lua-marshal    >= 0.2.1   && < 0.3
                      , pandoc-types          >= 1.22    && < 1.24
                      , parsec                >= 3.1     && < 3.2
                      , text                  >= 1.1.1   && < 2.1

--- a/pandoc-lua-engine/pandoc-lua-engine.cabal
+++ b/pandoc-lua-engine/pandoc-lua-engine.cabal
@@ -81,6 +81,7 @@ library
                      , Text.Pandoc.Lua.Marshal.WriterOptions
                      , Text.Pandoc.Lua.Module.CLI
                      , Text.Pandoc.Lua.Module.Format
+                     , Text.Pandoc.Lua.Module.JSON
                      , Text.Pandoc.Lua.Module.MediaBag
                      , Text.Pandoc.Lua.Module.Pandoc
                      , Text.Pandoc.Lua.Module.Scaffolding
@@ -95,6 +96,7 @@ library
                      , Text.Pandoc.Lua.Writer.Scaffolding
 
   build-depends:       SHA                   >= 1.6     && < 1.7
+                     , aeson
                      , bytestring            >= 0.9     && < 0.12
                      , citeproc              >= 0.8     && < 0.9
                      , containers            >= 0.6.0.1 && < 0.7

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Init.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Init.hs
@@ -39,6 +39,7 @@ import qualified HsLua.Module.Text as Module.Text
 import qualified HsLua.Module.Zip as Module.Zip
 import qualified Text.Pandoc.Lua.Module.CLI as Pandoc.CLI
 import qualified Text.Pandoc.Lua.Module.Format as Pandoc.Format
+import qualified Text.Pandoc.Lua.Module.JSON as Pandoc.JSON
 import qualified Text.Pandoc.Lua.Module.MediaBag as Pandoc.MediaBag
 import qualified Text.Pandoc.Lua.Module.Pandoc as Module.Pandoc
 import qualified Text.Pandoc.Lua.Module.Scaffolding as Pandoc.Scaffolding
@@ -86,6 +87,7 @@ loadedModules :: [Module PandocError]
 loadedModules =
   [ Pandoc.CLI.documentedModule
   , Pandoc.Format.documentedModule
+  , Pandoc.JSON.documentedModule
   , Pandoc.MediaBag.documentedModule
   , Pandoc.Scaffolding.documentedModule
   , Pandoc.Structure.documentedModule

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/JSON.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/JSON.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-|
+Module      : Text.Pandoc.Lua.Module.JSON
+Copyright   : © 2022-2023 Albert Krewinkel
+License     : MIT
+Maintainer  : Albert Krewinkel <albert@hslua.org>
+
+Lua module to work with JSON.
+-}
+module Text.Pandoc.Lua.Module.JSON (
+  -- * Module
+    documentedModule
+
+  -- ** Functions
+  , decode
+  , encode
+  )
+where
+
+import Prelude hiding (null)
+import Data.Maybe (fromMaybe)
+import Data.Monoid (Alt (..))
+import Data.Version (Version, makeVersion)
+import HsLua.Aeson
+import HsLua.Core
+import HsLua.Marshalling
+import HsLua.Packaging
+import Text.Pandoc.Error (PandocError)
+import Text.Pandoc.Lua.PandocLua ()
+import Text.Pandoc.Lua.Marshal.AST
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
+
+-- | The @aeson@ module specification.
+documentedModule :: Module PandocError
+documentedModule = Module
+  { moduleName = "pandoc.json"
+  , moduleDescription = "JSON module based on the Aeson Haskell package."
+  , moduleFields = fields
+  , moduleFunctions = functions
+  , moduleOperations = []
+  }
+
+--
+-- Fields
+--
+
+-- | Exported fields.
+fields :: LuaError e => [Field e]
+fields =
+  [ null
+  ]
+
+-- | The value used to represent the JSON @null@.
+null :: LuaError e => Field e
+null = Field
+  { fieldName = "null"
+  , fieldDescription = "Value used to represent the `null` JSON value."
+  , fieldPushValue = pushValue Aeson.Null
+  }
+
+--
+-- Functions
+--
+
+functions :: [DocumentedFunction PandocError]
+functions =
+  [ decode
+  , encode
+  ]
+
+-- | Decode a JSON string into a Lua object.
+decode :: DocumentedFunction PandocError
+decode = defun "decode"
+  ### (\str usePandocTypes ->
+         fromMaybe pushnil . getAlt . mconcat . map Alt $
+         (if usePandocTypes == Just False
+          then []
+          else [ pushInline  <$> Aeson.decode str
+               , pushBlock   <$> Aeson.decode str
+               , pushPandoc  <$> Aeson.decode str
+               , pushInlines <$> Aeson.decode str
+               , pushBlocks  <$> Aeson.decode str
+               ])
+         ++ [pushValue <$> Aeson.decode str])
+  <#> parameter peekLazyByteString "string" "str" "JSON string"
+  <#> opt (parameter peekBool "boolean" "pandoc_types"
+           "whether to use pandoc types when possible.")
+  =#> functionResult pure "any" "decoded object"
+  #? T.unlines
+     [ "Creates a Lua object from a JSON string. The function returns an"
+     , "[Inline], [Block], [Pandoc], [Inlines], or [Blocks] element if the"
+     , "input can be decoded into represent any of those types. Otherwise"
+     , "the default decoding is applied, using tables, booleans, numbers,"
+     , "and [null](#pandoc.json.null) to represent the JSON value."
+     , ""
+     , "The special handling of AST elements can be disabled by setting"
+     , "`pandoc_types` to `false`."
+     ]
+  `since` initialVersion
+
+-- | Encode a Lua object as JSON.
+encode :: LuaError e => DocumentedFunction e
+encode = defun "encode"
+  ### (\idx -> do
+          -- ensure that there are no other objects on the stack.
+          settop (nthBottom 1)
+          getmetafield idx "__tojson" >>= \case
+            TypeNil -> do
+              -- No metamethod, use default encoder.
+              value <- forcePeek $ peekValue idx
+              pushLazyByteString $ Aeson.encode value
+            _ -> do
+              -- Try to use the field value as function
+              insert (nth 2)
+              call 1 1
+              ltype top >>= \case
+                TypeString -> pure ()
+                _ -> failLua
+                     "Call to __tojson metamethod did not yield a string")
+  <#> parameter pure "any" "object" "object to convert"
+  =#> functionResult pure "string" "JSON encoding of `object`"
+  #? T.unlines
+     ["Encodes a Lua object as JSON string."
+     , ""
+     , "If the object has a metamethod with name `__tojson`, then the"
+     , "result is that of a call to that method with `object` passed as"
+     , "the sole argument. The result of that call is expected to be a"
+     , "valid JSON string, but this not checked."
+     ]
+  `since` initialVersion
+
+-- | First published version of this library.
+initialVersion :: Version
+initialVersion = makeVersion [1,0,0]

--- a/pandoc-lua-engine/test/Tests/Lua/Module.hs
+++ b/pandoc-lua-engine/test/Tests/Lua/Module.hs
@@ -25,6 +25,8 @@ tests =
                   ("lua" </> "module" </> "pandoc-list.lua")
   , testPandocLua "pandoc.format"
                   ("lua" </> "module" </> "pandoc-format.lua")
+  , testPandocLua "pandoc.json"
+                  ("lua" </> "module" </> "pandoc-json.lua")
   , testPandocLua "pandoc.mediabag"
                   ("lua" </> "module" </> "pandoc-mediabag.lua")
   , testPandocLua "pandoc.path"

--- a/pandoc-lua-engine/test/lua/module/pandoc-json.lua
+++ b/pandoc-lua-engine/test/lua/module/pandoc-json.lua
@@ -1,0 +1,101 @@
+--
+-- Tests for the system module
+--
+local json = require 'pandoc.json'
+local tasty = require 'tasty'
+
+local group = tasty.test_group
+local test = tasty.test_case
+local assert = tasty.assert
+
+return {
+  -- Check existence of static fields
+  group 'static fields' {
+    test('null', function ()
+      assert.are_equal(type(json.null), 'userdata')
+    end),
+  },
+
+  group 'encode' {
+    test('string', function ()
+      assert.are_equal(json.encode 'one\ntwo', '"one\\ntwo"')
+    end),
+    test('null', function ()
+      assert.are_equal(json.encode(json.null), 'null')
+    end),
+    test('number', function ()
+      assert.are_equal(json.encode(42), '42')
+    end),
+    test('object', function ()
+      assert.are_same(json.encode{a = 5}, '{"a":5}')
+    end),
+    test('object with metamethod', function ()
+      local obj = setmetatable(
+        {title = 23},
+        {
+          __tojson = function (obj)
+            return '"Nichts ist so wie es scheint"'
+          end
+        }
+      )
+      assert.are_same(json.encode(obj), [["Nichts ist so wie es scheint"]])
+    end),
+    test('Inline (Space)', function ()
+      assert.are_equal(
+        json.encode(pandoc.Space()),
+        '{"t":"Space"}'
+      )
+    end),
+    test('Block (HorizontalRule)', function ()
+      assert.are_equal(
+        json.encode(pandoc.HorizontalRule()),
+        '{"t":"HorizontalRule"}'
+      )
+    end),
+    test('Inlines list', function ()
+      assert.are_equal(
+        json.encode(pandoc.Inlines{pandoc.Space()}),
+        '[{"t":"Space"}]'
+      )
+    end),
+    test('Pandoc', function ()
+      assert.are_equal(
+        type(json.encode(pandoc.Pandoc{'Hello from Lua!'})),
+        'string'
+      )
+    end),
+  },
+
+  group 'decode' {
+    test('string', function ()
+      assert.are_equal(json.decode '"one\\ntwo"', 'one\ntwo')
+    end),
+    test('null', function ()
+      assert.are_equal(json.decode 'null', json.null)
+    end),
+    test('number', function ()
+      assert.are_equal(json.decode '42', 42)
+    end),
+    test('object', function ()
+      assert.are_same(json.decode '{"a":5}', {a = 5})
+    end),
+    test('Inline (Space)', function ()
+      assert.are_equal(json.decode '{"t":"Space"}', pandoc.Space())
+    end),
+    test('Inline (Str)', function ()
+      assert.are_equal(json.decode '{"t":"Str", "c":"a"}', pandoc.Str 'a')
+    end),
+    test('disabled AST check', function ()
+      assert.are_same(
+        json.decode('{"t":"Str", "c":"a"}', false),
+        {t = 'Str', c = 'a'}
+      )
+    end),
+    test('Inlines list', function ()
+      assert.are_equal(
+        json.decode '[{"t":"Space"}]',
+        pandoc.Inlines{pandoc.Space()}
+      )
+    end)
+  },
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,7 @@ extra-deps:
 - texmath-0.12.6
 - citeproc-0.8.1
 - pandoc-types-1.23
-- pandoc-lua-marshal-0.2.0
+- pandoc-lua-marshal-0.2.1
 - commonmark-pandoc-0.2.1.3
 - skylighting-0.13.2.1
 - skylighting-core-0.13.2.1


### PR DESCRIPTION
- Use latest pandoc-lua-marshal release, version 0.2.1.
- Lua: add module `pandoc.json` to handle JSON encoding
