### PR TITLE
Fix copy-pasteo in ANSI writer subscripts

### DIFF
--- a/src/Text/Pandoc/Writers/ANSI.hs
+++ b/src/Text/Pandoc/Writers/ANSI.hs
@@ -296,7 +296,7 @@ inlineToANSI opts (Superscript lst) = do
     Nothing -> inlineListToANSI opts lst >>= return . D.parens
 
 inlineToANSI opts (Subscript lst) = do
-  case traverse toSuperscriptInline lst of
+  case traverse toSubscriptInline lst of
     Just xs -> inlineListToANSI opts xs
     Nothing -> inlineListToANSI opts lst >>= return . D.parens
 

--- a/test/ansi-test.ansi
+++ b/test/ansi-test.ansi
@@ -111,6 +111,8 @@ More text.
 
 small caps
 
+We see a log₁₀ reduction in 2⁹ seconds.
+
                           ────────────────────
 
   1. Here’s the note.[0m]8;;\

--- a/test/ansi-test.txt
+++ b/test/ansi-test.txt
@@ -120,3 +120,4 @@ More text.
 
 [small caps]{.smallcaps}
 
+We see a log~10~ reduction in 2^9^ seconds.


### PR DESCRIPTION
The ANSI Superscript writer was copy-pasted and incompletely modified to create the Subscript output writer and I forgot to call the right function, so subscripts were getting rendered with superscripted numbers. Adds a line for this to the ANSI golden test.
