### PR TITLE
docx: use proper DPI for fallback PNG

### DIFF
--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/PandocLua.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/PandocLua.hs
@@ -70,6 +70,7 @@ instance PandocMonad PandocLua where
   readFileLazy = IO.readFileLazy
   readFileStrict = IO.readFileStrict
   readStdinStrict = IO.readStdinStrict
+  svgToPng = IO.svgToPng
 
   glob = IO.glob
   fileExists = IO.fileExists

--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -50,7 +50,6 @@ import qualified System.IO as IO (Newline (..))
 import Text.Pandoc
 import Text.Pandoc.Builder (setMeta)
 import Text.Pandoc.MediaBag (mediaItems)
-import Text.Pandoc.Image (svgToPng)
 import Text.Pandoc.App.Opt (Opt (..), LineEnding (..), defaultOpts,
                             IpynbOutput (..), OptInfo(..))
 import Text.Pandoc.App.CommandLineOptions (parseOptions, parseOptionsFromArgs,
@@ -368,14 +367,14 @@ readAbbreviations mbfilepath =
     >>= fmap (Set.fromList . filter (not . T.null) . T.lines) .
          toTextM (fromMaybe mempty mbfilepath)
 
-createPngFallbacks :: (PandocMonad m, MonadIO m) => Int -> m ()
+createPngFallbacks :: (PandocMonad m) => Int -> m ()
 createPngFallbacks dpi = do
   -- create fallback pngs for svgs
   items <- mediaItems <$> getMediaBag
   forM_ items $ \(fp, mt, bs) ->
     case T.takeWhile (/=';') mt of
       "image/svg+xml" -> do
-        res <- svgToPng dpi bs
+        res <- svgToPng dpi Nothing Nothing bs
         case res of
           Right bs' -> do
             let fp' = fp <> ".png"

--- a/src/Text/Pandoc/App.hs
+++ b/src/Text/Pandoc/App.hs
@@ -28,7 +28,7 @@ module Text.Pandoc.App (
           , applyFilters
           ) where
 import qualified Control.Exception as E
-import Control.Monad ( (>=>), when, forM, forM_ )
+import Control.Monad ( (>=>), when, forM )
 import Control.Monad.Trans ( MonadIO(..) )
 import Control.Monad.Catch ( MonadMask )
 import Control.Monad.Except (throwError)
@@ -49,7 +49,6 @@ import System.IO (nativeNewline, stdout)
 import qualified System.IO as IO (Newline (..))
 import Text.Pandoc
 import Text.Pandoc.Builder (setMeta)
-import Text.Pandoc.MediaBag (mediaItems)
 import Text.Pandoc.App.Opt (Opt (..), LineEnding (..), defaultOpts,
                             IpynbOutput (..), OptInfo(..))
 import Text.Pandoc.App.CommandLineOptions (parseOptions, parseOptionsFromArgs,
@@ -66,7 +65,6 @@ import qualified Text.Pandoc.Format as Format
 import Text.Pandoc.PDF (makePDF)
 import Text.Pandoc.Scripting (ScriptingEngine (..), CustomComponents(..))
 import Text.Pandoc.SelfContained (makeSelfContained)
-import Text.Pandoc.Shared (tshow)
 import Text.Pandoc.Writers.Shared (lookupMetaString)
 import Text.Pandoc.Readers.Markdown (yamlToMeta)
 import qualified Text.Pandoc.UTF8 as UTF8
@@ -300,9 +298,6 @@ convertWithOpts' scriptingEngine istty datadir opts = do
             >=> maybe return extractMedia (optExtractMedia opts)
             )
 
-  when (format == "docx" && not (optSandbox opts)) $ do
-    createPngFallbacks (writerDpi writerOptions)
-
   output <- case writer of
     ByteStringWriter f
       | format == "chunkedhtml" -> ZipOutput <$> f writerOptions doc
@@ -366,21 +361,6 @@ readAbbreviations mbfilepath =
     Just f  -> readFileStrict f)
     >>= fmap (Set.fromList . filter (not . T.null) . T.lines) .
          toTextM (fromMaybe mempty mbfilepath)
