### PR TITLE
Improve title and label parsing in the Jats reader

### DIFF
--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -170,19 +170,7 @@ parseBlock (Elem e) = do
         "code" -> codeBlockWithLang
         "preformat" -> codeBlockWithLang
         "disp-quote" -> parseWithHeader (sectionLevel+1) parseBlockquote
-        "list" ->  parseWithHeader (sectionLevel+1)
-          ( case attrValue "list-type" e of
-              "bullet" -> bulletList <$> listitems
-              listType -> do
-                let start =
-                      fromMaybe 1 $
-                        ( filterElement (named "list-item") e
-                            >>= filterElement (named "label")
-                        )
-                          >>= safeRead . textContent
-                orderedListWith (start, parseListStyleType listType, DefaultDelim)
-                  <$> listitems
-          )
+        "list" ->  parseWithHeader (sectionLevel+1) parseList
         "def-list" -> parseWithHeader (sectionLevel+1) (definitionList <$> deflistitems)
         "sec" -> parseBlockWithHeader
         "abstract" -> parseBlockWithHeader
@@ -254,6 +242,18 @@ parseBlock (Elem e) = do
                                               mapM parseInline (elContent z)
             contents <- getBlocks e
             return $ blockQuote (contents <> attrib)
+         parseList = do
+            case attrValue "list-type" e of
+              "bullet" -> bulletList <$> listitems
+              listType -> do
+                let start =
+                      fromMaybe 1 $
+                        ( filterElement (named "list-item") e
+                            >>= filterElement (named "label")
+                        )
+                          >>= safeRead . textContent
+                orderedListWith (start, parseListStyleType listType, DefaultDelim)
+                  <$> listitems
          parseListStyleType "roman-lower" = LowerRoman
          parseListStyleType "roman-upper" = UpperRoman
          parseListStyleType "alpha-lower" = LowerAlpha

--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -161,23 +161,54 @@ parseBlock (Text (CData _ s _)) = if T.all isSpace s
                                      then return mempty
                                      else return $ plain $ trimInlines $ text s
 parseBlock (CRef x) = return $ plain $ str $ T.toUpper x
-parseBlock (Elem e) =
+parseBlock (Elem e) = do
+  sectionLevel <- gets jatsSectionLevel 
+  let parseBlockWithHeader = parseWithHeader (sectionLevel+1) (getBlocks e)
+
   case qName (elName e) of
         "p" -> parseMixed para (elContent e)
         "code" -> codeBlockWithLang
         "preformat" -> codeBlockWithLang
-        "disp-quote" -> parseBlockquote
-        "list" -> case attrValue "list-type" e of
-                    "bullet" -> bulletList <$> listitems
-                    listType -> do
-                      let start = fromMaybe 1 $
-                                  (filterElement (named "list-item") e
-                                               >>= filterElement (named "label"))
-                                   >>= safeRead . textContent
-                      orderedListWith (start, parseListStyleType listType, DefaultDelim)
-                        <$> listitems
-        "def-list" -> definitionList <$> deflistitems
-        "sec" -> gets jatsSectionLevel >>= sect . (+1)
+        "disp-quote" -> parseWithHeader (sectionLevel+1) parseBlockquote
+        "list" ->  parseWithHeader (sectionLevel+1)
+          ( case attrValue "list-type" e of
+              "bullet" -> bulletList <$> listitems
+              listType -> do
+                let start =
+                      fromMaybe 1 $
+                        ( filterElement (named "list-item") e
+                            >>= filterElement (named "label")
+                        )
+                          >>= safeRead . textContent
+                orderedListWith (start, parseListStyleType listType, DefaultDelim)
+                  <$> listitems
+          )
+        "def-list" -> parseWithHeader (sectionLevel+1) (definitionList <$> deflistitems)
+        "sec" -> parseBlockWithHeader
+        "abstract" -> parseBlockWithHeader
+        "ack" -> parseBlockWithHeader
+        "answer" -> parseBlockWithHeader
+        "answer-set" -> parseBlockWithHeader
+        "app" -> parseBlockWithHeader
+        "app-group" -> parseBlockWithHeader
+        "author-comment" -> parseBlockWithHeader
+        "author-notes" -> parseBlockWithHeader
+        "back" -> parseBlockWithHeader
+        "bio" -> parseBlockWithHeader
+        "explanation" -> parseBlockWithHeader
+        "glossary" -> parseBlockWithHeader
+        "kwd-group" -> parseBlockWithHeader
+        "list-item" -> parseBlockWithHeader
+        "notes" -> parseBlockWithHeader
+        "option" -> parseBlockWithHeader
+        "question" -> parseBlockWithHeader
+        "question-preamble" -> parseBlockWithHeader
+        "question-wrap-group" -> parseBlockWithHeader
+        "statement" -> parseBlockWithHeader
+        "supplement" -> parseBlockWithHeader
+        "table-wrap-foot" -> parseBlockWithHeader
+        "trans-abstract" -> parseBlockWithHeader
+        "verse-group" -> parseBlockWithHeader
         "graphic" -> para <$> getGraphic Nothing e
         "journal-meta" -> parseMetadata e
         "article-meta" -> parseMetadata e
