### PR TITLE
Update MANUAL.txt to at least introduce term before shorten viersion

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -259,7 +259,7 @@ header when requesting a document from a URL:
     - `man` ([roff man])
     - `muse` ([Muse])
     - `native` (native Haskell)
-    - `odt` ([ODT])
+    - `odt` ([OpenOffice text document])
     - `opml` ([OPML])
     - `org` ([Emacs Org mode])
     - `ris` ([RIS] bibliography)


### PR DESCRIPTION
Should be in opposite order:
```
$ 2>&- man pandoc|grep -i odt|fgrep \(
              • odt (ODT)
              • odt (OpenOffice text document)
```
I'm saying that the detailed name should be shown first, or even better, both places.

There are several similar cases in this file of the same phenomena.