### PR TITLE
Add lang attribute to html tag in epub tpl

### DIFF
--- a/data/templates/default.epub2
+++ b/data/templates/default.epub2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ xml:lang="$lang$"$endif$>
+<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="Content-Style-Type" content="text/css" />

--- a/data/templates/default.epub3
+++ b/data/templates/default.epub3
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"$if(lang)$ xml:lang="$lang$"$endif$>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />


### PR DESCRIPTION
Hi,

in default.epub2 and default.epub3 templates, the `lang` attribute is missing in the `<html>` tag (it is there in the default.html4 and default.html5 templates)

This has the effect of raising USAGE(HTM_021) [Content file doesn't contain lang attribute.] when checking the epub with epubcheck. When setting the `lang` attribute, the usage message disappears.

Following https://kb.daisy.org/publishing/docs/html/lang.html
>Is it necessary to specify both the lang and xml:lang attributes?
>
>For optimal accessibility both should be specified when creating XHTML content. Assistive technologies may only recognize one or the other attribute.