### PR TITLE
Document typst-citations to enable citeproc for typst output

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1422,8 +1422,9 @@ header when requesting a document from a URL:
     The citation processing transformation may be applied before
     or after filters or Lua filters (see `--filter`,
     `--lua-filter`): these transformations are applied in the
-    order they appear on the command line.  For more
-    information, see the section on [Citations].
+    order they appear on the command line. **Note:** for `typst`
+    output you must pass `--to typst-citations` for citeproc
+    to work. For more information, see the section on [Citations].
 
 `--bibliography=`*FILE*
 


### PR DESCRIPTION
See https://github.com/jgm/pandoc/issues/8763#issuecomment-1753234008 for context, basically the `citations` extension applies to docx and org readers but has been overloaded to also affect the typst writer to allow citeproc to work instead of typst citation system. Not so easy to document so this seems the best place?