### PR TITLE
Add @var support in Texinfo Writer #8534

### DIFF
--- a/src/Text/Pandoc/Writers/Texinfo.hs
+++ b/src/Text/Pandoc/Writers/Texinfo.hs
@@ -446,6 +446,9 @@ inlineToTexinfo (Subscript lst) = do
 inlineToTexinfo (SmallCaps lst) =
   inCmd "sc" <$> inlineListToTexinfo lst
 
+inlineToTexinfo (Code (_, cls , _) str) | T.pack "variable" `elem` cls  =
+  return $ literal $ "@code{@var{" <> stringToTexinfo str <> "}}"
+
 inlineToTexinfo (Code _ str) =
   return $ literal $ "@code{" <> stringToTexinfo str <> "}"
 

--- a/test/command/8534.md
+++ b/test/command/8534.md
@@ -1,0 +1,11 @@
+```
+% pandoc -f html -t texinfo
+<html>
+foo <code>bar <var>baz</var> bar</code> foo
+</html>
+^D
+@node Top
+@top Top
+
+foo @code{bar }@code{@var{baz}}@code{ bar} foo
+```


### PR DESCRIPTION
Fixes #8534

Implements @jgm's suggestion, checking if the "variable" class is contained in the attributes, and without consolidation of adjacent code elements.