### PR TITLE
Update documentation for org-mode

### DIFF
--- a/doc/org.md
+++ b/doc/org.md
@@ -208,8 +208,8 @@ the variable `org-emphasis-regexp-components`. A variable like
 this doesn't fit well with pandoc's model. Instead, it is
 possible to use special lines to change these values:
 
-    #+pandoc-emphasis-pre: "-\t ('\"{"
-    #+pandoc-emphasis-post: "-\t\n .,:!?;'\")}["
+    #+pandoc-emphasis-pre: "-\t ('\"{\x200B"
+    #+pandoc-emphasis-post: "-\t\n .,:!?;'\")}[\x200B"
 
 The above describes the default values of these variables. The
 arguments must be valid (Haskell) strings. If interpretation of


### PR DESCRIPTION
Add zero width space to the default values of pandoc-emphasis-pre and pandoc-emphasis-post. Zero width space was added to solve issue #8716.