### PR TITLE
Added translation nb.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,3 @@
 .*sw?
 .DS_Store
 .stack-work
-.Rproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@
 .*sw?
 .DS_Store
 .stack-work
+.Rproj.user

--- a/data/translations/nb.yaml
+++ b/data/translations/nb.yaml
@@ -1,0 +1,21 @@
+Abstract: Sammendrag
+Appendix: Tillegg
+Bibliography: Bibliografi
+Cc: Kopi sendt
+Chapter: Kapittel
+Contents: Innhold
+Encl: Vedlegg
+Figure: Figur
+Glossary: Ordliste
+Index: Register
+ListOfFigures: Figurer
+ListOfTables: Tabeller
+Page: Side
+Part: Del
+Preface: Forord
+Proof: Bevis
+References: Referanser
+See: Se
+SeeAlso: Se også
+Table: Tabell
+To: Til


### PR DESCRIPTION
Added nb.yaml, which is a duplicate of no.yaml.
no=Norwegian major language consists in reality of two microlanguages nn=Nynorsk and nb=Bokmål. Downstream software (Quarto) requires consistency.