### PR TITLE
Fix abbreviation for astronomical unit

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX/SIunitx.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/SIunitx.hs
@@ -409,7 +409,7 @@ siUnitMap = M.fromList
   , ("arcmin", str "′")
   , ("arcminute", str "′")
   , ("arcsecond", str "″")
-  , ("astronomicalunit", str "ua")
+  , ("astronomicalunit", str "au")
   , ("atomicmassunit", str "u")
   , ("bar", str "bar")
   , ("barn", str "b")


### PR DESCRIPTION
In the siunitx implementation, the abbreviation for "astronomicalunit" is currently "ua". It should be "au" (see table 3 of the [official documentation](https://ctan.mirrors.hoobly.com/macros/latex/contrib/siunitx/siunitx.pdf)). This PR corrects that.