### PR TITLE
Clean up epub CSS

### DIFF
--- a/data/epub.css
+++ b/data/epub.css
@@ -56,7 +56,7 @@ h5 {
   margin: 1.1em 0 0 0;
   font-size: 1.1em;
 }
-h5 {
+h6 {
   font-size: 1em;
 }
 h1, h2, h3, h4, h5, h6 {

--- a/data/epub.css
+++ b/data/epub.css
@@ -2,14 +2,7 @@
 @page {
   margin: 10px;
 }
-html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  vertical-align: baseline;
-}
-ol, ul, li, dl, dt, dd {
+html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video, ol, ul, li, dl, dt, dd {
   margin: 0;
   padding: 0;
   border: 0;
@@ -28,60 +21,42 @@ p {
   widows: 2;
   orphans: 2;
 }
-a {
-  color: #1a1a1a;
-}
-a:visited {
+a, a:visited {
   color: #1a1a1a;
 }
 img {
   max-width: 100%;
 }
 h1 {
-  text-indent: 0;
-  text-align: left;
   margin: 3em 0 0 0;
   font-size: 2em;
-  font-weight: bold;
   page-break-before: always;
   line-height: 150%;
 }
 h2 {
-  text-indent: 0;
-  text-align: left;
   margin: 1.5em 0 0 0;
   font-size: 1.5em;
-  font-weight: bold;
   line-height: 135%;
 }
 h3 {
-  text-indent: 0;
-  text-align: left;
   margin: 1.3em 0 0 0;
   font-size: 1.3em;
-  font-weight: bold;
 }
 h4 {
-  text-indent: 0;
-  text-align: left;
   margin: 1.2em 0 0 0;
   font-size: 1.2em;
-  font-weight: bold;
 }
 h5 {
-  text-indent: 0;
-  text-align: left;
   margin: 1.1em 0 0 0;
   font-size: 1.1em;
-  font-weight: bold;
 }
 h5 {
-  text-indent: 0;
-  text-align: left;
   font-size: 1em;
-  font-weight: bold;
 }
 h1, h2, h3, h4, h5, h6 {
+  text-indent: 0;
+  text-align: left;
+  font-weight: bold;
   page-break-after: avoid;
   page-break-inside: avoid;
 }
@@ -135,12 +110,11 @@ tbody {
   border-top: 1px solid #1a1a1a;
   border-bottom: 1px solid #1a1a1a;
 }
-th {
-  border-top: 1px solid #1a1a1a;
+th, td {
   padding: 0.25em 0.5em 0.25em 0.5em;
 }
-td {
-  padding: 0.125em 0.5em 0.25em 0.5em;
+th {
+  border-top: 1px solid #1a1a1a;
 }
 header {
   margin-bottom: 4em;

--- a/data/epub.css
+++ b/data/epub.css
@@ -2,7 +2,13 @@
 @page {
   margin: 10px;
 }
-html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video, ol, ul, li, dl, dt, dd {
+html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p,
+blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img,
+ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center,
+fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, figure, figcaption, footer, header,
+hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video, ol,
+ul, li, dl, dt, dd {
   margin: 0;
   padding: 0;
   border: 0;
@@ -86,8 +92,8 @@ pre code {
   overflow-wrap: normal;
 }
 .sourceCode {
- background-color: transparent;
- overflow: visible;
+  background-color: transparent;
+  overflow: visible;
 }
 hr {
   background-color: #1a1a1a;
@@ -132,40 +138,73 @@ header {
 #TOC a:not(:hover) {
   text-decoration: none;
 }
-code{white-space: pre-wrap;}
-span.smallcaps{font-variant: small-caps;}
+code {
+  white-space: pre-wrap;
+}
+span.smallcaps {
+  font-variant: small-caps;
+}
 
 /* This is the most compatible CSS, but it only allows two columns: */
-div.column{ display: inline-block; vertical-align: top; width: 50%; }
-/* If you can rely on CSS3 support, use this instead:
-div.columns{display: flex; gap: min(4vw, 1.5em);}
-div.column{flex: auto; overflow-x: auto;}
-*/
+div.column {
+  display: inline-block;
+  vertical-align: top;
+  width: 50%;
+}
+/* If you can rely on CSS3 support, use this instead: */
+/* div.columns {
+  display: flex;
+  gap: min(4vw, 1.5em);
+}
+div.column {
+  flex: auto;
+  overflow-x: auto;
+} */
 
-div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-ul.task-list{list-style: none;}
+div.hanging-indent {
+  margin-left: 1.5em;
+  text-indent: -1.5em;
+}
+ul.task-list {
+  list-style: none;
+}
 ul.task-list li input[type="checkbox"] {
   width: 0.8em;
   margin: 0 0.8em 0.2em -1.6em;
   vertical-align: middle;
 }
-.display.math{
+.display.math {
   display: block;
   text-align: center;
   margin: 0.5rem auto;
 }
+
 /* For title, author, and date on the cover page */
 h1.title { }
 p.author { }
 p.date { }
-nav#toc ol,
-nav#landmarks ol { padding: 0; margin-left: 1em; }
-nav#toc ol li,
-nav#landmarks ol li { list-style-type: none; margin: 0; padding: 0; }
-a.footnote-ref { vertical-align: super; }
-em, em em em, em em em em em { font-style: italic;}
-em em, em em em em { font-style: normal; }
-q { quotes: "“" "”" "‘" "’"; }
+
+nav#toc ol, nav#landmarks ol {
+  padding: 0;
+  margin-left: 1em;
+}
+nav#toc ol li, nav#landmarks ol li {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+a.footnote-ref {
+  vertical-align: super;
+}
+em, em em em, em em em em em {
+  font-style: italic;
+}
+em em, em em em em {
+  font-style: normal;
+}
+q {
+  quotes: "“" "”" "‘" "’";
+}
 @media screen { /* Workaround for iBooks issue; see #6242 */
   .sourceCode {
     overflow: visible !important;


### PR DESCRIPTION
This PR contains mostly cosmetic changes, namely:
1. Combine identical styles
2. Wrap to 80 characters
3. Use consistent whitespace for brackets and indentation

It also includes one meaningful change:
1. Apply styles to `h6`. It looks like there was a typo in the previous rules, with two sets being applied to `h5` and none to `h6`.

Thanks for this incredible piece of software!