### PR TITLE
Handle empty cells correctly in creole reader. Fixes #9141

### DIFF
--- a/src/Text/Pandoc/Readers/Creole.hs
+++ b/src/Text/Pandoc/Readers/Creole.hs
@@ -149,7 +149,7 @@ table = try $ do
                  <$> (string "|=" >> many1Till inline cellEnd)
     row = try $ skipSpaces >> many1Till cell rowEnd
     cell = B.plain . B.trimInlines . mconcat
-           <$> (char '|' >> many1Till inline cellEnd)
+           <$> (char '|' >> manyTill inline cellEnd)
     rowEnd = try $ optional (char '|') >> skipSpaces >> newline
     cellEnd = lookAhead $ try $ char '|' <|> rowEnd
 


### PR DESCRIPTION
Handle empty table cells of the form `|||` correctly.  Without this fix empty cells must at least contain one space like so `| | |` which shouldn't be necessary. 