### PR TITLE
Include lua/module/sample.svg in hackage tarball

### DIFF
--- a/pandoc-lua-engine/pandoc-lua-engine.cabal
+++ b/pandoc-lua-engine/pandoc-lua-engine.cabal
@@ -27,6 +27,7 @@ extra-source-files:  README.md
                    , test/lua/*.lua
                    , test/lua/module/*.lua
                    , test/lua/module/partial.test
+                   , test/lua/module/sample.svg
                    , test/lua/module/tiny.epub
                    , test/sample.lua
                    , test/tables.custom


### PR DESCRIPTION
Should fix the following error when running tests from Hackage tarball:

```
    pandoc.mediabag:                            [WARNING] Could not fetch resource lua/module/sample.svg: replacing image with description
FAIL
      fetch // populates media bag:
      File lua/module/sample.svg not found in resource path
DEBUG:root:haskell-pandoc-lua-engine:
      fill // populates media bag:
      lua/module/pandoc-mediabag.lua:70:
      expected values to be equal, got 'nil' and 'image/svg+xml'
```