### PR TITLE
Fix background image in Beamer when there are figure environments

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -33,6 +33,9 @@ $if(background-image)$
 \usebackgroundtemplate{%
   \includegraphics[width=\paperwidth]{$background-image$}%
 }
+% In beamer background-image does not work well when other images are used, so this is the workaround
+\pgfdeclareimage[width=\paperwidth,height=\paperheight]{background}{$background-image$}
+\usebackgroundtemplate{\pgfuseimage{background}}
 $endif$
 \usepackage{pgfpages}
 \setbeamertemplate{caption}[numbered]


### PR DESCRIPTION
Fix background image in Beamer when there are figure environments, replicating the pull request done in the pandoc-templates repository with the updated template.