### PR TITLE
Lua: add new function pandoc.system.cputime.

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -4890,6 +4890,16 @@ The operating system on which the program is running.
 
 ## Functions
 
+### cputime {#pandoc.system.cputime}
+
+`cputime ()`
+
+Returns the number of picoseconds CPU time used by the current
+program. The precision of this result may vary in different
+versions and on different platforms.
+
+*Since*: 3.1.1
+
 ### environment {#pandoc.system.environment}
 
 `environment ()`

--- a/pandoc-lua-engine/pandoc-lua-engine.cabal
+++ b/pandoc-lua-engine/pandoc-lua-engine.cabal
@@ -109,7 +109,7 @@ library
                      , hslua-core            >= 2.2.1   && < 2.3
                      , hslua-module-doclayout>= 1.0.4   && < 1.1
                      , hslua-module-path     >= 1.0.3   && < 1.1
-                     , hslua-module-system   >= 1.0     && < 1.1
+                     , hslua-module-system   >= 1.0.3   && < 1.1
                      , hslua-module-text     >= 1.0.3   && < 1.1
                      , hslua-module-version  >= 1.0.3   && < 1.1
                      , hslua-module-zip      >= 1.0.0   && < 1.1

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/System.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/System.hs
@@ -14,9 +14,11 @@ module Text.Pandoc.Lua.Module.System
   ( documentedModule
   ) where
 
+import Data.Version (makeVersion)
 import HsLua
 import HsLua.Module.System
-  (arch, env, getwd, ls, mkdir, os, rmdir, with_env, with_tmpdir, with_wd)
+  ( arch, cputime, env, getwd, ls, mkdir, os, rmdir
+  , with_env, with_tmpdir, with_wd)
 
 -- | Push the pandoc.system module on the Lua stack.
 documentedModule :: LuaError e => Module e
@@ -28,7 +30,8 @@ documentedModule = Module
       , os
       ]
   , moduleFunctions =
-      [ setName "environment" env
+      [ cputime `since` makeVersion [3, 1, 1]
+      , setName "environment" env
       , setName "get_working_directory" getwd
       , setName "list_directory" ls
       , setName "make_directory" mkdir

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,7 @@ extra-deps:
 - gridtables-0.1.0.0
 - hslua-cli-1.2.0
 - hslua-list-1.1.0.1
+- hslua-module-system-1.0.3
 - hslua-module-zip-1.0.0
 - jira-wiki-markup-1.5.0
 - mime-types-0.1.1.0


### PR DESCRIPTION
The function returns the CPU time consumed by pandoc and can be used to
benchmark Lua computations.
