### PR TITLE
Add nix highlighting support

### DIFF
--- a/src/Text/Pandoc/Highlighting.hs
+++ b/src/Text/Pandoc/Highlighting.hs
@@ -180,6 +180,7 @@ langsList =
   ("modula2","Modula-2"),
   ("mupad","MuPAD"),
   ("nastran","NASTRAN"),
+  ("nix","nix"),
   ("oberon2","Oberon-2"),
   ("ocl","OCL"),
   ("octave","Octave"),


### PR DESCRIPTION
This is a very naive attempt at adding nix syntax highlighting support to pandoc.
It appears everything is in place in skylighting (see https://github.com/jgm/skylighting/blob/master/skylighting-core/xml/nix.xml), and this was the only thing to change to support nix.

I hope I am not missing something obvious.