### PR TITLE
Ignore <processing-meta> element

### DIFF
--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -201,6 +201,7 @@ parseBlock (Elem e) = do
         "journal-meta" -> parseMetadata e
         "article-meta" -> parseMetadata e
         "custom-meta" -> parseMetadata e
+        "processing-meta" -> return mempty
         "title" -> return mempty -- processed by header
         "label" -> return mempty -- processed by header
         "table" -> parseTable

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -2,6 +2,9 @@
 <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN"
                   "JATS-archivearticle1.dtd">
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" dtd-version="1.2" article-type="other">
+<processing-meta base-tagset="archiving" mathml-version="3.0" table-model="xhtml" tagset-family="jats">
+    <restricted-by>pmc</restricted-by>
+</processing-meta>
 <front>
 <journal-meta>
 <journal-title-group>


### PR DESCRIPTION
The content of the <processing-meta> element is metadata and as such we fix it so that it is not displayed in the output.