### PR TITLE
Markdown reader: use title of implicit figure as short caption.

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1092,7 +1092,9 @@ implicitFigure (ident, classes, attribs) capt url title =
               _               -> capt
       attribs' = filter ((/= "alt") . fst) attribs
       figattr = (ident, mempty, mempty)
-      caption = B.simpleCaption $ B.plain capt
+      caption = if T.null title
+                then B.simpleCaption $ B.plain capt
+                else B.caption (Just . B.toList $ B.text title) $ B.plain capt
       figbody = B.plain $ B.imageWith ("", classes, attribs') url title alt
   in B.figureWith figattr caption figbody
 

--- a/test/testsuite.native
+++ b/test/testsuite.native
@@ -1908,7 +1908,17 @@ Pandoc
       ]
   , Figure
       ( "" , [] , [] )
-      (Caption Nothing [ Plain [ Str "lalune" ] ])
+      (Caption
+         (Just
+            [ Str "Voyage"
+            , Space
+            , Str "dans"
+            , Space
+            , Str "la"
+            , Space
+            , Str "Lune"
+            ])
+         [ Plain [ Str "lalune" ] ])
       [ Plain
           [ Image
               ( "" , [] , [] )

--- a/test/writer.context
+++ b/test/writer.context
@@ -931,7 +931,7 @@ or here: <http://example.com/>
 
 From \quotation{Voyage dans la Lune} by Georges Melies (1902):
 
-\startplacefigure[title={lalune}]
+\startplacefigure[title={lalune},list={Voyage dans la Lune}]
 {\externalfigure[lalune.jpg]}
 \stopplacefigure
 

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -951,7 +951,7 @@ From ``Voyage dans la Lune'' by Georges Melies (1902):
 \begin{figure}
 \centering
 \includegraphics{lalune.jpg}
-\caption{lalune}
+\caption[Voyage dans la Lune]{lalune}
 \end{figure}
 
 Here is a movie \includegraphics{movie.jpg} icon.

--- a/test/writer.native
+++ b/test/writer.native
@@ -1843,7 +1843,17 @@ Pandoc
       ]
   , Figure
       ( "" , [] , [] )
-      (Caption Nothing [ Plain [ Str "lalune" ] ])
+      (Caption
+         (Just
+            [ Str "Voyage"
+            , Space
+            , Str "dans"
+            , Space
+            , Str "la"
+            , Space
+            , Str "Lune"
+            ])
+         [ Plain [ Str "lalune" ] ])
       [ Plain
           [ Image
               ( "" , [] , [] )


### PR DESCRIPTION
The title of an implicit figure, if set, is used as the short caption of
a figure. The short caption of a figure replaces the full caption in the
list of figures.

Closes: #7915
