### PR TITLE
fix: add highlight for F# language

### DIFF
--- a/src/Text/Pandoc/Writers/MediaWiki.hs
+++ b/src/Text/Pandoc/Writers/MediaWiki.hs
@@ -697,6 +697,7 @@ highlightingLangs = Set.fromList [
   "ex",
   "exs",
   "ezhil",
+  "f#",
   "factor",
   "fan",
   "fancy",


### PR DESCRIPTION
Fix for this SO question: https://tex.stackexchange.com/questions/563778/how-to-get-f-syntax-highlighting