### PR TITLE
Distinguish mutiple HTML5 footnote section ids

### DIFF
--- a/test/command/8770-block.md
+++ b/test/command/8770-block.md
@@ -1,0 +1,75 @@
+```
+% pandoc -t html5 --reference-location=block
+# Section 1
+
+hello[^1]
+
+: Sample table.[^2]
+
+-----------
+ Fruit[^3]
+-----------
+ Bans[^4]
+-----------
+
+# Section 2
+
+dolly[^5]
+
+[^1]: doc footnote
+[^2]: caption footnote
+[^3]: header footnote
+[^4]: table cell footnote
+[^5]: doc footnote
+^D
+<h1 id="section-1">Section 1</h1>
+<p>hello<a href="#fn1" class="footnote-ref" id="fnref1"
+role="doc-noteref"><sup>1</sup></a></p>
+<aside id="footnotes" class="footnotes footnotes-end-of-block"
+role="doc-footnote">
+<ol>
+<li id="fn1"><p>doc footnote<a href="#fnref1" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+</ol>
+</aside>
+<table style="width:17%;">
+<caption>Sample table.<a href="#fn2" class="footnote-ref" id="fnref2"
+role="doc-noteref"><sup>2</sup></a></caption>
+<colgroup>
+<col style="width: 16%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th style="text-align: center;">Fruit<a href="#fn3" class="footnote-ref"
+id="fnref3" role="doc-noteref"><sup>3</sup></a></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: center;">Bans<a href="#fn4" class="footnote-ref"
+id="fnref4" role="doc-noteref"><sup>4</sup></a></td>
+</tr>
+</tbody>
+</table>
+<aside id="footnotes-2" class="footnotes footnotes-end-of-block"
+role="doc-footnote">
+<ol start="2">
+<li id="fn2"><p>caption footnote<a href="#fnref2" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+<li id="fn3"><p>header footnote<a href="#fnref3" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+<li id="fn4"><p>table cell footnote<a href="#fnref4"
+class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+</ol>
+</aside>
+<h1 id="section-2">Section 2</h1>
+<p>dolly<a href="#fn5" class="footnote-ref" id="fnref5"
+role="doc-noteref"><sup>5</sup></a></p>
+<aside id="footnotes-3" class="footnotes footnotes-end-of-block"
+role="doc-footnote">
+<ol start="5">
+<li id="fn5"><p>doc footnote<a href="#fnref5" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+</ol>
+</aside>
+```

--- a/test/command/8770-document.md
+++ b/test/command/8770-document.md
@@ -1,0 +1,66 @@
+```
+% pandoc -t html5 --reference-location=document
+# Section 1
+
+hello[^1]
+
+: Sample table.[^2]
+
+-----------
+ Fruit[^3]
+-----------
+ Bans[^4]
+-----------
+
+# Section 2
+
+dolly[^5]
+
+[^1]: doc footnote
+[^2]: caption footnote
+[^3]: header footnote
+[^4]: table cell footnote
+[^5]: doc footnote
+^D
+<h1 id="section-1">Section 1</h1>
+<p>hello<a href="#fn1" class="footnote-ref" id="fnref1"
+role="doc-noteref"><sup>1</sup></a></p>
+<table style="width:17%;">
+<caption>Sample table.<a href="#fn2" class="footnote-ref" id="fnref2"
+role="doc-noteref"><sup>2</sup></a></caption>
+<colgroup>
+<col style="width: 16%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th style="text-align: center;">Fruit<a href="#fn3" class="footnote-ref"
+id="fnref3" role="doc-noteref"><sup>3</sup></a></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: center;">Bans<a href="#fn4" class="footnote-ref"
+id="fnref4" role="doc-noteref"><sup>4</sup></a></td>
+</tr>
+</tbody>
+</table>
+<h1 id="section-2">Section 2</h1>
+<p>dolly<a href="#fn5" class="footnote-ref" id="fnref5"
+role="doc-noteref"><sup>5</sup></a></p>
+<section id="footnotes" class="footnotes footnotes-end-of-document"
+role="doc-endnotes">
+<hr />
+<ol>
+<li id="fn1"><p>doc footnote<a href="#fnref1" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+<li id="fn2"><p>caption footnote<a href="#fnref2" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+<li id="fn3"><p>header footnote<a href="#fnref3" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+<li id="fn4"><p>table cell footnote<a href="#fnref4"
+class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+<li id="fn5"><p>doc footnote<a href="#fnref5" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+</ol>
+</section>
+```

