### PR TITLE
LaTeX template: add titlegraphicoptions

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2789,6 +2789,9 @@ These variables change the appearance of PDF slides using [`beamer`].
 `titlegraphic`
 :   image for title slide
 
+`titlegraphicoptions`
+:   options for title slide image
+
 ### Variables for PowerPoint
 
 These variables control the visual aspects of a slide show that

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -487,7 +487,7 @@ $if(institute)$
 \institute{$for(institute)$$institute$$sep$ \and $endfor$}
 $endif$
 $if(titlegraphic)$
-\titlegraphic{\includegraphics{$titlegraphic$}}
+\titlegraphic{\includegraphics$if(titlegraphicoptions)$[$titlegraphicoptions$]$endif${$titlegraphic$}}
 $endif$
 $if(logo)$
 \logo{\includegraphics{$logo$}}


### PR DESCRIPTION
Hi,

Including a title graphic on a beamer template might require some options, like e.g. `height=1.5cm` to ensure some image will fit at its place in a given template.

I suggest to add an option for this use case.

Without it, my current workaround is:
```yaml
header-includes:
- \titlegraphic{\includegraphics[height=1.5cm]{media/cdl23.pdf}}
```