### PR TITLE
ConTeXt template: support font fallback

### DIFF
--- a/data/templates/default.context
+++ b/data/templates/default.context
@@ -59,6 +59,17 @@ $endif$
 
 \setupbodyfontenvironment[default][em=italic] % use italic as em, not slanted
 
+% Set up font fallbacks
+$for(mainfontfallback)$
+\definefallbackfamily[mainface][rm][$mainfontfallback$][range=0x0000-0xFFFF, check=yes, force=no]
+$endfor$
+$for(sansfontfallback)$
+\definefallbackfamily[mainface][ss][$sansfontfallback$][range=0x0000-0xFFFF, check=yes, force=no]
+$endfor$
+$for(monofontfallback)$
+\definefallbackfamily[mainface][tt][$monofontfallback$][range=0x0000-0xFFFF, check=yes, force=no]
+$endfor$
+
 \definefallbackfamily[mainface][rm][CMU Serif][preset=range:greek, force=yes]
 \definefontfamily[mainface][rm][$if(mainfont)$$mainfont$$else$Latin Modern Roman$endif$]
 \definefontfamily[mainface][mm][$if(mathfont)$$mathfont$$else$Latin Modern Math$endif$]


### PR DESCRIPTION

Follow up to https://github.com/jgm/pandoc/pull/9204#issuecomment-1900741386.

You write:

```markdown
---
title: Demo Document
mainfontfallback:
  - EmojiOne Color
  - OpenSymbol
  - XITS Math
---

This empty set comes from OpenSymbol → ∅ ←

But these [stange operators](https://tex.stackexchange.com/a/397674)
aren't in OpenSymbol, so are fetched from XITS Math:

X × ⎰Y ⨿ Z⎱ → ⎰X × Y⎱ ⨿ ⎰X × Z⎱.

Emoji fallback doesn't work 🙁 .
```

You run:

```bash
pandoc src.md -o out.pdf --pdf-engine=context
```

You get:

![Screenshot from 2024-01-23 17-19-38](https://github.com/jgm/pandoc/assets/95857153/da0ab281-6b16-4682-8c98-c2319c8213b3)

Notes:

* You don't need to set mainfont (unlike in the `LaTeX` template)
* ConTeXt provdes two competing commands for fallback setup:
  * [`\definefontfallback`](https://wiki.contextgarden.net/Command/definefontfallback) requires a later call to `\definefontsynonym`
  * 👉 [`\definefallbackfamily`](https://wiki.contextgarden.net/Command/definefallbackfamily) allows setting fallbacks without knowing the default font
* I couldn't get emoji fallback to work
  * `NotoColorEmoji` fails to load (with a `loca table not foundmtx-context` error)
  * `EmojiOne Color` loads but doesn't substitute anything
* Testing `ConTeXt` with new fonts is fiddly
  * Must run `mtxrun --script fonts --reload`
* More tests needed (cc @tarleb)
