### PR TITLE
Correct location of alt-text content

### DIFF
--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -142,11 +142,13 @@ getGraphic :: PandocMonad m
            => Maybe (Inlines, Text) -> Element -> JATS m Inlines
 getGraphic mbfigdata e = do
   let atVal a = attrValue a e
+  let altText = filterElement (named "alt-text") e of
+    Just alt = alt
+    Nothing = mempty
       (ident, title, capt) =
          case mbfigdata of
            Just (capt', i) -> (i, "fig:" <> atVal "title", capt')
-           Nothing        -> (atVal "id", atVal "title",
-                              text (atVal "alt-text"))
+           Nothing        -> (atVal "id", atVal "title", altText)
       attr = (ident, T.words $ atVal "role", [])
       imageUrl = atVal "href"
   return $ imageWith attr imageUrl title capt

--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -142,8 +142,8 @@ getGraphic :: PandocMonad m
            => Maybe (Inlines, Text) -> Element -> JATS m Inlines
 getGraphic mbfigdata e = do
   let atVal a = attrValue a e
-  let altText = filterElement (named "alt-text") e of
-    Just alt = alt
+  let altText = case filterElement (named "alt-text") e of
+    Just alt = textContent alt
     Nothing = mempty
       (ident, title, capt) =
          case mbfigdata of

--- a/test/Tests/Readers/JATS.hs
+++ b/test/Tests/Readers/JATS.hs
@@ -35,6 +35,42 @@ tests = [ testGroup "inline code"
         , testGroup "images"
           [ test jats "basic" $ "<graphic mimetype=\"image\" mime-subtype=\"\" xlink:href=\"/url\" xlink:title=\"title\" />"
             =?> para (image "/url" "title" mempty)
+            , test jats "alt-text" $ 
+                          "<graphic id=\"graphic001\"\n\
+                          \ xlink:href=\"https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660\"\n\
+                          \ xlink:title=\"This is the title of the graphic\"\n\
+                          \ xlink:role=\"This is the role of the graphic\">\n\
+                          \ <alt-text>Alternative text of the graphic</alt-text>\n\
+                          \ <caption>\n\
+                          \ <title>This is the title of the caption</title>\n\
+                          \ <p>Google doodle from 14 March 2003</p></caption>\n\
+                          \ </graphic>"
+            =?> Para [ Image
+              ( "graphic001"
+              , [ "This"
+                , "is"
+                , "the"
+                , "role"
+                , "of"
+                , "the"
+                , "graphic"
+                ]
+              , []
+              )
+              [ Str "Alternative"
+              , Space
+              , Str "text"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "graphic"
+              ]
+              ( "https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660"
+              , "This is the title of the graphic"
+              )
+              ]
           ]
         , test jats "bullet list" $
                             "<list list-type=\"bullet\">\n\

--- a/test/jats-reader.native
+++ b/test/jats-reader.native
@@ -754,10 +754,29 @@ Pandoc
       [ Para [ Str "Abstract" , Space , Str "text" ]
       , Para
           [ Image
-              ( "" , [] , [] )
-              []
+              ( "graphic001"
+              , [ "This"
+                , "is"
+                , "the"
+                , "role"
+                , "of"
+                , "the"
+                , "graphic"
+                ]
+              , []
+              )
+              [ Str "Alternative"
+              , Space
+              , Str "text"
+              , Space
+              , Str "of"
+              , Space
+              , Str "the"
+              , Space
+              , Str "graphic"
+              ]
               ( "https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660"
-              , ""
+              , "This is the title of the graphic"
               )
           ]
       , Para [ Math DisplayMath "e=mc^2" ]

--- a/test/jats-reader.xml
+++ b/test/jats-reader.xml
@@ -198,9 +198,14 @@
         <abstract>
           <p>Abstract text</p>
         </abstract>
-        <graphic xlink:href="https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660">
-          <alt-text>Alternative text 1</alt-text>
-          <caption><p>Google doodle from 14 March 2003</p></caption>
+       <graphic id="graphic001"
+        xlink:href="https://lh3.googleusercontent.com/dB7iirJ3ncQaVMBGE2YX-WCeoAVIChb6NAzoFcKCFChMsrixJvD7ZRbvcaC-ceXEzXYaoH4K5vaoRDsUyBHFkpIDPnsn3bnzovbvi0a2Gg=s660"
+        xlink:title="This is the title of the graphic"
+        xlink:role="This is the role of the graphic">
+          <alt-text>Alternative text of the graphic</alt-text>
+          <caption>
+            <title>This is the title of the caption</title>
+            <p>Google doodle from 14 March 2003</p></caption>
         </graphic>
         <alternatives>
           <tex-math><![CDATA[e=mc^2]]></tex-math>


### PR DESCRIPTION
Fix JATS reader erroneously attempting to fetch alt-text content from non-existent @alt-text attribute, to optional child element <alt-text>