-
-createPngFallbacks :: (PandocMonad m) => Int -> m ()
-createPngFallbacks dpi = do
-  -- create fallback pngs for svgs
-  items <- mediaItems <$> getMediaBag
-  forM_ items $ \(fp, mt, bs) ->
-    case T.takeWhile (/=';') mt of
-      "image/svg+xml" -> do
-        res <- svgToPng dpi Nothing Nothing bs
-        case res of
-          Right bs' -> do
-            let fp' = fp <> ".png"
-            insertMedia fp' (Just "image/png") bs'
-          Left e -> report $ CouldNotConvertImage (T.pack fp) (tshow e)
-      _ -> return ()
 
 getMetadataFromFiles :: PandocMonad m
                      => Text -> ReaderOptions -> [FilePath] -> m Meta

--- a/src/Text/Pandoc/Class/IO.hs
+++ b/src/Text/Pandoc/Class/IO.hs
@@ -31,6 +31,7 @@ module Text.Pandoc.Class.IO
   , readFileLazy
   , readFileStrict
   , readStdinStrict
+  , svgToPng
   , extractMedia
   , writeMedia
  ) where
@@ -84,6 +85,7 @@ import qualified System.Random
 import qualified Text.Pandoc.UTF8 as UTF8
 import Data.Default (def)
 import System.X509 (getSystemCertificateStore)
+import Text.Pandoc.Image (svgToPngIO)
 #ifndef EMBED_DATA_FILES
 import qualified Paths_pandoc as Paths
 #endif
@@ -183,6 +185,11 @@ readFileStrict s = liftIOError B.readFile s
 -- an error on failure.
 readStdinStrict :: (PandocMonad m, MonadIO m) => m B.ByteString
 readStdinStrict = liftIOError (const B.getContents) "stdin"
+
+-- | Runs an image conversion step, returning an error on failure.
+-- Not available when sandboxed.
+svgToPng :: (PandocMonad m, MonadIO m) => Int -> Maybe Double -> Maybe Double -> BL.ByteString -> m (Either T.Text BL.ByteString)
+svgToPng = svgToPngIO
 
 -- | Return a list of paths that match a glob, relative to the working
 -- directory. See 'System.FilePath.Glob' for the glob syntax.

--- a/src/Text/Pandoc/Class/PandocIO.hs
+++ b/src/Text/Pandoc/Class/PandocIO.hs
@@ -63,6 +63,7 @@ instance PandocMonad PandocIO where
   readFileLazy = IO.readFileLazy
   readFileStrict = IO.readFileStrict
   readStdinStrict = IO.readStdinStrict
+  svgToPng = IO.svgToPng
 
   glob = IO.glob
   fileExists = IO.fileExists

--- a/src/Text/Pandoc/Class/PandocMonad.hs
+++ b/src/Text/Pandoc/Class/PandocMonad.hs
@@ -120,6 +120,9 @@ class (Functor m, Applicative m, Monad m, MonadError PandocError m)
   -- | Read the contents of stdin as a strict ByteString, raising
   -- an error on failure.
   readStdinStrict :: m B.ByteString
+  -- | Converts an SVG to a PNG (dpiX, widthPoints, heightPoints, svgBlob)
+  -- Not called when sandboxed.
+  svgToPng :: Int -> Maybe Double -> Maybe Double -> BL.ByteString -> m (Either T.Text BL.ByteString)
   -- | Return a list of paths that match a glob, relative to
   -- the working directory.  See 'System.FilePath.Glob' for
   -- the glob syntax.