@@ -194,7 +225,7 @@ parseBlock (Elem e) =
           inFigure <- gets jatsInFigure
           if inFigure -- handled by parseFigure
              then return mempty
-             else divWith (attrValue "id" e, ["caption"], []) <$> sect 6
+             else divWith (attrValue "id" e, ["caption"], []) <$> parseWithHeader 6 (getBlocks e)
         "fn-group" -> parseFootnoteGroup
         "ref-list" -> parseRefList e
         "?xml"  -> return mempty
@@ -321,24 +352,28 @@ parseBlock (Elem e) =
                                      (TableFoot nullAttr [])
          isEntry x  = named "entry" x || named "td" x || named "th" x
          parseElement = filterChildren isEntry
-         sect n = do isbook <- gets jatsBook
-                     let n' = if isbook || n == 0 then n + 1 else n
-                     labelText <- case filterChild (named "label") e of
-                                    Just t -> (<> ("." <> space)) <$>
-                                              getInlines t
-                                    Nothing -> return mempty
-                     headerText <- case filterChild (named "title") e `mplus`
-                                        (filterChild (named "info") e >>=
-                                            filterChild (named "title")) of
-                                      Just t  -> (labelText <>) <$>
-                                                  getInlines t
-                                      Nothing -> return mempty
-                     oldN <- gets jatsSectionLevel
-                     modify $ \st -> st{ jatsSectionLevel = n }
-                     b <- getBlocks e
-                     let ident = attrValue "id" e
-                     modify $ \st -> st{ jatsSectionLevel = oldN }
-                     return $ headerWith (ident,[],[]) n' headerText <> b
+         parseWithHeader n mBlocks = do 
+                            isbook <- gets jatsBook
+                            let n' = if isbook || n == 0 then n + 1 else n
+                            labelText <- case filterChild (named "label") e of
+                                            Just t -> (<> ("." <> space)) <$>
+                                                      getInlines t
+                                            Nothing -> return mempty
+                            headerText <- case filterChild (named "title") e `mplus`
+                                                (filterChild (named "info") e >>=
+                                                    filterChild (named "title")) of
+                                              Just t  -> (labelText <>) <$>
+                                                          getInlines t
+                                              Nothing -> return labelText
+                            oldN <- gets jatsSectionLevel
+                            modify $ \st -> st{ jatsSectionLevel = n }
+                            blocks <- mBlocks
+                            let ident = attrValue "id" e
+                            modify $ \st -> st{ jatsSectionLevel = oldN }
+                            return $ (if 
+                              headerText == mempty 
+                            then mempty 
+                            else headerWith (ident,[],[]) n' headerText) <> blocks
 
 getInlines :: PandocMonad m => Element -> JATS m Inlines
 getInlines e' = trimInlines . mconcat <$>

--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -163,15 +163,15 @@ parseBlock (Text (CData _ s _)) = if T.all isSpace s
 parseBlock (CRef x) = return $ plain $ str $ T.toUpper x
 parseBlock (Elem e) = do
   sectionLevel <- gets jatsSectionLevel 
-  let parseBlockWithHeader = parseWithHeader (sectionLevel+1) (getBlocks e)
+  let parseBlockWithHeader = wrapWithHeader (sectionLevel+1) (getBlocks e)
 
   case qName (elName e) of
         "p" -> parseMixed para (elContent e)
         "code" -> codeBlockWithLang
         "preformat" -> codeBlockWithLang
-        "disp-quote" -> parseWithHeader (sectionLevel+1) parseBlockquote
-        "list" ->  parseWithHeader (sectionLevel+1) parseList
-        "def-list" -> parseWithHeader (sectionLevel+1) (definitionList <$> deflistitems)
+        "disp-quote" -> wrapWithHeader (sectionLevel+1) parseBlockquote
+        "list" ->  wrapWithHeader (sectionLevel+1) parseList
+        "def-list" -> wrapWithHeader (sectionLevel+1) (definitionList <$> deflistitems)
         "sec" -> parseBlockWithHeader
         "abstract" -> parseBlockWithHeader
         "ack" -> parseBlockWithHeader
@@ -213,7 +213,7 @@ parseBlock (Elem e) = do
           inFigure <- gets jatsInFigure
           if inFigure -- handled by parseFigure
              then return mempty
-             else divWith (attrValue "id" e, ["caption"], []) <$> parseWithHeader 6 (getBlocks e)
+             else divWith (attrValue "id" e, ["caption"], []) <$> wrapWithHeader 6 (getBlocks e)
         "fn-group" -> parseFootnoteGroup
         "ref-list" -> parseRefList e
         "?xml"  -> return mempty
@@ -352,7 +352,7 @@ parseBlock (Elem e) = do
                                      (TableFoot nullAttr [])
          isEntry x  = named "entry" x || named "td" x || named "th" x
          parseElement = filterChildren isEntry
-         parseWithHeader n mBlocks = do 
+         wrapWithHeader n mBlocks = do 
                             isbook <- gets jatsBook
                             let n' = if isbook || n == 0 then n + 1 else n
                             labelText <- case filterChild (named "label") e of

--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -353,27 +353,22 @@ parseBlock (Elem e) = do
          isEntry x  = named "entry" x || named "td" x || named "th" x
          parseElement = filterChildren isEntry
          wrapWithHeader n mBlocks = do 
-                            isbook <- gets jatsBook
-                            let n' = if isbook || n == 0 then n + 1 else n
-                            labelText <- case filterChild (named "label") e of
-                                            Just t -> (<> ("." <> space)) <$>
-                                                      getInlines t
-                                            Nothing -> return mempty
-                            headerText <- case filterChild (named "title") e `mplus`
-                                                (filterChild (named "info") e >>=
-                                                    filterChild (named "title")) of
-                                              Just t  -> (labelText <>) <$>
-                                                          getInlines t
-                                              Nothing -> return labelText
-                            oldN <- gets jatsSectionLevel
-                            modify $ \st -> st{ jatsSectionLevel = n }
-                            blocks <- mBlocks
-                            let ident = attrValue "id" e
-                            modify $ \st -> st{ jatsSectionLevel = oldN }
-                            return $ (if 
-                              headerText == mempty 
-                            then mempty 
-                            else headerWith (ident,[],[]) n' headerText) <> blocks
+                      isBook <- gets jatsBook
+                      let n' = if isBook || n == 0 then n + 1 else n
+                      headerText <- case filterChild (named "title") e `mplus`
+                                          (filterChild (named "info") e >>=
+                                              filterChild (named "title")) of
+                                        Just t  -> getInlines t
+                                        Nothing -> return mempty
+                      oldN <- gets jatsSectionLevel
+                      modify $ \st -> st{ jatsSectionLevel = n }
+                      blocks <- mBlocks
+                      let ident = attrValue "id" e
+                      modify $ \st -> st{ jatsSectionLevel = oldN }
+                      return $ (if 
+                        headerText == mempty 
+                      then mempty 
+                      else headerWith (ident,[],[]) n' headerText) <> blocks
 
 getInlines :: PandocMonad m => Element -> JATS m Inlines
 getInlines e' = trimInlines . mconcat <$>

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -226,6 +226,37 @@ Pandoc
       , LineBreak
       , Str "here."
       ]
+  , Header 1 ( "statements" , [] , [] ) [ Str "Statements" ]
+  , Header
+      2
+      ( "" , [] , [] )
+      [ Str "A"
+      , Space
+      , Str "label"
+      , Space
+      , Str "for"
+      , Space
+      , Str "a"
+      , Space
+      , Str "statment."
+      , Space
+      , Str "CAP"
+      , Space
+      , Str "TITLE"
+      ]
+  , Para
+      [ Str "Some"
+      , Space
+      , Str "text"
+      , Space
+      , Str "to"
+      , Space
+      , Str "make"
+      , Space
+      , Str "this"
+      , Space
+      , Str "regular"
+      ]
   , Header
       1
       ( "block-quotes" , [] , [] )

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -228,22 +228,7 @@ Pandoc
       ]
   , Header 1 ( "statements" , [] , [] ) [ Str "Statements" ]
   , Header
-      2
-      ( "" , [] , [] )
-      [ Str "A"
-      , Space
-      , Str "label"
-      , Space
-      , Str "for"
-      , Space
-      , Str "a"
-      , Space
-      , Str "statment."
-      , Space
-      , Str "CAP"
-      , Space
-      , Str "TITLE"
-      ]
+      2 ( "" , [] , [] ) [ Str "CAP" , Space , Str "TITLE" ]
   , Para
       [ Str "Some"
       , Space

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -69,6 +69,14 @@
   <p>Here's one with a bullet. * criminey.</p>
   <p>There should be a hard line break<break />here.</p>
 </sec>
+<sec id="statements">
+  <title> Statements </title>
+  <statement>
+    <label> A label for a statment</label>
+    <title> CAP TITLE </title>
+    <p> Some text to make this regular </p>
+  </statement>
+</sec>
 <sec id="block-quotes">
   <title>Block Quotes</title>
   <p>E-mail style:</p>


### PR DESCRIPTION
Fixes #8718

## Description
There were a number of elements where the jats reader did not parse their `title` and `label` into headers. This PR fixes that