### PR TITLE
Correct name of JATS element <attrib>

### DIFF
--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -242,7 +242,7 @@ parseBlock (Elem e) = do
            return $ codeBlockWith (attrValue "id" e, classes', [])
                   $ trimNl $ strContentRecursive e
          parseBlockquote = do
-            attrib <- case filterChild (named "attribution") e of
+            attrib <- case filterChild (named "attrib") e of
                              Nothing  -> return mempty
                              Just z   -> para . (str "— " <>) . mconcat
                                          <$>


### PR DESCRIPTION
Replacement of wrong element name "attribution" by the correct one "attrib"