### PR TITLE
Support custom-style attribute for docx table

### DIFF
--- a/src/Text/Pandoc/Writers/Docx/Table.hs
+++ b/src/Text/Pandoc/Writers/Docx/Table.hs
@@ -22,7 +22,7 @@ import Control.Monad ( unless , zipWithM )
 import Control.Monad.Except ( throwError )
 import Data.Array ( elems, (!), assocs, indices )
 import Data.Text (Text)
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, fromMaybe)
 import Text.Pandoc.Definition
     ( ColSpec,
       Caption(Caption),
@@ -71,7 +71,7 @@ tableToOpenXML :: PandocMonad m
                -> WS m [Content]
 tableToOpenXML opts blocksToOpenXML gridTable = do
   setFirstPara
-  let (Grid.Table (ident,_,_) caption colspecs _rowheads thead tbodies tfoot) =
+  let (Grid.Table (ident,_,tableAttr) caption colspecs _rowheads thead tbodies tfoot) =
         gridTable
   let (Caption _maybeShortCaption captionBlocks) = caption
   tablenum <- gets stNextTableNum
@@ -109,11 +109,12 @@ tableToOpenXML opts blocksToOpenXML gridTable = do
   let tblLookVal = if hasHeader then (0x20 :: Int) else 0
   let (gridCols, tblWattr) = tableLayout (elems colspecs)
   listLevel <- asks envListLevel
+  let tblStyle =  fromMaybe "Table" (lookup "custom-style" tableAttr)
   let indent = (listLevel + 1) * 720
   let hasWidths = not $ all ((== ColWidthDefault) . snd) colspecs
   let tbl = mknode "w:tbl" []
         ( mknode "w:tblPr" []
-          ( [ mknode "w:tblStyle" [("w:val","Table")] (),
+          ( [ mknode "w:tblStyle" [("w:val",tblStyle)] (),
               mknode "w:tblW" tblWattr () ] ++
             [ mknode "w:jc" [("w:val","left")] () | indent > 0 ] ++
             [ mknode "w:tblInd" [("w:w", tshow indent),("w:type","dxa")] ()


### PR DESCRIPTION
This is a suggested fix to support the `custom-style` attribute for docx tables. I'm referring to the issues https://github.com/jgm/pandoc/issues/9603, https://github.com/jgm/pandoc/issues/7549, https://github.com/jgm/pandoc/issues/6496, https://github.com/jgm/pandoc/issues/4697. I needed this feature to support multiple table styles in one document and saw a lot of issues addressing this feature. With absolutely no prior experience in Haskell, I just gave it a shot :) 

The conversion from html to docx with and without it, worked fine. With the `table[custom-style="CustomStyle"]` attribute, it used the CustomStyle for the table and if omitted, the fallback/default style is "Table".

I hope the code is okayish, but happy to change it if needed.