### PR TITLE
Add support for verse lang with --listings

### DIFF
--- a/src/Text/Pandoc/Highlighting.hs
+++ b/src/Text/Pandoc/Highlighting.hs
@@ -215,6 +215,7 @@ langsList =
   ("tex","TeX"),
   ("latex","TeX"),
   ("vbscript","VBScript"),
+  ("verse","Verse"),
   ("verilog","Verilog"),
   ("vhdl","VHDL"),
   ("vrml","VRML"),


### PR DESCRIPTION
Verse lang is a new language introduced in Unreal Engine for Fortnite.
https://dev.epicgames.com/documentation/en-us/uefn/learn-programming-with-verse-in-unreal-editor-for-fortnite

This PR adds a verse lang support of listing.