### PR TITLE
typst template: move header-includes before show doc

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -20,6 +20,10 @@ $else$
 $template.typst()$
 $endif$
 
+$for(header-includes)$
+$header-includes$
+
+$endfor$
 #show: doc => conf(
 $if(title)$
   title: [$title$],
@@ -76,10 +80,6 @@ $endif$
   doc,
 )
 
-$for(header-includes)$
-$header-includes$
-
-$endfor$
 $for(include-before)$
 $include-before$
 


### PR DESCRIPTION
Please see #9996 for rationale.

The behavior of `header-includes` is untested, at least for Typst. Apparently one test uses `-s` and I saw it fail due to a line break issue (now fixed).

I have tested this for the example in #9996 and would be glad to add tests if appropriate.

cc @cscheid 