### PR TITLE
feat: add subtitle to Typst template

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -24,6 +24,9 @@ $endif$
 $if(title)$
   title: [$title$],
 $endif$
+$if(subtitle)$
+  subtitle: [$subtitle$],
+$endif$
 $if(author)$
   authors: (
 $for(author)$

--- a/data/templates/template.typst
+++ b/data/templates/template.typst
@@ -33,17 +33,13 @@
   set heading(numbering: sectionnumbering)
 
   if title != none {
-    if subtitle != none {
-       align(center)[#block(inset: 2em)[
-        #text(weight: "bold", size: 1.5em)[#title]
-        #parbreak()
-        #text(weight: "bold", size: 1.25em)[#subtitle]
-      ]]
-    } else {
-      align(center)[#block(inset: 2em)[
-        #text(weight: "bold", size: 1.5em)[#title]
-      ]]
-    }
+    align(center)[#block(inset: 2em)[
+      #text(weight: "bold", size: 1.5em)[#title]
+      #(if subtitle != none {
+        parbreak()
+        text(weight: "bold", size: 1.25em)[#subtitle]
+      })
+    ]]
   }
 
   if authors != none and authors != [] {

--- a/data/templates/template.typst
+++ b/data/templates/template.typst
@@ -1,5 +1,6 @@
 #let conf(
   title: none,
+  subtitle: none,
   authors: (),
   keywords: (),
   date: none,

--- a/data/templates/template.typst
+++ b/data/templates/template.typst
@@ -32,9 +32,17 @@
   set heading(numbering: sectionnumbering)
 
   if title != none {
-    align(center)[#block(inset: 2em)[
-      #text(weight: "bold", size: 1.5em)[#title]
-    ]]
+    if subtitle != none {
+       align(center)[#block(inset: 2em)[
+        #text(weight: "bold", size: 1.5em)[#title]
+        #parbreak()
+        #text(weight: "bold", size: 1.25em)[#subtitle]
+      ]]
+    } else {
+      align(center)[#block(inset: 2em)[
+        #text(weight: "bold", size: 1.5em)[#title]
+      ]]
+    }
   }
 
   if authors != none and authors != [] {

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -104,7 +104,6 @@
 }
 #show: doc => conf(
   title: [Pandoc Test Suite],
-  subtitle: [A set of tests for Pandoc],
   authors: (
     ( name: "John MacFarlane",
       affiliation: "",

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -22,6 +22,7 @@
 
 #let conf(
   title: none,
+  subtitle: none,
   authors: (),
   keywords: (),
   date: none,
@@ -54,9 +55,17 @@
   set heading(numbering: sectionnumbering)
 
   if title != none {
-    align(center)[#block(inset: 2em)[
-      #text(weight: "bold", size: 1.5em)[#title]
-    ]]
+    if subtitle != none {
+       align(center)[#block(inset: 2em)[
+        #text(weight: "bold", size: 1.5em)[#title]
+        #parbreak()
+        #text(weight: "bold", size: 1.25em)[#subtitle]
+      ]]
+    } else {
+      align(center)[#block(inset: 2em)[
+        #text(weight: "bold", size: 1.5em)[#title]
+      ]]
+    }
   }
 
   if authors != none and authors != [] {
@@ -95,6 +104,7 @@
 }
 #show: doc => conf(
   title: [Pandoc Test Suite],
+  subtitle: [A set of tests for Pandoc],
   authors: (
     ( name: "John MacFarlane",
       affiliation: "",

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -55,17 +55,13 @@
   set heading(numbering: sectionnumbering)
 
   if title != none {
-    if subtitle != none {
-       align(center)[#block(inset: 2em)[
-        #text(weight: "bold", size: 1.5em)[#title]
-        #parbreak()
-        #text(weight: "bold", size: 1.25em)[#subtitle]
-      ]]
-    } else {
-      align(center)[#block(inset: 2em)[
-        #text(weight: "bold", size: 1.5em)[#title]
-      ]]
-    }
+    align(center)[#block(inset: 2em)[
+      #text(weight: "bold", size: 1.5em)[#title]
+      #(if subtitle != none {
+        parbreak()
+        text(weight: "bold", size: 1.25em)[#subtitle]
+      })
+    ]]
   }
 
   if authors != none and authors != [] {


### PR DESCRIPTION
This PR adds support for `subtitle` in Typst template.