### PR TITLE
Fixed theorem label issue in Latex

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX/Math.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Math.hs
@@ -12,6 +12,7 @@ module Text.Pandoc.Readers.LaTeX.Math
   )
 where
 import Data.Maybe (fromMaybe, mapMaybe, listToMaybe)
+import Data.List (foldl')
 import Text.Pandoc.Walk (walk)
 import Text.Pandoc.Builder as B
 import qualified Data.Sequence as Seq
@@ -141,12 +142,13 @@ newtheorem inline = do
   return mempty
 
 extractLabelFromBlock :: Block -> Maybe Text
-extractLabelFromBlock (Para inlines) = extractLabel inlines
+extractLabelFromBlock (Para inlines) = extractLabel Nothing inlines
   where
-    extractLabel :: [Inline] -> Maybe Text
-    extractLabel (Span (_, _, attrs) _:_) = lookup "label" attrs
-    extractLabel (_:xs) = extractLabel xs
-    extractLabel [] = Nothing
+    extractLabel = foldl' go
+    go :: Maybe Text -> Inline -> Maybe Text
+    go (Just t) _ = Just t
+    go Nothing (Span (_, _, attrs) _) = lookup "label" attrs
+    go Nothing _ = Nothing
 extractLabelFromBlock _ = Nothing
 
 theoremEnvironment :: PandocMonad m

--- a/test/command/8872.md
+++ b/test/command/8872.md
@@ -1,0 +1,45 @@
+
+```
+% pandoc -f latex -t native
+\documentclass{amsart}
+\newtheorem{theorem}{Theorem}
+\begin{document}
+\begin{theorem}\label{thm}
+\begin{enumerate}
+\item \label{item1}text1
+\item \label{item2}text2
+\item text3
+\end{enumerate}
+\end{theorem}
+\end{document}
+^D
+[ Div
+    ( "thm" , [ "theorem" ] , [] )
+    [ Para
+        [ Strong [ Str "Theorem" , Space , Str "1" ]
+        , Str "."
+        , Space
+        , Space
+        , Emph []
+        ]
+    , OrderedList
+        ( 1 , DefaultStyle , DefaultDelim )
+        [ [ Para
+              [ Emph
+                  [ Span ( "item1" , [] , [ ( "label" , "item1" ) ] ) []
+                  , Str "text1"
+                  ]
+              ]
+          ]
+        , [ Para
+              [ Emph
+                  [ Span ( "item2" , [] , [ ( "label" , "item2" ) ] ) []
+                  , Str "text2"
+                  ]
+              ]
+          ]
+        , [ Para [ Emph [ Str "text3" ] ] ]
+        ]
+    ]
+]
+```


### PR DESCRIPTION
This patch addresses the bug raised in #8872.

In the current implementation , theorem labels in `theoremEnvironment` are determined by the `LastLabel` in the current state. This approach works well when the `\label{thm}` is placed at the end of the theorem body (, which is a standard place to put a label.)

However, when a label is placed at the beginning of the theorem (another common practice) and additional labels follow in the theorem body, `theoremEnvironment` incorrectly picks the last label (e.g., `\label{item2}` in #8872).

This patch addresses the issue by extracting the label extraction independently of the `LastLabel` state.