### PR TITLE
Documentation - FAQs - Links

### DIFF
--- a/doc/faqs.md
+++ b/doc/faqs.md
@@ -196,7 +196,7 @@ Or `--pdf-engine=lualatex` can be used with the following:
 
 Save this filter as `nowidths.lua` and then pass `--lua-filter
 nowidths.lua` as an additional option to pandoc.
-(See [issue](https://github.com/jgm/pandoc/issues/8139).)
+(See [issue 8139](https://github.com/jgm/pandoc/issues/8139).)
 
 ``` lua
 -- Unset the width attribute of HTML colspecs in tables

--- a/doc/faqs.md
+++ b/doc/faqs.md
@@ -116,7 +116,7 @@ and saving in a format from which pandoc can convert directly.
 No.  You can get by with a relatively small TeX installation,
 for example, by starting with MacTeX's Basic TeX distribution
 and using the `tlmgr` tool to install a few packages required by pandoc
-(see https://pandoc.org/MANUAL.html#creating-a-pdf).
+(see [the manual](https://pandoc.org/MANUAL.html#creating-a-pdf)).
 
 Or, you can produce PDFs via HTML and `wkhtmltopdf`,
 or via groff ms and `pdfroff`.  (These don't produce as nice
@@ -196,7 +196,7 @@ Or `--pdf-engine=lualatex` can be used with the following:
 
 Save this filter as `nowidths.lua` and then pass `--lua-filter
 nowidths.lua` as an additional option to pandoc.
-(See <https://github.com/jgm/pandoc/issues/8139>.)
+(See [issue](https://github.com/jgm/pandoc/issues/8139).)
 
 ``` lua
 -- Unset the width attribute of HTML colspecs in tables


### PR DESCRIPTION
Fixes the link to the manual that wasn't creating an anchor tag in HTML on line 119.

I also suggest that the link to the issue had a text like the all other links in this page.
