### PR TITLE
Adding new features to the Typst template

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -72,6 +72,12 @@ $endif$
 $if(fontsize)$
   fontsize: $fontsize$,
 $endif$
+$if(mathfont)$
+  mathfont: ($for(mathfont)$"$mathfont$",$endfor$),
+$endif$
+$if(codefont)$
+  codefont: ($for(codefont)$"$codefont$",$endfor$),
+$endif$
 $if(linestretch)$
   linestretch: $linestretch$,
 $endif$

--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -84,6 +84,15 @@ $endif$
 $if(section-numbering)$
   sectionnumbering: "$section-numbering$",
 $endif$
+$if(linkcolor)$
+  linkcolor: [$linkcolor$],
+$endif$
+$if(citecolor)$
+  citecolor: [$citecolor$],
+$endif$
+$if(toccolor)$
+  toccolor: [$toccolor$],
+$endif$
   cols: $if(columns)$$columns$$else$1$endif$,
   doc,
 )

--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -57,6 +57,9 @@ $endif$
 $if(abstract)$
   abstract: [$abstract$],
 $endif$
+$if(thanks)$
+  thanks: [$thanks$],
+$endif$
 $if(margin)$
   margin: ($for(margin/pairs)$$margin.key$: $margin.value$,$endfor$),
 $endif$

--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -72,6 +72,9 @@ $endif$
 $if(fontsize)$
   fontsize: $fontsize$,
 $endif$
+$if(linestretch)$
+  linestretch: $linestretch$,
+$endif$
 $if(section-numbering)$
   sectionnumbering: "$section-numbering$",
 $endif$

--- a/data/templates/template.typst
+++ b/data/templates/template.typst
@@ -28,11 +28,14 @@
   codefont: "DejaVu Sans Mono",
   linestretch: 1,
   sectionnumbering: none,
