### PR TITLE
Add TableCaption to ODT styles.xml

### DIFF
--- a/data/odt/styles.xml
+++ b/data/odt/styles.xml
@@ -148,6 +148,9 @@ xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.3">
       style:font-size-complex="12pt"
       style:font-style-complex="italic" />
     </style:style>
+    <style:style style:name="TableCaption" style:family="paragraph" 
+    style:parent-style-name="Caption" style:class="extra">
+    </style:style>
     <style:style style:name="Table" style:family="paragraph"
     style:parent-style-name="Caption" style:class="extra">
     </style:style>

--- a/data/odt/styles.xml
+++ b/data/odt/styles.xml
@@ -148,7 +148,7 @@ xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.3">
       style:font-size-complex="12pt"
       style:font-style-complex="italic" />
     </style:style>
-    <style:style style:name="TableCaption" style:family="paragraph" 
+    <style:style style:name="TableCaption" style:family="paragraph"
     style:parent-style-name="Caption" style:class="extra">
     </style:style>
     <style:style style:name="Table" style:family="paragraph"


### PR DESCRIPTION
See #10053 -- ODT output currently has no styling for table captions, and yet the writer is assigning the `TableCaption` style to table captions. But the reference.odt doesn't contain that style. We add `TableCaption` to the styles.xml as this is what Pandoc uses in the generated content. My current Libreoffice writes the style xml a bit differently, but I tried to follow the current style.xml formatting.