### PR TITLE
fixed <xref> references to tables in DocBook files

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -1359,6 +1359,7 @@ parseInline (Elem e) =
                   "cmdsynopsis"  -> descendantContent "command" el
                   "funcsynopsis" -> descendantContent "function" el
                   "figure"       -> descendantContent "title" el
+                  "table"        -> descendantContent "title" el
                   _              -> qName (elName el) <> "_title"
           where
             xrefLabel = attrValue "xreflabel" el

--- a/test/docbook-xref.docbook
+++ b/test/docbook-xref.docbook
@@ -27,6 +27,9 @@ cross-reference text: <xref linkend="ch02"/>.
 <listitem><para>A link to a
 <sgmltag>figure</sgmltag> element: <xref linkend="fig01"/>.
 </para></listitem>
+<listitem><para>A link to a
+<sgmltag>table</sgmltag> element: <xref linkend="table01"/>.
+</para></listitem>
 </itemizedlist>
 </chapter>
 
@@ -76,6 +79,26 @@ cross-reference text: <xref linkend="ch02"/>.
   <textobject><phrase>An illustration of the Pythagorean Theorem</phrase></textobject>
 </mediaobject>
 </figure>
+
+<table id="table01" frame="all" rowsep="1" colsep="1">
+  <title>Supported features by version</title>
+  <tgroup cols="2">
+    <colspec colname="col_1" colwidth="50*"/>
+    <colspec colname="col_2" colwidth="50*"/>
+    <thead>
+      <row>
+        <entry>Version</entry>
+        <entry>Feat</entry>
+      </row>
+    </thead>
+    <tbody>
+      <row>
+        <entry>Free</entry>
+        <entry>no</entry>
+      </row>
+    </tbody>
+  </tgroup>
+</table>
 
 </chapter>
 </book>

--- a/test/docbook-xref.native
+++ b/test/docbook-xref.native
@@ -168,6 +168,33 @@ Pandoc
             , Str "."
             ]
         ]
+      , [ Para
+            [ Str "A"
+            , Space
+            , Str "link"
+            , Space
+            , Str "to"
+            , Space
+            , Str "a"
+            , SoftBreak
+            , Str "table"
+            , Space
+            , Str "element:"
+            , Space
+            , Link
+                ( "" , [] , [] )
+                [ Str "Supported"
+                , Space
+                , Str "features"
+                , Space
+                , Str "by"
+                , Space
+                , Str "version"
+                ]
+                ( "#table01" , "" )
+            , Str "."
+            ]
+        ]
       ]
   , Header
       1
@@ -214,4 +241,61 @@ Pandoc
           ]
           ( "figures/pythag.png" , "fig:" )
       ]
+  , Table
+      ( "" , [] , [] )
+      (Caption
+         Nothing
+         [ Plain
+             [ Str "Supported"
+             , Space
+             , Str "features"
+             , Space
+             , Str "by"
+             , Space
+             , Str "version"
+             ]
+         ])
+      [ ( AlignDefault , ColWidth 0.5 )
+      , ( AlignDefault , ColWidth 0.5 )
+      ]
+      (TableHead
+         ( "" , [] , [] )
+         [ Row
+             ( "" , [] , [] )
+             [ Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Plain [ Str "Version" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Plain [ Str "Feat" ] ]
+             ]
+         ])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "Free" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "no" ] ]
+              ]
+          ]
+      ]
+      (TableFoot ( "" , [] , [] ) [])
   ]


### PR DESCRIPTION
_xref_ elements can also be used to link to _table_ elements. The DocBook reader did not correctly select the content of the referenced _table_'s _title_. The problem of link name selection is rather complex, as described in #8065. But it seems that the most used target elements have been covered so far. 

Closes #8626.