### PR TITLE
INSTALL.md — reorganise info on static binaries and add conda-forge install options

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,8 +7,10 @@ The simplest way to get the latest pandoc release is to use the installer.
   Download the latest installer
 </a>
 
-For alternative ways to install pandoc, see below
-under the heading for your operating system.
+For alternative ways to install pandoc, see below under the heading for
+your operating system. In cases where a statically linked executable is
+installed, the pandoc binary from this package cannot use lua filters that
+require external lua modules written in C.
 
 ## Windows
 
@@ -38,6 +40,18 @@ Or, you can install pandoc using
 [winget](https://github.com/microsoft/winget-pkgs):
 
     winget install --source winget --exact --id JohnMacFarlane.Pandoc
+
+Or, you can install pandoc using a [Conda
+forge](https://anaconda.org/conda-forge/pandoc) tool, like
+[`conda`](https://conda.pydata.org/docs/intro.html),
+[`[micro]mamba`](https://mamba.readthedocs.io/en/latest/index.html) or
+[`pixi`](https://prefix.dev). Conda forge contains multiple LaTeX and other
+packages (including `pandoc-citeproc`, `pandoc-plot`, `rsvg-convert` via
+`librsvg` etc.). Note this is a statically-linked executable:
+
+    conda install -c conda-forge pandoc
+    pixi global install pandoc
+    micromamba install pandoc
 
 Using multiple installation methods can result in two separate
 installations of pandoc; it is recommended to properly uninstall
@@ -70,6 +84,18 @@ Note: On unsupported versions of macOS (more than three releases old),
 Homebrew installs from source, which takes additional time and disk space
 for the `ghc` compiler and dependent Haskell libraries.
 
+Or, you can install pandoc using a [Conda
+forge](https://anaconda.org/conda-forge/pandoc) tool, like
+[`conda`](https://conda.pydata.org/docs/intro.html),
+[`[micro]mamba`](https://mamba.readthedocs.io/en/latest/index.html) or
+[`pixi`](https://prefix.dev). Conda forge contains multiple LaTeX and other
+packages (including `pandoc-citeproc`, `pandoc-plot`, `rsvg-convert` via
+`librsvg` etc.). Note this is a statically-linked executable:
+
+    conda install -c conda-forge pandoc
+    pixi global install pandoc
+    micromamba install pandoc
+
 We also provide a zip file containing the binaries and man
 pages, for those who prefer not to use the installer.  Simply
 unzip the file and move the binaries and man pages to
@@ -97,9 +123,7 @@ architecture on the **[download page]**.
 
 The executable is statically linked and
 has no dynamic dependencies or dependencies on external
-data files.  Note:  because of the static
-linking, the pandoc binary from this package cannot use lua
-filters that require external lua modules written in C.
+data files.
 
 Both a tarball and a deb installer are provided.  To install the deb:
 
@@ -121,6 +145,18 @@ For Pandoc versions before 2.0, which don't provide
 a tarball, try instead
 
     ar p $DEB data.tar.gz | tar xvz --strip-components 2 -C $DEST
+
+Or, you can install pandoc using a [Conda
+forge](https://anaconda.org/conda-forge/pandoc) tool, like
+[`conda`](https://conda.pydata.org/docs/intro.html),
+[`[micro]mamba`](https://mamba.readthedocs.io/en/latest/index.html) or
+[`pixi`](https://prefix.dev). Conda forge contains multiple LaTeX and other
+packages (including `pandoc-citeproc`, `pandoc-plot`, `rsvg-convert` via
+`librsvg` etc.). Note this is a statically-linked executable:
+
+    conda install -c conda-forge pandoc
+    pixi global install pandoc
+    micromamba install pandoc
 
 You can also install from source, using the
 instructions below under [Compiling from source].

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,9 +8,13 @@ The simplest way to get the latest pandoc release is to use the installer.
 </a>
 
 For alternative ways to install pandoc, see below under the heading for
-your operating system. In cases where a statically linked executable is
-installed, the pandoc binary from this package cannot use lua filters that
-require external lua modules written in C.
+your operating system. 
+
+**Note**: the statically linked Pandoc binaries provided by us (or those
+available on Conda Forge) have a limitation. They are unable to utilise Lua
+filters that rely on Lua modules written in C. If you require the
+functionality offered by these filters, please consider an alternative
+method of installation. 
 
 ## Windows
 
@@ -35,23 +39,13 @@ without SVG support), [Python] (to use Pandoc filters), and
 [MiKTeX] (to typeset PDFs with [LaTeX]):
 
     choco install rsvg-convert python miktex
-    
+
 Or, you can install pandoc using
 [winget](https://github.com/microsoft/winget-pkgs):
 
     winget install --source winget --exact --id JohnMacFarlane.Pandoc
 
-Or, you can install pandoc using a [Conda
-forge](https://anaconda.org/conda-forge/pandoc) tool, like
-[`conda`](https://conda.pydata.org/docs/intro.html),
-[`[micro]mamba`](https://mamba.readthedocs.io/en/latest/index.html) or
-[`pixi`](https://prefix.dev). Conda forge contains multiple LaTeX and other
-packages (including `pandoc-citeproc`, `pandoc-plot`, `rsvg-convert` via
-`librsvg` etc.). Note this is a statically-linked executable:
-
-    conda install -c conda-forge pandoc
-    pixi global install pandoc
-    micromamba install pandoc
+Or, you can install Pandoc using [Conda forge].
 
 Using multiple installation methods can result in two separate
 installations of pandoc; it is recommended to properly uninstall
@@ -84,17 +78,7 @@ Note: On unsupported versions of macOS (more than three releases old),
 Homebrew installs from source, which takes additional time and disk space
 for the `ghc` compiler and dependent Haskell libraries.
 
-Or, you can install pandoc using a [Conda
-forge](https://anaconda.org/conda-forge/pandoc) tool, like
-[`conda`](https://conda.pydata.org/docs/intro.html),
-[`[micro]mamba`](https://mamba.readthedocs.io/en/latest/index.html) or
-[`pixi`](https://prefix.dev). Conda forge contains multiple LaTeX and other
-packages (including `pandoc-citeproc`, `pandoc-plot`, `rsvg-convert` via
-`librsvg` etc.). Note this is a statically-linked executable:
-
-    conda install -c conda-forge pandoc
-    pixi global install pandoc
-    micromamba install pandoc
+Or, you can install Pandoc using [Conda forge].
 
 We also provide a zip file containing the binaries and man
 pages, for those who prefer not to use the installer.  Simply
@@ -146,17 +130,7 @@ a tarball, try instead
 
     ar p $DEB data.tar.gz | tar xvz --strip-components 2 -C $DEST
 
-Or, you can install pandoc using a [Conda
-forge](https://anaconda.org/conda-forge/pandoc) tool, like
-[`conda`](https://conda.pydata.org/docs/intro.html),
-[`[micro]mamba`](https://mamba.readthedocs.io/en/latest/index.html) or
-[`pixi`](https://prefix.dev). Conda forge contains multiple LaTeX and other
-packages (including `pandoc-citeproc`, `pandoc-plot`, `rsvg-convert` via
-`librsvg` etc.). Note this is a statically-linked executable:
-
-    conda install -c conda-forge pandoc
-    pixi global install pandoc
-    micromamba install pandoc
+Or, you can install Pandoc using [Conda forge].
 
 You can also install from source, using the
 instructions below under [Compiling from source].
@@ -185,6 +159,21 @@ device you are using.
 ## BSD
 
 Pandoc is in the [NetBSD], [FreeBSD], and [OpenBSD ports] repositories.
+
+## Conda Forge
+
+You can install Pandoc using a [Conda
+Forge](https://anaconda.org/conda-forge/pandoc) tool, like
+[Conda](https://conda.pydata.org/docs/intro.html),
+[[Micro]Mamba](https://mamba.readthedocs.io/en/latest/index.html) or
+[Pixi](https://prefix.dev). Conda forge also includes multiple LaTeX and
+other relevant packages for Pandoc (including `pandoc-citeproc`,
+`pandoc-plot`, `rsvg-convert` via `librsvg` etc.). **Note:** conda forge
+installs a statically-linked executable.
+
+    conda install -c conda-forge pandoc
+    pixi global install pandoc
+    micromamba install pandoc
 
 ## Docker
 


### PR DESCRIPTION
See #10069 -- the static linked pandoc on other OSes also have a limitation to use binary lua packages. So added this point at the top of the document. In addition conda-forge is cross-platform way to install pandoc and other tools, added to Windows, macOS and Linux sections. I wrapped at 75 characters, is that right?