### PR TITLE
Add Footer and Multiple body parsing to Jats table reader

### DIFF
--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -2940,7 +2940,7 @@ Pandoc
              ( "" , [] , [] )
              [ Cell
                  ( "" , [] , [] )
-                 AlignDefault
+                 AlignRight
                  (RowSpan 1)
                  (ColSpan 1)
                  [ Para [ Str "f1" ] ]
@@ -2958,6 +2958,69 @@ Pandoc
                  [ Para [ Str "f3" ] ]
              ]
          ])
+  , Header 2 ( "table-with-multiple-bodies" , [] , [] ) []
+  , Table
+      ( "" , [] , [] )
+      (Caption Nothing [])
+      [ ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      ]
+      (TableHead ( "" , [] , [] ) [])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignRight
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "a1" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "a2" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "a3" ] ]
+              ]
+          ]
+      , TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "b1" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "b2" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "b3" ] ]
+              ]
+          ]
+      ]
+      (TableFoot ( "" , [] , [] ) [])
   , Header
       2
       ( "empty-tables" , [] , [] )

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -2898,6 +2898,66 @@ Pandoc
           ]
       ]
       (TableFoot ( "" , [] , [] ) [])
+  , Header 2 ( "table-with-footer" , [] , [] ) []
+  , Table
+      ( "" , [] , [] )
+      (Caption Nothing [])
+      [ ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      ]
+      (TableHead ( "" , [] , [] ) [])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "1" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "2" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para [ Str "3" ] ]
+              ]
+          ]
+      ]
+      (TableFoot
+         ( "" , [] , [] )
+         [ Row
+             ( "" , [] , [] )
+             [ Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "f1" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "f2" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "f3" ] ]
+             ]
+         ])
   , Header
       2
       ( "empty-tables" , [] , [] )

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -2919,7 +2919,10 @@ Pandoc
           ]
       ]
       (TableFoot ( "" , [] , [] ) [])
-  , Header 2 ( "table-with-footer" , [] , [] ) []
+  , Header
+      2
+      ( "table-with-footer" , [] , [] )
+      [ Str "Table" , Space , Str "with" , Space , Str "footer" ]
   , Table
       ( "" , [] , [] )
       (Caption Nothing [])
@@ -3000,7 +3003,17 @@ Pandoc
                  [ Para [ Str "f6" ] ]
              ]
          ])
-  , Header 2 ( "table-with-multiple-bodies" , [] , [] ) []
+  , Header
+      2
+      ( "table-with-multiple-bodies" , [] , [] )
+      [ Str "Table"
+      , Space
+      , Str "With"
+      , Space
+      , Str "Multiple"
+      , Space
+      , Str "Bodies"
+      ]
   , Table
       ( "" , [] , [] )
       (Caption Nothing [])

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -2427,6 +2427,27 @@ Pandoc
                  AlignDefault
                  (RowSpan 1)
                  (ColSpan 1)
+                 [ Para [ Str "r1a" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "r1b" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "r1c" ] ]
+             ]
+         , Row
+             ( "" , [] , [] )
+             [ Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
                  [ Para [ Str "X" ] ]
              , Cell
                  ( "" , [] , [] )
@@ -2956,6 +2977,27 @@ Pandoc
                  (RowSpan 1)
                  (ColSpan 1)
                  [ Para [ Str "f3" ] ]
+             ]
+         , Row
+             ( "" , [] , [] )
+             [ Cell
+                 ( "" , [] , [] )
+                 AlignRight
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "f4" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "f5" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Para [ Str "f6" ] ]
              ]
          ])
   , Header 2 ( "table-with-multiple-bodies" , [] , [] ) []

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -1222,7 +1222,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       </tbody>
       <tfoot>
         <tr>
-          <td>
+          <td align="right">
             <p>f1</p>
           </td>
           <td>
@@ -1233,6 +1233,39 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tfoot>
+    </table>
+  </sec>
+  <sec id="table-with-multiple-bodies">
+    <table>
+      <col align="left" />
+      <col align="left" />
+      <col align="left" />
+      <tbody>
+        <tr>
+          <td align="right">
+            <p>a1</p>
+          </td>
+          <td>
+            <p>a2</p>
+          </td>
+          <td>
+            <p>a3</p>
+          </td>
+        </tr>
+      </tbody>
+      <tbody>
+        <tr>
+          <td>
+            <p>b1</p>
+          </td>
+          <td>
+            <p>b2</p>
+          </td>
+          <td>
+            <p>b3</p>
+          </td>
+        </tr>
+      </tbody>
     </table>
   </sec>
   <sec id="empty-tables">

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -1214,6 +1214,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
     </table>
   </sec>
   <sec id="table-with-footer">
+    <title>Table with footer</title>
     <table>
       <col align="left" />
       <col align="left" />
@@ -1258,6 +1259,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
     </table>
   </sec>
   <sec id="table-with-multiple-bodies">
+    <title>Table With Multiple Bodies</title>
     <table>
       <col align="left" />
       <col align="left" />

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -961,6 +961,17 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       <thead>
         <tr>
           <th>
+            <p>r1a</p>
+          </th>
+          <th>
+            <p>r1b</p>
+          </th>
+          <th>
+            <p>r1c</p>
+          </th>
+        </tr>
+        <tr>
+          <th>
             <p>X</p>
           </th>
           <th>
@@ -1230,6 +1241,17 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
           <td>
             <p>f3</p>
+          </td>
+        </tr>
+        <tr>
+          <td align="right">
+            <p>f4</p>
+          </td>
+          <td>
+            <p>f5</p>
+          </td>
+          <td>
+            <p>f6</p>
           </td>
         </tr>
       </tfoot>

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -1202,6 +1202,39 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       </tbody>
     </table>
   </sec>
+  <sec id="table-with-footer">
+    <table>
+      <col align="left" />
+      <col align="left" />
+      <col align="left" />
+      <tbody>
+        <tr>
+          <td>
+            <p>1</p>
+          </td>
+          <td>
+            <p>2</p>
+          </td>
+          <td>
+            <p>3</p>
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td>
+            <p>f1</p>
+          </td>
+          <td>
+            <p>f2</p>
+          </td>
+          <td>
+            <p>f3</p>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </sec>
   <sec id="empty-tables">
     <title>Empty Tables</title>
     <p>This section should be empty.</p>


### PR DESCRIPTION
## Description
Fixes: #8765

Essentially the Jats reader was not parsing table footers or multiple bodies, which are both valid jats XML.