### PR TITLE
Add gemini URI scheme

### DIFF
--- a/src/Text/Pandoc/URI.hs
+++ b/src/Text/Pandoc/URI.hs
@@ -84,7 +84,7 @@ schemes = Set.fromList
   , "xmlrpc.beep", "xmlrpc.beeps", "xmpp", "xri", "ymsgr", "z39.50", "z39.50r"
   , "z39.50s"
   -- Unofficial schemes
-  , "doi", "isbn", "javascript", "pmid"
+  , "doi", "gemini", "isbn", "javascript", "pmid"
   ]
 
 -- | Check if the string is a valid URL with a IANA or frequently used but


### PR DESCRIPTION
In order to detect properly `gemini://` links I propose to add it as an unofficial URI scheme.

More info regarding this scheme at [wikipedia](https://en.wikipedia.org/wiki/Gemini_(protocol)) and their [official website](https://geminiprotocol.net/).