### PR TITLE
ci(commit-validation): use git to walk commits

### DIFF
--- a/.github/workflows/commit-validation-pr.yml
+++ b/.github/workflows/commit-validation-pr.yml
@@ -1,0 +1,25 @@
+name: commit-validation-pr
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check-commit-msg-length:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check commit message length
+      run: |
+          git log ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | (
+            longlines=0
+            while IFS='' read -r line; do
+              if [ "${#line}" -gt 78 ]; then
+                echo "Overlong line: ${line}" >&2
+                longlines=$(( longlines + 1 ))
+              fi
+            done
+            [ "${longlines}" -eq 0 ]
+          )

--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -1,5 +1,5 @@
 name: commit-validation
-on: [ push, pull_request ]
+on: [ push ]
 
 permissions:
   contents: read
@@ -16,8 +16,7 @@ jobs:
         result-encoding: json
         script: |
           var longlines = 0;
-          const pr = ${{ toJSON(github.event.pull_request) }};
-          const commits = (pr && pr.commits) || ${{ toJSON(github.event.commits) }};
+          const commits = ${{ toJSON(github.event.commits) }};
           for (const commit of commits) {
             for (const line of commit.message.split('\n')) {
               if (line.length > 78) {


### PR DESCRIPTION
The PR event doesn't include the actual commits, just a count and a URL to fetch it.
But we've already checked out the entire git history, so we might as well use `git` itself to walk the commit history.
(Using the remote commits URL would be useful only if we'd want to do a shallow clone because we have too many commits)

We can revisit this once pandoc's commit history grows large enough that this takes too long. For now it should unblock the CI.