### PR TITLE
Typst property output

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -835,6 +835,7 @@ test-suite test-pandoc
                   Tests.Writers.OOXML
                   Tests.Writers.Ms
                   Tests.Writers.AnnotatedTable
+                  Tests.Writers.Typst
 
 benchmark benchmark-pandoc
   import:          common-executable

--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -232,10 +232,10 @@ blockToTypst block =
             let typstAttrs2 = filter ((/="typst:align") . fst) typstAttrs
             let halign =
                   (case alignment of
-                            AlignDefault -> []
-                            AlignLeft -> [ "left" ]
-                            AlignRight -> [ "right" ]
-                            AlignCenter -> [ "center" ])
+                    AlignDefault -> []
+                    AlignLeft -> [ "left" ]
+                    AlignRight -> [ "right" ]
+                    AlignCenter -> [ "center" ])
             let cellaligns = valign ++ halign
             let cellattrs =
                   (case cellaligns of
@@ -316,9 +316,10 @@ blockToTypst block =
       blocksToTypst (Header lev (ident,cls,kvs) ils:rest)
     Div (ident,_,kvs) blocks -> do
       let lab = toLabel FreestandingLabel ident
-      let (typstAttrs,_) = pickTypstAttrs kvs
+      let (typstAttrs,typstTextAttrs) = pickTypstAttrs kvs
       contents <- blocksToTypst blocks
-      return $ "#block" <> (ifNotEmpty typstAttrs (parens . toTypstProps)) <> "[" $$ contents $$ ("]" <+> lab)
+      let contents2 = ifNotEmpty typstTextAttrs toTypstSetText <> contents
+      return $ "#block" <> (ifNotEmpty typstAttrs (parens . toTypstProps)) <> "[" $$ contents2 $$ ("]" <+> lab)
 
 defListItemToTypst :: PandocMonad m => ([Inline], [[Block]]) -> TW m (Doc Text)
 defListItemToTypst (term, defns) = do

--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -125,10 +125,13 @@ ifNotEmptyWrap f list contents =
     [] -> contents
     _ -> f list contents
 
+typst_props_list :: [(Text, Text)] -> Doc Text
 typst_props_list = ifNotEmpty toTypstPropsList
 
+typst_text_element :: [(Text, Text)] -> Doc Text -> Doc Text
 typst_text_element = ifNotEmptyWrap toTypstTextElement
 
+typst_set_text :: [(Text, Text)] -> Doc Text
 typst_set_text = ifNotEmpty toTypstSetText
 
 blocksToTypst :: PandocMonad m => [Block] -> TW m (Doc Text)

--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -94,8 +94,7 @@ pickTypstAttrs =
 
 formatTypstProps :: [(Text, Text)] -> [Text]
 formatTypstProps =
-  map (\(k,v) -> let prop = last $ T.splitOn (T.pack ":") k in
-        prop <> ": " <> v)
+  map (\(k,v) -> last (T.splitOn (T.pack ":") k) <> ": " <> v)
 
 toTypstText :: [(Text, Text)] -> Doc Text -> Doc Text
 toTypstText typstTextAttrs content =

--- a/test/Tests/Writers/Typst.hs
+++ b/test/Tests/Writers/Typst.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Tests.Writers.Typst (tests) where
+
+import Data.Text (unpack)
+import Test.Tasty
+import Test.Tasty.HUnit (HasCallStack)
+import Tests.Helpers
+import Text.Pandoc
+import Text.Pandoc.Arbitrary ()
+import Text.Pandoc.Builder
+
+typstWithOpts :: (ToPandoc a) => WriterOptions -> a -> String
+typstWithOpts opts = unpack . purely (writeTypst opts) . toPandoc
+
+typst :: (ToPandoc a) => a -> String
+typst = typstWithOpts def
+
+{-
+  "my test" =: X =?> Y
+
+is shorthand for
+
+  test html "my test" $ X =?> Y
+
+which is in turn shorthand for
+
+  test html "my test" (X,Y)
+-}
+
+infix 4 =:
+(=:) :: (ToString a, ToPandoc a, HasCallStack)
+     => String -> (a, String) -> TestTree
+(=:) = test typst
+
+toRow :: [Blocks] -> Row
+toRow = Row nullAttr . map simpleCell
+
+toHeaderRow :: [Blocks] -> [Row]
+toHeaderRow l = [toRow l | not (null l)]
+
+
+tests :: [TestTree]
+tests =
+  [ testGroup "typst properties"
+    [ "span text" =:
+     spanWith ("", [], [("typst:text:fill", "orange")]) "foo"
+    =?> "#text(fill: orange)[foo]"
+    , "table" =:
+      let headers = []
+          rows = []
+      in tableWith ("", [], [("typst:fill", "blue")])
+                    emptyCaption
+                    []
+                    (TableHead nullAttr $ toHeaderRow headers)
+                    [TableBody nullAttr 0 [] $ map toRow rows]
+                    (TableFoot nullAttr [])
+    =?> unlines [ 
+        "#figure("
+      , "  align(center)[#table("
+      , "    columns: 0,"
+      , "    align: (),"
+      , "    fill: blue,"
+      , "  )]"
+      , "  , kind: table"
+      , "  )"
+      ]
+    , "table text" =:
+      let headers = []
+          rows = []
+      in tableWith ("", [], [("typst:text:fill", "orange")])
+                    emptyCaption
+                    []
+                    (TableHead nullAttr $ toHeaderRow headers)
+                    [TableBody nullAttr 0 [] $ map toRow rows]
+                    (TableFoot nullAttr [])
+    =?> unlines [ 
+        "#figure("
+      , "  align(center)[#text(fill: orange)[#table("
+      , "    columns: 0,"
+      , "    align: (),"
+      , "  )]]"
+      , "  , kind: table"
+      , "  )"
+      ]
+    , "table cell" =:
+      let headers = []
+          rows = [Row nullAttr [
+              cellWith ("", [], [("typst:fill", "blue")]) AlignDefault (RowSpan 1) (ColSpan 1) $ para "Foo"
+            , simpleCell $ para "Bar"
+            ]]
+      in table
+                    emptyCaption
+                    [(AlignDefault,ColWidthDefault),(AlignDefault,ColWidthDefault)]
+                    (TableHead nullAttr $ toHeaderRow headers)
+                    [TableBody nullAttr 0 [] rows]
+                    (TableFoot nullAttr [])
+    =?> unlines [ 
+        "#figure("
+      , "  align(center)[#table("
+      , "    columns: 2,"
+      , "    align: (auto,auto,),"
+      , "    table.cell(fill: blue)[Foo"
+      , ""
+      , "    ], [Bar"
+      , ""
+      , "    ],"
+      , "  )]"
+      , "  , kind: table"
+      , "  )"
+      ]
+    , "table cell text" =:
+      let headers = []
+          rows = [Row nullAttr [
+              cellWith ("", [], [("typst:text:fill", "orange")]) AlignDefault (RowSpan 1) (ColSpan 1) $ para "Foo"
+            , simpleCell $ para "Bar"
+            ]]
+      in table
+                    emptyCaption
+                    [(AlignDefault,ColWidthDefault),(AlignDefault,ColWidthDefault)]
+                    (TableHead nullAttr $ toHeaderRow headers)
+                    [TableBody nullAttr 0 [] rows]
+                    (TableFoot nullAttr [])
+    =?> unlines [ 
+        "#figure("
+      , "  align(center)[#table("
+      , "    columns: 2,"
+      , "    align: (auto,auto,),"
+      , "    [#set text(fill: orange); Foo"
+      , ""
+      , "    ], [Bar"
+      , ""
+      , "    ],"
+      , "  )]"
+      , "  , kind: table"
+      , "  )"
+      ]
+    ]
+  ]

--- a/test/Tests/Writers/Typst.hs
+++ b/test/Tests/Writers/Typst.hs
@@ -43,8 +43,22 @@ tests :: [TestTree]
 tests =
   [ testGroup "typst properties"
     [ "span text" =:
-     spanWith ("", [], [("typst:text:fill", "orange")]) "foo"
+      spanWith ("", [], [("typst:text:fill", "orange")]) "foo"
     =?> "#text(fill: orange)[foo]"
+    , "block" =:
+      (divWith ("", [], [("typst:inset", "10pt")]) $ plain "Foo")
+    =?> unlines [
+        "#block(inset: 10pt)["
+      , "Foo"
+      , "]"
+      ]
+    , "block text" =:
+      (divWith ("", [], [("typst:text:fill", "purple")]) $ plain "Foo")
+    =?> unlines [
+        "#block["
+      , "#set text(fill: purple); Foo"
+      , "]"
+      ]
     , "table" =:
       let headers = []
           rows = []
@@ -54,7 +68,7 @@ tests =
                     (TableHead nullAttr $ toHeaderRow headers)
                     [TableBody nullAttr 0 [] $ map toRow rows]
                     (TableFoot nullAttr [])
-    =?> unlines [ 
+    =?> unlines [
         "#figure("
       , "  align(center)[#table("
       , "    columns: 0,"
@@ -73,7 +87,7 @@ tests =
                     (TableHead nullAttr $ toHeaderRow headers)
                     [TableBody nullAttr 0 [] $ map toRow rows]
                     (TableFoot nullAttr [])
-    =?> unlines [ 
+    =?> unlines [
         "#figure("
       , "  align(center)[#text(fill: orange)[#table("
       , "    columns: 0,"
@@ -94,7 +108,7 @@ tests =
                     (TableHead nullAttr $ toHeaderRow headers)
                     [TableBody nullAttr 0 [] rows]
                     (TableFoot nullAttr [])
-    =?> unlines [ 
+    =?> unlines [
         "#figure("
       , "  align(center)[#table("
       , "    columns: 2,"
@@ -108,7 +122,7 @@ tests =
       , "  , kind: table"
       , "  )"
       ]
-    , "table cell text" =:
+    , "table cell text no attr" =:
       let headers = []
           rows = [Row nullAttr [
               cellWith ("", [], [("typst:text:fill", "orange")]) AlignDefault (RowSpan 1) (ColSpan 1) $ para "Foo"
@@ -120,12 +134,38 @@ tests =
                     (TableHead nullAttr $ toHeaderRow headers)
                     [TableBody nullAttr 0 [] rows]
                     (TableFoot nullAttr [])
-    =?> unlines [ 
+    =?> unlines [
         "#figure("
       , "  align(center)[#table("
       , "    columns: 2,"
       , "    align: (auto,auto,),"
       , "    [#set text(fill: orange); Foo"
+      , ""
+      , "    ], [Bar"
+      , ""
+      , "    ],"
+      , "  )]"
+      , "  , kind: table"
+      , "  )"
+      ]
+    , "table cell text w attr" =:
+      let headers = []
+          rows = [Row nullAttr [
+              cellWith ("", [], [("typst:text:fill", "orange")]) AlignCenter (RowSpan 1) (ColSpan 1) $ para "Foo"
+            , simpleCell $ para "Bar"
+            ]]
+      in table
+                    emptyCaption
+                    [(AlignDefault,ColWidthDefault),(AlignDefault,ColWidthDefault)]
+                    (TableHead nullAttr $ toHeaderRow headers)
+                    [TableBody nullAttr 0 [] rows]
+                    (TableFoot nullAttr [])
+    =?> unlines [
+        "#figure("
+      , "  align(center)[#table("
+      , "    columns: 2,"
+      , "    align: (auto,auto,),"
+      , "    table.cell(align: center)[#set text(fill: orange); Foo"
       , ""
       , "    ], [Bar"
       , ""

--- a/test/test-pandoc.hs
+++ b/test/test-pandoc.hs
@@ -47,6 +47,7 @@ import qualified Tests.Writers.Org
 import qualified Tests.Writers.Plain
 import qualified Tests.Writers.Powerpoint
 import qualified Tests.Writers.RST
+import qualified Tests.Writers.Typst
 import qualified Tests.Writers.AnnotatedTable
 import qualified Tests.Writers.TEI
 import qualified Tests.Writers.Markua
@@ -80,6 +81,7 @@ tests pandocPath = testGroup "pandoc tests"
           , testGroup "PowerPoint" Tests.Writers.Powerpoint.tests
           , testGroup "Ms" Tests.Writers.Ms.tests
           , testGroup "AnnotatedTable" Tests.Writers.AnnotatedTable.tests
+          , testGroup "Typst" Tests.Writers.Typst.tests
           ]
         , testGroup "Readers"
           [ testGroup "LaTeX" Tests.Readers.LaTeX.tests


### PR DESCRIPTION
Here is my work in progress on Typst property output. Supercedes #9623.

https://github.com/gordonwoodhull/pandoc/tree/typst-property-output

It handles 8 cases of attribute-bearing AST nodes:
* span text (no element properties because `text()` is the closest element to span)
* div and div text
* table and table text
* td and td text (3 cases)

Now that I have tests I would be comfortable implementing the rest, but I haven't needed them yet. Thought I'd check in to ask if I'm on track here. All suggestions are welcome!

I think the code is more idiomatic Haskell (but not perfect) and the usage is terse (except for the align case, see below). Some details of whitespace/line breaks probably need more work.

There aren't row elements in Typst; tr attributes would have to be underlaid on cell properties.

#### align is messy

There is one case that is very bad - the Typst reader extracts (horizontal) `align`, but this needs to be coalesced with `vertical-align` for the Typst cell `align`. An alternative design would be to not remove the style in the reader, and allow Lua to override the whole property. Technically I should also parse `typst:align` as addition and then dedupe, because Typst will error if there are duplicate terms in the align expression, but Lua only sees `vertical-align` currently, so it works out.