### PR TITLE
Fix display of block elements in JATS reader - Issue 8889

### DIFF
--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -221,7 +221,8 @@ parseBlock (Elem e) = do
                             else getBlocks e
         "disp-formula" -> if hasFormulaChild e
                             then blockFormula displayMath e
-                            else getBlocks e
+                            else divWith (attrValue "id" e, ["disp-formula"], []) 
+                                    <$> getBlocks e
         "?xml"  -> return mempty
         _       -> getBlocks e
    where parseMixed container conts = do

--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -637,9 +637,6 @@ inlineFormula constructor e = do
                             filterChildren isMathML whereToLook
             return . mconcat . take 1 . map constructor $ texMaths ++ mathMLs
 
--- Needs to cater to situations where other elements are also included?
--- Reaches here if disp-formula/formula or disp-formula/alternatives/formula
--- Does not handle captions, for example   
 blockFormula ::  PandocMonad m => (Text->Inlines) -> Element -> JATS m Blocks
 blockFormula constructor e = do
             let whereToLook = fromMaybe e $ filterElement (named "alternatives") e

--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -108,28 +108,14 @@ isBlockElement :: Content -> Bool
 isBlockElement (Elem e) = qName (elName e) `S.member` blocktags
   where blocktags = S.fromList (paragraphLevel ++ lists ++ mathML ++ other) \\ S.fromList inlinetags
         paragraphLevel = ["address", "answer", "answer-set", "array", "boxed-text", "chem-struct-wrap",
-            "code", "explanation", "fig", "fig-group", "graphic", "media", "preformat", "question", "question-wrap-group"
+            "code", "explanation", "fig", "fig-group", "graphic", "media", "preformat", "question", "question-wrap", "question-wrap-group"
             "supplementary-material", "table-wrap", "table-wrap-group",
             "alternatives", "disp-formula", "disp-formula-group"]
         lists = ["def-list", "list"]
         mathML = ["tex-math", "mml:math"]
         other = ["p", "related-article", "related-object", "ack", "disp-quote",
             "speech", "statement", "verse-group", "x"]
-        inlinetags = ["email", "ext-link", "uri", "inline-supplementary-material",
-            "related-article", "related-object", "hr", "bold", "fixed-case",
-            "italic", "monospace", "overline", "overline-start", "overline-end",
-            "roman", "sans-serif", "sc", "strike", "underline", "underline-start",
-            "underline-end", "ruby", "alternatives", "inline-graphic", "private-char",
-            "chem-struct", "inline-formula", "tex-math", "mml:math", "abbrev",
-            "milestone-end", "milestone-start", "named-content", "styled-content",
-            "fn", "target", "xref", "sub", "sup", "x", "address", "array",
-            "boxed-text", "chem-struct-wrap", "code", "fig", "fig-group", "graphic",
-            "media", "preformat", "supplementary-material", "table-wrap",
-            "table-wrap-group", "disp-formula", "disp-formula-group",
-            "citation-alternatives", "element-citation", "mixed-citation",
-            "nlm-citation", "award-id", "funding-source", "open-access",
-            "def-list", "list", "ack", "disp-quote", "speech", "statement",
-            "verse-group"]
+        inlinetags = ["alternatives", "tex-math", "mml:math", "x"]
 isBlockElement _ = False
 
 -- Trim leading and trailing newline characters

--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -107,8 +107,8 @@ instance HasMeta JATSState where
 isBlockElement :: Content -> Bool
 isBlockElement (Elem e) = qName (elName e) `S.member` blocktags
   where blocktags = S.fromList (paragraphLevel ++ lists ++ mathML ++ other) \\ S.fromList inlinetags
