### PR TITLE
asciidoc{,tor} template: fix revision date when author is unset

### DIFF
--- a/data/templates/default.asciidoc
+++ b/data/templates/default.asciidoc
@@ -2,9 +2,11 @@ $if(titleblock)$
 = $title$
 $if(author)$
 $for(author)$$author$$sep$; $endfor$
-$endif$
 $if(date)$
 $date$
+$endif$
+$elseif(date)$
+:revdate: $date$
 $endif$
 $if(keywords)$
 :keywords: $for(keywords)$$keywords$$sep$, $endfor$

--- a/data/templates/default.asciidoctor
+++ b/data/templates/default.asciidoctor
@@ -2,9 +2,11 @@ $if(titleblock)$
 = $title$
 $if(author)$
 $for(author)$$author$$sep$; $endfor$
-$endif$
 $if(date)$
 $date$
+$endif$
+$elseif(date)$
+:revdate: $date$
 $endif$
 $if(keywords)$
 :keywords: $for(keywords)$$keywords$$sep$, $endfor$


### PR DESCRIPTION
Revision line syntax [is only valid in combination with an author line](https://docs.asciidoctor.org/asciidoc/latest/document/revision-line/#when-can-i-use-the-revision-line). The documentation indicates that [the metadata attributes must be set explicitly](https://docs.asciidoctor.org/asciidoc/latest/document/revision-attribute-entries/) when the author line is missing, so the template has been updated to match.

Fixes #8637