### PR TITLE
fix(ci): explicitly choose a .Net version

### DIFF
--- a/.github/workflows/docx-validation.yaml
+++ b/.github/workflows/docx-validation.yaml
@@ -4,11 +4,13 @@ on:
     paths:
       - test/docx/golden/*.docx
       - tools/validate-docx.sh
+      - tools/validate-docx2.sh
       - .github/workflows/docx-validation.yaml
   pull_request:
     paths:
       - test/docx/golden/*.docx
       - tools/validate-docx.sh
+      - tools/validate-docx2.sh
       - .github/workflows/docx-validation.yaml
 
 permissions:

--- a/tools/validate-docx2.sh
+++ b/tools/validate-docx2.sh
@@ -3,7 +3,7 @@
 set -eu
 
 (for i in "$@"; do
-  dotnet run --configuration=Release --no-build --no-restore --project OOXML-Validator/OOXMLValidatorCLI -- "${i}" -r
+  dotnet run --configuration=Release --framework=net8.0 --no-build --no-restore --project OOXML-Validator/OOXMLValidatorCLI -- "${i}" -r
 done) >validation
 json_reformat -s <validation
 


### PR DESCRIPTION
Upstream https://github.com/mikeebowen/OOXML-Validator/commit/29af1086b5c78b6a213e70d2e1cb8da2a8e5b876 has added support for building with .Net 8.0.
But that means OOXML-Validator can now be built for both .Net 6.0 and .Net 8.0, so we need to pick which one we want when running, otherwise we get an error:
```
Unable to run your project
Your project targets multiple frameworks. Specify which framework to run using '--framework'.
```

This should fix the failure mentioned in https://github.com/jgm/pandoc/pull/9277#issuecomment-1925604065, and be future proof against more runtime changes upstream because we've now picked a version explicitly (at least until `net8.0` support is dropped).