-        paragraphLevel = ["address", "array", "boxed-text", "chem-struct-wrap",
-            "code", "fig", "fig-group", "graphic", "media", "preformat",
+        paragraphLevel = ["address", "answer", "answer-set", "array", "boxed-text", "chem-struct-wrap",
+            "code", "explanation", "fig", "fig-group", "graphic", "media", "preformat", "question", "question-wrap-group"
             "supplementary-material", "table-wrap", "table-wrap-group",
             "alternatives", "disp-formula", "disp-formula-group"]
         lists = ["def-list", "list"]
@@ -363,9 +363,7 @@ parseBlock (Elem e) = do
          wrapWithHeader n mBlocks = do
                       isBook <- gets jatsBook
                       let n' = if isBook || n == 0 then n + 1 else n
-                      headerText <- case filterChild (named "title") e `mplus`
-                                          (filterChild (named "info") e >>=
-                                              filterChild (named "title")) of
+                      headerText <- case filterChild (named "title") e of
                                         Just t  -> getInlines t
                                         Nothing -> return mempty
                       oldN <- gets jatsSectionLevel

--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -15,7 +15,7 @@ Conversion of JATS XML to 'Pandoc' document.
 
 module Text.Pandoc.Readers.JATS ( readJATS ) where
 import Control.Monad.State.Strict ( StateT(runStateT), gets, modify )
-import Control.Monad (forM_,  when, unless, MonadPlus(mplus))
+import Control.Monad (forM_,  when, unless)
 import Control.Monad.Except (throwError)
 import Text.Pandoc.Error (PandocError(..))
 import Data.Char (isDigit, isSpace)

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -8,6 +8,13 @@ Pandoc
                 , MetaInlines [ Str "Anonymous" ]
                 ]
             )
+          , ( "references"
+            , MetaList
+                [ MetaMap (fromList [ ( "id" , MetaString "note_1" ) ])
+                , MetaMap
+                    (fromList [ ( "id" , MetaString "note_longnote" ) ])
+                ]
+            )
           , ( "title"
             , MetaInlines
                 [ Str "Pandoc"
@@ -218,12 +225,14 @@ Pandoc
       , Space
       , Str "a"
       , Space
-      , Str "hard"
-      , Space
-      , Str "line"
-      , Space
-      , Str "break"
-      , LineBreak
+      , Strong
+          [ Str "hard"
+          , Space
+          , Str "line"
+          , Space
+          , Str "break"
+          , LineBreak
+          ]
       , Str "here."
       ]
   , Header 1 ( "statements" , [] , [] ) [ Str "Statements" ]
@@ -366,6 +375,428 @@ Pandoc
       , Space
       , Str "paragraph."
       ]
