### PR TITLE
Center tables in HTML

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -136,11 +136,9 @@ hr {
   margin: 1em 0;
 }
 table {
-  margin: 1em 0;
+  margin: auto;
   border-collapse: collapse;
-  width: 100%;
   overflow-x: auto;
-  display: block;
   font-variant-numeric: lining-nums tabular-nums;
 }
 table caption {


### PR DESCRIPTION
Modern computer screens are quite wide, so a center-aligned table looks much better than a left-aligned one. For example, compare the two below. This can be achieved by simplifying the CSS template as done in this PR. 

<img width="678" alt="Screenshot 2023-11-01 at 8 49 41 PM" src="https://github.com/jgm/pandoc/assets/6758001/e7c8a6b5-3618-42eb-8366-67e8fc11f3d0">
<img width="679" alt="Screenshot 2023-11-01 at 8 49 33 PM" src="https://github.com/jgm/pandoc/assets/6758001/b0679d55-a9a4-4429-bd2f-877d1f68fe70">
