### PR TITLE
Retain image query parameters in dokuwiki reader

### DIFF
--- a/src/Text/Pandoc/Readers/DokuWiki.hs
+++ b/src/Text/Pandoc/Readers/DokuWiki.hs
@@ -389,7 +389,11 @@ image = try $ parseLink fromRaw "{{" "}}"
         parameterList = T.splitOn "&" $ T.drop 1 parameters
         linkOnly = "linkonly" `elem` parameterList
         (width, height) = maybe (Nothing, Nothing) parseWidthHeight (F.find isWidthHeightParameter parameterList)
-        attributes = catMaybes [fmap ("width",) width, fmap ("height",) height]
+        attributes = catMaybes [
+                fmap ("width",) width,
+                fmap ("height",) height,
+                fmap ("query",) (if T.null parameters then Nothing else Just parameters)
+            ]
         defaultDescription = B.str $ urlToText path'
 
 -- * Block parsers

--- a/test/Tests/Readers/DokuWiki.hs
+++ b/test/Tests/Readers/DokuWiki.hs
@@ -167,10 +167,10 @@ tests = [ testGroup "inlines"
               para (imageWith ("", ["align-center"], []) "/wiki/dokuwiki-128.png" "" (str "dokuwiki-128.png"))
             , "Image with width" =:
               "{{wiki:dokuwiki-128.png?50}}" =?>
-              para (imageWith ("", [], [("width", "50")]) "/wiki/dokuwiki-128.png" "" (str "dokuwiki-128.png"))
+              para (imageWith ("", [], [("width", "50"), ("query", "?50")]) "/wiki/dokuwiki-128.png" "" (str "dokuwiki-128.png"))
             , "Image with width and height" =:
               "{{wiki:dokuwiki-128.png?nocache&50x100}}" =?>
-              para (imageWith ("", [], [("width", "50"), ("height", "100")]) "/wiki/dokuwiki-128.png" "" (str "dokuwiki-128.png"))
+              para (imageWith ("", [], [("width", "50"), ("height", "100"), ("query", "?nocache&50x100")]) "/wiki/dokuwiki-128.png" "" (str "dokuwiki-128.png"))
             , "Linkonly" =:
               "{{wiki:dokuwiki-128.png?linkonly}}" =?>
               para (link "/wiki/dokuwiki-128.png" "" (str "dokuwiki-128.png"))


### PR DESCRIPTION
While converting dokuwiki syntax to gfm, I noticed that the query parameters of images were stripped from the output. In general this makes sense, as the parameters' semantics are specific to dokuwiki. However, I wanted to use a custom filter to convert these parameters properly. So this pull request retains the query parameters of image urls in the dokuwiki reader, by adding it as an extra `query` attribute.

As far as I can see, this wont have any (negative) effect on existing writers, but allows users to access them in a filter and do with them what they want.