### PR TITLE
Check if supplied FORMAT matches with an HTML slide deck value. Return True for isRawHtml.

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -1731,11 +1731,20 @@ intrinsicEventsHTML4 =
   [ "onclick", "ondblclick", "onmousedown", "onmouseup", "onmouseover"
   , "onmouseout", "onmouseout", "onkeypress", "onkeydown", "onkeyup"]
 
+
+-- | Check to see if Format is valid HTML 
 isRawHtml :: PandocMonad m => Format -> StateT WriterState m Bool
 isRawHtml f = do
   html5 <- gets stHtml5
   return $ f == Format "html" ||
-           ((html5 && f == Format "html5") || f == Format "html4")
+           ((html5 && f == Format "html5") || f == Format "html4") ||
+           isSlideVariant f
+
+-- | Check to see if Format matches with an HTML slide variant
+isSlideVariant :: Format -> Bool
+isSlideVariant f = f `elem` [Format "s5", Format "slidy", Format "slideous", 
+                             Format "dzslides", Format "revealjs"]
+
 
 -- We need to remove links from link text, because an <a> element is
 -- not allowed inside another <a> element.


### PR DESCRIPTION
This PR attempts to close out the `HTML` writer portion of #8880. 

The change implement seeks to check whether `f` is part of the supported HTML slide formats. Thus, if we have a code block in `revealjs` of:

````md
```{=revealjs}
Hello there!
```
````

The text will be retained and treated as raw in the output format, e.g. 

```
Hello there!
```

Presently, the text will be deleted in the output, e.g. 

````md
````

We've supplied a sample test document.

If this is okay, we can submit a follow-up PR to address the EPUB issue or add it into this PR.

<details>
<summary> Test Markdown Document </summary>

````markdown
---
title: Test HTML Raw Fix
author: JJB
date: Sept 29, 2023
---

# Test Slide Format Retention

```{=revealjs}
Retain this text as we're under `revealjs`
```

```{=s5}
Retain this text as we're under `s5`
```

```{=slidy}
Retain this text as we're under slidy
```

```{=slideous}
Retain this text as we're under slideous
```

```{=dzslides}
Retain this text as we're under dzslides
```

# Verify HTML content is retained

```{=html}
Retain Hard `html` tag content
```

```{=html4}
Retain Hard `html4` tag content
```

```{=html5}
Retain Hard `html5` tag content
```

# Verify LaTeX via MathJax is okay

Verify we're okay with Math/LaTeX blocks.

$1 + 1$

# Check other raw block formats do not come through

There should be no warning after this ... 

```{=toad}
WARNING CONTENT WAS NOT DROPPED 
```
````
</details>