### PR TITLE
Add `readMan` to `Text.Pandoc.Readers` exports

### DIFF
--- a/src/Text/Pandoc/Readers.hs
+++ b/src/Text/Pandoc/Readers.hs
@@ -50,6 +50,7 @@ module Text.Pandoc.Readers
   , readTxt2Tags
   , readEPUB
   , readMuse
+  , readMan
   , readFB2
   , readIpynb
   , readCSV

--- a/test/Tests/Readers/Man.hs
+++ b/test/Tests/Readers/Man.hs
@@ -20,7 +20,6 @@ import Tests.Helpers
 import Text.Pandoc
 import Text.Pandoc.Arbitrary ()
 import Text.Pandoc.Builder
-import Text.Pandoc.Readers.Man
 
 man :: Text -> Pandoc
 man = purely $ readMan def


### PR DESCRIPTION
It looks like `readMan` is missing in the list of exports of the module `Text.Pandoc.Readers`. I couldn't see why, so I've added it here.