### PR TITLE
LaTeX writer: set font fallback for babel main font

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -413,7 +413,7 @@ $if(babel-lang)$
 $if(mainfont)$
 \ifPDFTeX
 \else
-\babelfont{rm}[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
+\babelfont{rm}[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$$if(mainfontfallback)$,RawFeature={fallback=mainfontfallback}$endif$]{$mainfont$}
 \fi
 $endif$
 $endif$


### PR DESCRIPTION
Follow up to #9204. Also sets `mainfontfallback` when the main font is set with `\babelfont`.