@@ -529,6 +532,7 @@ instance (MonadTrans t, PandocMonad m, Functor (t m),
   readFileLazy = lift . readFileLazy
   readFileStrict = lift . readFileStrict
   readStdinStrict = lift readStdinStrict
+  svgToPng dpi width height bs = lift $ svgToPng dpi width height bs
   glob = lift . glob
   fileExists = lift . fileExists
   getDataFileName = lift . getDataFileName
@@ -547,6 +551,7 @@ instance {-# OVERLAPS #-} PandocMonad m => PandocMonad (ParsecT s st m) where
   readFileLazy = lift . readFileLazy
   readFileStrict = lift . readFileStrict
   readStdinStrict = lift readStdinStrict
+  svgToPng dpi width height bs = lift $ svgToPng dpi width height bs
   glob = lift . glob
   fileExists = lift . fileExists
   getDataFileName = lift . getDataFileName

--- a/src/Text/Pandoc/Class/PandocPure.hs
+++ b/src/Text/Pandoc/Class/PandocPure.hs
@@ -205,6 +205,8 @@ instance PandocMonad PandocPure where
       Nothing -> throwError $ PandocResourceNotFound $ T.pack fp
 
   readStdinStrict = getsPureState stStdin
+  
+  svgToPng _ _ _ _ = return $ Left "SVG conversion not available in PandocPure"
 
   glob s = do
     FileTree ftmap <- getsPureState stFiles

--- a/src/Text/Pandoc/Image.hs
+++ b/src/Text/Pandoc/Image.hs
@@ -18,18 +18,22 @@ import Data.Text (Text)
 import Text.Pandoc.Shared (tshow)
 import qualified Control.Exception as E
 import Control.Monad.IO.Class (MonadIO(liftIO))
+import Text.Pandoc.Class.PandocMonad
+import qualified Data.Text as T
 
 -- | Convert svg image to png. rsvg-convert
 -- is used and must be available on the path.
-svgToPng :: MonadIO m
+svgToPng :: (PandocMonad m, MonadIO m)
          => Int           -- ^ DPI
          -> L.ByteString  -- ^ Input image as bytestring
          -> m (Either Text L.ByteString)
 svgToPng dpi bs = do
   let dpi' = show dpi
+  let args = ["-f","png","-a","--dpi-x",dpi',"--dpi-y",dpi']
+  trace (T.intercalate " " $ map T.pack $ "rsvg-convert" : args)
   liftIO $ E.catch
        (do (exit, out) <- pipeProcess Nothing "rsvg-convert"
-                          ["-f","png","-a","--dpi-x",dpi',"--dpi-y",dpi']
+                          args
                           bs
            return $ if exit == ExitSuccess
               then Right out

--- a/src/Text/Pandoc/ImageSize.hs
+++ b/src/Text/Pandoc/ImageSize.hs
@@ -174,8 +174,8 @@ sizeInPoints s = (pxXf * 72 / dpiXf, pxYf * 72 / dpiYf)
 -- | Calculate (height, width) in points, considering the desired dimensions in the
 -- attribute, while falling back on the image file's dpi metadata if no dimensions
 -- are specified in the attribute (or only dimensions in percentages).
-desiredSizeInPoints :: WriterOptions -> Attr -> ImageSize -> (Double, Double)
-desiredSizeInPoints opts attr s =
+desiredSizeInPoints :: WriterOptions -> Attr -> Maybe Integer -> ImageSize -> (Double, Double)
+desiredSizeInPoints opts attr pageWidthPoints' s =
   case (getDim Width, getDim Height) of
     (Just w, Just h)   -> (w, h)
     (Just w, Nothing)  -> (w, w / ratio)
@@ -184,7 +184,11 @@ desiredSizeInPoints opts attr s =
   where
     ratio = fromIntegral (pxX s) / fromIntegral (pxY s)
     getDim dir = case dimension dir attr of
-                   Just (Percent _) -> Nothing
+                   Just (Percent a) ->
+                     case (dir, pageWidthPoints') of
+                     (Width, Just pageWidthPoints) ->
+                       Just $ fromIntegral pageWidthPoints * a
+                     _ -> Nothing
                    Just dim         -> Just $ inPoints opts dim
                    Nothing          -> Nothing
 

--- a/src/Text/Pandoc/Writers/Docx/OpenXML.hs
+++ b/src/Text/Pandoc/Writers/Docx/OpenXML.hs
@@ -24,6 +24,7 @@ import Control.Monad (when, unless)
 import Control.Applicative ((<|>))
 import Control.Monad.Except (catchError)
 import Crypto.Hash (hashWith, SHA1(SHA1))
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import Data.Char (isLetter, isSpace)
 import Text.Pandoc.Char (isCJK)
@@ -48,6 +49,7 @@ import Text.Pandoc.UTF8 (fromText)
 import Text.Pandoc.Definition
 import Text.Pandoc.Highlighting (highlight)
 import Text.Pandoc.Templates (compileDefaultTemplate, renderTemplate)
+import Text.Pandoc.Image (createPngFallback)
 import Text.Pandoc.ImageSize
 import Text.Pandoc.Logging
 import Text.Pandoc.MIME (extensionFromMimeType, getMimeType)
@@ -60,6 +62,7 @@ import Text.Pandoc.Walk
 import qualified Text.Pandoc.Writers.GridTable as Grid
 import Text.Pandoc.Writers.Math
 import Text.Pandoc.Writers.Shared
+import Text.Printf (printf)
 import Text.TeXMath
 import Text.Pandoc.Writers.OOXML
 import Text.Pandoc.XML.Light as XML
@@ -718,6 +721,16 @@ formattedRun els = do
   props <- getTextProps
   return $ mknode "w:r" [] $ props ++ els
 
+getOrCreateFallback :: PandocMonad m => Int -> (Integer, Integer) -> FilePath -> ByteString -> m (Maybe MediaItem)
+getOrCreateFallback dpi (xemu, yemu) src' img = do
+  mediabag <- getMediaBag
+  let src = printf "%s_%d_%d.png" src' xemu yemu
+  let xyPt = (fromIntegral xemu / 12700.0, fromIntegral yemu / 12700.0)
+  case lookupMedia src mediabag of
+    Just item -> return $ Just item
+    Nothing -> createPngFallback dpi xyPt src $ BL.fromStrict img
+
+ -- | Convert an inline element to OpenXML.
 -- | Convert an inline element to OpenXML.
 inlineToOpenXML :: PandocMonad m => WriterOptions -> Inline -> WS m [Content]
 inlineToOpenXML opts il = withDirection $ inlineToOpenXML' opts il
@@ -919,17 +932,26 @@ inlineToOpenXML' opts (Image attr@(imgident, _, _) alt (src, title)) = do
   imgs <- gets stImages
   let
     stImage = M.lookup (T.unpack src) imgs
-    generateImgElt (ident, _fp, mt, img) = do
+    generateImgElt (ident, fp, mt, img) = do
       docprid <- getUniqueId
       nvpicprid <- getUniqueId
+      let
+        (xpt,ypt) = desiredSizeInPoints opts attr
+               (either (const def) id (imageSize opts img))
+        -- 12700 emu = 1 pt
+        pageWidthPt = case dimension Width attr of
+                        Just (Percent a) -> pageWidth * floor (a * 127)
+                        _                -> pageWidth * 12700
+        (xemu,yemu) = fitToPage (xpt * 12700, ypt * 12700) pageWidthPt
       (blipAttrs, blipContents) <-
         case T.takeWhile (/=';') <$> mt of
           Just "image/svg+xml" -> do
             -- get fallback png
-            mediabag <- getMediaBag
+            fallback <- getOrCreateFallback (writerDpi opts) (xemu, yemu) fp img
             mbFallback <-
-              case lookupMedia (T.unpack (src <> ".png")) mediabag of
+              case fallback of
                 Just item -> do
+                  P.trace $ "Found fallback " <> tshow (mediaPath item)
                   id' <- T.unpack . ("rId" <>) <$> getUniqueId
                   let fp' = "media/" <> id' <> ".png"
                   let imgdata = (id',
@@ -956,13 +978,6 @@ inlineToOpenXML' opts (Image attr@(imgident, _, _) alt (src, title)) = do
                     [extLst])
           _ -> return ([("r:embed", T.pack ident)], [])
       let
-        (xpt,ypt) = desiredSizeInPoints opts attr
-               (either (const def) id (imageSize opts img))
-        -- 12700 emu = 1 pt
-        pageWidthPt = case dimension Width attr of
-                        Just (Percent a) -> pageWidth * floor (a * 127)
-                        _                -> pageWidth * 12700
-        (xemu,yemu) = fitToPage (xpt * 12700, ypt * 12700) pageWidthPt
         cNvPicPr = mknode "pic:cNvPicPr" [] $
                          mknode "a:picLocks" [("noChangeArrowheads","1")
                                              ,("noChangeAspect","1")] ()

--- a/src/Text/Pandoc/Writers/Docx/OpenXML.hs
+++ b/src/Text/Pandoc/Writers/Docx/OpenXML.hs
@@ -928,7 +928,7 @@ inlineToOpenXML' opts (Link _ txt (src,_)) = do
               return i
   return [ Elem $ mknode "w:hyperlink" [("r:id",id')] contents ]
 inlineToOpenXML' opts (Image attr@(imgident, _, _) alt (src, title)) = do
-  pageWidth <- asks envPrintWidth
+  pageWidth <- asks envPrintWidth -- in Points
   imgs <- gets stImages
   let
     stImage = M.lookup (T.unpack src) imgs
@@ -936,7 +936,7 @@ inlineToOpenXML' opts (Image attr@(imgident, _, _) alt (src, title)) = do
       docprid <- getUniqueId
       nvpicprid <- getUniqueId
       let
-        (xpt,ypt) = desiredSizeInPoints opts attr
+        (xpt,ypt) = desiredSizeInPoints opts attr (Just pageWidth)
                (either (const def) id (imageSize opts img))
         -- 12700 emu = 1 pt
         pageWidthPt = case dimension Width attr of

--- a/src/Text/Pandoc/Writers/ICML.hs
+++ b/src/Text/Pandoc/Writers/ICML.hs
@@ -615,7 +615,7 @@ imageICML opts style attr (src, _) = do
                report $ CouldNotFetchResource src $ tshow e
                return def)
   let (ow, oh) = sizeInPoints imgS
-      (imgWidth, imgHeight) = desiredSizeInPoints opts attr imgS
+      (imgWidth, imgHeight) = desiredSizeInPoints opts attr Nothing imgS
       hw = showFl $ ow / 2
       hh = showFl $ oh / 2
       scale = showFl (imgWidth / ow) <> " 0 0 " <> showFl (imgHeight / oh)

--- a/src/Text/Pandoc/Writers/RTF.hs
+++ b/src/Text/Pandoc/Writers/RTF.hs
@@ -64,7 +64,7 @@ rtfEmbedImage opts x@(Image attr _ (src,_)) = catchError
                                 <> "\\pichgoal" <> tshow (floor (ypt * 20) :: Integer)
                         -- twip = 1/1440in = 1/20pt
                         where (xpx, ypx) = sizeInPixels sz
-                              (xpt, ypt) = desiredSizeInPoints opts attr sz
+                              (xpt, ypt) = desiredSizeInPoints opts attr Nothing sz
              let raw = "{\\pict" <> filetype <> sizeSpec <> " " <>
                         T.concat bytes <> "}"
              if B.null imgdata

--- a/test/command/9288.md
+++ b/test/command/9288.md
@@ -45,8 +45,9 @@
 2> [trace] rsvg-convert -f png -a --dpi-x 96 --dpi-y 96 --width 360.000000pt --height 360.000000pt
 2> [trace] Found fallback "media/rId20.svg_4572000_4572000.png"
 2> [trace] Found fallback "media/rId20.svg_4572000_4572000.png"
+2> [trace] rsvg-convert -f png -a --dpi-x 96 --dpi-y 96 --width 336.000000pt --height 336.000000pt
+2> [trace] Found fallback "media/rId20.svg_4267200_4267200.png"
 2> [trace] rsvg-convert -f png -a --dpi-x 96 --dpi-y 96 --width 75.000000pt --height 75.000000pt
-2> [trace] Found fallback "media/rId20.svg_952500_952500.png"
 2> [trace] Found fallback "media/rId20.svg_952500_952500.png"
 
 ```

--- a/test/command/9288.md
+++ b/test/command/9288.md
@@ -1,0 +1,52 @@
+```
+% pandoc -f native -t docx -o 9288.docx  --trace
+[ Figure
+    ( "" , [] , [] )
+    (Caption Nothing [ Plain [ Str "5in" ] ])
+    [ Plain
+        [ Image
+            ( "" , [] , [ ( "width" , "5in" ) ] )
+            [ Str "5in" ]
+            ( "command/SVG_logo.svg" , "" )
+        ]
+    ]
+, Figure
+    ( "" , [] , [] )
+    (Caption Nothing [ Plain [ Str "5in" ] ])
+    [ Plain
+        [ Image
+            ( "" , [] , [ ( "width" , "5in" ) ] )
+            [ Str "5in" ]
+            ( "command/SVG_logo.svg" , "" )
+        ]
+    ]
+, Figure
+    ( "" , [] , [] )
+    (Caption Nothing [ Plain [ Str "80%" ] ])
+    [ Plain
+        [ Image
+            ( "" , [] , [ ( "width" , "80%" ) ] )
+            [ Str "5in" ]
+            ( "command/SVG_logo.svg" , "" )
+        ]
+    ]
+, Figure
+    ( "" , [] , [] )
+    (Caption Nothing [ Plain [ Str "default" ] ])
+    [ Plain
+        [ Image
+            ( "" , [] , [] )
+            [ Str "5in" ]
+            ( "command/SVG_logo.svg" , "" )
+        ]
+    ]
+]
+^D
+2> [trace] rsvg-convert -f png -a --dpi-x 96 --dpi-y 96 --width 360.000000pt --height 360.000000pt
+2> [trace] Found fallback "media/rId20.svg_4572000_4572000.png"
+2> [trace] Found fallback "media/rId20.svg_4572000_4572000.png"
+2> [trace] rsvg-convert -f png -a --dpi-x 96 --dpi-y 96 --width 75.000000pt --height 75.000000pt
+2> [trace] Found fallback "media/rId20.svg_952500_952500.png"
+2> [trace] Found fallback "media/rId20.svg_952500_952500.png"
+
+```


### PR DESCRIPTION
Pandoc calls `rsvg-convert` by specifying only a DPI. But that causes `rsvg-convert` to try to guess a pixel size as [documented in its manpage](https://man.archlinux.org/man/rsvg-convert.1.en#DEFAULT_OUTPUT_SIZE).

Quite often that will result in a very low dpi (much lower than 72).
That is actually a useful diagnostic tool to see when the fallback image is used instead of SVG, but there should be a way to override this from the command-line.

Here is how a document using the `SVG_logo` from pandoc's `test/command` looks like.

test.md:
```
![Caption test](images/SVG_logo){fig-alt="Alt test" width="5in"}
```

Convert with:
`/usr/bin/pandoc --default-image-extension=svg img.md -t docx -o img.docx --trace`

This is how it looks like in the free version of Office.com:
![office](https://github.com/jgm/pandoc/assets/721894/646081de-96ad-48c0-ae9a-e4e8a3de4b6d)

LibreOffice 7.6.4.1:
![lo](https://github.com/jgm/pandoc/assets/721894/3b223399-d592-4ade-92b9-b8a8016a3c2c)

Google Docs:
![gdocs](https://github.com/jgm/pandoc/assets/721894/420dffbe-4fd4-4fd7-98e2-07e01f8661dd)

The PNG produced has only 100x100 pixels (matching the SVG's viewbox):
```
$ unzip -o img.docx
$ file word/media/rId23.png
word/media/rId23.png: PNG image data, 100 x 100, 8-bit/color RGBA, non-interlaced
```

And the `--dpi` flag of `pandoc` has no effect, you can specify a DPI of 1000 and it'll still produce the exact same image.

# Solution

Pandoc needs to tell `rsvg-convert`  the desired size in the document, at least when it is known in inches or pixels.
Add the image attributes to the mediabag to allow access to this information in the fallback conversion code.

Currently this is only done when something like a markdown source is used, I haven't updated all the other readers to extract the image attributes.

It'd be good if it also did this when the image is specified as a percentage of pagesize, but I couldn't figure out how to do the `asks pagewidth` inside `PandocMonad`.

And now it looks OK everywhere:
Google Docs:
![gdocsok](https://github.com/jgm/pandoc/assets/721894/05142f3a-6826-4ae6-9aaf-4f62767dd0d8)
LibreOffice:
![logood](https://github.com/jgm/pandoc/assets/721894/cb16f7c6-0f90-4380-8fe1-910be1483b25)
Office:
![officeok](https://github.com/jgm/pandoc/assets/721894/4ce97652-a221-46bd-8081-8815e732134a)


# Workarounds:

* Convert SVG to .EMF:
```
$ inkscape images/SVG_logo.svg --export-filename images/SVG_logo.emf
$ pandoc --default-image-extension=emf img.md -t docx -o img.docx --trace
```

That will look better, but still have jagged edges everywhere except Office365.
The advantage is that this format doesn't need any PNG fallbacks, and remains an actual vector format.
Still out of all the current options, this is currently (with an unpatched pandoc) the best way I could find to embed vector images.

* Use ODT instead

That will look the best with LibreOffice:
![odtlocalok](https://github.com/jgm/pandoc/assets/721894/f72eb264-7f94-475e-a2c9-a0304bdf9a2b)

But Google Docs will convert to some unknown DPI when opened and still look bad
![odtjagged](https://github.com/jgm/pandoc/assets/721894/3a83f621-ee12-4b38-a5b6-05df56fb660d)

