### PR TITLE
LaTeX writer: support beamer overlays

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX/Table.hs
+++ b/src/Text/Pandoc/Writers/LaTeX/Table.hs
@@ -34,7 +34,7 @@ import Text.Pandoc.Writers.LaTeX.Notes (notesToLaTeX)
 import Text.Pandoc.Writers.LaTeX.Types
   ( LW, WriterState (stBeamer, stExternalNotes, stInMinipage, stMultiRow
                     , stNotes, stTable) )
-import Text.Pandoc.Writers.LaTeX.Util (labelFor)
+import Text.Pandoc.Writers.LaTeX.Util (labelFor,generateOverlay)
 import Text.Printf (printf)
 import qualified Text.Pandoc.Builder as B
 import qualified Text.Pandoc.Writers.AnnotatedTable as Ann
@@ -45,8 +45,9 @@ tableToLaTeX :: PandocMonad m
              -> Ann.Table
              -> LW m (Doc Text)
 tableToLaTeX inlnsToLaTeX blksToLaTeX tbl = do
-  let (Ann.Table (ident, _, _) caption specs thead tbodies tfoot) = tbl
+  let (Ann.Table (ident, _, kvs) caption specs thead tbodies tfoot) = tbl
   CaptionDocs capt captNotes <- captionToLaTeX inlnsToLaTeX caption ident
+  overlay <- generateOverlay kvs
   let isSimpleTable =
         all ((== ColWidthDefault) . snd) specs &&
         all (all isSimpleCell)
@@ -86,7 +87,7 @@ tableToLaTeX inlnsToLaTeX blksToLaTeX tbl = do
   notes <- notesToLaTeX <$> gets stNotes
   beamer <- gets stBeamer
   return
-    $  "\\begin{longtable}[]" <>
+    $  "\\begin" <> overlay <> "{longtable}[]" <>
           braces ("@{}" <> colDescriptors isSimpleTable tbl <> "@{}")
           -- the @{} removes extra space at beginning and end
     $$ head'

--- a/src/Text/Pandoc/Writers/LaTeX/Util.hs
+++ b/src/Text/Pandoc/Writers/LaTeX/Util.hs
@@ -18,6 +18,7 @@ module Text.Pandoc.Writers.LaTeX.Util (
   , labelFor
   , getListingsLanguage
   , mbBraced
+  , generateOverlay
   )
 where
 
@@ -278,3 +279,16 @@ mbBraced :: Text -> Text
 mbBraced x = if not (T.all isAlphaNum x)
                 then "{" <> x <> "}"
                 else x
+
+-- Generate a beamer overlay specification (possibly empty)
+--  from the attributes of a Pandoc element
+-- Generates nothing outside beamer-mode
+-- e.g. ![My picture](pic.jpg){on=4-} generates "<4->"
+-- e.g. ![My picture](pic.jpg) generates ""
+generateOverlay :: (PandocMonad m) => [(Text,Text)] -> LW m (Doc Text)
+generateOverlay attrs = do
+  beamer <- gets stBeamer
+  return $
+    case (beamer, lookup "on" attrs) of
+      (True, Just overlay) -> "<" <> literal overlay <> ">" 
+      _ -> ""


### PR DESCRIPTION

# Support beamer overlays

This PR allows scripting beamer animations in markdown (and other formats).

The input syntax uses the `on` attribute, e.g.

```markdown

# What type? {.t}

`parseInt :: ???`{.haskell on=1}

. . .

`parseInt :: String -> Int`{.haskell on=2-3}

. . .

`parseInt "haha" == ???`{.haskell on=3}

![](https://openclipart.org/image/800px/190136){on=3}

. . .

`parseInt :: String -> Maybe Int`{.haskell}

`parseInt "haha" == Nothing`{.haskell}

```

This compiles to the following beamer-LaTeX:

```latex
\begin{frame}[fragile,t]{What type?}
\phantomsection\label{what-type}
\only<1>{\VERB|\OtherTok{parseInt ::} \OperatorTok{???}|}

\pause

\only<2-3>{\VERB|\OtherTok{parseInt ::} \DataTypeTok{String} \OtherTok{{-}\textgreater{}} \DataTypeTok{Int}|}

\pause

\only<3>{\VERB|\NormalTok{parseInt }\StringTok{"haha"} \OperatorTok{==} \OperatorTok{???}|}

\includegraphics<3>{https://openclipart.org/image/800px/190136}

\pause

\VERB|\OtherTok{parseInt ::} \DataTypeTok{String} \OtherTok{{-}\textgreater{}} \DataTypeTok{Maybe} \DataTypeTok{Int}|

\VERB|\NormalTok{parseInt }\StringTok{"haha"} \OperatorTok{==} \DataTypeTok{Nothing}|
\end{frame}

```

## Related issues

* #8118 (similar feature proposed, but div-specific)
* #7848 (similar feature proposed, but note-specific)
* #3184 (similar feature proposed, discussion of work-around using raw LaTeX)

## Coverage

Tested:

* Block images
* Inline code

TODO:

* [ ] Test tables
* [ ] Test divs
* [ ] Test spans
* [ ] Test links
* [ ] Test inline images
* [ ] Debug fenced code blocks **(currently broken)**
* [ ] Finalize syntax (currently `on=OVERLAY` attribute, but open for bike-shedding)
* [ ] Write regression tests

Feedback welcome.
