### PR TITLE
Use latest KaTeX CDN asset

### DIFF
--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -376,7 +376,7 @@ defaultMathJaxURL :: Text
 defaultMathJaxURL = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"
 
 defaultKaTeXURL :: Text
-defaultKaTeXURL = "https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/"
+defaultKaTeXURL = "https://cdn.jsdelivr.net/npm/katex@latest/dist/"
 
 -- Update documentation in doc/filters.md if this is changed.
 $(deriveJSON defaultOptions{ fieldLabelModifier =


### PR DESCRIPTION
When [`--katex`](https://pandoc.org/MANUAL.html#math-rendering-in-html) is specified without a URL, this change makes Pandoc insert CDN URLs[^url1] into the compiled output that always point to the *latest* released KaTeX version. This is in line with the behaviour for `--mathjax`, which falls back to a CDN URL that also points to the latest released MathJax version[^url2].

[^url1]: https://cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.js etc.

[^url2]: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js; note that [there would also be versioned URLs available from cdn.jsdelivr.net for MathJax](https://www.mathjax.org/#gettingstarted)