+  , Para
+      [ Str "Here"
+      , Space
+      , Str "is"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "inside"
+      , Space
+      , Str "a"
+      , Space
+      , Str "paragraph."
+      , Space
+      , Str "Start"
+      , Space
+      , Str "of"
+      , Space
+      , Str "a"
+      , Space
+      , Str "paragraph"
+      , Space
+      , Str "is"
+      , Space
+      , Str "here,"
+      , Space
+      , Str "and"
+      , Space
+      , Str "the"
+      , Space
+      , Str "quote"
+      , Space
+      , Str "is"
+      , Space
+      , Str "below:"
+      ]
+  , BlockQuote
+      [ Para
+          [ Str "My" , Space , Str "block" , Space , Str "quote" ]
+      ]
+  , Para
+      [ Str "End"
+      , Space
+      , Str "of"
+      , Space
+      , Str "a"
+      , Space
+      , Str "paragraph"
+      ]
+  , Header 1 ( "formulae" , [] , [] ) [ Str "Formulae" ]
+  , Header
+      2
+      ( "inline-formulae" , [] , [] )
+      [ Str "Inline"
+      , Space
+      , Str "formulae"
+      , Space
+      , Str "with"
+      , Space
+      , Emph [ Str "inline-formula" ]
+      ]
+  , Para
+      [ Strong
+          [ Str "Inside" , Space , Str "a" , Space , Str "paragraph" ]
+      , Str ","
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "natively"
+      , Space
+      , Str "coded"
+      , Space
+      , Str "inside"
+      , Space
+      , Str "the"
+      , Space
+      , Str "paragraph,"
+      , Space
+      , Str "and"
+      , Space
+      , Str "show"
+      , Space
+      , Str "inline:"
+      ]
+  , Para
+      [ Str "Einstein"
+      , Space
+      , Str "showed"
+      , Space
+      , Str "that"
+      , Space
+      , Math InlineMath "e=mc^2"
+      , Str "."
+      , SoftBreak
+      , Str "This"
+      , Space
+      , Str "formula"
+      , Space
+      , Str "is"
+      , Space
+      , Str "important"
+      , Space
+      , Str "because\8230"
+      ]
+  , Header
+      2
+      ( "disp-formulae" , [] , [] )
+      [ Str "Block"
+      , Space
+      , Str "formulae"
+      , Space
+      , Str "with"
+      , Space
+      , Emph [ Str "disp-formula" ]
+      ]
+  , Para
+      [ Strong
+          [ Str "Inside" , Space , Str "a" , Space , Str "paragraph" ]
+      , Str ","
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "natively"
+      , Space
+      , Str "coded"
+      , Space
+      , Str "inside"
+      , Space
+      , Str "the"
+      , Space
+      , Str "pragraph,"
+      , Space
+      , Str "but"
+      , Space
+      , Str "show"
+      , Space
+      , Str "as"
+      , Space
+      , Str "block:"
+      ]
+  , Para
+      [ Str "Einstein"
+      , Space
+      , Str "showed"
+      , Space
+      , Str "that"
+      , Space
+      , Math DisplayMath "e=mc^2"
+      , Str "."
+      , SoftBreak
+      , Str "This"
+      , Space
+      , Str "formula"
+      , Space
+      , Str "is"
+      , Space
+      , Str "important"
+      , Space
+      , Str "because\8230"
+      ]
+  , Para
+      [ Strong
+          [ Str "Outside" , Space , Str "a" , Space , Str "pararaph" ]
+      , Str ","
+      , Space
+      , Str "should"
+      , Space
+      , Str "show"
+      , Space
+      , Str "as"
+      , Space
+      , Str "block:"
+      ]
+  , Para
+      [ Str "Einstein"
+      , Space
+      , Str "showed"
+      , Space
+      , Str "that"
+      ]
+  , Div
+      ( "" , [ "disp-formula" ] , [] )
+      [ LineBlock [ [ Math DisplayMath "e=mc^2" ] ] ]
+  , Para
+      [ Str "This"
+      , Space
+      , Str "formula"
+      , Space
+      , Str "is"
+      , Space
+      , Str "important"
+      , Space
+      , Str "because\8230"
+      ]
+  , Header
+      2
+      ( "no-formula-wrapper" , [] , [] )
+      [ Str "Without"
+      , Space
+      , Str "a"
+      , Space
+      , Str "formula"
+      , Space
+      , Str "wrapper"
+      ]
+  , Para
+      [ Strong
+          [ Str "Inside" , Space , Str "a" , Space , Str "pragraph" ]
+      , Str ","
+      , Space
+      , Str "should"
+      , Space
+      , Str "show"
+      , Space
+      , Str "inline:"
+      ]
+  , Para
+      [ Str "Einstein"
+      , Space
+      , Str "showed"
+      , Space
+      , Str "that"
+      , Space
+      , Math InlineMath "e=mc^2"
+      , Str "."
+      , SoftBreak
+      , Str "This"
+      , Space
+      , Str "formula"
+      , Space
+      , Str "is"
+      , Space
+      , Str "important"
+      , Space
+      , Str "because\8230"
+      ]
+  , Para
+      [ Strong
+          [ Str "Outside"
+          , Space
+          , Str "a"
+          , Space
+          , Str "paragraph"
+          ]
+      , Str ","
+      , Space
+      , Str "should"
+      , Space
+      , Str "show"
+      , Space
+      , Str "as"
+      , Space
+      , Str "block:"
+      ]
+  , Para
+      [ Str "Einstein"
+      , Space
+      , Str "showed"
+      , Space
+      , Str "that"
+      ]
+  , LineBlock [ [ Math DisplayMath "e=mc^2" ] ]
+  , Para
+      [ Str "This"
+      , Space
+      , Str "formula"
+      , Space
+      , Str "is"
+      , Space
+      , Str "important"
+      , Space
+      , Str "because\8230"
+      ]
+  , Header
+      2
+      ( "misc-formulae" , [] , [] )
+      [ Str "Formulae"
+      , Space
+      , Str "with"
+      , Space
+      , Str "miscelaneus"
+      , Space
+      , Str "elements"
+      ]
+  , Para
+      [ Str "Regardless"
+      , Space
+      , Str "of"
+      , Space
+      , Str "whether"
+      , Space
+      , Str "or"
+      , Space
+      , Str "not"
+      , Space
+      , Str "they"
+      , Space
+      , Str "are"
+      , Space
+      , Str "inside"
+      , Space
+      , Str "a"
+      , Space
+      , Str "paragraph,"
+      , Space
+      , Str "should"
+      , Space
+      , Str "be"
+      , Space
+      , Str "wrapped"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "div,"
+      , Space
+      , Str "and"
+      , Space
+      , Str "displayed"
+      , Space
+      , Str "in"
+      , Space
+      , Str "a"
+      , Space
+      , Str "block:"
+      ]
+  , Para
+      [ Strong
+          [ Str "Inside"
+          , Space
+          , Str "a"
+          , Space
+          , Str "paragraph:"
+          ]
+      ]
+  , Para
+      [ Str "Einstein"
+      , Space
+      , Str "showed"
+      , Space
+      , Str "that"
+      ]
+  , Div
+      ( "" , [ "disp-formula" ] , [] )
+      [ Para [ Str "Abstract" , Space , Str "text" ]
+      , Para
+          [ Image
+              ( "" , [] , [] )
+              []
+              ( "https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660"
+              , ""
+              )
+          ]
+      , LineBlock [ [ Math DisplayMath "e=mc^2" ] ]
+      ]
+  , Para
+      [ Str "."
+      , SoftBreak
+      , Str "This"
+      , Space
+      , Str "formula"
+      , Space
+      , Str "is"
+      , Space
+      , Str "important"
+      , Space
+      , Str "because\8230"
+      ]
+  , Para
+      [ Strong
+          [ Str "Outside"
+          , Space
+          , Str "of"
+          , Space
+          , Str "a"
+          , Space
+          , Str "paragraph:"
+          ]
+      ]
+  , Para
+      [ Str "Paragraph"
+      , Space
+      , Str "before:"
+      , Space
+      , Str "Einstein"
+      , Space
+      , Str "showed"
+      , Space
+      , Str "that"
+      ]
+  , Div
+      ( "" , [ "disp-formula" ] , [] )
+      [ Para [ Str "Abstract" , Space , Str "text" ]
+      , Para
+          [ Image
+              ( "" , [] , [] )
+              []
+              ( "https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660"
+              , ""
+              )
+          ]
+      , LineBlock [ [ Math DisplayMath "e=mc^2" ] ]
+      ]
+  , Para
+      [ Str "This"
+      , Space
+      , Str "formula"
+      , Space
+      , Str "is"
+      , Space
+      , Str "important"
+      , Space
+      , Str "because\8230"
+      ]
   , Header
       1
       ( "code-blocks" , [] , [] )
