### PR TITLE
HTML writer: use the ID prefix in the ID for the footnotes section.

### DIFF
--- a/test/command/4235.md
+++ b/test/command/4235.md
@@ -4,7 +4,7 @@ This.^[Has a footnote.]
 ^D
 <p>This.<a href="#foofn1" class="footnote-ref" id="foofnref1"
 role="doc-noteref"><sup>1</sup></a></p>
-<aside id="footnotes" class="footnotes footnotes-end-of-document"
+<aside id="foofootnotes" class="footnotes footnotes-end-of-document"
 role="doc-endnotes">
 <hr />
 <ol>


### PR DESCRIPTION
In general, the ID prefix makes it possible to combine multiple pieces of Pandoc-generated HTML with no possibility that IDs will conflict. One exception to this was that the footnotes were always put into an element like

    <aside id="foonotes" ...>

This commit applies the ID prefix to this ID as well.