### PR TITLE
Solve #8118 and #4317 by adding 1 line to LaTeX.hs

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -259,6 +259,9 @@ elementToBeamer slideLevel (Div (ident,"section":dclasses,dkvs)
               [Div (_,"notes":_,_) _] ->  -- see #7857, don't create frame
                     -- just for speaker notes after section heading
                     Div (ident,"section":dclasses,dkvs) xs
+                    -- See #8118 and #4317, don't create frame to change mode
+              [RawBlock (Format "latex") str] | "\\mode<presentation>" `T.isInfixOf` str ->
+                    Div (ident,"section":dclasses,dkvs) xs
               _  -> Div (ident,"section":dclasses,dkvs)
                      (h : Div ("","slide":dclasses,dkvs) (h:titleBs) : slideBs)
   | otherwise


### PR DESCRIPTION
Before Pandoc 2.7, choosing slide_level: 3 meant that ### was needed to create a slide. This commit https://github.com/jgm/pandoc/commit/5990f14ad497999141a5b975651f83d751ec421f caused this desired behavior to no longer be true and content above slide level is automatically included onto a slide, to accommodate compatibility with reveal.js format. At JGM's request, who could not think of a quick fix at the time, I posted a request on https://groups.google.com/g/pandoc-discuss/c/joqekZQRpq8, but no resolution was suggested.

This suggested simple 1 extra line change fixes these issues #8118 and #4317. Thank you in advance for entertaining this suggestion. FYI, I ran the tests to make sure all ok. Test suite test-pandoc: RUNNING... Test suite test-pandoc: PASS (I also compiled and used this pandoc.exe to make sure it works as expected and it does).