@@ -493,8 +924,18 @@ Pandoc
       , [ Para [ Str "Item" , Space , Str "3." ] ]
       ]
   , Para [ Str "List" , Space , Str "styles:" ]
-  , OrderedList ( 1 , DefaultStyle , DefaultDelim ) []
-  , OrderedList ( 1 , LowerRoman , DefaultDelim ) []
+  , OrderedList
+      ( 1 , DefaultStyle , DefaultDelim )
+      [ [ Para [ Str "one" ] ]
+      , [ Para [ Str "two" ] ]
+      , [ Para [ Str "three" ] ]
+      ]
+  , OrderedList
+      ( 1 , LowerRoman , DefaultDelim )
+      [ [ Para [ Str "one" ] ]
+      , [ Para [ Str "two" ] ]
+      , [ Para [ Str "three" ] ]
+      ]
   , Header 2 ( "nested" , [] , [] ) [ Str "Nested" ]
   , BulletList
       [ [ Para [ Str "Tab" ]
@@ -653,7 +1094,10 @@ Pandoc
             ]
           ]
         )
-      , ( [ Str "Cello" , LineBreak , Str "Violoncello" ]
+      , ( [ Str "Cello"
+          , Strong [ LineBreak ]
+          , Str "Violoncello"
+          ]
         , [ [ Para
                 [ Str "Low-voiced"
                 , Space
@@ -665,6 +1109,30 @@ Pandoc
           ]
         )
       ]
+  , Header
+      2
+      ( "list-inside-paragraph" , [] , [] )
+      [ Str "List"
+      , Space
+      , Str "inside"
+      , Space
+      , Str "a"
+      , Space
+      , Str "paragraph"
+      ]
+  , Para
+      [ Str "Start"
+      , Space
+      , Str "of"
+      , Space
+      , Str "a"
+      , Space
+      , Str "paragraph."
+      ]
+  , BulletList
+      [ [ Para [ Str "Red" ] ] , [ Para [ Str "Blue" ] ] ]
+  , Para
+      [ Str "End" , Space , Str "of" , Space , Str "paragraph." ]
   , Header
       1
       ( "inline-markup" , [] , [] )
@@ -1851,747 +2319,774 @@ Pandoc
       , Space
       , Str "Headers"
       ]
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "r1a" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "r1b" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "r1c" ] ]
-             ]
-         , Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "r1a" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "r1b" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "r1c" ] ]
+                 ]
+             , Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "X" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Y" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "Z" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "X" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Y" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "Z" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
   , Header
       2
       ( "tables-without-headers" , [] , [] )
