### PR TITLE
Fix for #8788: update boolean flags to take an optional 'true' or 'false' value

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -415,7 +415,7 @@ header when requesting a document from a URL:
 
 :   Suppress warning messages.
 
-`--fail-if-warnings`
+`--fail-if-warnings[=true|false]`
 
 :   Exit with error status if there are any warnings.
 
@@ -559,7 +559,7 @@ header when requesting a document from a URL:
     require different kinds of images.  Currently this option only affects
     the Markdown and LaTeX readers.
 
-`--file-scope`
+`--file-scope[=true|false]`
 
 :   Parse each file individually before combining for multifile
     documents. This will allow footnotes in different files with the
@@ -670,7 +670,7 @@ header when requesting a document from a URL:
     for first in the working directory, and then in the `metadata`
     subdirectory of the user data directory (see `--data-dir`).
 
-`-p`, `--preserve-tabs`
+`-p`, `--preserve-tabs[=true|false]`
 
 :   Preserve tabs instead of converting them to spaces. (By default, pandoc
     converts tabs to spaces before parsing its input.)  Note that this will
@@ -723,7 +723,7 @@ header when requesting a document from a URL:
     space, and the period will not produce sentence-ending space
     in formats like LaTeX.  The strings may not contain spaces.
 
-`--trace`
+`--trace[=true|false]`
 
 :   Print diagnostic output tracing parser progress to stderr.
     This option is intended for use by developers in diagnosing
@@ -763,7 +763,7 @@ header when requesting a document from a URL:
     document in standalone mode. If no *VAL* is specified, the
     key will be given the value `true`.
 
-`--sandbox`
+`--sandbox[=true|false]`
 
 :   Run pandoc in a sandbox, limiting IO operations in readers
     and writers to reading the files specified on the command line.
@@ -837,7 +837,7 @@ header when requesting a document from a URL:
     in the generated source code (see `--wrap`).  It also affects
     calculation of column widths for plain text tables (see [Tables] below).
 
-`--toc`, `--table-of-contents`
+`--toc[=true|false]`, `--table-of-contents[=true|false]`
 
 :   Include an automatically generated table of contents (or, in
     the case of `latex`, `context`, `docx`, `odt`,
@@ -858,7 +858,7 @@ header when requesting a document from a URL:
     of contents.  The default is 3 (which means that level-1, 2, and 3
     headings will be listed in the contents).
 
-`--strip-comments`
+`--strip-comments[=true|false]`
 
 :   Strip out HTML comments in the Markdown or Textile source,
     rather than passing them on to Markdown, Textile or HTML
@@ -956,7 +956,7 @@ header when requesting a document from a URL:
     downloaded). If you're behind a proxy, you also need to set
     the environment variable `http_proxy` to `http://...`.
 