+  linkcolor: ["#800000"],
+  citecolor: ["#0000FF"],
+  toccolor: ["#800000"],
   doc,
 ) = {
   set document(
     title: title,
-    author: authors.map(author => content-to-string(author.name)),
+    author: authors.map(author => content-to-string(author.name)).join(", ", last: ", and "),
     keywords: keywords,
   )
   set page(
@@ -51,6 +54,17 @@
   show math.equation: set text(font: mathfont)
   show raw: set text(font: codefont)
   set heading(numbering: sectionnumbering)
+
+  show link: set text(fill: rgb(content-to-string(linkcolor)))
+
+  show link: this => {
+    if type(this.dest) == label {
+        text(this, fill: rgb(content-to-string(filecolor)))
+    }
+  }
+  show ref: this => {
+    text(this, fill: rgb(content-to-string(citecolor)))
+  }
 
   if title != none {
     align(center)[#block(inset: 2em)[

--- a/data/templates/template.typst
+++ b/data/templates/template.typst
@@ -16,6 +16,7 @@
   keywords: (),
   date: none,
   abstract: none,
+  thanks: none,
   cols: 1,
   margin: (x: 1.25in, y: 1.25in),
   paper: "us-letter",
@@ -45,7 +46,10 @@
 
   if title != none {
     align(center)[#block(inset: 2em)[
-      #text(weight: "bold", size: 1.5em)[#title]
+      #text(weight: "bold", size: 1.5em)[#title #if thanks != none {
+            footnote(thanks, numbering: "*")
+            counter(footnote).update(n => n - 1)
+          }]
       #(if subtitle != none {
         parbreak()
         text(weight: "bold", size: 1.25em)[#subtitle]

--- a/data/templates/template.typst
+++ b/data/templates/template.typst
@@ -24,6 +24,7 @@
   region: "US",
   font: (),
   fontsize: 11pt,
+  linestretch: 1,
   sectionnumbering: none,
   doc,
 ) = {
@@ -37,7 +38,10 @@
     margin: margin,
     numbering: "1",
   )
-  set par(justify: true)
+  set par(
+    justify: true,
+    leading: linestretch * 0.65em
+  )
   set text(lang: lang,
            region: region,
            font: font,

--- a/data/templates/template.typst
+++ b/data/templates/template.typst
@@ -24,6 +24,8 @@
   region: "US",
   font: (),
   fontsize: 11pt,
+  mathfont: "New Computer Modern Math",
+  codefont: "DejaVu Sans Mono",
   linestretch: 1,
   sectionnumbering: none,
   doc,
@@ -46,6 +48,8 @@
            region: region,
            font: font,
            size: fontsize)
+  show math.equation: set text(font: mathfont)
+  show raw: set text(font: codefont)
   set heading(numbering: sectionnumbering)
 
   if title != none {

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -46,6 +46,7 @@
   region: "US",
   font: (),
   fontsize: 11pt,
+  linestretch: 1,
   sectionnumbering: none,
   doc,
 ) = {

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -59,7 +59,10 @@
     margin: margin,
     numbering: "1",
   )
-  set par(justify: true)
+  set par(
+    justify: true,
+    leading: linestretch * 0.65em
+  )
   set text(lang: lang,
            region: region,
            font: font,

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -38,6 +38,7 @@
   keywords: (),
   date: none,
   abstract: none,
+  thanks: none,
   cols: 1,
   margin: (x: 1.25in, y: 1.25in),
   paper: "us-letter",
@@ -67,7 +68,10 @@
 
   if title != none {
     align(center)[#block(inset: 2em)[
-      #text(weight: "bold", size: 1.5em)[#title]
+      #text(weight: "bold", size: 1.5em)[#title #if thanks != none {
+            footnote(thanks, numbering: "*")
+            counter(footnote).update(n => n - 1)
+          }]
       #(if subtitle != none {
         parbreak()
         text(weight: "bold", size: 1.25em)[#subtitle]

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -46,6 +46,8 @@
   region: "US",
   font: (),
   fontsize: 11pt,
+  mathfont: "New Computer Modern Math",
+  codefont: "DejaVu Sans Mono",
   linestretch: 1,
   sectionnumbering: none,
   doc,
@@ -68,6 +70,8 @@
            region: region,
            font: font,
            size: fontsize)
+  show math.equation: set text(font: mathfont)
+  show raw: set text(font: codefont)
   set heading(numbering: sectionnumbering)
 
   if title != none {

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -50,11 +50,14 @@
   codefont: "DejaVu Sans Mono",
   linestretch: 1,
   sectionnumbering: none,
+  linkcolor: ["#800000"],
+  citecolor: ["#0000FF"],
+  toccolor: ["#800000"],
   doc,
 ) = {
   set document(
     title: title,
-    author: authors.map(author => content-to-string(author.name)),
+    author: authors.map(author => content-to-string(author.name)).join(", ", last: ", and "),
     keywords: keywords,
   )
   set page(
@@ -73,6 +76,17 @@
   show math.equation: set text(font: mathfont)
   show raw: set text(font: codefont)
   set heading(numbering: sectionnumbering)
+
+  show link: set text(fill: rgb(content-to-string(linkcolor)))
+
+  show link: this => {
+    if type(this.dest) == label {
+        text(this, fill: rgb(content-to-string(filecolor)))
+    }
+  }
+  show ref: this => {
+    text(this, fill: rgb(content-to-string(citecolor)))
+  }
 
   if title != none {
     align(center)[#block(inset: 2em)[


### PR DESCRIPTION
This implements the changes suggested in #9956, with the exception of the `filecolor`/`urlcolor` one. These would require adding some regex to guess the link types. This is theoretically possible to do, but it wasn't clear to me that this is a good thing to put in a default template. Happy to adjust if you have thoughts on this.

Some things to note: 

- I'm converting colors by passing them as content, as I was seeing pandoc escape `#` if that was included. An alternative here is to just do something like: `rgb(linkcolor.replace("\\#", "#"))`.
- I set the default fonts for math and code ("raw") to fonts that are bundled with Typst. These need not be those fonts if there are more familiar pandoc preferences.
