### PR TITLE
RST reader: fix `figclass` and `align` annotations for figures

### DIFF
--- a/test/command/7473.md
+++ b/test/command/7473.md
@@ -1,0 +1,32 @@
+```
+% pandoc -f rst -t native
+.. figure:: example.png
+   :figclass: foo bar
+   :align: right
+   :width: 1in
+
+   This is a caption.
+^D
+[ Figure
+    ( "" , [ "foo" , "bar" , "align-right" ] , [] )
+    (Caption
+       Nothing
+       [ Plain
+           [ Str "This"
+           , Space
+           , Str "is"
+           , Space
+           , Str "a"
+           , Space
+           , Str "caption."
+           ]
+       ])
+    [ Plain
+        [ Image
+            ( "" , [] , [ ( "width" , "1in" ) ] )
+            [ Str "example.png" ]
+            ( "example.png" , "" )
+        ]
+    ]
+]
+```


### PR DESCRIPTION
Fixes #7473 

This PR implements the following:
1. It seems `figclass`es are currently not being extracted correctly since the wrong key-values are used - this PR extracts them from `keyvals` instead of the key-value output from `imgAttr`
2. `figclass` and `align` annotations are implemented following the [rst docs](https://docutils.sourceforge.io/docs/ref/rst/directives.html#figure): these options apply to the figure while other options are passed onto the underlying image.
