### PR TITLE
Remove links from inside links in mediawiki writer

### DIFF
--- a/test/command/8738.md
+++ b/test/command/8738.md
@@ -1,0 +1,6 @@
+```
+% pandoc -f native -t mediawiki
+[Link ("",[],[]) [Link ("",[],[]) [Str "test"] ("https://bar.example.com",""),Str "Test"] ("https://foo.example.com","")]
+^D
+[https://foo.example.com testTest]
+```


### PR DESCRIPTION
Fixes issue https://github.com/jgm/pandoc/issues/8738

I am not sure if this is the most desired way to do it.

Other thing to consider:

```hs
removeLinks :: [Inline] -> [Inline]
removeLinks = walk go
 where
  go (Link _ ils _) = Underline ils
  go x = x
```