### PR TITLE
LaTeX writer: support beamer overlays (take 2)

### DIFF
--- a/test/Tests/Writers/LaTeX.hs
+++ b/test/Tests/Writers/LaTeX.hs
@@ -12,6 +12,9 @@ import Text.Pandoc.Builder
 latex :: (ToPandoc a) => a -> String
 latex = latexWithOpts def
 
+beamer :: (ToPandoc a) => a -> String
+beamer = beamerWithOpts def
+
 latexListing :: (ToPandoc a) => a -> String
 latexListing = latexWithOpts def{ writerListings = True }
 
@@ -173,5 +176,25 @@ tests = [ testGroup "code blocks"
                       , "\\addcontentsline{toc}{paragraph}{header6}"
                       ]
             ]
+          ]
+        , testGroup "beamer overlays"
+          [ test beamer "code block" $ codeBlockWith ("",[],[("only","2")]) "hi" =?>
+            unlines
+              [ "\\begin{frame}[fragile]"
+              , "\\begin{onlyenv}<2>\\begin{verbatim}"
+              , "hi"
+              , "\\end{verbatim}"
+              , "\\end{onlyenv}"
+              , "\\end{frame}"
+              ]
+          , test beamer "code block, nested overlays" $ codeBlockWith ("",[],[("only","1-3"),("invisible","2")]) "hi" =?>
+            unlines
+              [ "\\begin{frame}[fragile]"
+              , "\\begin{onlyenv}<1-3>\\begin{invisibleenv}<2>\\begin{verbatim}"
+              , "hi"
+              , "\\end{verbatim}"
+              , "\\end{invisibleenv}\\end{onlyenv}"
+              , "\\end{frame}"
+              ]
           ]
         ]


### PR DESCRIPTION
This PR is a successor to #9203, with a different implementation.

This PR allows ergonomic beamer scripting, via attributes on pandoc elements.

* The key-value attributes [`only`,`visible`,`uncover`,`invisible`] are interpreted specially by the beamer writer
* These can be applied to any (attribute-carrying) `Block` or `Inline` element
* The generated beamer-LaTeX code for those elements is wrapped in `\begin{XXXenv}<YYY>...\end{XXXenv}`,
   for each (special) attribute pair `(XXX,YYY)`

Example
------------

I can write a presentation in markdown:

````````markdown

---
header-includes: |
  \setbeamercovered{transparent=25}
---


# How to print a tree {.t}

`{-# LANGUAGE StandaloneDeriving #-}`{.haskell visible=5-}

`data Tree a = Leaf a | Branch [Tree a]`{.haskell}

![](https://upload.wikimedia.org/wikipedia/commons/1/1c/Haskell-Logo.svg){only=1}

[*Many* options:]{invisible=1-5}

```{.haskell visible=3,6-}
  deriving (Show)
```

```{.haskell visible=4,6-}
instance (Show a) => Show (Tree a) where
  show :: Tree a -> String
  show (Leaf x) = "Leaf (" ++ show x ++ ")"
  show (Branch ts) = "Branch " ++ show ts
```

`deriving instance (Show a) => Show (Tree a)`{.haskell visible=5-}

## Discussion {visible=7-}

::::: {uncover=8-}
* Not all at once
  * `OverlappingInstances`
  * [Choose max. 1!]{only=9}
:::::
::::: {uncover=11-}
* See also
  * [Tweag on run-time instances](https://www.tweag.io/blog/2021-04-08-capabilities-ad-hoc-interpreters/){only=12-}
:::::

````````

Then `pandoc src.md -o slides.pdf --to beamer` generates a 12-page slideshow:

![Screenshot from 2023-11-24 18-18-54](https://github.com/jgm/pandoc/assets/95857153/fc87a6b3-c7f8-44d7-a370-b79b6c9e2fc0)

[slides.pdf](https://github.com/jgm/pandoc/files/13461261/slides.pdf)