-`--no-check-certificate`
+`--no-check-certificate[=true|false]`
 
 :   Disable the certificate verification to allow access to
     unsecure HTTP resources (for example when the certificate
@@ -964,11 +964,11 @@ header when requesting a document from a URL:
 
 ## Options affecting specific writers {.options}
 
-`--self-contained`
+`--self-contained[=true|false]`
 
 :   *Deprecated synonym for `--embed-resources --standalone`.*
 
-`--embed-resources`
+`--embed-resources[=true|false]`
 
 :   Produce a standalone HTML file with no external dependencies, using
     `data:` URIs to incorporate the contents of linked scripts, stylesheets,
@@ -989,13 +989,13 @@ header when requesting a document from a URL:
     advanced features (e.g.  zoom or speaker notes) may not work
     in an offline "self-contained" `reveal.js` slide show.
 
-`--html-q-tags`
+`--html-q-tags[=true|false]`
 
 :   Use `<q>` tags for quotes in HTML.  (This option only has an
     effect if the `smart` extension is enabled for the input
     format used.)
 
-`--ascii`
+`--ascii[=true|false]`
 
 :   Use only ASCII characters in output. Currently supported for XML
     and HTML formats (which use entities instead of UTF-8 when this
@@ -1004,7 +1004,7 @@ header when requesting a document from a URL:
     limited degree LaTeX (which uses standard commands for accented
     characters when possible).
 
-`--reference-links`
+`--reference-links[=true|false]`
 
 :   Use reference-style links, rather than inline links, in writing Markdown
     or reStructuredText.  By default inline links are used.  The
@@ -1030,7 +1030,7 @@ header when requesting a document from a URL:
     ATX-style headings are always used for levels 3+.
     This option also affects Markdown cells in `ipynb` output.
 
-`--list-tables`
+`--list-tables[=true|false]`
 
 :   Render tables as list tables in RST output.
 
@@ -1068,14 +1068,14 @@ header when requesting a document from a URL:
     be numbered "1.5", specify `--number-offset=1,4`.
     Offsets are 0 by default.  Implies `--number-sections`.
 
-`--listings`
+`--listings[=true|false]`
 
 :   Use the [`listings`] package for LaTeX code blocks. The package
     does not support multi-byte encoding for source code. To handle UTF-8
     you would need to use a custom template. This issue is fully
     documented here: [Encoding issue with the listings package].
 
-`-i`, `--incremental`
+`-i`, `--incremental[=true|false]`
 
 :   Make list items in slide shows display incrementally (one by one).
     The default is for lists to be displayed all at once.
@@ -1092,7 +1092,7 @@ header when requesting a document from a URL:
     explicitly, the slide level will be set automatically based on
     the contents of the document; see [Structuring the slide show].
 
-`--section-divs`
+`--section-divs[=true|false]`
 
 :   Wrap sections in `<section>` tags (or `<div>` tags for `html4`),
     and attach identifiers to the enclosing `<section>` (or `<div>`)
@@ -1528,7 +1528,7 @@ results only for basic math, usually you will want to use
 
 ## Options for wrapper scripts {.options}
 
-`--dump-args`
+`--dump-args[=true|false]`
 
 :   Print information about command-line arguments to *stdout*, then exit.
     This option is intended primarily for use in wrapper scripts.
@@ -1539,7 +1539,7 @@ results only for basic math, usually you will want to use
     pandoc options and their arguments, but do include any options appearing
     after a `--` separator at the end of the line.
 
-`--ignore-args`
+`--ignore-args[=true|false]`
 
 :   Ignore command-line arguments (for use in wrapper scripts).
     Regular pandoc options are not ignored.  Thus, for example,

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -297,7 +297,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optFileScope = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Parse input files before combining"
 
     , Option "" ["sandbox"]
@@ -305,7 +305,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optSandbox = boolValue })
-                  "[true|false]")
+                  "true|false")
                  ""
 
     , Option "s" ["standalone"]
@@ -313,7 +313,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optStandalone = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Include needed header and footer on output"
 
     , Option "" ["template"]
@@ -350,7 +350,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optAscii = boolValue })
-                  "[true|false]")
+                  "true|false")
                  ""  -- "Prefer ASCII output"
 
     , Option "" ["toc", "table-of-contents"]
@@ -358,7 +358,7 @@ options =
                  (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optTableOfContents = boolValue })
-                 "[true|false]")
+                 "true|false")
                "" -- "Include table of contents"
 
     , Option "" ["toc-depth"]
@@ -505,7 +505,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optPreserveTabs = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Preserve tabs instead of converting to spaces"
 
     , Option "" ["tab-stop"]
@@ -552,7 +552,7 @@ options =
                         deprecatedOption "--self-contained" "use --embed-resources --standalone"
                         boolValue <- readBoolFromOptArg arg
                         return opt { optSelfContained = boolValue })
-                    "[true|false]")
+                    "true|false")
                  "" -- "Make slide shows include all the needed js and css (deprecated)"
 
     , Option "" ["embed-resources"] -- maybe True (\argStr -> argStr == "true") arg
@@ -560,7 +560,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optEmbedResources =  boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Make slide shows include all the needed js and css"
 
     , Option "" ["request-header"]
@@ -577,7 +577,7 @@ options =
                  (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optNoCheckCertificate = boolValue })
-                 "[true|false]")
+                 "true|false")
                 "" -- "Disable certificate validation"
 
     , Option "" ["abbreviations"]
@@ -657,7 +657,7 @@ options =
                  (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optStripComments = boolValue })
-                 "[true|false]")
+                 "true|false")
                "" -- "Strip HTML comments"
 
     , Option "" ["reference-links"]
@@ -665,7 +665,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optReferenceLinks = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Use reference links in parsing HTML"
 
     , Option "" ["reference-location"]
