### PR TITLE
Add rowspan, colspan and alignment to cells in jats table reader

### DIFF
--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -2794,6 +2794,96 @@ Pandoc
       (TableFoot ( "" , [] , [] ) [])
   , Header
       2
+      ( "table-with-spans-and-alignments" , [] , [] )
+      [ Str "Tables"
+      , Space
+      , Str "with"
+      , Space
+      , Str "spans"
+      , Space
+      , Str "and"
+      , Space
+      , Str "alignments"
+      ]
+  , Table
+      ( "" , [] , [] )
+      (Caption Nothing [])
+      [ ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      ]
+      (TableHead
+         ( "" , [] , [] )
+         [ Row
+             ( "" , [] , [] )
+             [ Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 2)
+                 [ Para [ Str "1" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignRight
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "2" ] ]
+             ]
+         ])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 2)
+                  [ Para [ Str "1" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignLeft
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "2" ] ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 2)
+                  (ColSpan 1)
+                  [ Para [ Str "4" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "5" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "6" ] ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 2)
+                  [ Para [ Str "7" ] ]
+              ]
+          ]
+      ]
+      (TableFoot ( "" , [] , [] ) [])
+  , Header
+      2
       ( "empty-tables" , [] , [] )
       [ Str "Empty" , Space , Str "Tables" ]
   , Para

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -1150,6 +1150,50 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       </tbody>
     </table>
   </sec>
+  <sec id="table-with-spans-and-alignments">
+    <title>Tables with spans and alignments</title>
+    <table>
+      <col align="left" />
+      <col align="left" />
+      <col align="left" />
+      <thead>
+        <tr>
+            <td colspan="2">
+                <p>1</p>
+            </td>
+            <td align="right">
+                <p>2</p>
+            </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+        <td colspan="2">
+            <p>1</p>
+        </td>
+        <td align="left">
+            <p>2</p>
+        </td>
+        </tr>
+        <tr>
+        <td rowspan="2">
+            <p>4</p>
+        </td>
+        <td>
+            <p>5</p>
+        </td>
+        <td>
+            <p>6</p>
+        </td>
+        </tr>
+        <tr>
+        <td colspan="2">
+            <p>7</p>
+        </td>
+        </tr>
+      </tbody>
+    </table>
+  </sec>
   <sec id="empty-tables">
     <title>Empty Tables</title>
     <p>This section should be empty.</p>


### PR DESCRIPTION
### Description 
I'm looking for some guidance on completing this code change. This is my first time writing Haskell code and I'm getting stuck on some code and I can't tell if my design is wrong/bad or if I'm just missing something syntactically or conceptually.

My issue is arising from trying to parse the xml `Element` attributes at the same time as when we parse the content of the `Element` itself, so when we create a `Cell`, we have all of the information we need.

The previous design of the code just parsed the xml row `Element`s into `Blocks` and then made `simpleCell`s (which don't accept rowspan, colspan or alignment attributes) from those `Blocks`.

So, I'm getting stuck with a typing/monad issue. I'm able to parse out the `colspan`, `rowspan` and `alignment` attributes from the xml and push those values into cells, but I'm having a heard time using `parseMixed` to parse an `Element` into `Blocks`. `parseMixed`  returns the type `StateT JATSState Blocks`. What would be an idiomatic way to get the `Blocks` value out of the `StateT JATSState` monad that is returned by this function?

I also realize that because I'm new to Haskell and Pandoc that my approach to this problem may be way off base, so any direction there would be welcome as well!