### PR TITLE
Fix build (transitive dep not in lts)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -26,6 +26,7 @@ extra-deps:
 - skylighting-core-0.13.4
 - skylighting-0.13.4
 - typst-0.3.0.0
+- xml-conduit-1.9.1.3
 
 ghc-options:
    "$locals": -fhide-source-paths -Wno-missing-home-modules


### PR DESCRIPTION
Commit 921b0949f4400af2e602982806e48222b7611bd9 bumped the skylighting-core version, which requires a newer version of xml-conduit than is available in lts-21.0.
Bump the version in stack.yaml