@@ -700,7 +700,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optListTables = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Use list tables for RST"
 
     , Option "" ["listings"]
@@ -708,7 +708,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optListings = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Use listings package for LaTeX code blocks"
 
     , Option "i" ["incremental"]
@@ -716,7 +716,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optIncremental = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Make list items display incrementally in Slidy/Slideous/S5"
 
     , Option "" ["slide-level"]
@@ -735,7 +735,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optSectionDivs = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Put sections in div tags in HTML"
 
     , Option "" ["html-q-tags"]
@@ -743,7 +743,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optHtmlQTags = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Use <q> tags for quotes in HTML"
 
     , Option "" ["email-obfuscation"]
@@ -957,7 +957,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optTrace = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Turn on diagnostic tracing in readers."
 
     , Option "" ["dump-args"]
@@ -965,7 +965,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optDumpArgs = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Print output filename and arguments to stdout."
 
     , Option "" ["ignore-args"]
@@ -973,7 +973,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optIgnoreArgs = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Ignore command-line arguments."
 
     , Option "" ["verbose"]
@@ -991,7 +991,7 @@ options =
                   (\arg opt -> do
                         boolValue <- readBoolFromOptArg arg
                         return opt { optFailIfWarnings = boolValue })
-                  "[true|false]")
+                  "true|false")
                  "" -- "Exit with error status if there were  warnings."
 
     , Option "" ["log"]

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -293,18 +293,30 @@ options =
                 ""
 
     , Option "" ["file-scope"]
