### PR TITLE
Provide selnolig with babel language

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -444,9 +444,11 @@ $endif$
 $for(header-includes)$
 $header-includes$
 $endfor$
+$if(babel-lang)$
 \ifLuaTeX
-  \usepackage{selnolig}  % disable illegal ligatures
+  \usepackage[$babel-lang$]{selnolig}  % disable illegal ligatures
 \fi
+$endif$
 $if(dir)$
 \ifPDFTeX
   \TeXXeTstate=1

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -446,7 +446,7 @@ $header-includes$
 $endfor$
 $if(babel-lang)$
 \ifLuaTeX
-  \usepackage[$babel-lang$]{selnolig}  % disable illegal ligatures
+  \usepackage[$babel-lang$$for(babel-otherlangs)$,$babel-otherlangs$$endfor$]{selnolig}  % disable illegal ligatures
 \fi
 $endif$
 $if(dir)$


### PR DESCRIPTION
Since 3d8f011, the babel language is not
a classoption anymore, on which selnolig
relied. Now the babel language is directly
passed to selnolig.

Fixes #9863