### PR TITLE
Doc: fix typo in run_json_filter

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3918,7 +3918,7 @@ Usage:
 
 `run_json_filter (doc, filter[, args])`
 
-Filter the given doc by passing it through the a JSON filter.
+Filter the given doc by passing it through a JSON filter.
 
 Parameters:
 


### PR DESCRIPTION
Changed:
"Filter the given doc by passing it through the a JSON filter."
to:
"Filter the given doc by passing it through a JSON filter."
