### PR TITLE
Fix for #8869 in addition to proper handling of quoted header args in Org

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Blocks.hs
+++ b/src/Text/Pandoc/Readers/Org/Blocks.hs
@@ -415,7 +415,7 @@ blockOption = try $ do
   return (argKey, paramValue)
 
 orgParamValue :: Monad m => OrgParser m Text
-orgParamValue = try $ fmap T.pack $
+orgParamValue = try $ fmap (stripQuotes . T.pack) $
   skipSpaces
     *> notFollowedBy orgArgKey
     *> noneOf "\n\r" `many1Till` endOfValue
@@ -423,6 +423,9 @@ orgParamValue = try $ fmap T.pack $
  where
   endOfValue = lookAhead $  try (skipSpaces <* oneOf "\n\r")
                         <|> try (skipSpaces1 <* orgArgKey)
+
+  stripQuotes :: Text -> Text
+  stripQuotes = T.dropAround (== '\"')
 
 
 --

--- a/src/Text/Pandoc/Readers/Org/Blocks.hs
+++ b/src/Text/Pandoc/Readers/Org/Blocks.hs
@@ -415,18 +415,18 @@ blockOption = try $ do
   return (argKey, paramValue)
 
 orgParamValue :: Monad m => OrgParser m Text
-orgParamValue = try $ fmap (stripQuotes . T.pack) $
+orgParamValue = try $ fmap T.pack $
   skipSpaces
     *> notFollowedBy orgArgKey
-    *> noneOf "\n\r" `many1Till` endOfValue
+    *> (quotedValue <|> regularValue)
     <* skipSpaces
  where
   endOfValue = lookAhead $  try (skipSpaces <* oneOf "\n\r")
                         <|> try (skipSpaces1 <* orgArgKey)
 
-  stripQuotes :: Text -> Text
-  stripQuotes = T.dropAround (== '\"')
+  quotedValue = char '\"' *> manyTill anyChar (char '\"')
 
+  regularValue = noneOf "\n\r" `many1Till` endOfValue
 
 --
 -- Drawers

--- a/test/Tests/Readers/Org/Block/CodeBlock.hs
+++ b/test/Tests/Readers/Org/Block/CodeBlock.hs
@@ -202,4 +202,18 @@ tests =
                     , ("city", "Zürich")
                     ]
       in codeBlockWith ( "", ["c"], params) "code body\n"
+
+  , "Header args with quotes" =:
+     T.unlines [ "#+begin_src haskell :exports \"both\" :tangle \"main.hs\""
+               , "main :: IO ()"
+               , "main = putStrLn \"Hello, World!\""
+               , "#+end_src"
+               ] =?>
+     let params  = [ ("org-language", "haskell")
+                   , ("exports", "both")
+                   , ("tangle", "main.hs")
+                   ]
+     in codeBlockWith ("", ["haskell"], params)
+        "main :: IO ()\nmain = putStrLn \"Hello, World!\"\n"
+
   ]

--- a/test/Tests/Readers/Org/Block/CodeBlock.hs
+++ b/test/Tests/Readers/Org/Block/CodeBlock.hs
@@ -209,11 +209,21 @@ tests =
                , "main = putStrLn \"Hello, World!\""
                , "#+end_src"
                ] =?>
-     let params  = [ ("org-language", "haskell")
-                   , ("exports", "both")
+     let params  = [ ("exports", "both")
                    , ("tangle", "main.hs")
                    ]
      in codeBlockWith ("", ["haskell"], params)
         "main :: IO ()\nmain = putStrLn \"Hello, World!\"\n"
 
+  , "Header args with colon" =:
+     T.unlines [ "#+begin_src haskell :exports \"both\" :session \"my :session\""
+               , "main :: IO ()"
+               , "main = putStrLn \"Hello, World!\""
+               , "#+end_src"
+               ] =?>
+     let params  = [ ("exports", "both")
+                   , ("session", "my :session")
+                   ]
+     in codeBlockWith ("", ["haskell"], params)
+        "main :: IO ()\nmain = putStrLn \"Hello, World!\"\n"
   ]


### PR DESCRIPTION
In addition to fixing #8869, this should also properly handle cases such as

```org
#+begin_src python :session "my :session"
...
#+end_src
```

which is valid Org but is currently not supported by pandoc.

Note that this is, I believe, the first time I've actually touched Haskell, so feel free to make changes:) But at least my test cases seem to pass nicely now :+1: 