### PR TITLE
default.latex: wrong beamer color in (sub)section page

### DIFF
--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -60,13 +60,13 @@ $if(section-titles)$
 }
 \setbeamertemplate{section page}{
   \centering
-  \begin{beamercolorbox}[sep=12pt,center]{part title}
+  \begin{beamercolorbox}[sep=12pt,center]{section title}
     \usebeamerfont{section title}\insertsection\par
   \end{beamercolorbox}
 }
 \setbeamertemplate{subsection page}{
   \centering
-  \begin{beamercolorbox}[sep=8pt,center]{part title}
+  \begin{beamercolorbox}[sep=8pt,center]{subsection title}
     \usebeamerfont{subsection title}\insertsubsection\par
   \end{beamercolorbox}
 }


### PR DESCRIPTION
The default.latex template defines "part title", "section title" and "subsection title" via \setbeamertemplate. But for "section title" and "subsection title", the beamercolorbox also used the "part title" parameter instead of the "(sub)section title". This had the effect that for (sub)section pages the color attributes of the part title were used instead of the ones for (sub)section title.

PS: It's my first pull request, please let me know if I'm doing something wrong or against good practice. I wasn't sure if I should open an issue first (or in addition to the pull request). Since this fix seems quite trivial, I just created the pull request.

Best,
Jonathan