### PR TITLE
Fix apparent inaccuracy in MANUAL.txt

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2179,7 +2179,7 @@ The styles may also be mixed in the same template, but the
 opening and closing delimiter must match in each case.  The
 opening delimiter may be followed by one or more spaces
 or tabs, which will be ignored. The closing delimiter may
-be followed by one or more spaces or tabs, which will be
+be preceded by one or more spaces or tabs, which will be
 ignored.
 
 To include a literal `$` in the document, use `$$`.


### PR DESCRIPTION
The section about pandoc's template syntax used to state that
spaces and tabs following the closing delimiter around variables
and control structures will be ignored. Some quick testing with
pandoc version 2.9.2.1 suggests that this is not the case. Spaces
and tabs _preceding_ the closing delimiter, however, are indeed
ignored. I therefore assume that this is simply a slight inaccuracy
in the manual; possibly produced by copying the sentence about the
opening delimiter and forgetting to adjust that word.