### PR TITLE
Update TableBody RowHeadColumns caculation: change from max to min

### DIFF
--- a/src/Text/Pandoc/Readers/HTML/Table.hs
+++ b/src/Text/Pandoc/Readers/HTML/Table.hs
@@ -191,10 +191,12 @@ pTableBody block = try $ do
   optional $ pSatisfy (matchTagClose "tbody")
   guard $ isJust mbattribs || not (null bodyheads && null rows)
   let attribs = fromMaybe [] mbattribs
-  return $ TableBody (toAttr attribs) (foldr max 0 rowheads) bodyheads rows
+  return $ TableBody (toAttr attribs) (getMin rowheads) bodyheads rows
   where
     getAttribs (TagOpen _ attribs) = attribs
     getAttribs _ = []
+    getMin [] = 0
+    getMin (x:xs) = foldr min x xs
 
 -- | Parses a simple HTML table
 pTable :: PandocMonad m

--- a/test/html-reader.html
+++ b/test/html-reader.html
@@ -524,6 +524,34 @@ An e-mail address: nobody [at] nowhere.net<blockquote>
         <td>2</td>
         <td>3</td>
     </tr>
+    <tr>
+        <td colspan="3">Details</td>
+    </tr>
+    </tbody>
+    <tfoot>
+    <tr>
+        <th>4</th>
+        <td>5</td>
+        <td>6</td>
+    </tr>
+    </tfoot>
+</table>
+<hr />
+<table>
+    <tbody>
+    <tr>
+        <th>X</th>
+        <th>Y</th>
+        <th>Z</th>
+    </tr>
+    <tr>
+        <td>1</td>
+        <td>2</td>
+        <td>3</td>
+    </tr>
+    <tr>
+        <td colspan="3">Details</td>
+    </tr>
     </tbody>
     <tfoot>
     <tr>

--- a/test/html-reader.native
+++ b/test/html-reader.native
@@ -2262,7 +2262,7 @@ Pandoc
          ])
       [ TableBody
           ( "" , [] , [] )
-          (RowHeadColumns 1)
+          (RowHeadColumns 0)
           []
           [ Row
               ( "" , [] , [] )
@@ -2284,6 +2284,105 @@ Pandoc
                   (RowSpan 1)
                   (ColSpan 1)
                   [ Plain [ Str "3" ] ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 3)
+                  [ Plain [ Str "Details" ] ]
+              ]
+          ]
+      ]
+      (TableFoot
+         ( "" , [] , [] )
+         [ Row
+             ( "" , [] , [] )
+             [ Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Plain [ Str "4" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Plain [ Str "5" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Plain [ Str "6" ] ]
+             ]
+         ])
+  , HorizontalRule
+  , Table
+      ( "" , [] , [] )
+      (Caption Nothing [])
+      [ ( AlignDefault , ColWidthDefault )
+      , ( AlignDefault , ColWidthDefault )
+      , ( AlignDefault , ColWidthDefault )
+      ]
+      (TableHead ( "" , [] , [] ) [])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "X" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "Y" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "Z" ] ]
+              ]
+          ]
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "1" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "2" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "3" ] ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 3)
+                  [ Plain [ Str "Details" ] ]
               ]
           ]
       ]


### PR DESCRIPTION
Recently I noticed that if a HTML table have different number of leading `th` tag in each row, colspan would be lost and some `td` cells would be converted to `th` cells. I looked into the HTML table parsing code, and currently the `TableBody` data struct assume each row have the same number of leading `th` tags.

This PR will set `RowHeadColumns` to the minimum value of each row, to reduce such abnormal colspan cases. Actually I believe this `RowHeadColumns` should be discarded, and we should move `CellType` to `Cell` attribute instead.

For example the Infobox in this page: https://en.wikipedia.org/w/index.php?title=Anna_Sorokin&oldid=1139601226 , the image is in a `td` cell with `colspan="2"`, but for the rows below, each row got one leading `th` cell.