### PR TITLE
doc/lua-filters: use full field name in example

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -42,7 +42,7 @@ to small caps:
 return {
   {
     Strong = function (elem)
-      return pandoc.SmallCaps(elem.c)
+      return pandoc.SmallCaps(elem.content)
     end,
   }
 }
@@ -52,7 +52,7 @@ or equivalently,
 
 ``` lua
 function Strong(elem)
-  return pandoc.SmallCaps(elem.c)
+  return pandoc.SmallCaps(elem.content)
 end
 ```
 


### PR DESCRIPTION
Remove old `.c` alias that mimics the JSON representation:
- Since 2.15ish, the lua structure no longer closely resembles that JSON representation
- even if it did, introductory examples should be explicit. Using an undocumented alias creates ambiguity.