### PR TITLE
remove duplicates for Ext_raw_html and Ext_pipe_tables

### DIFF
--- a/src/Text/Pandoc/Extensions.hs
+++ b/src/Text/Pandoc/Extensions.hs
@@ -408,8 +408,6 @@ getDefaultExtensions "commonmark_x"    = extensionsFromList
   , Ext_strikeout
   , Ext_task_lists
   , Ext_emoji
-  , Ext_pipe_tables
-  , Ext_raw_html
   , Ext_smart
   , Ext_tex_math_dollars
   , Ext_superscript


### PR DESCRIPTION
`Ext_pipe_tables` and `Ext_raw_html` each appear two times in the list. This commit deletes 2nd occurrence of each.

```haskell
getDefaultExtensions "commonmark_x"    = extensionsFromList
  [ Ext_pipe_tables
  , Ext_raw_html
  , Ext_gfm_auto_identifiers
  , Ext_strikeout
  , Ext_task_lists
  , Ext_emoji
  , Ext_pipe_tables
  , Ext_raw_html
  , Ext_smart
  , Ext_tex_math_dollars
  , Ext_superscript
  , Ext_subscript
  , Ext_definition_lists
  , Ext_footnotes
  , Ext_fancy_lists
  , Ext_fenced_divs
  , Ext_bracketed_spans
  , Ext_raw_attribute
  , Ext_implicit_header_references
  , Ext_attributes
  , Ext_yaml_metadata_block
  ]
```