### PR TITLE
Textile reader: Add support for link references

### DIFF
--- a/src/Text/Pandoc/Readers/Textile.hs
+++ b/src/Text/Pandoc/Readers/Textile.hs
@@ -40,6 +40,7 @@ import Control.Monad.Except (throwError)
 import Data.Char (digitToInt, isUpper)
 import Data.List (intersperse, transpose, foldl')
 import Data.List.NonEmpty (NonEmpty(..), nonEmpty)
+import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import Text.HTML.TagSoup (Tag (..), fromAttrib)
@@ -79,7 +80,7 @@ parseTextile = do
   -- docMinusKeys is the raw document with blanks where the keys/notes were...
   let firstPassParser = do
         pos <- getPosition
-        t <- noteBlock <|> lineClump
+        t <- noteBlock <|> referenceKey <|> lineClump
         return (pos, t)
   manyTill firstPassParser eof >>= setInput . Sources
   setPosition startPos
@@ -108,6 +109,27 @@ noteBlock = try $ do
   updateState $ \s -> s { stateNotes = newnote : oldnotes }
   -- return blanks so line count isn't affected
   return $ T.replicate (sourceLine endPos - sourceLine startPos) "\n"
+
+referenceKey :: PandocMonad m => TextileParser m Text
+referenceKey = try $ do
+  pos <- getPosition
+  char '['
+  refName <- T.pack <$> many1Till nonspaceChar (char ']')
+  refDestination <- T.pack <$> many1Till anyChar newline
+  st <- getState
+  let oldKeys = stateKeys st
+  let key = toKey refName
+  -- Textile doesn't support link titles on the reference
+  -- definition, so use the empty string
+  let target = (refDestination, "")
+  case M.lookup key oldKeys of
+    Just (t, _) | not (t == target) ->
+      -- similar to Markdown, only warn when the targets
+      -- for matching named references differ
+      logMessage $ DuplicateLinkReference refName pos
+    _ -> return ()
+  updateState $ \s -> s {stateKeys = M.insert key (target, nullAttr) oldKeys }
+  return "\n"
 
 -- | Parse document blocks
 parseBlocks :: PandocMonad m => TextileParser m Blocks
@@ -624,7 +646,11 @@ linkUrl bracketed = do
                 else lookAhead $ space <|> eof' <|> oneOf "[]" <|>
                        try (oneOf "!.,;:*" *>
                               (space <|> newline <|> eof'))
-  T.pack <$> many1Till nonspaceChar stop
+  rawLink <- T.pack <$> many1Till nonspaceChar stop
+  st <- getState
+  return $ case M.lookup (toKey rawLink) (stateKeys st) of
+    Nothing -> rawLink
+    Just ((src, _), _) -> src
 
 -- | image embedding
 image :: PandocMonad m => TextileParser m Inlines

--- a/src/Text/Pandoc/Readers/Textile.hs
+++ b/src/Text/Pandoc/Readers/Textile.hs
@@ -50,6 +50,7 @@ import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Class.PandocMonad (PandocMonad (..))
 import Text.Pandoc.CSS
 import Text.Pandoc.Definition
+import Text.Pandoc.Logging
 import Text.Pandoc.Options
 import Text.Pandoc.Parsing
 import Text.Pandoc.Readers.HTML (htmlTag, isBlockTag, isInlineTag)

--- a/test/textile-reader.native
+++ b/test/textile-reader.native
@@ -749,6 +749,35 @@ Pandoc
       , Space
       , Str "spaces."
       ]
+  , Para
+      [ Str "A"
+      , Space
+      , Link
+          ( "" , [] , [] )
+          [ Str "link" ]
+          ( "ftp://example.com" , "" )
+      , Space
+      , Str "to"
+      , Space
+      , Str "a"
+      , Space
+      , Str "named"
+      , Space
+      , Str "target"
+      ]
+  , Para
+      [ Str "A"
+      , Space
+      , Link ( "" , [] , [] ) [ Str "link" ] ( "missing" , "" )
+      , Space
+      , Str "to"
+      , Space
+      , Str "a"
+      , Space
+      , Str "missing"
+      , Space
+      , Str "target"
+      ]
   , Header 1 ( "tables" , [] , [] ) [ Str "Tables" ]
   , Para
       [ Str "Textile"

--- a/test/textile-reader.native
+++ b/test/textile-reader.native
@@ -753,9 +753,7 @@ Pandoc
       [ Str "A"
       , Space
       , Link
-          ( "" , [] , [] )
-          [ Str "link" ]
-          ( "ftp://example.com" , "" )
+          ( "" , [] , [] ) [ Str "link" ] ( "ftp://example.com" , "" )
       , Space
       , Str "to"
       , Space

--- a/test/textile-reader.textile
+++ b/test/textile-reader.textile
@@ -183,6 +183,10 @@ Automatic linking to "$":http://www.example.com.
 
 A link["with brackets":http://www.example.com]and no spaces.
 
+A "link":link-target to a named target
+
+A "link":missing to a missing target
+
 h1. Tables
 
 Textile allows tables with and without headers :
@@ -277,3 +281,5 @@ h1. Comment blocks
 is here.
 
 not a comment.
+
+[link-target]ftp://example.com


### PR DESCRIPTION
Textile supports what it calls a "link alias", which is analogous to Markdown's reference-style links.

During the parser's first-pass, we can collect link references in addition to footnotes. Textile differs from Markdown in that reference definitions don't have titles nor attributes, so the stored values in `stateKeys` is relatively sparse.

I modeled the parser after the Markdown, and the new test cases are passing, but let me know if there's anything essential from Markdown's reference parsing that I missed.