### PR TITLE
docx+citations: Add "SuppressAuthor", "AuthorOnly" to citationMode

### DIFF
--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -510,6 +510,13 @@ parPartToInlines' (Field info children) =
          else smushInlines <$> mapM parPartToInlines' children
     _ -> smushInlines <$> mapM parPartToInlines' children
 
+-- Helper function to convert CitationItemType to CitationMode
+convertCitationMode :: Citeproc.CitationItemType -> CitationMode
+convertCitationMode itemType = case itemType of
+                                 Citeproc.NormalCite -> NormalCitation
+                                 Citeproc.SuppressAuthor -> SuppressAuthor
+                                 Citeproc.AuthorOnly -> AuthorInText
+
 -- Turn a 'Citeproc.Citation' into a list of 'Text.Pandoc.Definition.Citation',
 -- and store the embedded bibliographic data in state.
 handleCitation :: PandocMonad m
@@ -526,7 +533,7 @@ handleCitation citation = do
                          <> x <> " ")
                      (Citeproc.citationItemLocator item)
                     <> fromMaybe mempty (Citeproc.citationItemSuffix item)
-                , citationMode = NormalCitation -- TODO for now
+                , citationMode = convertCitationMode (Citeproc.citationItemType item)
                 , citationNoteNum = 0
                 , citationHash = 0 }
   let items = Citeproc.citationItems citation


### PR DESCRIPTION
When converting DOCX -> Markdown with embedded citations using Zotero Plugin, the standard citation mode was `NormalCitation` (see current version, l. 529). This was not optimal since it meant that one had to manually go through the Markdown and mark suppressed author citations with `-`. The proposed change forwards the information from `CitationItem.citationItemType` to `citationMode`. I tested it with several DOCX files using Zotero plugin, and it worked for me.

I have the impression that this was a requested feature, see among others here: https://github.com/jgm/pandoc/issues/9116 (the last comments).

Please note that I am a complete Haskell noob, I know other programming languages, but not Haskell. Adjustments and comments are thus very much appreciated.