@@ -2601,234 +3096,246 @@ Pandoc
       , Space
       , Str "Headers"
       ]
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead ( "" , [] , [] ) [])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead ( "" , [] , [] ) [])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead ( "" , [] , [] ) [])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead ( "" , [] , [] ) [])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead ( "" , [] , [] ) [])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead ( "" , [] , [] ) [])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead ( "" , [] , [] ) [])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead ( "" , [] , [] ) [])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
   , Header
       2
       ( "table-with-spans-and-alignments" , [] , [] )
@@ -2842,167 +3349,173 @@ Pandoc
       , Space
       , Str "alignments"
       ]
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 2)
-                 [ Para [ Str "1" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignRight
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "2" ] ]
-             ]
-         ])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 2)
+                     [ Para [ Str "1" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignRight
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "2" ] ]
+                 ]
+             ])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 2)
-                  [ Para [ Str "1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 2)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignLeft
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignLeft
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 2)
+                      (ColSpan 1)
+                      [ Para [ Str "4" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "5" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "6" ] ]
+                  ]
+              , Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 2)
-                  (ColSpan 1)
-                  [ Para [ Str "4" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "5" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "6" ] ]
-              ]
-          , Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 2)
-                  [ Para [ Str "7" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 2)
+                      [ Para [ Str "7" ] ]
+                  ]
               ]
           ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
   , Header
       2
       ( "table-with-footer" , [] , [] )
       [ Str "Table" , Space , Str "with" , Space , Str "footer" ]
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead ( "" , [] , [] ) [])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead ( "" , [] , [] ) [])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "1" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "3" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "3" ] ]
+                  ]
               ]
           ]
+          (TableFoot
+             ( "" , [] , [] )
+             [ Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignRight
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "f1" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "f2" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "f3" ] ]
+                 ]
+             , Row
+                 ( "" , [] , [] )
+                 [ Cell
+                     ( "" , [] , [] )
+                     AlignRight
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "f4" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "f5" ] ]
+                 , Cell
+                     ( "" , [] , [] )
+                     AlignDefault
+                     (RowSpan 1)
+                     (ColSpan 1)
+                     [ Para [ Str "f6" ] ]
+                 ]
+             ])
       ]
-      (TableFoot
-         ( "" , [] , [] )
-         [ Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignRight
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "f1" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "f2" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "f3" ] ]
-             ]
-         , Row
-             ( "" , [] , [] )
-             [ Cell
-                 ( "" , [] , [] )
-                 AlignRight
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "f4" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "f5" ] ]
-             , Cell
-                 ( "" , [] , [] )
-                 AlignDefault
-                 (RowSpan 1)
-                 (ColSpan 1)
-                 [ Para [ Str "f6" ] ]
-             ]
-         ])
   , Header
       2
       ( "table-with-multiple-bodies" , [] , [] )
@@ -3014,68 +3527,71 @@ Pandoc
       , Space
       , Str "Bodies"
       ]
-  , Table
-      ( "" , [] , [] )
-      (Caption Nothing [])
-      [ ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      , ( AlignLeft , ColWidthDefault )
-      ]
-      (TableHead ( "" , [] , [] ) [])
-      [ TableBody
+  , Div
+      ( "" , [ "table-wrap" ] , [] )
+      [ Table
           ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
+          (Caption Nothing [])
+          [ ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          , ( AlignLeft , ColWidthDefault )
+          ]
+          (TableHead ( "" , [] , [] ) [])
+          [ TableBody
               ( "" , [] , [] )
-              [ Cell
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignRight
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "a1" ] ]
-              , Cell
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignRight
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "a1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "a2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "a3" ] ]
+                  ]
+              ]
+          , TableBody
+              ( "" , [] , [] )
+              (RowHeadColumns 0)
+              []
+              [ Row
                   ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "a2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "a3" ] ]
+                  [ Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "b1" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "b2" ] ]
+                  , Cell
+                      ( "" , [] , [] )
+                      AlignDefault
+                      (RowSpan 1)
+                      (ColSpan 1)
+                      [ Para [ Str "b3" ] ]
+                  ]
               ]
           ]
