### PR TITLE
Bug fix for the Latex writer issue #8982

### DIFF
--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -127,41 +127,6 @@ convertWithOpts scriptingEngine opts = do
                Left e -> E.throwIO $ PandocShouldNeverHappenError $ T.pack e
           | otherwise -> writeFnBinary outputFile bs
 
-isolateBigNote :: ([Inline] -> Inline) -> [Inline] -> [Inline]
-isolateBigNote constructor xs
-  | any isBigNote xs = let (before, after) = break isBigNote xs
-              in case after of
-                   (noteInline:rest) -> constructor before : noteInline : isolateBigNote constructor rest
-                   _ -> error "break should always return a non-empty 'after' when 'any isNote xs' is True."
-  | otherwise = [constructor xs]
-  where
-    isBigNote :: Inline -> Bool
-    isBigNote (Note blocks) = countParas blocks > 1
-      where
-        countParas :: [Block] -> Int
-        countParas = length . filter isPara
-
-        isPara :: Block -> Bool
-        isPara (Para _) = True
-        isPara _        = False
-    isBigNote _ = False
-
-liftBigNotes :: [Inline] -> [Inline]
-liftBigNotes [] = []
-liftBigNotes (x:xs) =
-    case x of
-        Emph inner    -> isolateBigNote Emph (liftBigNotes inner) ++ liftBigNotes xs
-        Strong inner  -> isolateBigNote Strong (liftBigNotes inner) ++ liftBigNotes xs
-        _             -> x : liftBigNotes xs
-
-liftBigNotesInBody :: Pandoc -> Pandoc
-liftBigNotesInBody (Pandoc meta bs) = Pandoc meta (fmap liftBigNotesInBlock bs)
-  where
-    liftBigNotesInBlock :: Block -> Block
-    liftBigNotesInBlock (Para xs)  = Para (liftBigNotes xs)
-    liftBigNotesInBlock (Plain xs) = Plain (liftBigNotes xs)
-    liftBigNotesInBlock others     = others
-
 convertWithOpts' :: (PandocMonad m, MonadIO m, MonadMask m)
                  => ScriptingEngine
                  -> Bool
@@ -276,8 +241,7 @@ convertWithOpts' scriptingEngine istty datadir opts = do
   metadataFromFile <- getMetadataFromFiles readerNameBase readerOpts
                          (optMetadataFiles opts)
 