-                 (NoArg
-                  (\opt -> return opt { optFileScope = True }))
+                 (OptArg
+                  (\arg opt -> 
+                    case readBoolFromOptArg arg of 
+                        Just boolValue -> return opt { optFileScope = boolValue }
+                        Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Parse input files before combining"
 
     , Option "" ["sandbox"]
-                 (NoArg
-                  (\opt -> return opt { optSandbox = True }))
+                 (OptArg
+                  (\arg opt -> 
+                       case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optSandbox = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  ""
 
     , Option "s" ["standalone"]
-                 (NoArg
-                  (\opt -> return opt { optStandalone = True }))
+                 (OptArg
+                  (\arg opt -> 
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optStandalone = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Include needed header and footer on output"
 
     , Option "" ["template"]
@@ -337,13 +349,21 @@ options =
                  "" -- "Option for wrapping text in output"
 
     , Option "" ["ascii"]
-                 (NoArg
-                  (\opt -> return opt { optAscii = True }))
+                 (OptArg
+                  (\arg opt -> 
+                       case readBoolFromOptArg arg of 
+                          Just boolValue -> return opt { optAscii = boolValue }
+                          Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  ""  -- "Prefer ASCII output"
 
     , Option "" ["toc", "table-of-contents"]
-                (NoArg
-                 (\opt -> return opt { optTableOfContents = True }))
+                (OptArg
+                 (\arg opt -> 
+                      case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optTableOfContents = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                 "[true|false]")
                "" -- "Include table of contents"
 
     , Option "" ["toc-depth"]
@@ -486,8 +506,12 @@ options =
                  "" -- "Length of line in characters"
 
     , Option "p" ["preserve-tabs"]
-                 (NoArg
-                  (\opt -> return opt { optPreserveTabs = True }))
+                 (OptArg
+                  (\arg opt -> 
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optPreserveTabs = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Preserve tabs instead of converting to spaces"
 
     , Option "" ["tab-stop"]
@@ -529,16 +553,22 @@ options =
                  "" -- "Path of custom reference doc"
 
     , Option "" ["self-contained"]
-                 (NoArg
-                  (\opt -> do
+                 (OptArg
+                  (\arg opt -> do
                     deprecatedOption "--self-contained" "use --embed-resources --standalone"
-                    return opt { optSelfContained = True }))
+                    case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optSelfContained = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                    "[true|false]")
                  "" -- "Make slide shows include all the needed js and css (deprecated)"
 
-    , Option "" ["embed-resources"]
+    , Option "" ["embed-resources"] -- maybe True (\argStr -> argStr == "true") arg
                  (OptArg
-                  (\arg opt -> return opt { optEmbedResources = maybe True (\argStr -> argStr == "true") arg })
-                  "STRING")
+                  (\arg opt -> 
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optEmbedResources =  boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Make slide shows include all the needed js and css"
 
     , Option "" ["request-header"]
@@ -551,8 +581,12 @@ options =
                  ""
 
     , Option "" ["no-check-certificate"]
-                (NoArg
-                 (\opt -> return opt { optNoCheckCertificate = True }))
+                (OptArg
+                 (\arg opt -> 
+                       case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optNoCheckCertificate = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                 "[true|false]")
                 "" -- "Disable certificate validation"
 
     , Option "" ["abbreviations"]
@@ -628,13 +662,21 @@ options =
                  "" -- "Accepting or reject MS Word track-changes.""
 
     , Option "" ["strip-comments"]
-                (NoArg
-                 (\opt -> return opt { optStripComments = True }))
+                (OptArg
+                 (\arg opt -> 
+                      case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optStripComments = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                 "[true|false]")
                "" -- "Strip HTML comments"
 
     , Option "" ["reference-links"]
-                 (NoArg
-                  (\opt -> return opt { optReferenceLinks = True } ))
+                 (OptArg
+                  (\arg opt ->  
+                      case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optReferenceLinks = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Use reference links in parsing HTML"
 
     , Option "" ["reference-location"]
@@ -665,19 +707,30 @@ options =
                   ""
 
     , Option "" ["list-tables"]
-                 (NoArg
-                  (\opt -> do
-                    return opt { optListTables = True } ))
+                 (OptArg
+                  (\arg opt ->  
+                        case readBoolFromOptArg arg of 
+                            Just boolValue -> return opt { optListTables = boolValue }
+                            Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Use list tables for RST"
 
     , Option "" ["listings"]
-                 (NoArg
-                  (\opt -> return opt { optListings = True }))
+                 (OptArg
+                  (\arg opt -> 
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optListings = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Use listings package for LaTeX code blocks"
 
     , Option "i" ["incremental"]
-                 (NoArg
-                  (\opt -> return opt { optIncremental = True }))
+                 (OptArg
+                  (\arg opt -> 
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optIncremental = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Make list items display incrementally in Slidy/Slideous/S5"
 
     , Option "" ["slide-level"]
@@ -692,14 +745,21 @@ options =
                  "" -- "Force header level for slides"
 
     , Option "" ["section-divs"]
-                 (NoArg
-                  (\opt -> return opt { optSectionDivs = True }))
+                 (OptArg
+                  (\arg opt -> 
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optSectionDivs = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Put sections in div tags in HTML"
 
     , Option "" ["html-q-tags"]
-                 (NoArg
-                  (\opt ->
-                     return opt { optHtmlQTags = True }))
+                 (OptArg
+                  (\arg opt -> 
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optHtmlQTags = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Use <q> tags for quotes in HTML"
 
     , Option "" ["email-obfuscation"]
@@ -909,18 +969,30 @@ options =
                  "" -- "Use gladtex for HTML math"
 
     , Option "" ["trace"]
-                 (NoArg
-                  (\opt -> return opt { optTrace = True }))
+                 (OptArg
+                  (\arg opt ->
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optTrace = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Turn on diagnostic tracing in readers."
 
     , Option "" ["dump-args"]
-                 (NoArg
-                  (\opt -> return opt { optDumpArgs = True }))
+                 (OptArg
+                  (\arg opt ->
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optDumpArgs = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Print output filename and arguments to stdout."
 
     , Option "" ["ignore-args"]
-                 (NoArg
-                  (\opt -> return opt { optIgnoreArgs = True }))
+                 (OptArg
+                  (\arg opt ->
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optIgnoreArgs = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Ignore command-line arguments."
 
     , Option "" ["verbose"]
@@ -934,8 +1006,12 @@ options =
                  "" -- "Suppress warnings."
 
     , Option "" ["fail-if-warnings"]
-                 (NoArg
-                  (\opt -> return opt { optFailIfWarnings = True }))
+                 (OptArg
+                  (\arg opt ->
+                        case readBoolFromOptArg arg of 
+                           Just boolValue -> return opt { optFailIfWarnings = boolValue }
+                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  "[true|false]")
                  "" -- "Exit with error status if there were  warnings."
 
     , Option "" ["log"]
@@ -1098,6 +1174,13 @@ readMetaValue s
   | s == "False" = MetaBool False
   | s == "FALSE" = MetaBool False
   | otherwise    = MetaString $ T.pack s
+
+readBoolFromOptArg :: Maybe String -> Maybe Bool
+readBoolFromOptArg arg = case arg of 
+   Nothing      -> return True
+   Just "true"  -> return True
+   Just "false" -> return False
+   _            -> Nothing
 
 -- On Windows with ghc 8.6+, we need to rewrite paths
 -- beginning with \\ to \\?\UNC\. -- See #5127.

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -1156,7 +1156,7 @@ readMetaValue s
   | otherwise    = MetaString $ T.pack s
 
 readBoolFromOptArg ::  Maybe String -> ExceptT OptInfo IO Bool
-readBoolFromOptArg optArg = maybe (return True) readBoolFromArg optArg
+readBoolFromOptArg = maybe (return True) readBoolFromArg
     where readBoolFromArg arg = case toLower <$> arg of
             "true"  -> return True
             "false" -> return False

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -294,28 +294,25 @@ options =
 
     , Option "" ["file-scope"]
                  (OptArg
-                  (\arg opt -> 
-                    case readBoolFromOptArg arg of 
-                        Just boolValue -> return opt { optFileScope = boolValue }
-                        Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optFileScope = boolValue })
                   "[true|false]")
                  "" -- "Parse input files before combining"
 
     , Option "" ["sandbox"]
                  (OptArg
-                  (\arg opt -> 
-                       case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optSandbox = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optSandbox = boolValue })
                   "[true|false]")
                  ""
 
     , Option "s" ["standalone"]
                  (OptArg
-                  (\arg opt -> 
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optStandalone = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optStandalone = boolValue })
                   "[true|false]")
                  "" -- "Include needed header and footer on output"
 
@@ -350,19 +347,17 @@ options =
 
     , Option "" ["ascii"]
                  (OptArg
-                  (\arg opt -> 
-                       case readBoolFromOptArg arg of 
-                          Just boolValue -> return opt { optAscii = boolValue }
-                          Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optAscii = boolValue })
                   "[true|false]")
                  ""  -- "Prefer ASCII output"
 
     , Option "" ["toc", "table-of-contents"]
                 (OptArg
-                 (\arg opt -> 
-                      case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optTableOfContents = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                 (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optTableOfContents = boolValue })
                  "[true|false]")
                "" -- "Include table of contents"
 
@@ -507,10 +502,9 @@ options =
 
     , Option "p" ["preserve-tabs"]
                  (OptArg
-                  (\arg opt -> 
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optPreserveTabs = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optPreserveTabs = boolValue })
                   "[true|false]")
                  "" -- "Preserve tabs instead of converting to spaces"
 
@@ -555,19 +549,17 @@ options =
     , Option "" ["self-contained"]
                  (OptArg
                   (\arg opt -> do
-                    deprecatedOption "--self-contained" "use --embed-resources --standalone"
-                    case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optSelfContained = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                        deprecatedOption "--self-contained" "use --embed-resources --standalone"
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optSelfContained = boolValue })
                     "[true|false]")
                  "" -- "Make slide shows include all the needed js and css (deprecated)"
 
     , Option "" ["embed-resources"] -- maybe True (\argStr -> argStr == "true") arg
                  (OptArg
-                  (\arg opt -> 
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optEmbedResources =  boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optEmbedResources =  boolValue })
                   "[true|false]")
                  "" -- "Make slide shows include all the needed js and css"
 
@@ -582,10 +574,9 @@ options =
 
     , Option "" ["no-check-certificate"]
                 (OptArg
-                 (\arg opt -> 
-                       case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optNoCheckCertificate = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                 (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optNoCheckCertificate = boolValue })
                  "[true|false]")
                 "" -- "Disable certificate validation"
 
@@ -663,19 +654,17 @@ options =
 
     , Option "" ["strip-comments"]
                 (OptArg
-                 (\arg opt -> 
-                      case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optStripComments = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                 (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optStripComments = boolValue })
                  "[true|false]")
                "" -- "Strip HTML comments"
 
     , Option "" ["reference-links"]
                  (OptArg
-                  (\arg opt ->  
-                      case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optReferenceLinks = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optReferenceLinks = boolValue })
                   "[true|false]")
                  "" -- "Use reference links in parsing HTML"
 
@@ -708,28 +697,25 @@ options =
 
     , Option "" ["list-tables"]
                  (OptArg
-                  (\arg opt ->  
-                        case readBoolFromOptArg arg of 
-                            Just boolValue -> return opt { optListTables = boolValue }
-                            Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optListTables = boolValue })
                   "[true|false]")
                  "" -- "Use list tables for RST"
 
     , Option "" ["listings"]
                  (OptArg
-                  (\arg opt -> 
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optListings = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optListings = boolValue })
                   "[true|false]")
                  "" -- "Use listings package for LaTeX code blocks"
 
     , Option "i" ["incremental"]
                  (OptArg
-                  (\arg opt -> 
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optIncremental = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optIncremental = boolValue })
                   "[true|false]")
                  "" -- "Make list items display incrementally in Slidy/Slideous/S5"
 
@@ -746,19 +732,17 @@ options =
 
     , Option "" ["section-divs"]
                  (OptArg
-                  (\arg opt -> 
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optSectionDivs = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optSectionDivs = boolValue })
                   "[true|false]")
                  "" -- "Put sections in div tags in HTML"
 
     , Option "" ["html-q-tags"]
                  (OptArg
-                  (\arg opt -> 
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optHtmlQTags = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optHtmlQTags = boolValue })
                   "[true|false]")
                  "" -- "Use <q> tags for quotes in HTML"
 
@@ -970,28 +954,25 @@ options =
 
     , Option "" ["trace"]
                  (OptArg
-                  (\arg opt ->
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optTrace = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optTrace = boolValue })
                   "[true|false]")
                  "" -- "Turn on diagnostic tracing in readers."
 
     , Option "" ["dump-args"]
                  (OptArg
-                  (\arg opt ->
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optDumpArgs = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optDumpArgs = boolValue })
                   "[true|false]")
                  "" -- "Print output filename and arguments to stdout."
 
     , Option "" ["ignore-args"]
                  (OptArg
-                  (\arg opt ->
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optIgnoreArgs = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optIgnoreArgs = boolValue })
                   "[true|false]")
                  "" -- "Ignore command-line arguments."
 
@@ -1007,10 +988,9 @@ options =
 
     , Option "" ["fail-if-warnings"]
                  (OptArg
-                  (\arg opt ->
-                        case readBoolFromOptArg arg of 
-                           Just boolValue -> return opt { optFailIfWarnings = boolValue }
-                           Nothing -> optError $ PandocOptionError "value must be either true or false")
+                  (\arg opt -> do
+                        boolValue <- readBoolFromOptArg arg
+                        return opt { optFailIfWarnings = boolValue })
                   "[true|false]")
                  "" -- "Exit with error status if there were  warnings."
 
@@ -1175,12 +1155,12 @@ readMetaValue s
   | s == "FALSE" = MetaBool False
   | otherwise    = MetaString $ T.pack s
 
-readBoolFromOptArg :: Maybe String -> Maybe Bool
-readBoolFromOptArg arg = case arg of 
-   Nothing      -> return True
-   Just "true"  -> return True
-   Just "false" -> return False
-   _            -> Nothing
+readBoolFromOptArg ::  Maybe String -> ExceptT OptInfo IO Bool
+readBoolFromOptArg optArg = maybe (return True) readBoolFromArg optArg
+    where readBoolFromArg arg = case toLower <$> arg of
+            "true"  -> return True
+            "false" -> return False
+            _       -> optError $ PandocOptionError "value must be either true or false"
 
 -- On Windows with ghc 8.6+, we need to rewrite paths
 -- beginning with \\ to \\?\UNC\. -- See #5127.

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -536,8 +536,9 @@ options =
                  "" -- "Make slide shows include all the needed js and css (deprecated)"
 
     , Option "" ["embed-resources"]
-                 (NoArg
-                  (\opt -> return opt { optEmbedResources = True }))
+                 (OptArg
+                  (\arg opt -> return opt { optEmbedResources = maybe True (\argStr -> argStr == "true") arg })
+                  "STRING")
                  "" -- "Make slide shows include all the needed js and css"
 
     , Option "" ["request-header"]


### PR DESCRIPTION
This pull request introduces an optional value to the --embed-resources flag. To ensure backward compatibility, the default value is set to true unless false is explicitly provided.

Resolves #8788 