### PR TITLE
Change semicolon to colon in inline CSS in HTML template

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -63,7 +63,7 @@ img {
   max-width: 100%;
 }
 svg {
-  height; auto;
+  height: auto;
   max-width: 100%;
 }
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Converting to standalone html uses a template with a type with a semicolon where there should be a colon in the inline CSS.