### PR TITLE
Manual: clarify scope of option --resource-path

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -951,6 +951,9 @@ header when requesting a document from a URL:
     those that come earlier, so
     `--resource-path foo:bar --resource-path baz:bim` is
     equivalent to `--resource-path baz:bim:foo:bar`.
+    Note: `--resource-path` is only used when Pandoc itself 
+    tries to find images.  E.g., when generating TeX, 
+    `--resource-path` does nothing.
 
 `--request-header=`*NAME*`:`*VAL*
 


### PR DESCRIPTION
Add a note to the documentation of the `--resource-path` option that it is only used by Pandoc itself. This should clarify its scope for users, even if the text is listed in the "General Writer Options" section. 

The relevant discussion on this was at https://github.com/jgm/pandoc/discussions/9360#discussioncomment-8373190.