### PR TITLE
New approach to preventing image overflow in LaTeX (fixes #9660)

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -302,15 +302,17 @@ $endif$
 $if(graphics)$
 \usepackage{graphicx}
 \makeatletter
-\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
-\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
-\makeatother
-% Scale images if necessary, so that they will not overflow the page
-% margins by default, and it is still possible to overwrite the defaults
-% using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+\newsavebox\pandoc@box
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+  \sbox\pandoc@box{#1}%
+  \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+  \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+  \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+  \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+  \else\usebox{\pandoc@box}%
+  \fi%
+}
 % Set default figure placement to htbp
-\makeatletter
 \def\fps@figure{htbp}
 \makeatother
 $endif$

--- a/test/Tests/Writers/LaTeX.hs
+++ b/test/Tests/Writers/LaTeX.hs
@@ -70,7 +70,7 @@ tests = [ testGroup "code blocks"
             "\\begin{description}\n\\item[foo] ~ \n\\subsection{bar}\n\nbaz\n\\end{description}"
           , "containing image" =:
             header 1 (image "imgs/foo.jpg" "" (text "Alt text")) =?>
-            "\\section{\\texorpdfstring{\\protect\\includegraphics{imgs/foo.jpg}}{Alt text}}"
+            "\\section{\\texorpdfstring{\\protect\\pandocbounded{\\includegraphics[keepaspectratio]{imgs/foo.jpg}}}{Alt text}}"
           ]
         , testGroup "inline code"
           [ "struck out and highlighted" =:

--- a/test/command/3450.md
+++ b/test/command/3450.md
@@ -8,5 +8,5 @@
 % pandoc -fmarkdown-implicit_figures -t latex
 ![image](lalune.jpg){height=2em}
 ^D
-\includegraphics[width=\linewidth,height=2em]{lalune.jpg}
+\includegraphics[width=\linewidth,height=2em,keepaspectratio]{lalune.jpg}
 ```

--- a/test/command/5476.md
+++ b/test/command/5476.md
@@ -4,7 +4,7 @@
 ^D
 \begin{figure}
 \centering
-\includegraphics{test/lalune.jpg}
+\pandocbounded{\includegraphics[keepaspectratio]{test/lalune.jpg}}
 \caption[moon]{moon\footnotemark{}}
 \end{figure}
 \footnotetext{the moon}

--- a/test/command/7181.md
+++ b/test/command/7181.md
@@ -4,7 +4,7 @@
 ^D
 \begin{figure}
 \centering
-\includegraphics[page=13,trim=1cm,clip,width=4cm]{slides.pdf}
+\pandocbounded{\includegraphics[keepaspectratio,page=13,trim=1cm,clip,width=4cm]{slides.pdf}}
 \caption{Global frog population.}
 \end{figure}
 

--- a/test/command/9045.md
+++ b/test/command/9045.md
@@ -4,7 +4,7 @@
 ^D
 \begin{figure}
 \centering
-\includegraphics{there.jpg}
+\pandocbounded{\includegraphics[keepaspectratio]{there.jpg}}
 \caption{hi}\label{foo}
 \end{figure}
 ```

--- a/test/writer.latex
+++ b/test/writer.latex
@@ -39,15 +39,17 @@
 \usepackage{xcolor}
 \usepackage{graphicx}
 \makeatletter
-\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
-\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
-\makeatother
-% Scale images if necessary, so that they will not overflow the page
-% margins by default, and it is still possible to overwrite the defaults
-% using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+\newsavebox\pandoc@box
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+  \sbox\pandoc@box{#1}%
+  \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+  \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+  \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+  \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+  \else\usebox{\pandoc@box}%
+  \fi%
+}
 % Set default figure placement to htbp
-\makeatletter
 \def\fps@figure{htbp}
 \makeatother
 \ifLuaTeX
@@ -922,11 +924,12 @@ From ``Voyage dans la Lune'' by Georges Melies (1902):
 
 \begin{figure}
 \centering
-\includegraphics{lalune.jpg}
+\pandocbounded{\includegraphics[keepaspectratio]{lalune.jpg}}
 \caption{lalune}
 \end{figure}
 
-Here is a movie \includegraphics{movie.jpg} icon.
+Here is a movie \pandocbounded{\includegraphics[keepaspectratio]{movie.jpg}}
+icon.
 
 \begin{center}\rule{0.5\linewidth}{0.5pt}\end{center}
 


### PR DESCRIPTION
Instead of relying on graphicx internals, we now define a macro that gets used with images when explicit size information is not provided. This macro prevents the image from overflowing vertically or horizontally.

Templates will have to be updated to include the new macro.

Closes #9660.

The macro should be credited to @mrpiggi. See https://github.com/mrpiggi/svg/issues/60 for discussion.