-  let transforms = (liftBigNotesInBody :) .
-                   (case optShiftHeadingLevelBy opts of
+  let transforms = (case optShiftHeadingLevelBy opts of
                         0             -> id
                         x             -> (headerShift x :)) .
                    (if extensionEnabled Ext_east_asian_line_breaks

--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -276,7 +276,8 @@ convertWithOpts' scriptingEngine istty datadir opts = do
   metadataFromFile <- getMetadataFromFiles readerNameBase readerOpts
                          (optMetadataFiles opts)
 
-  let transforms = (case optShiftHeadingLevelBy opts of
+  let transforms = (liftBigNotesInBody :) .
+                   (case optShiftHeadingLevelBy opts of
                         0             -> id
                         x             -> (headerShift x :)) .
                    (if extensionEnabled Ext_east_asian_line_breaks

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -64,6 +64,7 @@ import Text.Pandoc.Writers.LaTeX.Util (stringToLaTeX, StringContext(..),
                                        getListingsLanguage, mbBraced)
 import Text.Pandoc.Writers.Shared
 import qualified Text.Pandoc.Writers.AnnotatedTable as Ann
+-- Work around problems with notes inside emphasis (see #8982)
 
 isolateBigNotes :: ([Inline] -> Inline) -> [Inline] -> [Inline]
 isolateBigNotes constructor xs =

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -799,7 +799,20 @@ inlineToLaTeX (Span (id',classes,kvs) ils) = do
     (if null cmds
         then braces contents
         else foldr inCmd contents cmds)
-inlineToLaTeX (Emph lst) = inCmd "emph" <$> inlineListToLaTeX lst
+inlineToLaTeX (Emph lst)
+    | any isNote lst = case break isNote lst of
+                        (nonNote, []) ->
+                          inCmd "emph" <$> inlineListToLaTeX nonNote
+                        (nonNote, note:rest) -> do
+                          nonNoteDoc <- inCmd "emph" <$> inlineListToLaTeX nonNote
+                          noteDoc <- inlineListToLaTeX [note]
+                          restDoc <- inlineListToLaTeX [Emph rest]
+                          return (nonNoteDoc <> noteDoc <> restDoc)
+    | otherwise      = inCmd "emph" <$> inlineListToLaTeX lst
+    where
+      isNote :: Inline -> Bool
+      isNote (Note _) = True
+      isNote _        = False
 inlineToLaTeX (Underline lst) = do
   modify $ \st -> st{ stStrikeout = True } -- this gives us the soul package
   inCmd "ul" <$> inlineListToLaTeX lst

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -799,20 +799,7 @@ inlineToLaTeX (Span (id',classes,kvs) ils) = do
     (if null cmds
         then braces contents
         else foldr inCmd contents cmds)
-inlineToLaTeX (Emph lst)
-    | any isNote lst = case break isNote lst of
-                        (nonNote, []) ->
-                          inCmd "emph" <$> inlineListToLaTeX nonNote
-                        (nonNote, note:rest) -> do
-                          nonNoteDoc <- inCmd "emph" <$> inlineListToLaTeX nonNote
-                          noteDoc <- inlineListToLaTeX [note]
-                          restDoc <- inlineListToLaTeX [Emph rest]
-                          return (nonNoteDoc <> noteDoc <> restDoc)
-    | otherwise      = inCmd "emph" <$> inlineListToLaTeX lst
-    where
-      isNote :: Inline -> Bool
-      isNote (Note _) = True
-      isNote _        = False
+inlineToLaTeX (Emph lst) = inCmd "emph" <$> inlineListToLaTeX lst
 inlineToLaTeX (Underline lst) = do
   modify $ \st -> st{ stStrikeout = True } -- this gives us the soul package
   inCmd "ul" <$> inlineListToLaTeX lst

--- a/test/Tests/Writers/LaTeX.hs
+++ b/test/Tests/Writers/LaTeX.hs
@@ -86,11 +86,6 @@ tests = [ testGroup "code blocks"
           , "backtick" =:
               code "`nu?`" =?> "\\texttt{\\textasciigrave{}nu?\\textasciigrave{}}"
           ]
-        , testGroup "inline emph"
-          [ "note in emph constructor" =:
-            emph (str "This sentence" <> note (para (str "paragraph1") <> para (str "paragraph2")) <> str " has footnote.") =?>
-               "\\emph{This sentence}\\footnote{paragraph1\n\n  paragraph2}\\emph{ has footnote.}"
-          ]
         , testGroup "writer options"
           [ testGroup "top-level division" $
             let

--- a/test/Tests/Writers/LaTeX.hs
+++ b/test/Tests/Writers/LaTeX.hs
@@ -86,6 +86,11 @@ tests = [ testGroup "code blocks"
           , "backtick" =:
               code "`nu?`" =?> "\\texttt{\\textasciigrave{}nu?\\textasciigrave{}}"
           ]
+        , testGroup "inline emph"
+          [ "note in emph constructor" =:
+            emph (str "This sentence" <> note (para (str "paragraph1") <> para (str "paragraph2")) <> str " has footnote.") =?>
+               "\\emph{This sentence}\\footnote{paragraph1\n\n  paragraph2}\\emph{ has footnote.}"
+          ]
         , testGroup "writer options"
           [ testGroup "top-level division" $
             let

--- a/test/Tests/Writers/LaTeX.hs
+++ b/test/Tests/Writers/LaTeX.hs
@@ -86,6 +86,74 @@ tests = [ testGroup "code blocks"
           , "backtick" =:
               code "`nu?`" =?> "\\texttt{\\textasciigrave{}nu?\\textasciigrave{}}"
           ]
+        , testGroup "inline note"
+          [ "Big note in emph" =:
+              emph (str "This sentence"
+                    <> note (para (str "paragraph1")
+                             <> para (str "paragraph2"))
+                    <> str " has footnote.")
+              =?>
+                 "\\emph{This sentence}\\footnote{paragraph1\n\n  paragraph2}"
+                 <> "\\emph{ has footnote.}"
+           , "Big note in strong" =:
+              strong (str "This sentence"
+                      <> note (para (str "paragraph1")
+                               <> para (str "paragraph2"))
+                      <> str " has footnote.")
+              =?>
+                 "\\textbf{This sentence}\\footnote{paragraph1\n\n  paragraph2}"
+                 <> "\\textbf{ has footnote.}"
+
+           , "Big note in underline" =:
+              underline (str "This sentence"
+                         <> note (para (str "paragraph1")
+                                  <> para (str "paragraph2"))
+                         <> str " has footnote.")
+              =?>
+                 "\\ul{This sentence}\\footnote{paragraph1\n\n  paragraph2}"
+                 <> "\\ul{ has footnote.}"
+
+           , "Big note in strikeout" =:
+              strikeout (str "This sentence"
+                         <> note (para (str "paragraph1")
+                                  <> para (str "paragraph2"))
+                         <> str " has footnote.")
+              =?>
+                 "\\st{This sentence}\\footnote{paragraph1\n\n  paragraph2}"
+                 <> "\\st{ has footnote.}"
+
+           , "Small note in emph" =:
+              emph (str "This sentence"
+                    <> note (para (str "paragraph"))
+                    <> str " has footnote.")
+              =?>
+                 "\\emph{This sentence\\footnote{paragraph} has footnote.}"
+
+           , "Big note nested in emph and strong" =:
+              emph (str "This "
+                    <> strong (str "nested sentence "
+                               <> note (para (str "paragraph1")
+                                        <> para (str "paragraph2"))
+                               <> str "has ")
+                    <> str "footnote."
+              )
+              =?>
+                 "\\emph{This \\textbf{nested sentence }}\\footnote{paragraph1\n\n"
+                 <> "  paragraph2}\\emph{\\textbf{has }footnote.}"
+
+          , "Two Big notes in emph" =:
+              emph (str "This sentence"
+                    <> note (para (str "1-paragraph1")
+                             <> para (str "1-paragraph2"))
+                    <> str " has"
+                    <> note (para (str "2-paragraph1")
+                             <> para (str "2-paragraph2"))
+                    <> str " footnote.")
+              =?>
+                 "\\emph{This sentence}\\footnote{1-paragraph1\n\n  1-paragraph2}"
+                 <> "\\emph{ has}\\footnote{2-paragraph1\n\n  2-paragraph2}"
+                 <> "\\emph{ footnote.}"
+          ]
         , testGroup "writer options"
           [ testGroup "top-level division" $
             let


### PR DESCRIPTION
Latex Writer converts
`emph (str "This sentence" <> note (para (str "paragraph1") <> para (str "paragraph2")) <> str " has footnote.")` to
`"\\emph{This sentence}\\footnote{paragraph1\n\n  paragraph2}\\emph{ has footnote.}"` instead of
`"\\emph{This sentence\\footnote{paragraph1\n\n  paragraph2} has footnote.}"`