### PR TITLE
typst,table - support '.typst-no-figure' and 'typst-figure-kind=kind'

### DIFF
--- a/doc/typst-property-output.md
+++ b/doc/typst-property-output.md
@@ -96,6 +96,14 @@ The following Pandoc AST elements are currently supported. More may be supported
 
   : The table is wrapped in a Typst [text element](https://typst.app/docs/reference/text/text/) with `prop` as one of its parameters.
 
+  `typst:no-figure`
+
+  : By default, Pandoc will wrap the table in a Typst [figure element](https://typst.app/docs/reference/model/figure/). If this attribute is set, only the table element itself will be emitted. This avoids Typst's crossreference counter of kind `table` from being incremented.
+
+  `typst:figure:kind`
+
+  : If this attribute is set, Pandoc will wrap the table in a Typst [figure element](https://typst.app/docs/reference/model/figure/) with the specified `kind` attribute. This is useful for tables that should be cross-referenced as something other than `Table ...` in the document. Typst will use the `kind` attribute to increment the corresponding counter: `raw` and `image`.
+
 - Table [Cell](https://pandoc.org/lua-filters.html#type-cell)
 
   `typst:prop`

--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -203,7 +203,7 @@ blockToTypst block =
                   else do
                     captcontents <- blocksToTypst caption
                     return $ ", caption: " <> brackets captcontents
-      let typstFigureKind = literal (", kind: " <> fromMaybe "table" (lookup "typst-figure-kind" tabkvs))
+      let typstFigureKind = literal (", kind: " <> fromMaybe "table" (lookup "typst:figure:kind" tabkvs))
       let numcols = length colspecs
       let (aligns, widths) = unzip colspecs
       let commaSep = hcat . intersperse ", "
@@ -285,7 +285,7 @@ blockToTypst block =
                 $$ footer
             )
             $$ ")"
-      return $ case Data.List.find (== "typst-no-figure") tabclasses of
+      return $ case Data.List.find (== "typst:no-figure") tabclasses of
         Just _ -> table
         Nothing -> "#figure("
             $$

--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -20,7 +20,7 @@ import Text.Pandoc.Definition
 import Text.Pandoc.Class ( PandocMonad)
 import Text.Pandoc.Options ( WriterOptions(..), WrapOption(..), isEnabled )
 import Data.Text (Text)
-import Data.List (intercalate, intersperse, find)
+import Data.List (intercalate, intersperse)
 import Data.Bifunctor (first, second)
 import Network.URI (unEscapeString)
 import qualified Data.Text as T
@@ -285,9 +285,9 @@ blockToTypst block =
                 $$ footer
             )
             $$ ")"
-      return $ case Data.List.find (== "typst:no-figure") tabclasses of
-        Just _ -> table
-        Nothing -> "#figure("
+      return $ if "typst:no-figure" `elem` tabclasses
+        then table
+        else "#figure("
             $$
             nest 2
             ("align(center)[" <> table <> "]"

--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -20,7 +20,7 @@ import Text.Pandoc.Definition
 import Text.Pandoc.Class ( PandocMonad)
 import Text.Pandoc.Options ( WriterOptions(..), WrapOption(..), isEnabled )
 import Data.Text (Text)
-import Data.List (intercalate, intersperse)
+import Data.List (intercalate, intersperse, find)
 import Data.Bifunctor (first, second)
 import Network.URI (unEscapeString)
 import qualified Data.Text as T
@@ -37,6 +37,7 @@ import Text.Pandoc.Extensions (Extension(..))
 import Text.Collate.Lang (Lang(..), parseLang)
 import Text.Printf (printf)
 import Data.Char (isAlphaNum)
+import Data.Maybe (fromMaybe)
 
 -- | Convert Pandoc to Typst.
 writeTypst :: PandocMonad m => WriterOptions -> Pandoc -> m Text
@@ -195,13 +196,14 @@ blockToTypst block =
                    else vsep items') $$ blankline
     DefinitionList items ->
       ($$ blankline) . vsep <$> mapM defListItemToTypst items
-    Table (ident,_,tabkvs) (Caption _ caption) colspecs thead tbodies tfoot -> do
+    Table (ident,tabclasses,tabkvs) (Caption _ caption) colspecs thead tbodies tfoot -> do
       let lab = toLabel FreestandingLabel ident
       capt' <- if null caption
                   then return mempty
                   else do
                     captcontents <- blocksToTypst caption
                     return $ ", caption: " <> brackets captcontents
+      let typstFigureKind = literal (", kind: " <> fromMaybe "table" (lookup "typst-figure-kind" tabkvs))
       let numcols = length colspecs
       let (aligns, widths) = unzip colspecs
       let commaSep = hcat . intersperse ", "
@@ -273,25 +275,27 @@ blockToTypst block =
       header <- fromHead thead
       footer <- fromFoot tfoot
       body <- vcat <$> mapM fromTableBody tbodies
-      return $
-        "#figure("
-        $$
-        nest 2
-         ("align(center)[" <> toTypstSetText typstTextAttrs <> "#table("
-          $$ nest 2
-             (  "columns: " <> columns <> ","
-             $$ "align: " <> alignarray <> ","
-             $$ toTypstPropsListTerm typstAttrs
-             $$ header
-             $$ body
-             $$ footer
-             )
-          $$ ")]"
-          $$ capt'
-          $$ ", kind: table"
-          $$ ")")
-        $$ lab
-        $$ blankline
+      let table = toTypstSetText typstTextAttrs <> "#table("
+            $$ nest 2
+                (  "columns: " <> columns <> ","
+                $$ "align: " <> alignarray <> ","
+                $$ toTypstPropsListTerm typstAttrs
+                $$ header
+                $$ body
+                $$ footer
+            )
+            $$ ")"
+      return $ case Data.List.find (== "typst-no-figure") tabclasses of
+        Just _ -> table
+        Nothing -> "#figure("
+            $$
+            nest 2
+            ("align(center)[" <> table <> "]"
+              $$ capt'
+              $$ typstFigureKind
+              $$ ")")
+            $$ lab
+          $$ blankline
     Figure (ident,_,_) (Caption _mbshort capt) blocks -> do
       caption <- blocksToTypst capt
       contents <- case blocks of

--- a/test/command/9777-b.md
+++ b/test/command/9777-b.md
@@ -1,7 +1,7 @@
 ```
 % pandoc -f native -t typst
 [ Table
-    ( "" , [] , [ ( "typst-figure-kind" , "figure" ) ] )
+    ( "" , [] , [ ( "typst:figure:kind" , "figure" ) ] )
     (Caption Nothing [])
     [ ( AlignDefault , ColWidthDefault )
     , ( AlignDefault , ColWidthDefault )

--- a/test/command/9777-b.md
+++ b/test/command/9777-b.md
@@ -1,0 +1,62 @@
+```
+% pandoc -f native -t typst
+[ Table
+    ( "" , [] , [ ( "typst-figure-kind" , "figure" ) ] )
+    (Caption Nothing [])
+    [ ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    ]
+    (TableHead
+       ( "" , [] , [] )
+       [ Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "f" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "b" ] ]
+           ]
+       ])
+    [ TableBody
+        ( "" , [] , [] )
+        (RowHeadColumns 0)
+        []
+        [ Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "1" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "2" ] ]
+            ]
+        ]
+    ]
+    (TableFoot ( "" , [] , [] ) [])
+]
+^D
+#figure(
+  #align(center)[#table(
+    columns: 2,
+    align: (auto,auto,),
+    table.header([f], [b],),
+    table.hline(),
+    [1], [2],
+  )]
+  , kind: figure
+  )
+```
+

--- a/test/command/9777-b.md
+++ b/test/command/9777-b.md
@@ -49,7 +49,7 @@
 ]
 ^D
 #figure(
-  #align(center)[#table(
+  align(center)[#table(
     columns: 2,
     align: (auto,auto,),
     table.header([f], [b],),

--- a/test/command/9777.md
+++ b/test/command/9777.md
@@ -1,0 +1,58 @@
+```
+% pandoc -f native -t typst
+[ Table
+    ( "" , [ "typst-no-figure" ] , [] )
+    (Caption Nothing [])
+    [ ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    ]
+    (TableHead
+       ( "" , [] , [] )
+       [ Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "f" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "b" ] ]
+           ]
+       ])
+    [ TableBody
+        ( "" , [] , [] )
+        (RowHeadColumns 0)
+        []
+        [ Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "1" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "2" ] ]
+            ]
+        ]
+    ]
+    (TableFoot ( "" , [] , [] ) [])
+]
+^D
+#table(
+  columns: 2,
+  align: (auto,auto,),
+  table.header([f], [b],),
+  table.hline(),
+  [1], [2],
+)
+```

--- a/test/command/9777.md
+++ b/test/command/9777.md
@@ -1,7 +1,7 @@
 ```
 % pandoc -f native -t typst
 [ Table
-    ( "" , [ "typst-no-figure" ] , [] )
+    ( "" , [ "typst:no-figure" ] , [] )
     (Caption Nothing [])
     [ ( AlignDefault , ColWidthDefault )
     , ( AlignDefault , ColWidthDefault )


### PR DESCRIPTION
This is intended to close #9777 in a configurable way.

It also supports a slight generalization of the solution in https://github.com/jgm/pandoc/issues/9574 by enabling control of the `kind` parameter for `#figure()`.

I didn't know how to add classes and attributes to a plain markdown table in a clean way and so I used a Lua filter for that, but of course that can be changed if there's a better way to do it.

EDIT: I see that the test failure comes from CI on windows building Pandoc without Lua support. I'm going to change the tests to provide native input.