### PR TITLE
PandocMonad: allow nested data files

### DIFF
--- a/src/Text/Pandoc/Class/PandocMonad.hs
+++ b/src/Text/Pandoc/Class/PandocMonad.hs
@@ -417,16 +417,19 @@ findFileWithDataFallback subdir fp = do
   existsInWorkingDir <- fileExists fp
   if existsInWorkingDir
      then return $ Just fp
-     else do
-       mbDataDir <- checkUserDataDir fp
-       case mbDataDir of
-         Nothing -> return Nothing
-         Just datadir -> do
-           let datafp = datadir </> subdir </> fp
-           existsInDataDir <- fileExists datafp
-           return $ if existsInDataDir
-                    then Just datafp
-                    else Nothing
+     else checkUserDataDir fp >>= findInDataDir
+ where
+  findInDataDir Nothing = pure Nothing
+  findInDataDir (Just datadir) = do
+    let datafp = datadir </> subdir </> fp
+    let nested = datadir </> subdir </> dropExtension fp </> fp
+    existsInDataDir <- fileExists datafp
+    nestedInDataDir <- fileExists nested
+    return $
+      case () of
+        _ | existsInDataDir -> Just datafp
+        _ | nestedInDataDir -> Just nested
+        _ -> Nothing
 
 -- | Traverse tree, filling media bag for any images that
 -- aren't already in the media bag.


### PR DESCRIPTION
Data file fallbacks are now also searched in the directory that has the same name as the file minus the extension. For example, a filter with name `frob.lua` will be searched in `$DATADIR/filters/frob.lua` as well as in `$DATADIR/filters/frob/frob.lua`.

This allows to place full git repositories in the data directory.

Closes: #6635