### PR TITLE
EPUB accessibility: roles

### DIFF
--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -948,7 +948,7 @@ createNavEntry opts meta metadata
   let tocBlocks = evalState (catMaybes <$> mapM mkItem secs) 1
   let navBlocks = [RawBlock (Format "html")
                   $ showElement $ -- prettyprinting introduces bad spaces
-                   unode navtag ! ([("epub:type","toc") | version == EPUB3] ++
+                   unode navtag ! ([("epub:type","toc"), ("role", "doc-toc") | version == EPUB3] ++
                                    [("id","toc")]) $
                     [ unode "h1" ! [("id","toc-title")] $ tocTitle
                     , unode "ol" ! [("class","toc")] $ tocBlocks ]]

--- a/src/Text/Pandoc/Writers/EPUB.hs
+++ b/src/Text/Pandoc/Writers/EPUB.hs
@@ -948,7 +948,8 @@ createNavEntry opts meta metadata
   let tocBlocks = evalState (catMaybes <$> mapM mkItem secs) 1
   let navBlocks = [RawBlock (Format "html")
                   $ showElement $ -- prettyprinting introduces bad spaces
-                   unode navtag ! ([("epub:type","toc"), ("role", "doc-toc") | version == EPUB3] ++
+                   unode navtag ! ([("epub:type","toc") | version == EPUB3] ++
+                                   [("role","doc-toc") | version == EPUB3] ++
                                    [("id","toc")]) $
                     [ unode "h1" ! [("id","toc-title")] $ tocTitle
                     , unode "ol" ! [("class","toc")] $ tocBlocks ]]

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -1605,7 +1605,7 @@ inlineToHtml opts inline = do
                                              else H.sup)
                                        $ toHtml ref
                         return $ case epubVersion of
-                                      Just EPUB3 -> link ! customAttribute "epub:type" "noteref"
+                                      Just EPUB3 -> link ! customAttribute "epub:type" "noteref" ! customAttribute "role" "doc-noteref"
                                       _ | html5  -> link ! A5.role "doc-noteref"
                                       _          -> link
     (Cite cits il)-> do contents <- inlineListToHtml opts
@@ -1668,7 +1668,7 @@ blockListToNote opts ref blocks = do
              _ -> Para [backlink , Str "."] : blocks
       contents <- blockListToHtml opts blocks'
       let noteItem = (if epubv == EPUB3
-                         then H5.aside ! customAttribute "epub:type" "footnote"
+                         then H5.aside ! customAttribute "epub:type" "footnote" ! customAttribute "role" "doc-footnote"
                          else H.div) ! prefixedId opts ("fn" <> ref)
                       $ nl >> contents >> nl
       return $ noteItem >> nl


### PR DESCRIPTION
Roles are added to some elements within epub for accessibility best practices.

Footnote references are given role "doc-noteref",footnote text gets
"doc-footnote", and nav gets "doc-toc". Cf.
https://kb.daisy.org/publishing/docs/html/roles.html for reference.