-      , TableBody
-          ( "" , [] , [] )
-          (RowHeadColumns 0)
-          []
-          [ Row
-              ( "" , [] , [] )
-              [ Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "b1" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "b2" ] ]
-              , Cell
-                  ( "" , [] , [] )
-                  AlignDefault
-                  (RowSpan 1)
-                  (ColSpan 1)
-                  [ Para [ Str "b3" ] ]
-              ]
-          ]
+          (TableFoot ( "" , [] , [] ) [])
       ]
-      (TableFoot ( "" , [] , [] ) [])
   , Header
       2
       ( "empty-tables" , [] , [] )
@@ -3091,4 +3607,8 @@ Pandoc
       , Space
       , Str "empty."
       ]
+  , Header 1 ( "" , [] , [] ) [ Str "References" ]
+  , Div ( "refs" , [] , [] ) []
+  , Header 1 ( "" , [] , [] ) [ Str "Notes" ]
+  , Div ( "refs" , [] , [] ) []
   ]

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -67,7 +67,7 @@
   <p>Here's a regular paragraph.</p>
   <p>In Markdown 1.0.0 and earlier. Version 8. This line turns into a list item. Because a hard-wrapped line in the middle of a paragraph looked like a list item.</p>
   <p>Here's one with a bullet. * criminey.</p>
-  <p>There should be a hard line break<break />here.</p>
+  <p>There should be a <bold>hard line break<break /></bold>here.</p>
 </sec>
 <sec id="statements">
   <title> Statements </title>
@@ -289,8 +289,16 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       </list-item>
     </list>
     <p>List styles:</p>
-    <list list-type="order"></list>
-    <list list-type="roman-lower"></list>
+    <list list-type="order">
+      <list-item><p>one</p></list-item><x>,</x>
+      <list-item><p>two</p></list-item><x>,</x>
+      <list-item><p>three</p></list-item>
+    </list>
+    <list list-type="roman-lower">
+      <list-item><p>one</p></list-item><x>,</x>
+      <list-item><p>two</p></list-item><x>,</x>
+      <list-item><p>three</p></list-item>
+    </list>
   </sec>
   <sec id="nested">
     <title>Nested</title>
@@ -406,7 +414,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
       </def-item>
       <def-item>
         <term>
-          Cello<break />Violoncello
+          Cello<bold><break /></bold>Violoncello
         </term>
         <def>
           <p>Low-voiced stringed instrument.</p>
@@ -419,20 +427,20 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   <title>Inline Markup</title>
   <p>This is <italic>emphasized</italic>, and so <italic>is
     this</italic>.</p>
-  <p>This is <bold role="strong">strong</bold>, and so
-    <bold role="strong">is this</bold>.</p>
-  <p>Empty <bold role="strong"></bold> and <italic></italic>.</p>
+  <p>This is <bold>strong</bold>, and so
+    <bold>is this</bold>.</p>
+  <p>Empty <bold></bold> and <italic></italic>.</p>
   <p>An
     <italic><ext-link ext-link-type="uri" xlink:href="/url">emphasized
     link</ext-link></italic>.</p>
-  <p><bold role="strong"><italic>This is strong and em.</italic></bold></p>
-  <p>So is <bold role="strong"><italic>this</italic></bold> word.</p>
-  <p><bold role="strong"><italic>This is strong and em.</italic></bold></p>
-  <p>So is <bold role="strong"><italic>this</italic></bold> word.</p>
+  <p><bold><italic>This is strong and em.</italic></bold></p>
+  <p>So is <bold><italic>this</italic></bold> word.</p>
+  <p><bold><italic>This is strong and em.</italic></bold></p>
+  <p>So is <bold><italic>this</italic></bold> word.</p>
   <p>This is code: <monospace>&gt;</monospace>, <monospace>$</monospace>,
     <monospace>\</monospace>, <monospace>\$</monospace>,
     <monospace>&lt;html&gt;</monospace>.</p>
-  <p>This is <sc role="smallcaps">small caps</sc>.</p>
+  <p>This is <sc>small caps</sc>.</p>
   <p>These are all underlined: foo and bar.</p>
   <p>These are all strikethrough: <strike>foo</strike>,
     <strike>bar</strike>, and <strike>baz</strike>.</p>
