### PR TITLE
Update MANUAL.txt to remove false info on Lua mode not supporting -i

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -7455,7 +7455,6 @@ Calling the pandoc executable under the name `pandoc-lua` or with
 `lua` as the first argument will make it function as a standalone
 Lua interpreter. The behavior is mostly identical to that of the
 [standalone `lua` executable][lua standalone], version 5.4.
-However, there is no REPL yet, and the `-i` option has no effect.
 For full documentation, see the [pandoc-lua] man page.
 
 [lua standalone]: https://www.lua.org/manual/5.4/manual.html#7


### PR DESCRIPTION
Current pandoc-lua does support REPL and `-i` as far as I understand.