### PR TITLE
fix(docx): support absolute header/footer paths

### DIFF
--- a/src/Text/Pandoc/Readers/Docx/Parse.hs
+++ b/src/Text/Pandoc/Readers/Docx/Parse.hs
@@ -56,6 +56,7 @@ module Text.Pandoc.Readers.Docx.Parse ( Docx(..)
                                       , constructBogusParStyleData
                                       , leftBiasedMergeRunStyle
                                       , rowsToRowspans
+                                      , extractTarget
                                       ) where
 import Text.Pandoc.Readers.Docx.Parse.Styles
 import Codec.Archive.Zip
@@ -537,6 +538,10 @@ relElemToRelationship fp relType element | qName (elName element) == "Relationsh
            T.stripPrefix frontOfFp $ T.dropWhile (== '/') target
     return $ Relationship relType relId target'
 relElemToRelationship _ _ _ = Nothing
+
+extractTarget :: Element -> Maybe Target
+extractTarget element = do (Relationship _ _ target) <- relElemToRelationship "word/" InDocument element
+                           return target
 
 filePathToRelationships :: Archive -> FilePath -> FilePath ->  [Relationship]
 filePathToRelationships ar docXmlPath fp

--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -64,6 +64,7 @@ import Text.Pandoc.ImageSize
 import Text.Pandoc.Logging
 import Text.Pandoc.MIME (extensionFromMimeType, getMimeType, getMimeTypeDef)
 import Text.Pandoc.Options
+import Text.Pandoc.Readers.Docx.Parse (extractTarget)
 import Text.Pandoc.Writers.Docx.StyleMap
 import Text.Pandoc.Writers.Docx.Table as Table
 import Text.Pandoc.Writers.Docx.Types
@@ -309,8 +310,6 @@ writeDocx opts doc = do
   let isFooterNode e = findAttr (QName "Type" Nothing Nothing) e == Just "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer"
   let headers = filterElements isHeaderNode parsedRels
   let footers = filterElements isFooterNode parsedRels
-
-  let extractTarget = findAttr (QName "Target" Nothing Nothing)
 
   -- we create [Content_Types].xml and word/_rels/document.xml.rels
   -- from scratch rather than reading from reference.docx,


### PR DESCRIPTION
Header and footer references may be absolute in the reference.docx.

E.g. editing it with dotnet's Open-XML-SDK causes this error:

```
+ pandoc test.md -t docx --reference-doc referenceh.docx -o test.docx
word//word/header1.xml missing in reference docx
```

There was already code in pandoc to handle relative vs absolute paths in references, so use it.

# Background: how to reproduce this

Modified [referenceh.docx](https://github.com/jgm/pandoc/files/13763071/referenceh.docx) produced by the following F# code:
(for convenience creating, building, running the F# code and then pandoc on the new reference.docx is all in a single script below)

```
#!/bin/sh
set -eu
dotnet new console -lang F# -o AddHeader -f net6.0 >/dev/null
cd AddHeader
dotnet add package DocumentFormat.OpenXml >/dev/null
cat >Program.fs <<EOF
open System.Linq
open DocumentFormat.OpenXml.Packaging
open DocumentFormat.OpenXml.Wordprocessing

type private E = DocumentFormat.OpenXml.OpenXmlElement

let () =
    use source = WordprocessingDocument.Open("reference.docx", isEditable = false) in
    use wd = source.Clone("referenceh.docx", isEditable = true) in
    let md = wd.MainDocumentPart in

    let headerPart = md.AddNewPart<HeaderPart>() in
    let id = md.GetIdOfPart(headerPart) in
    (* See https://stackoverflow.com/a/5708088 why all the :> E casts are needed *)
    headerPart.Header <- Header([ Paragraph([ Run([ Text("Test") :> E ]) :> E ]) :> E ])

    let sectPr = md.Document.Body.Descendants<SectionProperties>().First() in

    let ref =
        sectPr.AppendChild(HeaderReference(Id = id, Type = HeaderFooterValues.Default)) in

    wd.Save()
EOF

pandoc --print-default-data-file=reference.docx >|reference.docx
dotnet run

touch test.md
pandoc test.md -t docx --reference-doc referenceh.docx -o test.docx
```

P.S.:  Merry Christmas