### PR TITLE
Don't emit unnecessary classes in HTML tables (#9325)

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -1253,12 +1253,6 @@ tableRowToHtml :: PandocMonad m
                -> TableRow
                -> StateT WriterState m Html
 tableRowToHtml opts (TableRow tblpart attr rownum rowhead rowbody) = do
-  let rowclass = case rownum of
-        Ann.RowNumber x | x `rem` 2 == 1   -> "odd"
-        _               | tblpart /= Thead -> "even"
-        _                                  -> "header"
-  let attr' = case attr of
-                (id', classes, rest) -> (id', rowclass:classes, rest)
   let celltype = case tblpart of
                    Thead -> HeaderCell
                    _     -> BodyCell

--- a/test/command/1166.md
+++ b/test/command/1166.md
@@ -17,28 +17,28 @@ col 1  col 2
 ^D
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>col 1</th>
 <th>col 2</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>1</td>
 <td>Second column of row 1.</td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>2</p></td>
 <td><p>Second column of row 2. Second line of paragraph.</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p>3</p></td>
 <td><ul>
 <li>Second column of row 3.</li>
 <li>Second item in bullet list (row 3, column 2).</li>
 </ul></td>
 </tr>
-<tr class="even">
+<tr>
 <td></td>
 <td>Row 4; column 1 will be empty.</td>
 </tr>

--- a/test/command/1881.md
+++ b/test/command/1881.md
@@ -3,7 +3,7 @@
 <table>
 <caption>Demonstration of simple table syntax.</caption>
 <thead>
-<tr class="header">
+<tr>
 <th align="right">Right</th>
 <th align="left">Left</th>
 <th align="center">Center</th>
@@ -11,7 +11,7 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td align="right">12</td>
 <td align="left">12</td>
 <td align="center">12</td>
