### PR TITLE
HTML writer: Use different structure for epub footnotes.

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -564,7 +564,7 @@ footnoteSection refLocation startCounter notes = do
              Nothing | startCounter == 1 ->
                (H.ol (nl >> mconcat notes)) >> nl
              Nothing -> (H.ol ! A.start (fromString (show startCounter)) $
-                         mconcat notes) >> nl
+                         nl >> mconcat notes) >> nl
 
 -- | Parse a mailto link; return Just (name, domain) or Nothing.
 parseMailto :: Text -> Maybe (Text, Text)

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -560,12 +560,11 @@ footnoteSection refLocation startCounter notes = do
            -- Keep the previous output exactly the same if we don't
            -- have multiple notes sections
            case epubVersion of
-             Just _ -> mconcat notes >> nl
+             Just _ -> mconcat notes
              Nothing | startCounter == 1 ->
-               H.ol $ mconcat notes >> nl
-             Nothing -> H.ol ! A.start (fromString (show startCounter)) $
-                         mconcat notes >> nl
-           nl
+               (H.ol (nl >> mconcat notes)) >> nl
+             Nothing -> (H.ol ! A.start (fromString (show startCounter)) $
+                         mconcat notes) >> nl
 
 -- | Parse a mailto link; return Just (name, domain) or Nothing.
 parseMailto :: Text -> Maybe (Text, Text)
@@ -1641,7 +1640,7 @@ blockListToNote opts ref blocks = do
                                                      Plain backlink]
       contents <- blockListToHtml opts blocks'
       let noteItem = H.li ! prefixedId opts ("fn" <> ref) $ contents
-      return $ nl >> noteItem
+      return $ noteItem >> nl
     Just epubv -> do
       let kvs = [("role","doc-backlink") | html5]
       let backlink = Link ("",["footnote-back"],kvs)
@@ -1656,8 +1655,9 @@ blockListToNote opts ref blocks = do
       contents <- blockListToHtml opts blocks'
       let noteItem = (if epubv == EPUB3
                          then H5.aside ! customAttribute "epub:type" "footnote"
-                         else H.div) ! prefixedId opts ("fn" <> ref) $ contents
-      return $ nl >> noteItem
+                         else H.div) ! prefixedId opts ("fn" <> ref)
+                      $ nl >> contents >> nl
+      return $ noteItem >> nl
 
 inDiv :: PandocMonad m=> Text -> Html -> StateT WriterState m Html
 inDiv cls x = do

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -559,9 +559,11 @@ footnoteSection refLocation startCounter notes = do
            hrtag
            -- Keep the previous output exactly the same if we don't
            -- have multiple notes sections
-           if startCounter == 1
-             then H.ol $ mconcat notes >> nl
-             else H.ol ! A.start (fromString (show startCounter)) $
+           case epubVersion of
+             Just _ -> mconcat notes >> nl
+             Nothing | startCounter == 1 ->
+               H.ol $ mconcat notes >> nl
+             Nothing -> H.ol ! A.start (fromString (show startCounter)) $
                          mconcat notes >> nl
            nl
 
@@ -1612,36 +1614,50 @@ blockListToNote :: PandocMonad m
                 => WriterOptions -> Text -> [Block]
                 -> StateT WriterState m Html
 blockListToNote opts ref blocks = do
-  html5 <- gets stHtml5
-  -- If last block is Para or Plain, include the backlink at the end of
-  -- that block. Otherwise, insert a new Plain block with the backlink.
-  let kvs = [("role","doc-backlink") | html5]
-  let backlink = [Link ("",["footnote-back"],kvs)
-                    [Str "↩"] ("#" <> "fnref" <> ref,"")]
-  let blocks'  = if null blocks
-                    then []
-                    else let lastBlock   = last blocks
-                             otherBlocks = init blocks
-                         in  case lastBlock of
-                                  Para [Image (_,cls,_) _ (_,tit)]
-                                      | "fig:" `T.isPrefixOf` tit
-                                        || "r-stretch" `elem` cls
-                                            -> otherBlocks ++ [lastBlock,
-                                                  Plain backlink]
-                                  Para lst  -> otherBlocks ++
-                                                 [Para (lst ++ backlink)]
-                                  Plain lst -> otherBlocks ++
-                                                 [Plain (lst ++ backlink)]
-                                  _         -> otherBlocks ++ [lastBlock,
-                                                 Plain backlink]
-  contents <- blockListToHtml opts blocks'
-  let noteItem = H.li ! prefixedId opts ("fn" <> ref) $ contents
   epubVersion <- gets stEPUBVersion
-  let noteItem' = case epubVersion of
-                       Just EPUB3 -> noteItem !
-                                       customAttribute "epub:type" "footnote"
-                       _          -> noteItem
-  return $ nl >> noteItem'
+  html5 <- gets stHtml5
+  case epubVersion of
+    Nothing -> do -- web page
+      -- If last block is Para or Plain, include the backlink at the end of
+      -- that block. Otherwise, insert a new Plain block with the backlink.
+      let kvs = [("role","doc-backlink") | html5]
+      let backlink = [Link ("",["footnote-back"],kvs)
+                        [Str "↩"] ("#" <> "fnref" <> ref,"")]
+      let blocks'  = if null blocks
+                        then []
+                        else let lastBlock   = last blocks
+                                 otherBlocks = init blocks
+                             in  case lastBlock of
+                                      Para [Image (_,cls,_) _ (_,tit)]
+                                          | "fig:" `T.isPrefixOf` tit
+                                            || "r-stretch" `elem` cls
+                                                -> otherBlocks ++ [lastBlock,
+                                                      Plain backlink]
+                                      Para lst  -> otherBlocks ++
+                                                     [Para (lst ++ backlink)]
+                                      Plain lst -> otherBlocks ++
+                                                     [Plain (lst ++ backlink)]
+                                      _         -> otherBlocks ++ [lastBlock,
+                                                     Plain backlink]
+      contents <- blockListToHtml opts blocks'
+      let noteItem = H.li ! prefixedId opts ("fn" <> ref) $ contents
+      return $ nl >> noteItem
+    Just epubv -> do
+      let kvs = [("role","doc-backlink") | html5]
+      let backlink = Link ("",["footnote-back"],kvs)
+                        [Str ref] ("#" <> "fnref" <> ref,"")
+      let blocks' =
+           case blocks of
+             (Para ils : rest) ->
+                Para (backlink : Str "." : Space : ils) : rest
+             (Plain ils : rest) ->
+                Plain (backlink : Str "." : Space : ils) : rest
+             _ -> Para [backlink , Str "."] : blocks
+      contents <- blockListToHtml opts blocks'
+      let noteItem = (if epubv == EPUB3
+                         then H5.aside ! customAttribute "epub:type" "footnote"
+                         else H.div) ! prefixedId opts ("fn" <> ref) $ contents
+      return $ nl >> noteItem
 
 inDiv :: PandocMonad m=> Text -> Html -> StateT WriterState m Html
 inDiv cls x = do


### PR DESCRIPTION
Many EPUB readers are thrown off by pandoc's current footnote output.  Both the ol and the fact that the footnote backlink is at the end of the note seem to pose problems.

With this commit, we now create a list of aside (or div) elements, instead of an ordered list. Each element begins with a note number that is linked back to the note reference.  (So, the backlink occurs at the beginning rather than the end.)

References:

- https://kindlegen.s3.amazonaws.com/AmazonKindlePublishingGuidelines.pdf
- http://kb.daisy.org/publishing/docs/html/notes.html

Obsoletes #8672, closes #5583.

Thanks to @Porges and @lewer.