@@ -660,7 +668,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
   <title>Tables</title>
   <sec id="tables-with-headers">
     <title>Tables with Headers</title>
-    <table>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -701,8 +709,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -743,8 +751,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -785,8 +793,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -827,8 +835,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -869,8 +877,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -911,8 +919,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -953,8 +961,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -1006,8 +1014,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col width="33*" align="left" />
       <col width="33*" align="left" />
       <col width="33*" align="left" />
@@ -1048,11 +1056,11 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
+    </table></table-wrap>
   </sec>
   <sec id="tables-without-headers">
     <title>Tables without Headers</title>
-    <table>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -1080,8 +1088,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -1109,8 +1117,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -1138,8 +1146,8 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
-    <table>
+    </table></table-wrap>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -1167,11 +1175,11 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
+    </table></table-wrap>
   </sec>
   <sec id="table-with-spans-and-alignments">
     <title>Tables with spans and alignments</title>
-    <table>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -1211,27 +1219,14 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
         </td>
         </tr>
       </tbody>
-    </table>
+    </table></table-wrap>
   </sec>
   <sec id="table-with-footer">
     <title>Table with footer</title>
-    <table>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
-      <tbody>
-        <tr>
-          <td>
-            <p>1</p>
-          </td>
-          <td>
-            <p>2</p>
-          </td>
-          <td>
-            <p>3</p>
-          </td>
-        </tr>
-      </tbody>
       <tfoot>
         <tr>
           <td align="right">
@@ -1256,11 +1251,24 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tfoot>
-    </table>
+      <tbody>
+        <tr>
+          <td>
+            <p>1</p>
+          </td>
+          <td>
+            <p>2</p>
+          </td>
+          <td>
+            <p>3</p>
+          </td>
+        </tr>
+      </tbody>
+    </table></table-wrap>
   </sec>
   <sec id="table-with-multiple-bodies">
     <title>Table With Multiple Bodies</title>
-    <table>
+    <table-wrap><table>
       <col align="left" />
       <col align="left" />
       <col align="left" />
@@ -1290,7 +1298,7 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
           </td>
         </tr>
       </tbody>
-    </table>
+    </table></table-wrap>
   </sec>
   <sec id="empty-tables">
     <title>Empty Tables</title>
@@ -1299,5 +1307,15 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
 </sec>
 </body>
 <back>
+  <ref-list>
+    <title>References</title>
+    <ref id="ref_1"><note><p>This is reference 1</p></note></ref>
+    <ref id="ref_longnote"><note><p>This is a long note</p></note></ref>
+  </ref-list>
+  <ref-list>
+    <title>Notes</title>
+    <ref id="note_1"><note><p>This is note 1</p></note></ref>
+    <ref id="note_longnote"><note><p>This is another long note</p></note></ref>
+  </ref-list>
 </back>
 </article>

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -131,6 +131,96 @@
     </disp-quote>
   </disp-quote>
   <p>And a following paragraph.</p>
