### PR TITLE
Fix beamer highlights

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -297,6 +297,15 @@ $-- also used for underline
   \usepackage[soul]{lua-ul}
 \else
   \usepackage{soul}
+$if(beamer)$
+  \makeatletter
+  \let\HL\hl
+  \renewcommand\hl{% fix for beamer highlighting
+    \let\set@color\beamerorig@set@color
+    \let\reset@color\beamerorig@reset@color
+    \HL}
+  \makeatother
+$endif$
 $if(CJKmainfont)$
   \ifXeTeX
     % soul's \st doesn't work for CJK:


### PR DESCRIPTION
Fixing #8803 . The changes introduced in #8707 makes the highlighting works with lualatex, but changes in the template are still needed for pdflatex and xelatex. I tested these changes with pdflatex and lualatex both with standard and beamer output and it works.