### PR TITLE
Remove `pkg-config` installation step in nightly workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
 # We no longer run the macos tests, to make CI faster.
 # macos:
 
-#   runs-on: macos-11
+#   runs-on: macos-12
 #   strategy:
 #     fail-fast: true
 #     matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,7 @@ jobs:
 
   macos:
 
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,9 +73,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    # pkg-config is now needed for some cabal builds
-    - name: Install pkg-config
-      run: brew install pkg-config
     - name: Install ghc
       run: |
         ghcup install ghc --set 9.4.4

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -77,7 +77,7 @@ jobs:
 
   macos:
 
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
There is a [warning message](https://github.com/jgm/pandoc/actions/runs/9641649564) of nightly workflow: `pkg-config 0.29.2_3 is already installed and up-to-date. To reinstall 0.29.2_3, run: brew reinstall pkg-config`.

`pkg-config` has been pre-installed on `macos-12` runner since June, 2023, see https://github.com/actions/runner-images/commit/0a6e640250d4b1406160dabadcf2f832e0ec6393 and https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md.

