### PR TITLE
Make suppress-bibliography work with --biblatex

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -553,7 +553,6 @@ $body$
 $if(has-frontmatter)$
 \backmatter
 $endif$
-$if(suppress-bibliography)$$else$
 $if(natbib)$
 $if(bibliography)$
 $if(biblio-title)$
@@ -574,6 +573,7 @@ $endif$
 
 $endif$
 $endif$
+$if(suppress-bibliography)$$else$
 $if(biblatex)$
 $if(beamer)$
 \begin{frame}[allowframebreaks]{$biblio-title$}

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -553,6 +553,7 @@ $body$
 $if(has-frontmatter)$
 \backmatter
 $endif$
+$if(suppress-bibliography)$$else$
 $if(natbib)$
 $if(bibliography)$
 $if(biblio-title)$
@@ -583,6 +584,7 @@ $else$
 \printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
 $endif$
 
+$endif$
 $endif$
 $for(include-after)$
 $include-after$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -573,7 +573,8 @@ $endif$
 
 $endif$
 $endif$
-$if(suppress-bibliography)$$else$
+$if(suppress-bibliography)$
+$else$
 $if(biblatex)$
 $if(beamer)$
 \begin{frame}[allowframebreaks]{$biblio-title$}


### PR DESCRIPTION
Currently, setting the metadata variable suppress-bibliography has no effect with --biblatex nor --natbib. I add a simple conditional to make it work.