### PR TITLE
LaTeX template: support font fallback

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -139,13 +139,37 @@ $endif$
 \ifPDFTeX\else
   % xetex/luatex font selection
 $if(mainfont)$
-  \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
+  $if(mainfontfallback)$
+    \ifLuaTeX
+      \usepackage{luaotfload}
+      \directlua{luaotfload.add_fallback("mainfontfallback",{
+        $for(mainfontfallback)$"$mainfontfallback$"$sep$,$endfor$
+      })}
+    \fi
+  $endif$
+  \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$$if(mainfontfallback)$,RawFeature={fallback=mainfontfallback}$endif$]{$mainfont$}
 $endif$
 $if(sansfont)$
-  \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
+  $if(sansfontfallback)$
+    \ifLuaTeX
+      \usepackage{luaotfload}
+      \directlua{luaotfload.add_fallback("sansfontfallback",{
+        $for(sansfontfallback)$"$sansfontfallback$"$sep$,$endfor$
+      })}
+    \fi
+  $endif$
+  \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$$if(sansfontfallback)$,RawFeature={fallback=sansfontfallback}$endif$]{$sansfont$}
 $endif$
 $if(monofont)$
-  \setmonofont[$for(monofontoptions)$$monofontoptions$$sep$,$endfor$]{$monofont$}
+  $if(monofontfallback)$
+    \ifLuaTeX
+      \usepackage{luaotfload}
+      \directlua{luaotfload.add_fallback("monofontfallback",{
+        $for(monofontfallback)$"$monofontfallback$"$sep$,$endfor$
+      })}
+    \fi
+  $endif$
+  \setmonofont[$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$if(monofontfallback)$,RawFeature={fallback=monofontfallback}$endif$]{$monofont$}
 $endif$
 $for(fontfamilies)$
   \newfontfamily{$fontfamilies.name$}[$for(fontfamilies.options)$$fontfamilies.options$$sep$,$endfor$]{$fontfamilies.font$}


### PR DESCRIPTION
This allows low-effort PDF generation from Unicode source.

e.g. I can write `src.md`:

```markdown
---
title: Demo Document
mainfont: Latin Modern Sans
mainfontfallback:
  - "FreeSans:"
  - "NotoColorEmoji:mode=harf"
---

Look, the empty set! → ∅ ←

Emoji work too 😎!
```

Then convert with `pandoc -s src.md -o out.pdf --pdf-engine=lualatex`

The PDF file then contains the Unicode as expected:

![Screenshot from 2023-11-20 12-41-42](https://github.com/jgm/pandoc/assets/95857153/4da0936f-e0b9-4a4c-a69c-eb7c405a98d1)
Notes:

* Only the `lualatex` PDF engine is supported
  * Since this patch calls `luaotfload`
  * Other PDF engines are unaffected
* `mainfont`, `sansfont`, and `monofont` can each be given a separate fallback chain
* For each `XXXfontfallback` to work, the YAML option `XXXfont` must also be set
  * I could not work out how to control `fontspec` without knowing the names of fonts