### PR TITLE
Org reader: allow example lines to end immediately after the colon

### DIFF
--- a/src/Text/Pandoc/Readers/Org/BlockStarts.hs
+++ b/src/Text/Pandoc/Readers/Org/BlockStarts.hs
@@ -115,7 +115,7 @@ commentLineStart = try $
   skipSpaces <* string "#" <* lookAhead (oneOf " \n")
 
 exampleLineStart :: Monad m => OrgParser m ()
-exampleLineStart = () <$ try (skipSpaces *> string ": ")
+exampleLineStart = () <$ try (skipSpaces *> char ':' *> (void (char ' ') <|> lookAhead eol))
 
 noteMarker :: Monad m => OrgParser m Text
 noteMarker = try $ do

--- a/test/command/8997.md
+++ b/test/command/8997.md
@@ -1,0 +1,77 @@
+```
+% pandoc -f org -t native
+* has space after second colon
+: aaa
+: 
+: bbb
+
+
+* has no space after second colon
+: aaa
+:
+: bbb
+^D
+[ Header
+    1
+    ( "has-space-after-second-colon" , [] , [] )
+    [ Str "has"
+    , Space
+    , Str "space"
+    , Space
+    , Str "after"
+    , Space
+    , Str "second"
+    , Space
+    , Str "colon"
+    ]
+, CodeBlock ( "" , [ "example" ] , [] ) "aaa\n\nbbb\n"
+, Header
+    1
+    ( "has-no-space-after-second-colon" , [] , [] )
+    [ Str "has"
+    , Space
+    , Str "no"
+    , Space
+    , Str "space"
+    , Space
+    , Str "after"
+    , Space
+    , Str "second"
+    , Space
+    , Str "colon"
+    ]
+, CodeBlock ( "" , [ "example" ] , [] ) "aaa\n\nbbb\n"
+]
+```
+
+```
+% pandoc -f org -t native
+* only the colon
+:
+
+* only the colon and a space
+: 
+^D
+[ Header
+    1
+    ( "only-the-colon" , [] , [] )
+    [ Str "only" , Space , Str "the" , Space , Str "colon" ]
+, CodeBlock ( "" , [ "example" ] , [] ) "\n"
+, Header
+    1
+    ( "only-the-colon-and-a-space" , [] , [] )
+    [ Str "only"
+    , Space
+    , Str "the"
+    , Space
+    , Str "colon"
+    , Space
+    , Str "and"
+    , Space
+    , Str "a"
+    , Space
+    , Str "space"
+    ]
+, CodeBlock ( "" , [ "example" ] , [] ) "\n"
+]
+```


### PR DESCRIPTION
See the regexp at https://git.savannah.gnu.org/cgit/emacs/org-mode.git/tree/lisp/org-element.el?h=d1e4b9351941aa9241ab3aa0a34256376b7eca94#n2420.

Fixes #8997.