@@ -111,7 +111,7 @@
 ```
 % pandoc -f html -t native
 <table>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">12</td>
 <td style="text-align:left;">12</td>
 <td style="text-align:  center">12</td>

--- a/test/command/2606.md
+++ b/test/command/2606.md
@@ -6,7 +6,7 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>* hello</p></td>
 </tr>
 </tbody>
@@ -22,7 +22,7 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td><ul>
 <li>hello</li>
 </ul></td>
@@ -40,7 +40,7 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p><code>* hello</code></p></td>
 </tr>
 </tbody>

--- a/test/command/2649.md
+++ b/test/command/2649.md
@@ -7,7 +7,7 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 </tr>
 </tbody>
 </table>
@@ -31,24 +31,24 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>peildatum Simbase</p></td>
 <td><p>november 2005</p></td>
 <td colspan="2"><p><strong>uitslagen Flohrgambiet</strong></p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>totaal aantal partijen Simbase</p></td>
 <td><p>7.316.773</p></td>
 <td><p>wit wint</p></td>
 <td><p>53%</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p>percentage (en partijen) Flohrgambiet</p></td>
 <td><p>0.023 % (1.699)</p></td>
 <td><p>zwart wint</p></td>
 <td><p>27%</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>percentage Flohrgambiet in aug 2003</p></td>
 <td><p>0.035 %</p></td>
 <td><p>remise</p></td>
@@ -80,26 +80,26 @@
 ^D
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th><p>Plaats</p></th>
 <th><p>Rijder</p></th>
 <th><p>Aantal</p></th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>1</p></td>
 <td style="text-align: left;"><p><a href="Sébastien_Loeb"
 title="wikilink">Sébastien Loeb</a></p></td>
 <td><p>78</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>2</p></td>
 <td style="text-align: left;"><p><strong><a href="Sébastien_Ogier"
 title="wikilink">Sébastien Ogier</a></strong></p></td>
 <td><p>38</p></td>
 </tr>
-<tr class="odd">
+<tr>
 <td><p>10</p></td>
 <td style="text-align: left;"><p><a href="Hannu_Mikkola"
 title="wikilink">Hannu Mikkola</a></p></td>

--- a/test/command/3314.md
+++ b/test/command/3314.md
@@ -18,12 +18,12 @@ See #3315 and <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.htm
 <col style="width: 15%" />
 </colgroup>
 <tbody>
-<tr class="odd">
+<tr>
 <td>First</td>
 <td>12.0</td>
 <td>Example row spanning lines</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Second</td>
 <td>5.0</td>
 <td>Another</td>

--- a/test/command/3432.md
+++ b/test/command/3432.md
@@ -28,24 +28,24 @@ List-table with header-rows and widths options.
 <col style="width: 54%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th>Treat</th>
 <th>Quantity</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Albatross</td>
 <td>2.99</td>
 <td>On a stick!</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Crunchy Frog</td>
 <td>1.49</td>
 <td>If we took the bones out, it wouldn't be crunchy, now would it?</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Gannet Ripple</td>
 <td>1.99</td>
 <td>On a stick!</td>
@@ -79,24 +79,24 @@ List-table whose widths is "auto".
 <table>
 <caption>Frozen Delights!</caption>
 <thead>
-<tr class="header">
+<tr>
 <th>Treat</th>
 <th>Quantity</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Albatross</td>
 <td>2.99</td>
 <td>On a stick!</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Crunchy Frog</td>
 <td>1.49</td>
 <td>If we took the bones out, it wouldn't be crunchy, now would it?</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Gannet Ripple</td>
 <td>1.99</td>
 <td>On a stick!</td>
@@ -130,24 +130,24 @@ List-table with header-rows which is bigger than 1. Only the first row is treate
 <table>
 <caption>Frozen Delights!</caption>
 <thead>
-<tr class="header">
+<tr>
 <th>Treat</th>
 <th>Quantity</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Albatross</td>
 <td>2.99</td>
 <td>On a stick!</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Crunchy Frog</td>
 <td>1.49</td>
 <td>If we took the bones out, it wouldn't be crunchy, now would it?</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Gannet Ripple</td>
 <td>1.99</td>
 <td>On a stick!</td>
@@ -176,17 +176,17 @@ List-table without header-rows.
 <table>
 <caption>Frozen Delights!</caption>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Albatross</td>
 <td>2.99</td>
 <td>On a stick!</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Crunchy Frog</td>
 <td>1.49</td>
 <td>If we took the bones out, it wouldn't be crunchy, now would it?</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Gannet Ripple</td>
 <td>1.99</td>
 <td>On a stick!</td>
@@ -219,24 +219,24 @@ List-table with empty cells. You need a space after '-', otherwise the row will 
 <table>
 <caption>Frozen Delights!</caption>
 <thead>
-<tr class="header">
+<tr>
 <th>Treat</th>
 <th>Quantity</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Albatross</td>
 <td>2.99</td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Crunchy Frog</td>
 <td></td>
 <td>If we took the bones out, it wouldn't be crunchy, now would it?</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Gannet Ripple</td>
 <td>1.99</td>
 <td>On a stick!</td>
@@ -266,7 +266,7 @@ List-table with a cell having a bulletlist
 <table>
 <caption>Frozen Delights!</caption>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Albatross</td>
 <td>2.99</td>
 <td><ul>
@@ -274,12 +274,12 @@ List-table with a cell having a bulletlist
 <li>In a cup!</li>
 </ul></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Crunchy Frog</td>
 <td>1.49</td>
 <td>If we took the bones out, it wouldn't be crunchy, now would it?</td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Gannet Ripple</td>
 <td>1.99</td>
 <td>On a stick!</td>

--- a/test/command/3494.md
+++ b/test/command/3494.md
@@ -14,22 +14,22 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: right;"><span><strong>ﺍ</strong></span></td>
 <td style="text-align: left;"></td>
 <td style="text-align: left;"></td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: right;"><strong>ﺄﺤﺴﻨﺘـ(ﻭﺍ) IV</strong></td>
 <td style="text-align: left;"><em><span>ʾaḥsant(ū)</span></em></td>
 <td style="text-align: left;">thank you</td>
 </tr>
-<tr class="odd">
+<tr>
 <td style="text-align: right;"><em>blah</em></td>
 <td style="text-align: left;"><em>blah</em></td>
 <td style="text-align: left;"><em>blah</em></td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: right;">blah</td>
 <td style="text-align: left;">blah</td>
 <td style="text-align: left;">blah</td>

--- a/test/command/3499.md
+++ b/test/command/3499.md
@@ -9,7 +9,7 @@ Org-mode tables can't be on the same line as list markers:
 <li>|something|</li>
 <li><table>
 <tbody>
-<tr class="odd">
+<tr>
 <td>else</td>
 </tr>
 </tbody>

--- a/test/command/3667.md
+++ b/test/command/3667.md
@@ -4,7 +4,7 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td><a href="http://example.com/">link text</a></td>
 </tr>
 </tbody>

--- a/test/command/6441.md
+++ b/test/command/6441.md
@@ -7,13 +7,13 @@
 ^D
 <table class="table-dark">
 <thead>
-<tr class="header">
+<tr>
 <th>h1</th>
 <th>h2</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>c1</td>
 <td>c2</td>
 </tr>

--- a/test/command/6481.md
+++ b/test/command/6481.md
@@ -18,7 +18,7 @@
 <col style="width: 69%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: center;">Col 1</th>
 <th style="text-align: center;">Col 2</th>
 <th style="text-align: center;">Col 3</th>
@@ -26,7 +26,7 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: center;">High</td>
 <td style="text-align: center;">Med</td>
 <td style="text-align: center;">Med</td>

--- a/test/command/6549.md
+++ b/test/command/6549.md
@@ -8,13 +8,13 @@
 <table>
 <caption>Test table</caption>
 <thead>
-<tr class="header">
+<tr>
 <th>Column1</th>
 <th>Column2</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Data1</td>
 <td><ul>
 <li>data1</li>

--- a/test/command/7064.md
+++ b/test/command/7064.md
@@ -15,14 +15,14 @@
 <col style="width: 70%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th>Version</th>
 <th>Date</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>0.1.0</td>
 <td>18/02/2013</td>
 <td>Initial Release</td>

--- a/test/command/7112.md
+++ b/test/command/7112.md
@@ -6,7 +6,7 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td>setting</td>
 <td><code>echo PATH="path"</code></td>
 </tr>

--- a/test/command/7214.md
+++ b/test/command/7214.md
@@ -13,12 +13,12 @@
 <col style="width: 26%" />
 </colgroup>
 <tbody>
-<tr class="odd">
+<tr>
 <td>日本語</td>
 <td>の文字列</td>
 <td>words in english</td>
 </tr>
-<tr class="even">
+<tr>
 <td>abc defghij</td>
 <td>def</td>
 <td>xyz</td>

--- a/test/command/7713.md
+++ b/test/command/7713.md
@@ -11,14 +11,14 @@
 <col style="width: 33%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th>aaaaaaaaaaaa</th>
 <th>bbbbb</th>
 <th>ccccccccccc</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td></td>
 <td></td>
 <td>cccccccccc cccccccccc cccccccccc cccccccccc cccccccccc

--- a/test/command/7847.md
+++ b/test/command/7847.md
@@ -7,14 +7,14 @@
 <col style="width: 20%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th>aaa</th>
 <th>bbb</th>
 <th>ccc</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Consequat nisi sit amet nibh. Nunc mi tortor, tristique
 sit amet, rhoncus porta, malesuada elementum, nisi.</td>
 <td></td>
@@ -60,14 +60,14 @@ sit amet, rhoncus porta, malesuada elementum, nisi.</td>
 <col style="width: 20%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th>aaa</th>
 <th>bbb</th>
 <th>ccc</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Consequat nisi sit amet nibh. Nunc mi tortor, tristique
 sit amet, rhoncus porta, malesuada elementum, nisi.</td>
 <td>bbb</td>

--- a/test/command/7871.md
+++ b/test/command/7871.md
@@ -6,7 +6,7 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: right; padding-right: 4px;">a</td>
 </tr>
 </tbody>

--- a/test/command/7919.md
+++ b/test/command/7919.md
@@ -7,15 +7,15 @@ item 2              |
 ^D
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>single column table</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>item 1</td>
 </tr>
-<tr class="even">
+<tr>
 <td>item 2</td>
 </tr>
 </tbody>
@@ -31,15 +31,15 @@ item 2              |
 ^D
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>single column table</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>item 1</td>
 </tr>
-<tr class="even">
+<tr>
 <td>item 2</td>
 </tr>
 </tbody>
@@ -66,15 +66,15 @@ item 2              |
 ^D
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>single column table</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>item 1</td>
 </tr>
-<tr class="even">
+<tr>
 <td>item 2</td>
 </tr>
 </tbody>
@@ -90,15 +90,15 @@ item 2              |
 ^D
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th>single column table</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>item 1</td>
 </tr>
-<tr class="even">
+<tr>
 <td>item 2</td>
 </tr>
 </tbody>

--- a/test/command/8110.md
+++ b/test/command/8110.md
@@ -18,19 +18,19 @@
 ^D
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th><p>Header text</p></th>
 <th><p>Header text</p></th>
 <th><p>Header text</p></th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td><p>Example</p></td>
 <td><p>Example</p></td>
 <td><p>Example</p></td>
 </tr>
-<tr class="even">
+<tr>
 <td><p>Example</p></td>
 <td><p>Example</p></td>
 <td><p>Example</p></td>

--- a/test/command/8216.md
+++ b/test/command/8216.md
@@ -18,15 +18,15 @@ Misaligned separators in grid table
 <col style="width: 44%" />
 </colgroup>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Some text</td>
 <td><span class="class1 class2 class3">text</span></td>
 </tr>
-<tr class="even">
+<tr>
 <td>Some text</td>
 <td><span class="class1 class2 class3">text</span></td>
 </tr>
-<tr class="odd">
+<tr>
 <td>Some text</td>
 <td><span class="class1 class2 class3">text</span></td>
 </tr>

--- a/test/command/8257.md
+++ b/test/command/8257.md
@@ -16,22 +16,22 @@
 <col style="width: 11%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th>Item</th>
 <th>Price</th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td>Eggs</td>
 <td>5£</td>
 </tr>
-<tr class="even">
+<tr>
 <td>Spam</td>
 <td>3£</td>
 </tr>
 </tbody><tfoot>
-<tr class="odd">
+<tr>
 <td>Sum</td>
 <td>8£</td>
 </tr>

--- a/test/command/8307.md
+++ b/test/command/8307.md
@@ -13,7 +13,7 @@ breaks">hello</td>
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td title="this
   &#10;
 breaks">hello</td>

--- a/test/command/8659.md
+++ b/test/command/8659.md
@@ -5,7 +5,7 @@
 ^D
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 </tr>
 </tbody>
 </table>
@@ -30,20 +30,20 @@ The misaligned pipe in the first row is treated as an empty table.
 <col style="width: 16%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: left;"></th>
 <th></th>
 <th style="text-align: right;"></th>
 <th style="text-align: right;"><table>
 <tbody>
-<tr class="odd">
+<tr>
 </tr>
 </tbody>
 </table></th>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: left;">a</td>
 <td>b</td>
 <td style="text-align: right;">c</td>

--- a/test/command/8789.md
+++ b/test/command/8789.md
@@ -16,7 +16,7 @@
 ^D
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: right;"><strong>First</strong></th>
 <th style="text-align: right;"><strong>Second</strong></th>
 <th style="text-align: left;"><strong>Third</strong></th>
@@ -24,13 +24,13 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">160</td>
 <td style="text-align: right;">1</td>
 <td style="text-align: left;">test</td>
 <td style="text-align: left;">test</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: right;">160</td>
 <td style="text-align: right;">2</td>
 <td colspan="2" style="text-align: left;"><em>This is a test:</em> <span

--- a/test/command/9002.md
+++ b/test/command/9002.md
@@ -8,7 +8,7 @@
 <col style="width: 50%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th>a</th>
 <th>b</th>
 </tr>

--- a/test/tables.html4
+++ b/test/tables.html4
@@ -2,7 +2,7 @@
 <table>
 <caption>Demonstration of simple table syntax.</caption>
 <thead>
-<tr class="header">
+<tr>
 <th align="right">Right</th>
 <th align="left">Left</th>
 <th align="center">Center</th>
@@ -10,19 +10,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td align="right">12</td>
 <td align="left">12</td>
 <td align="center">12</td>
 <td>12</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="right">123</td>
 <td align="left">123</td>
 <td align="center">123</td>
 <td>123</td>
 </tr>
-<tr class="odd">
+<tr>
 <td align="right">1</td>
 <td align="left">1</td>
 <td align="center">1</td>
@@ -33,7 +33,7 @@
 <p>Simple table without caption:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th align="right">Right</th>
 <th align="left">Left</th>
 <th align="center">Center</th>
@@ -41,19 +41,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td align="right">12</td>
 <td align="left">12</td>
 <td align="center">12</td>
 <td>12</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="right">123</td>
 <td align="left">123</td>
 <td align="center">123</td>
 <td>123</td>
 </tr>
-<tr class="odd">
+<tr>
 <td align="right">1</td>
 <td align="left">1</td>
 <td align="center">1</td>
@@ -65,7 +65,7 @@
 <table>
 <caption>Demonstration of simple table syntax.</caption>
 <thead>
-<tr class="header">
+<tr>
 <th align="right">Right</th>
 <th align="left">Left</th>
 <th align="center">Center</th>
@@ -73,19 +73,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td align="right">12</td>
 <td align="left">12</td>
 <td align="center">12</td>
 <td>12</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="right">123</td>
 <td align="left">123</td>
 <td align="center">123</td>
 <td>123</td>
 </tr>
-<tr class="odd">
+<tr>
 <td align="right">1</td>
 <td align="left">1</td>
 <td align="center">1</td>
@@ -103,7 +103,7 @@
 <col width="35%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th align="center">Centered Header</th>
 <th align="left">Left Aligned</th>
 <th align="right">Right Aligned</th>
@@ -111,13 +111,13 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td align="center">First</td>
 <td align="left">row</td>
 <td align="right">12.0</td>
 <td align="left">Example of a row that spans multiple lines.</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="center">Second</td>
 <td align="left">row</td>
 <td align="right">5.0</td>
@@ -134,7 +134,7 @@
 <col width="35%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th align="center">Centered Header</th>
 <th align="left">Left Aligned</th>
 <th align="right">Right Aligned</th>
@@ -142,13 +142,13 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td align="center">First</td>
 <td align="left">row</td>
 <td align="right">12.0</td>
 <td align="left">Example of a row that spans multiple lines.</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="center">Second</td>
 <td align="left">row</td>
 <td align="right">5.0</td>
@@ -159,19 +159,19 @@
 <p>Table without column headers:</p>
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td align="right">12</td>
 <td align="left">12</td>
 <td align="center">12</td>
 <td align="right">12</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="right">123</td>
 <td align="left">123</td>
 <td align="center">123</td>
 <td align="right">123</td>
 </tr>
-<tr class="odd">
+<tr>
 <td align="right">1</td>
 <td align="left">1</td>
 <td align="center">1</td>
@@ -188,13 +188,13 @@
 <col width="35%" />
 </colgroup>
 <tbody>
-<tr class="odd">
+<tr>
 <td align="center">First</td>
 <td align="left">row</td>
 <td align="right">12.0</td>
 <td>Example of a row that spans multiple lines.</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="center">Second</td>
 <td align="left">row</td>
 <td align="right">5.0</td>

--- a/test/tables.html5
+++ b/test/tables.html5
@@ -2,7 +2,7 @@
 <table>
 <caption>Demonstration of simple table syntax.</caption>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: right;">Right</th>
 <th style="text-align: left;">Left</th>
 <th style="text-align: center;">Center</th>
@@ -10,19 +10,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">12</td>
 <td style="text-align: left;">12</td>
 <td style="text-align: center;">12</td>
 <td>12</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: right;">123</td>
 <td style="text-align: left;">123</td>
 <td style="text-align: center;">123</td>
 <td>123</td>
 </tr>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">1</td>
 <td style="text-align: left;">1</td>
 <td style="text-align: center;">1</td>
@@ -33,7 +33,7 @@
 <p>Simple table without caption:</p>
 <table>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: right;">Right</th>
 <th style="text-align: left;">Left</th>
 <th style="text-align: center;">Center</th>
@@ -41,19 +41,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">12</td>
 <td style="text-align: left;">12</td>
 <td style="text-align: center;">12</td>
 <td>12</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: right;">123</td>
 <td style="text-align: left;">123</td>
 <td style="text-align: center;">123</td>
 <td>123</td>
 </tr>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">1</td>
 <td style="text-align: left;">1</td>
 <td style="text-align: center;">1</td>
@@ -65,7 +65,7 @@
 <table>
 <caption>Demonstration of simple table syntax.</caption>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: right;">Right</th>
 <th style="text-align: left;">Left</th>
 <th style="text-align: center;">Center</th>
@@ -73,19 +73,19 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">12</td>
 <td style="text-align: left;">12</td>
 <td style="text-align: center;">12</td>
 <td>12</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: right;">123</td>
 <td style="text-align: left;">123</td>
 <td style="text-align: center;">123</td>
 <td>123</td>
 </tr>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">1</td>
 <td style="text-align: left;">1</td>
 <td style="text-align: center;">1</td>
@@ -103,7 +103,7 @@
 <col style="width: 35%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: center;">Centered Header</th>
 <th style="text-align: left;">Left Aligned</th>
 <th style="text-align: right;">Right Aligned</th>
@@ -111,13 +111,13 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: center;">First</td>
 <td style="text-align: left;">row</td>
 <td style="text-align: right;">12.0</td>
 <td style="text-align: left;">Example of a row that spans multiple lines.</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: center;">Second</td>
 <td style="text-align: left;">row</td>
 <td style="text-align: right;">5.0</td>
@@ -135,7 +135,7 @@ rows.</td>
 <col style="width: 35%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: center;">Centered Header</th>
 <th style="text-align: left;">Left Aligned</th>
 <th style="text-align: right;">Right Aligned</th>
@@ -143,13 +143,13 @@ rows.</td>
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: center;">First</td>
 <td style="text-align: left;">row</td>
 <td style="text-align: right;">12.0</td>
 <td style="text-align: left;">Example of a row that spans multiple lines.</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: center;">Second</td>
 <td style="text-align: left;">row</td>
 <td style="text-align: right;">5.0</td>
@@ -161,19 +161,19 @@ rows.</td>
 <p>Table without column headers:</p>
 <table>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">12</td>
 <td style="text-align: left;">12</td>
 <td style="text-align: center;">12</td>
 <td style="text-align: right;">12</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: right;">123</td>
 <td style="text-align: left;">123</td>
 <td style="text-align: center;">123</td>
 <td style="text-align: right;">123</td>
 </tr>
-<tr class="odd">
+<tr>
 <td style="text-align: right;">1</td>
 <td style="text-align: left;">1</td>
 <td style="text-align: center;">1</td>
@@ -190,13 +190,13 @@ rows.</td>
 <col style="width: 35%" />
 </colgroup>
 <tbody>
-<tr class="odd">
+<tr>
 <td style="text-align: center;">First</td>
 <td style="text-align: left;">row</td>
 <td style="text-align: right;">12.0</td>
 <td>Example of a row that spans multiple lines.</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: center;">Second</td>
 <td style="text-align: left;">row</td>
 <td style="text-align: right;">5.0</td>

--- a/test/tables/nordics.html4
+++ b/test/tables/nordics.html4
@@ -17,38 +17,38 @@
 </tr>
 </thead>
 <tbody class="souvereign-states">
-<tr class="odd country">
+<tr class="country">
 <th align="center">Denmark</th>
 <td align="left">Copenhagen</td>
 <td align="left">5,809,502</td>
 <td align="left">43,094</td>
 </tr>
-<tr class="even country">
+<tr class="country">
 <th align="center">Finland</th>
 <td align="left">Helsinki</td>
 <td align="left">5,537,364</td>
 <td align="left">338,145</td>
 </tr>
-<tr class="odd country">
+<tr class="country">
 <th align="center">Iceland</th>
 <td align="left">Reykjavik</td>
 <td align="left">343,518</td>
 <td align="left">103,000</td>
 </tr>
-<tr class="even country">
+<tr class="country">
 <th align="center">Norway</th>
 <td align="left">Oslo</td>
 <td align="left">5,372,191</td>
 <td align="left">323,802</td>
 </tr>
-<tr class="odd country">
+<tr class="country">
 <th align="center">Sweden</th>
 <td align="left">Stockholm</td>
 <td align="left">10,313,447</td>
 <td align="left">450,295</td>
 </tr>
 </tbody><tfoot>
-<tr id="summary" class="even">
+<tr id="summary">
 <td align="center">Total</td>
 <td align="left"></td>
 <td id="total-population" align="left">27,376,022</td>

--- a/test/tables/nordics.html5
+++ b/test/tables/nordics.html5
@@ -17,38 +17,38 @@
 </tr>
 </thead>
 <tbody class="souvereign-states">
-<tr class="odd country">
+<tr class="country">
 <th style="text-align: center;">Denmark</th>
 <td style="text-align: left;">Copenhagen</td>
 <td style="text-align: left;">5,809,502</td>
 <td style="text-align: left;">43,094</td>
 </tr>
-<tr class="even country">
+<tr class="country">
 <th style="text-align: center;">Finland</th>
 <td style="text-align: left;">Helsinki</td>
 <td style="text-align: left;">5,537,364</td>
 <td style="text-align: left;">338,145</td>
 </tr>
-<tr class="odd country">
+<tr class="country">
 <th style="text-align: center;">Iceland</th>
 <td style="text-align: left;">Reykjavik</td>
 <td style="text-align: left;">343,518</td>
 <td style="text-align: left;">103,000</td>
 </tr>
-<tr class="even country">
+<tr class="country">
 <th style="text-align: center;">Norway</th>
 <td style="text-align: left;">Oslo</td>
 <td style="text-align: left;">5,372,191</td>
 <td style="text-align: left;">323,802</td>
 </tr>
-<tr class="odd country">
+<tr class="country">
 <th style="text-align: center;">Sweden</th>
 <td style="text-align: left;">Stockholm</td>
 <td style="text-align: left;">10,313,447</td>
 <td style="text-align: left;">450,295</td>
 </tr>
 </tbody><tfoot>
-<tr id="summary" class="even">
+<tr id="summary">
 <td style="text-align: center;">Total</td>
 <td style="text-align: left;"></td>
 <td id="total-population" style="text-align: left;">27,376,022</td>

--- a/test/tables/planets.html4
+++ b/test/tables/planets.html4
@@ -1,7 +1,7 @@
 <table>
 <caption><p>Data about the planets of our solar system.</p></caption>
 <thead>
-<tr class="header">
+<tr>
 <th colspan="2" align="center"></th>
 <th>Name</th>
 <th align="right">Mass (10^24kg)</th>
@@ -16,7 +16,7 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <th colspan="2" rowspan="4" align="center">Terrestrial planets</th>
 <th>Mercury</th>
 <td align="right">0.330</td>
@@ -29,7 +29,7 @@
 <td align="right">0</td>
 <td>Closest to the Sun</td>
 </tr>
-<tr class="even">
+<tr>
 <th>Venus</th>
 <td align="right">4.87</td>
 <td align="right">12,104</td>
@@ -41,7 +41,7 @@
 <td align="right">0</td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <th>Earth</th>
 <td align="right">5.97</td>
 <td align="right">12,756</td>
@@ -53,7 +53,7 @@
 <td align="right">1</td>
 <td>Our world</td>
 </tr>
-<tr class="even">
+<tr>
 <th>Mars</th>
 <td align="right">0.642</td>
 <td align="right">6,792</td>
@@ -65,7 +65,7 @@
 <td align="right">2</td>
 <td>The red planet</td>
 </tr>
-<tr class="odd">
+<tr>
 <th rowspan="4" align="center">Jovian planets</th>
 <th rowspan="2" align="center">Gas giants</th>
 <th>Jupiter</th>
@@ -79,7 +79,7 @@
 <td align="right">67</td>
 <td>The largest planet</td>
 </tr>
-<tr class="even">
+<tr>
 <th>Saturn</th>
 <td align="right">568</td>
 <td align="right">120,536</td>
@@ -91,7 +91,7 @@
 <td align="right">62</td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <th rowspan="2" align="center">Ice giants</th>
 <th>Uranus</th>
 <td align="right">86.8</td>
@@ -104,7 +104,7 @@
 <td align="right">27</td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <th>Neptune</th>
 <td align="right">102</td>
 <td align="right">49,528</td>
@@ -116,7 +116,7 @@
 <td align="right">14</td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <th colspan="2" align="center">Dwarf planets</th>
 <th>Pluto</th>
 <td align="right">0.0146</td>

--- a/test/tables/planets.html5
+++ b/test/tables/planets.html5
@@ -1,7 +1,7 @@
 <table>
 <caption><p>Data about the planets of our solar system.</p></caption>
 <thead>
-<tr class="header">
+<tr>
 <th colspan="2" style="text-align: center;"></th>
 <th>Name</th>
 <th style="text-align: right;">Mass (10^24kg)</th>
@@ -16,7 +16,7 @@
 </tr>
 </thead>
 <tbody>
-<tr class="odd">
+<tr>
 <th colspan="2" rowspan="4" style="text-align: center;">Terrestrial planets</th>
 <th>Mercury</th>
 <td style="text-align: right;">0.330</td>
@@ -29,7 +29,7 @@
 <td style="text-align: right;">0</td>
 <td>Closest to the Sun</td>
 </tr>
-<tr class="even">
+<tr>
 <th>Venus</th>
 <td style="text-align: right;">4.87</td>
 <td style="text-align: right;">12,104</td>
@@ -41,7 +41,7 @@
 <td style="text-align: right;">0</td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <th>Earth</th>
 <td style="text-align: right;">5.97</td>
 <td style="text-align: right;">12,756</td>
@@ -53,7 +53,7 @@
 <td style="text-align: right;">1</td>
 <td>Our world</td>
 </tr>
-<tr class="even">
+<tr>
 <th>Mars</th>
 <td style="text-align: right;">0.642</td>
 <td style="text-align: right;">6,792</td>
@@ -65,7 +65,7 @@
 <td style="text-align: right;">2</td>
 <td>The red planet</td>
 </tr>
-<tr class="odd">
+<tr>
 <th rowspan="4" style="text-align: center;">Jovian planets</th>
 <th rowspan="2" style="text-align: center;">Gas giants</th>
 <th>Jupiter</th>
@@ -79,7 +79,7 @@
 <td style="text-align: right;">67</td>
 <td>The largest planet</td>
 </tr>
-<tr class="even">
+<tr>
 <th>Saturn</th>
 <td style="text-align: right;">568</td>
 <td style="text-align: right;">120,536</td>
@@ -91,7 +91,7 @@
 <td style="text-align: right;">62</td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <th rowspan="2" style="text-align: center;">Ice giants</th>
 <th>Uranus</th>
 <td style="text-align: right;">86.8</td>
@@ -104,7 +104,7 @@
 <td style="text-align: right;">27</td>
 <td></td>
 </tr>
-<tr class="even">
+<tr>
 <th>Neptune</th>
 <td style="text-align: right;">102</td>
 <td style="text-align: right;">49,528</td>
@@ -116,7 +116,7 @@
 <td style="text-align: right;">14</td>
 <td></td>
 </tr>
-<tr class="odd">
+<tr>
 <th colspan="2" style="text-align: center;">Dwarf planets</th>
 <th>Pluto</th>
 <td style="text-align: right;">0.0146</td>

--- a/test/tables/students.html4
+++ b/test/tables/students.html4
@@ -5,49 +5,49 @@
 <col width="50%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th align="center">Student ID</th>
 <th align="center">Name</th>
 </tr>
 </thead>
 <tbody class="souvereign-states">
-<tr class="odd">
+<tr>
 <th colspan="2" align="left">Computer Science</th>
 </tr>
 
-<tr class="odd">
+<tr>
 <td align="left">3741255</td>
 <td align="left">Jones, Martha</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="left">4077830</td>
 <td align="left">Pierce, Benjamin</td>
 </tr>
-<tr class="odd">
+<tr>
 <td align="left">5151701</td>
 <td align="left">Kirk, James</td>
 </tr>
 </tbody>
 <tbody>
-<tr class="odd">
+<tr>
 <th colspan="2" align="left">Russian Literature</th>
 </tr>
 
-<tr class="odd">
+<tr>
 <td align="left">3971244</td>
 <td align="left">Nim, Victor</td>
 </tr>
 </tbody>
 <tbody>
-<tr class="odd">
+<tr>
 <th colspan="2" align="left">Astrophysics</th>
 </tr>
 
-<tr class="odd">
+<tr>
 <td align="left">4100332</td>
 <td align="left">Petrov, Alexandra</td>
 </tr>
-<tr class="even">
+<tr>
 <td align="left">4100332</td>
 <td align="left">Toyota, Hiroko</td>
 </tr>

--- a/test/tables/students.html5
+++ b/test/tables/students.html5
@@ -5,49 +5,49 @@
 <col style="width: 50%" />
 </colgroup>
 <thead>
-<tr class="header">
+<tr>
 <th style="text-align: center;">Student ID</th>
 <th style="text-align: center;">Name</th>
 </tr>
 </thead>
 <tbody class="souvereign-states">
-<tr class="odd">
+<tr>
 <th colspan="2" style="text-align: left;">Computer Science</th>
 </tr>
 
-<tr class="odd">
+<tr>
 <td style="text-align: left;">3741255</td>
 <td style="text-align: left;">Jones, Martha</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: left;">4077830</td>
 <td style="text-align: left;">Pierce, Benjamin</td>
 </tr>
-<tr class="odd">
+<tr>
 <td style="text-align: left;">5151701</td>
 <td style="text-align: left;">Kirk, James</td>
 </tr>
 </tbody>
 <tbody>
-<tr class="odd">
+<tr>
 <th colspan="2" style="text-align: left;">Russian Literature</th>
 </tr>
 
-<tr class="odd">
+<tr>
 <td style="text-align: left;">3971244</td>
 <td style="text-align: left;">Nim, Victor</td>
 </tr>
 </tbody>
 <tbody>
-<tr class="odd">
+<tr>
 <th colspan="2" style="text-align: left;">Astrophysics</th>
 </tr>
 
-<tr class="odd">
+<tr>
 <td style="text-align: left;">4100332</td>
 <td style="text-align: left;">Petrov, Alexandra</td>
 </tr>
-<tr class="even">
+<tr>
 <td style="text-align: left;">4100332</td>
 <td style="text-align: left;">Toyota, Hiroko</td>
 </tr>


### PR DESCRIPTION
Here is a try for #9325 according to @jgm guidance :

- The change in the writer needs to be refined but I guess this is the idea.
- I found no use of `header`/`odd`/`even` classes in `data/templates/styles.html`.
- I removed `header`/`odd`/`even` accross the tests; I'm not sure about changes in `update test/command/*.md` so I put it in a separate commit.

I also found occurence of `odd`/`even` in:

- `pandoc-lua-engine/test/sample.lua` and `pandoc-lua-engine/test/tables.custom`
- and `/src/Text/Pandoc/Writers/Textile.hs` and `test/tables.textile`

Do they need updating too?

_PS: This is my first pull request. It is only WIP but I hope it helps. Otherwise, feel free to close!_