### PR TITLE
Add rowspan, colspan and alignment to cells in jats table reader

### DIFF
--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -305,10 +305,7 @@ parseBlock (Elem e) =
                                                             in  ColWidth . (/ tot) <$> ws'
                                                 Nothing  -> replicate numrows ColWidthDefault
 
-                      -- How do I parse an Element into Blocks?
-                      -- parseCell takes an element and returns a StateT JATSState Blocks, but I need it to return the unwrapped value
                       let parseCell = parseMixed plain . elContent
-
                       let elementToCell element = cell (toAlignment element) (RowSpan $ toRowSpan element) (ColSpan $ toColSpan element) <$> (parseCell element)
                       let rowElementsToCells elements = mapM elementToCell elements
                       let toRow = fmap (Row nullAttr) . rowElementsToCells

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -2794,6 +2794,96 @@ Pandoc
       (TableFoot ( "" , [] , [] ) [])
   , Header
       2
+      ( "table-with-spans-and-alignments" , [] , [] )
+      [ Str "Tables"
+      , Space
+      , Str "with"
+      , Space
+      , Str "spans"
+      , Space
+      , Str "and"
+      , Space
+      , Str "alignments"
+      ]
+  , Table
+      ( "" , [] , [] )
+      (Caption Nothing [])
+      [ ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      ]
+      (TableHead
+         ( "" , [] , [] )
+         [ Row
+             ( "" , [] , [] )
+             [ Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 2)
+                 [ Para [ Str "1" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignRight
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "2" ] ]
+             ]
+         ])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 2)
+                  [ Para [ Str "1" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignLeft
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "2" ] ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 2)
+                  (ColSpan 1)
+                  [ Para [ Str "4" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "5" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "6" ] ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 2)
+                  [ Para [ Str "7" ] ]
+              ]
+          ]
+      ]
+      (TableFoot ( "" , [] , [] ) [])
+  , Header
+      2
       ( "empty-tables" , [] , [] )
       [ Str "Empty" , Space , Str "Tables" ]
   , Para

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -1150,6 +1150,50 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       </tbody>
     </table>
   </sec>
+  <sec id="table-with-spans-and-alignments">
+    <title>Tables with spans and alignments</title>
+    <table>
+      <col align="left" />
+      <col align="left" />
+      <col align="left" />
+      <thead>
+        <tr>
+            <td colspan="2">
+                <p>1</p>
+            </td>
+            <td align="right">
+                <p>2</p>
+            </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+        <td colspan="2">
+            <p>1</p>
+        </td>
+        <td align="left">
+            <p>2</p>
+        </td>
+        </tr>
+        <tr>
+        <td rowspan="2">
+            <p>4</p>
+        </td>
+        <td>
+            <p>5</p>
+        </td>
+        <td>
+            <p>6</p>
+        </td>
+        </tr>
+        <tr>
+        <td colspan="2">
+            <p>7</p>
+        </td>
+        </tr>
+      </tbody>
+    </table>
+  </sec>
   <sec id="empty-tables">
     <title>Empty Tables</title>
     <p>This section should be empty.</p>


### PR DESCRIPTION
### Background 
See [this issue](https://github.com/jgm/pandoc/issues/8408) for background

### Description 
Parse the colspan, rowspan and alignment attributes of Jats table into the Cell node 