### PR TITLE
8764 Writers.OpenDocument: don't lose row header column

### DIFF
--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -442,7 +442,7 @@ blockToOpenDocument o = \case
                                 then numberedTableCaption ident
                                 else unNumberedCaption "TableCaption"
         th <- colHeadsToOpenDocument o (map fst paraHStyles) thead
-        tr <- mapM (tableBodyToOpenDocument o (map fst paraStyles)) tbodies
+        tr <- mapM (tableBodyToOpenDocument o (map fst paraHStyles) (map fst paraStyles)) tbodies
         let tableDoc = inTags True "table:table" [
                             ("table:name"      , name)
                           , ("table:style-name", name)
@@ -506,19 +506,21 @@ colHeadsToOpenDocument o ns (Ann.TableHead _ hs) =
         vcat <$> mapM (tableItemToOpenDocument o "TableHeaderRowCell") (zip ns c)
 
 tableBodyToOpenDocument:: PandocMonad m
-                       => WriterOptions -> [Text] -> Ann.TableBody
+                       => WriterOptions -> [Text] -> [Text] -> Ann.TableBody
                        -> OD m (Doc Text)
-tableBodyToOpenDocument o ns tb =
+tableBodyToOpenDocument o headns bodyns tb =
     let (Ann.TableBody _ _ _ r) = tb
-    in vcat <$> mapM (tableRowToOpenDocument o ns) r
+    in vcat <$> mapM (tableRowToOpenDocument o headns bodyns) r
 
 tableRowToOpenDocument :: PandocMonad m
-                       => WriterOptions -> [Text] -> Ann.BodyRow
+                       => WriterOptions -> [Text] -> [Text] -> Ann.BodyRow
                        -> OD m (Doc Text)
-tableRowToOpenDocument o ns r =
+
+tableRowToOpenDocument o headns bodyns r =
     let (Ann.BodyRow _ _ rowheaders cs) = r
     in inTagsIndented "table:table-row" . vcat <$>
-    mapM (tableItemToOpenDocument o "TableRowCell") (zip ns (rowheaders ++ cs))
+    mapM (tableItemToOpenDocument o "TableRowCell")
+        ((zip headns rowheaders) ++ (zip (drop (length rowheaders) bodyns) cs))
 
 colspanAttrib :: ColSpan -> [(Text, Text)]
 colspanAttrib cs =

--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -516,9 +516,9 @@ tableRowToOpenDocument :: PandocMonad m
                        => WriterOptions -> [Text] -> Ann.BodyRow
                        -> OD m (Doc Text)
 tableRowToOpenDocument o ns r =
-    let (Ann.BodyRow _ _ _ c ) = r
+    let (Ann.BodyRow _ _ rowheaders cs) = r
     in inTagsIndented "table:table-row" . vcat <$>
-    mapM (tableItemToOpenDocument o "TableRowCell") (zip ns c)
+    mapM (tableItemToOpenDocument o "TableRowCell") (zip ns (rowheaders ++ cs))
 
 colspanAttrib :: ColSpan -> [(Text, Text)]
 colspanAttrib cs =

--- a/test/command/8764.md
+++ b/test/command/8764.md
@@ -1,0 +1,50 @@
+```
+% pandoc -f html -t opendocument
+<table>
+  <tbody>
+    <tr>
+      <th>Header</th>
+      <td>Normal cell (column 2)</td>
+      <td>Normal cell (column 3)</td>
+    </tr>
+    <tr>
+      <td>Normal cell (column 1)</td>
+      <td>Normal cell (column 2)</td>
+      <td>Normal cell (column 3)</td>
+    </tr>
+  </tbody>
+</table>
+^D
+<table:table table:name="Table1" table:style-name="Table1">
+  <table:table-column table:style-name="Table1.A" />
+  <table:table-column table:style-name="Table1.B" />
+  <table:table-column table:style-name="Table1.C" />
+  <table:table-row>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="Table_20_Contents">Header</text:p>
+    </table:table-cell>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="Table_20_Contents">Normal cell (column
+      2)</text:p>
+    </table:table-cell>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="Table_20_Contents">Normal cell (column
+      3)</text:p>
+    </table:table-cell>
+  </table:table-row>
+  <table:table-row>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="Table_20_Contents">Normal cell (column
+      1)</text:p>
+    </table:table-cell>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="Table_20_Contents">Normal cell (column
+      2)</text:p>
+    </table:table-cell>
+    <table:table-cell table:style-name="TableRowCell" office:value-type="string">
+      <text:p text:style-name="Table_20_Contents">Normal cell (column
+      3)</text:p>
+    </table:table-cell>
+  </table:table-row>
+</table:table>
+```

--- a/test/command/8764.md
+++ b/test/command/8764.md
@@ -21,7 +21,7 @@
   <table:table-column table:style-name="Table1.C" />
   <table:table-row>
     <table:table-cell table:style-name="TableRowCell" office:value-type="string">
-      <text:p text:style-name="Table_20_Contents">Header</text:p>
+      <text:p text:style-name="Table_20_Heading">Header</text:p>
     </table:table-cell>
     <table:table-cell table:style-name="TableRowCell" office:value-type="string">
       <text:p text:style-name="Table_20_Contents">Normal cell (column
@@ -34,7 +34,7 @@
   </table:table-row>
   <table:table-row>
     <table:table-cell table:style-name="TableRowCell" office:value-type="string">
-      <text:p text:style-name="Table_20_Contents">Normal cell (column
+      <text:p text:style-name="Table_20_Heading">Normal cell (column
       1)</text:p>
     </table:table-cell>
     <table:table-cell table:style-name="TableRowCell" office:value-type="string">


### PR DESCRIPTION
not sure if the 2nd commit is a good idea, guess it depends on how "common" various different shapes of HTML (or other) tables are, please read the commit message...