### PR TITLE
LaTeX template: fix `\CSLRightInline` vertical space

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -362,7 +362,7 @@ $if(csl-refs)$
 \usepackage{calc}
 \newcommand{\CSLBlock}[1]{#1\hfill\break}
 \newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
-\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1\\[-1.7ex]}}
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
 $endif$
 $if(lang)$


### PR DESCRIPTION
When using a CSL stylesheet with the `citation-number` attribute e.g. `nature`, when `\CSLRightInline` is only one line currently extraneous vertical space is added.