### PR TITLE
Update default.typst to support csl

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -83,7 +83,10 @@ $endif$
 $body$
 
 $if(citations)$
-$if(bibliographystyle)$
+$if(csl)$
+
+#set bibliography(style: "$csl$")
+$elseif(bibliographystyle)$
 
 #set bibliography(style: "$bibliographystyle$")
 $endif$


### PR DESCRIPTION
Typst now supports CSL for its native citation engine, so Pandoc should pass that as a priority in the template, falling back to `bibliographystyle`

https://typst.app/docs/reference/meta/bibliography/