### PR TITLE
INSTALL.md: Use more relevant link to NetBSD/pkgsrc entry

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -376,7 +376,7 @@ To run just the markdown benchmarks:
 [MiKTeX]: https://miktex.org/
 [librsvg]: https://wiki.gnome.org/Projects/LibRsvg
 [Python]: https://www.python.org
-[NetBSD]: https://pkgsrc.se/wip/pandoc
+[NetBSD]: https://pkgsrc.se/converters/pandoc
 [NixOS]: https://nixos.org/nixos/packages.html
 [Slackware]: https://www.slackbuilds.org/result/?search=pandoc&sv=
 [Ubuntu]: https://packages.ubuntu.com/pandoc


### PR DESCRIPTION
Just a minor detail, but pandoc hasn't been a 'work in progress' in pkgsrc for a while now.