### PR TITLE
pandoc-cli: Behave like a Lua interpreter when progname starts with lua

### DIFF
--- a/pandoc-cli/src/pandoc.hs
+++ b/pandoc-cli/src/pandoc.hs
@@ -56,6 +56,7 @@ main = E.handle (handleError . Left) $ do
     "pandoc-server.cgi" -> versionOr runCGI
     "pandoc-server"     -> versionOr $ runServer rawArgs
     "pandoc-lua"        -> runLuaInterpreter prg rawArgs
+    ('l':'u':'a':_)     -> runLuaInterpreter prg rawArgs
     _ ->
       case rawArgs of
         "lua" : args   -> runLuaInterpreter "pandoc lua" args


### PR DESCRIPTION
This allows to use pandoc as a drop-in replacement for the default Lua interpreter.