### PR TITLE
LaTeX template: fix \CSLBlock vertical space

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -364,7 +364,7 @@ $if(csl-refs)$
   \setlength{\itemsep}{#2\baselineskip}}}
  {\end{list}}
 \usepackage{calc}
-\newcommand{\CSLBlock}[1]{\hfill\break#1\hfill\break}
+\newcommand{\CSLBlock}[1]{\hfill\break\parbox[t]{\linewidth}{\strut\ignorespaces#1\strut}}
 \newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{\strut#1\strut}}
 \newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{\strut#1\strut}}
 \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}


### PR DESCRIPTION
When using a CSL style which has an item with the `display="block"` attribute, the vertical space after the block depends on if the block item is the last item of the bibitem, or otherwise. This fixes that. Examples with the block item bordered by an `\fbox` for illustration:

---

<img width="601" alt="20230910T172042-PDF Expert@2x" src="https://github.com/jgm/pandoc/assets/39587/558e8dea-59bd-4ebf-bf42-015ea7031c89">

---

<img width="578" alt="20230910T175215-PDF Expert@2x" src="https://github.com/jgm/pandoc/assets/39587/f13d6bbf-9da3-4ca8-a64e-ce4ac9379110">

---