### PR TITLE
User Guide: Fix CSL Docs broken link

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -5740,7 +5740,7 @@ author-in-text style inside notes when using a note style.
 
 [CSL user documentation]: https://citationstyles.org/authors/
 [CSL]: https://docs.citationstyles.org/en/stable/specification.html
-[CSL markup specs]: https://docs.citationstyles.org/en/1.0/release-notes.html#rich-text-markup-within-fields
+[CSL markup specs]: https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#html-like-formatting-tags
 [Chicago Manual of Style]: https://chicagomanualofstyle.org
 [Citation Style Language]: https://citationstyles.org
 [Zotero Style Repository]: https://www.zotero.org/styles


### PR DESCRIPTION
In "Specifying bibliographic data," update the URL for CSL YAML/JSON HTML-like markup: that section is no longer part of the officia
In section [Specifying bibliographic data] of the _Pandoc User's Guide_ there's a broken link:

> In BibTeX and BibLaTeX databases, pandoc parses LaTeX markup inside fields such as title; in CSL YAML databases, pandoc Markdown; and in CSL JSON databases, an [HTML-like markup]:

The original page/anchor no longer exists, but can still be viewed via Wayback Machine:

<https://web.archive.org/web/20220205142608/https://docs.citationstyles.org/en/1.0/release-notes.html#rich-text-markup-within-fields>

That section referred to a **citeproc-js** specific feature, its documentation has now been moved to the citeproc-js documentation:

<https://citeproc-js.readthedocs.io/en/latest/csl-json/markup.html#html-like-formatting-tags>

This PR fixes the old and broken link by replacing it with the working link at citeproc-js documentation.

[HTML-like markup]: https://docs.citationstyles.org/en/1.0/release-notes.html#rich-text-markup-within-fields
l CSL documentation and has been moved to the citeproc-js documentation.