### PR TITLE
Update macOS version in GitHub workflows to `macos-12`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
 # We no longer run the macos tests, to make CI faster.
 # macos:
 
-#   runs-on: macos-11
+#   runs-on: macos-12
 #   strategy:
 #     fail-fast: true
 #     matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,7 @@ jobs:
 
   macos:
 
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -77,7 +77,7 @@ jobs:
 
   macos:
 
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
In January 2024, GitHub announced the [deprecation of macOS 11](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal) and the removal of the runner image by June 2024. The macOS 11 runner image will be removed on 6/28/2024.