+  <p>
+     Here is a block quote inside a paragraph. Start of a paragraph is here, and the quote is below:
+      <disp-quote>
+        <p>My block quote</p>
+      </disp-quote>
+     End of a paragraph
+  </p>
+</sec>
+<sec id="formulae">
+  <title>Formulae</title>
+  <sec id="inline-formulae">
+    <title>Inline formulae with <italic>inline-formula</italic></title>
+    <p><bold>Inside a paragraph</bold>, should be natively coded inside the paragraph, and show inline:</p>
+    <p>Einstein showed that <inline-formula><alternatives>
+      <tex-math><![CDATA[e=mc^2]]></tex-math>
+      <mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>e</mml:mi><mml:mo>=</mml:mo><mml:mi>m</mml:mi><mml:msup><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></alternatives></inline-formula>.
+      This formula is important because…</p>
+  </sec>
+  <sec id="disp-formulae">
+    <title>Block formulae with <italic>disp-formula</italic></title>
+    <p><bold>Inside a paragraph</bold>, should be natively coded inside the pragraph, but show as block:</p>
+    <p>Einstein showed that <disp-formula><alternatives>
+      <tex-math><![CDATA[e=mc^2]]></tex-math>
+      <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>e</mml:mi><mml:mo>=</mml:mo><mml:mi>m</mml:mi><mml:msup><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></alternatives></disp-formula>.
+      This formula is important because…</p>
+    <p><bold>Outside a pararaph</bold>, should show as block:</p>
+    <p>Einstein showed that </p>
+    <disp-formula><alternatives>
+      <tex-math><![CDATA[e=mc^2]]></tex-math>
+      <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>e</mml:mi><mml:mo>=</mml:mo><mml:mi>m</mml:mi><mml:msup><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></alternatives></disp-formula>
+    <p>This formula is important because…</p>
+  </sec>
+  <sec id="no-formula-wrapper">
+    <title>Without a formula wrapper</title>
+    <p><bold>Inside a pragraph</bold>, should show inline:</p>
+    <p>Einstein showed that <alternatives>
+      <tex-math><![CDATA[e=mc^2]]></tex-math>
+      <mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>e</mml:mi><mml:mo>=</mml:mo><mml:mi>m</mml:mi><mml:msup><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></alternatives>.
+      This formula is important because…</p>
+    <p><bold>Outside a paragraph</bold>, should show as block:</p>
+    <p>Einstein showed that </p>
+    <alternatives>
+      <tex-math><![CDATA[e=mc^2]]></tex-math>
+      <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>e</mml:mi><mml:mo>=</mml:mo><mml:mi>m</mml:mi><mml:msup><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></alternatives>
+    <p>This formula is important because…</p>
+  </sec>
+  <sec id="misc-formulae">
+    <title>Formulae with miscelaneus elements</title>
+    <p>Regardless of whether or not they are inside a paragraph, should be wrapped in a div, and displayed in a block:</p>
+    <p><bold>Inside a paragraph:</bold></p>
+    <p>Einstein showed that 
+      <disp-formula>
+        <abstract>
+          <p>Abstract text</p>
+        </abstract>
+        <graphic xlink:href="https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660">
+          <alt-text>Alternative text 1</alt-text>
+          <caption><p>Google doodle from 14 March 2003</p></caption>
+        </graphic>
+        <alternatives>
+          <tex-math><![CDATA[e=mc^2]]></tex-math>
+          <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>e</mml:mi><mml:mo>=</mml:mo><mml:mi>m</mml:mi><mml:msup><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math>
+          <graphic xlink:href="https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660">
+            <alt-text>Alternative text 2</alt-text>
+            <caption><p>Google doodle from 14 March 2003</p></caption>
+          </graphic>
+        </alternatives>
+      </disp-formula>.
+      This formula is important because…</p>
+    <p><bold>Outside of a paragraph:</bold></p>
+    <p>Paragraph before: Einstein showed that </p>
+    <disp-formula>
+      <abstract>
+        <p>Abstract text</p>
+      </abstract>
+      <graphic xlink:href="https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660">
+        <alt-text>Alternative text 1</alt-text>
+        <caption><p>Google doodle from 14 March 2003</p></caption>
+      </graphic>
+      <alternatives>
+        <tex-math><![CDATA[e=mc^2]]></tex-math>
+        <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>e</mml:mi><mml:mo>=</mml:mo><mml:mi>m</mml:mi><mml:msup><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math>
+        <graphic xlink:href="https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660">
+          <alt-text>Alternative text 2</alt-text>
+          <caption><p>Google doodle from 14 March 2003</p></caption>
+        </graphic>
+      </alternatives>
+    </disp-formula>
+    <p>This formula is important because…</p>
+  </sec>
 </sec>
 <sec id="code-blocks">
   <title>Code Blocks</title>
@@ -421,6 +511,23 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</preformat>
         </def>
       </def-item>
     </def-list>
+  </sec>
+  <sec id="list-inside-paragraph">
+    <title>List inside a paragraph</title>
+    <p>
+      Start of a paragraph.
+      <list list-type="bullet">
+        <list-item>
+          <label>&#8226;</label>
+          <p>Red</p>
+        </list-item>
+        <list-item>
+          <label>&#8226;</label>
+          <p>Blue</p>
+        </list-item>
+      </list>
+      End of paragraph.
+    </p>
   </sec>
 </sec>
 <sec id="inline-markup">


### PR DESCRIPTION
A number of block elements, like `disp-quote`, `list`, and `disp-formula`, were always treated as inlines if appearing inside paragraphs, even if their usage granted a separate block. The function `isElementBlock` has been refined to prevent this, and a number of specific parse cases have been added to `parseBlock`. Also some general cleanup and removal of redundant lines.