--- a/test/command/8770-section.md
+++ b/test/command/8770-section.md
@@ -1,0 +1,72 @@
+```
+% pandoc -t html5 --reference-location=section
+# Section 1
+
+hello[^1]
+
+: Sample table.[^2]
+
+-----------
+ Fruit[^3]
+-----------
+ Bans[^4]
+-----------
+
+# Section 2
+
+dolly[^5]
+
+[^1]: doc footnote
+[^2]: caption footnote
+[^3]: header footnote
+[^4]: table cell footnote
+[^5]: doc footnote
+^D
+<h1 id="section-1">Section 1</h1>
+<p>hello<a href="#fn1" class="footnote-ref" id="fnref1"
+role="doc-noteref"><sup>1</sup></a></p>
+<table style="width:17%;">
+<caption>Sample table.<a href="#fn2" class="footnote-ref" id="fnref2"
+role="doc-noteref"><sup>2</sup></a></caption>
+<colgroup>
+<col style="width: 16%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th style="text-align: center;">Fruit<a href="#fn3" class="footnote-ref"
+id="fnref3" role="doc-noteref"><sup>3</sup></a></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: center;">Bans<a href="#fn4" class="footnote-ref"
+id="fnref4" role="doc-noteref"><sup>4</sup></a></td>
+</tr>
+</tbody>
+</table>
+<aside id="footnotes" class="footnotes footnotes-end-of-section"
+role="doc-footnote">
+<hr />
+<ol>
+<li id="fn1"><p>doc footnote<a href="#fnref1" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+<li id="fn2"><p>caption footnote<a href="#fnref2" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+<li id="fn3"><p>header footnote<a href="#fnref3" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+<li id="fn4"><p>table cell footnote<a href="#fnref4"
+class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+</ol>
+</aside>
+<h1 id="section-2">Section 2</h1>
+<p>dolly<a href="#fn5" class="footnote-ref" id="fnref5"
+role="doc-noteref"><sup>5</sup></a></p>
+<aside id="footnotes-2" class="footnotes footnotes-end-of-section"
+role="doc-footnote">
+<hr />
+<ol start="5">
+<li id="fn5"><p>doc footnote<a href="#fnref5" class="footnote-back"
+role="doc-backlink">↩︎</a></p></li>
+</ol>
+</aside>
+```


### PR DESCRIPTION
The HTML5 writer generates an `<aside>` tag grouping all footnotes written to a particular location, and gives it a `#footnotes` ID for ease of navigation.  However, it gives that *same* ID for every `<aside>` if the footnotes occur in multiple locations within the file (`--reference-location=block` or `=section`).  This PR adds a counter to the writer state to track how many footnote-blocks have been written, and uses that to uniquely identify each `<aside>`.

The first ID remains simply `#footnotes` for backwards compatibility with incoming links and for cases where only a single `<aside>` is needed, but all following ones are given a suffix `#footnotes-2`, `#footnotes-3`, and so on (one-indexed to match the individual-note numbering style).  As far as I could tell, none of the other writers supporting `--reference-location` give the blocks a presumed-unique ID, and while it seems like that would be a good feature to add support for in the HTML4 format defined in the same file, I've not made that change since I don't know if there's some use case which *expects* that lack of ID for some reason.

I didn't see any good way to test this without creating a new output -- and continuing to test endnotes is definitely important -- so I hope the naming pattern I used (modeled on the `dokuwiki_*.*` tests) and the entry in the testrunner are acceptable.