### PR TITLE
Lua: add function `pandoc.template.get`.

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -6207,6 +6207,28 @@ Returns:
 
 *Since: 2.17*
 
+### get {#pandoc.template.get}
+
+`get (filename)`
+
+Retrieve text for a template.
+
+This function first checks the resource paths for a file of this
+name; if none is found, the `templates` directory in the user data
+directory is checked. Returns the content of the file, or throws
+an error if no file is found.
+
+Parameters:
+
+`filename`
+:   name of the template (string)
+
+Returns:
+
+-   content of template file (string)
+
+*Since: 3.2.1*
+
 ### meta_to_context {#pandoc.template.meta_to_context}
 
 `meta_to_context (meta, blocks_writer, inlines_writer)`

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Template.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Template.hs
@@ -21,7 +21,7 @@ import Text.Pandoc.Lua.Marshal.Template (typeTemplate, peekTemplate, pushTemplat
 import Text.Pandoc.Lua.PandocLua (PandocLua (unPandocLua), liftPandocLua)
 import Text.Pandoc.Writers.Shared (metaToContext')
 import Text.Pandoc.Templates
-  ( compileTemplate, getDefaultTemplate, renderTemplate
+  ( compileTemplate, getDefaultTemplate, getTemplate, renderTemplate
   , runWithPartials, runWithDefaultPartials )
 
 import qualified Data.Text as T
@@ -91,13 +91,26 @@ functions =
      <#> opt (textParam "writer"
               ("name of the writer for which the template should be " <>
                "retrieved; defaults to the global `FORMAT`."))
-     =#> functionResult pushText "string"
-           "raw template"
+     =#> functionResult pushText "string" "raw template"
     #? T.unlines
     [ "Returns the default template for a given writer as a string. An"
     , "error is thrown if no such template can be found."
     ]
     `since` makeVersion [2,17]
+
+  , defun "get"
+     ### (unPandocLua . getTemplate)
+     <#> stringParam "filename" "name of the template"
+     =#> textResult "content of template file"
+     #? T.unlines
+     [ "Retrieve text for a template."
+     , ""
+     , "This function first checks the resource paths for a file of this"
+     , "name; if none is found, the `templates` directory in the user data"
+     , "directory is checked.  Returns the content of the file, or throws"
+     , "an error if no file is found."
+     ]
+    `since` makeVersion [3,2,1]
 
   , defun "meta_to_context"
      ### (\meta blockWriterIdx inlineWriterIdx -> unPandocLua $ do

--- a/pandoc-lua-engine/test/lua/module/pandoc-template.lua
+++ b/pandoc-lua-engine/test/lua/module/pandoc-template.lua
@@ -1,4 +1,5 @@
 local tasty = require 'tasty'
+local pandoc = require 'pandoc'
 local template = require 'pandoc.template'
 
 local assert = tasty.assert
@@ -24,8 +25,25 @@ return {
       )
     end),
     test('fails on unknown format', function ()
+           local success, msg = pcall(function ()
+               return pandoc.utils.type(template.default 'nosuchformat')
+           end)
+           assert.is_falsy(success)
+    end),
+                  },
+  group 'get' {
+    test('is function', function ()
+           assert.are_equal(type(template.get), 'function')
+    end),
+    test('searches the template data directory', function ()
+      assert.are_equal(
+        template.default 'html5',
+        template.get 'default.html5'
+      )
+    end),
+    test('fails on non-existent file', function ()
       local success, msg = pcall(function ()
-          return pandoc.utils.type(template.default 'nosuchformat')
+        return pandoc.utils.type(template.get 'nosuchfile.nope')
       end)
       assert.is_falsy(success)
     end),


### PR DESCRIPTION
The function allows to specify a template with the same argument value that would be used with the `--template` command line parameter.

Closes: #9854