### PR TITLE
feat: Add CJKsansfont and CJKmonofont for XeLatex

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -176,6 +176,18 @@ $if(CJKmainfont)$
   \fi
 $endif$
 \fi
+$if(CJKsansfont)$
+  \ifXeTeX
+    \usepackage{xeCJK}
+    \setCJKsansfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKsansfont$}
+  \fi
+$endif$
+$if(CJKmonofont)$
+  \ifXeTeX
+    \usepackage{xeCJK}
+    \setCJKmonofont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmonofont$}
+  \fi
+$endif$
 $if(zero-width-non-joiner)$
 %% Support for zero-width non-joiner characters.
 \makeatletter

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -162,6 +162,12 @@ $if(CJKmainfont)$
   \ifXeTeX
     \usepackage{xeCJK}
     \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+    $if(CJKsansfont)$
+      \setCJKsansfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKsansfont$}
+    $endif$
+    $if(CJKmonofont)$
+      \setCJKmonofont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmonofont$}
+    $endif$
   \fi
 $endif$
 $if(luatexjapresetoptions)$
@@ -176,18 +182,6 @@ $if(CJKmainfont)$
   \fi
 $endif$
 \fi
-$if(CJKsansfont)$
-  \ifXeTeX
-    \usepackage{xeCJK}
-    \setCJKsansfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKsansfont$}
-  \fi
-$endif$
-$if(CJKmonofont)$
-  \ifXeTeX
-    \usepackage{xeCJK}
-    \setCJKmonofont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmonofont$}
-  \fi
-$endif$
 $if(zero-width-non-joiner)$
 %% Support for zero-width non-joiner characters.
 \makeatletter


### PR DESCRIPTION
The XeLaTex supports `CJKsansfont` and `CJKmonofont` which is useful to change the CJK fonts for titles and codes.

The following args were tested and worked well.

```
---

mainfont: "Noto Serif SC"
sansfont: "Noto Sans SC"
monofont: "Ubuntu Mono"
CJKmainfont: "Noto Serif SC"
CJKsansfont: "Noto Sans SC"
CJKmonofont: "Noto Sans SC"

...
```
