### PR TITLE
Org reader: Allow zero width space as an escape character

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -758,7 +758,7 @@ many1TillNOrLessNewlines n p end = try $
 
 -- | Chars not allowed at the (inner) border of emphasis
 emphasisForbiddenBorderChars :: [Char]
-emphasisForbiddenBorderChars = "\t\n\r "
+emphasisForbiddenBorderChars = "\t\n\r \x200B"
 
 -- | The maximum number of newlines within
 emphasisAllowedNewlines :: Int

--- a/src/Text/Pandoc/Readers/Org/ParserState.hs
+++ b/src/Text/Pandoc/Readers/Org/ParserState.hs
@@ -164,8 +164,8 @@ instance Default OrgParserState where
 defaultOrgParserState :: OrgParserState
 defaultOrgParserState = OrgParserState
   { orgStateAnchorIds = []
-  , orgStateEmphasisPreChars = "-\t ('\"{"
-  , orgStateEmphasisPostChars  = "-\t\n .,:!?;'\")}["
+  , orgStateEmphasisPreChars = "-\t ('\"{\x200B"
+  , orgStateEmphasisPostChars  = "-\t\n .,:!?;'\")}[\x200B"
   , orgStateEmphasisCharStack = []
   , orgStateEmphasisNewlines = Nothing
   , orgStateExportSettings = def

--- a/test/Tests/Readers/Org/Inline.hs
+++ b/test/Tests/Readers/Org/Inline.hs
@@ -120,12 +120,13 @@ tests =
       para (spcSep [ "//", "**", "__", "<>", "==", "~~", "$$" ])
 
   , "Adherence to Org's rules for markup borders" =:
-      "/t/& a/ / ./r/ (*l*) /e/! /b/." =?>
+      "/t/& a/ / ./r/ (*l*) /e/! ze\x200b/r/\x200bo /b/." =?>
       para (spcSep [ emph $ "t/&" <> space <> "a"
                    , "/"
                    , "./r/"
                    , "(" <> strong "l" <> ")"
                    , emph "e" <> "!"
+                   , "ze\x200b" <> emph "r" <> "\x200bo"
                    , emph "b" <> "."
                    ])
 
@@ -136,6 +137,10 @@ tests =
   , "Spaces are forbidden border chars" =:
       "/nada /" =?>
       para "/nada /"
+
+  , "Zero width spaces are forbidden border chars" =:
+      "/emph\x200b/asis" =?>
+      para "/emph\x200b/asis"
 
   , "Markup should work properly after a blank line" =:
     T.unlines ["foo", "", "/bar/"] =?>


### PR DESCRIPTION
Allow the character U+200B to be used as an escape character as described in the Org-mode documentation https://orgmode.org/manual/Escape-Character.html

Closes issue #8716.