### PR TITLE
Parse id, class, and tabstyle on tables in DocBook Reader

### DIFF
--- a/src/Text/Pandoc/Readers/DocBook.hs
+++ b/src/Text/Pandoc/Readers/DocBook.hs
@@ -1022,6 +1022,11 @@ parseBlock (Elem e) =
                      items' <- mapM getBlocks items
                      return (mconcat $ intersperse (str "; ") terms', items')
          parseTable = do
+                      let elId = attrValue "id" e
+                      let attrs = case attrValue "tabstyle" e of
+                                    "" -> []
+                                    x  -> [("custom-style", x)]
+                      let classes = T.words $ attrValue "class" e
                       let isCaption x = named "title" x || named "caption" x
                       capt <- case filterChild isCaption e of
                                     Just t  -> getInlines t
@@ -1075,7 +1080,8 @@ parseBlock (Elem e) =
                                                 Nothing  -> replicate numrows ColWidthDefault
                       let toRow = Row nullAttr
                           toHeaderRow l = [toRow l | not (null l)]
-                      return $ table (simpleCaption $ plain capt)
+                      return $ tableWith (elId,classes,attrs)
+                                     (simpleCaption $ plain capt)
                                      (zip aligns widths)
                                      (TableHead nullAttr $ toHeaderRow headrows)
                                      [TableBody nullAttr 0 [] $ map toRow bodyrows]

--- a/test/docbook-reader.docbook
+++ b/test/docbook-reader.docbook
@@ -1406,6 +1406,75 @@ or here: &lt;http://example.com/&gt;
     </tgroup>
   </table>
   <para>
+    Table with attributes
+  </para>
+  <table xml:id="mytableid1" class="mytableclass1 mytableclass2" tabstyle="mytabstyle1">
+    <title>
+      Attribute table caption
+    </title>
+    <tgroup>
+      <thead>
+	<th>
+	  <para>
+	    header cell 1
+	  </para>
+	</th>
+	<th>
+	  <para>
+	    header cell 2
+	  </para>
+	</th>
+      </thead>
+      <tbody>
+	<tr>
+	  <td>
+	    <para>
+	      body cell 1
+	    </para>
+	  </td>
+	  <td>
+	    <para>
+	      body cell 2
+	    </para>
+	  </td>
+	</tr>
+      </tbody>
+    </tgroup>
+  </table>
+  <para>
+    Table with attributes, without caption
+  </para>
+  <informaltable xml:id="mytableid2" class="mytableclass3 mytableclass4" tabstyle="mytabstyle2">
+    <tgroup>
+      <thead>
+	<th>
+	  <para>
+	    header cell 1
+	  </para>
+	</th>
+	<th>
+	  <para>
+	    header cell 2
+	  </para>
+	</th>
+      </thead>
+      <tbody>
+	<tr>
+	  <td>
+	    <para>
+	      body cell 1
+	    </para>
+	  </td>
+	  <td>
+	    <para>
+	      body cell 2
+	    </para>
+	  </td>
+	</tr>
+      </tbody>
+    </tgroup>
+  </informaltable>
+  <para>
     Multiline table without caption:
   </para>
   <informaltable>

--- a/test/docbook-reader.native
+++ b/test/docbook-reader.native
@@ -2561,6 +2561,125 @@ Pandoc
       ]
       (TableFoot ( "" , [] , [] ) [])
   , Para
+      [ Str "Table"
+      , Space
+      , Str "with"
+      , Space
+      , Str "attributes"
+      ]
+  , Table
+      ( "mytableid1"
+      , [ "mytableclass1" , "mytableclass2" ]
+      , [ ( "custom-style" , "mytabstyle1" ) ]
+      )
+      (Caption
+         Nothing
+         [ Plain
+             [ Str "Attribute"
+             , Space
+             , Str "table"
+             , Space
+             , Str "caption"
+             ]
+         ])
+      [ ( AlignDefault , ColWidthDefault )
+      , ( AlignDefault , ColWidthDefault )
+      ]
+      (TableHead ( "" , [] , [] ) [])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para
+                      [ Str "body"
+                      , Space
+                      , Str "cell"
+                      , Space
+                      , Str "1"
+                      ]
+                  ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para
+                      [ Str "body"
+                      , Space
+                      , Str "cell"
+                      , Space
+                      , Str "2"
+                      ]
+                  ]
+              ]
+          ]
+      ]
+      (TableFoot ( "" , [] , [] ) [])
+  , Para
+      [ Str "Table"
+      , Space
+      , Str "with"
+      , Space
+      , Str "attributes,"
+      , Space
+      , Str "without"
+      , Space
+      , Str "caption"
+      ]
+  , Table
+      ( "mytableid2"
+      , [ "mytableclass3" , "mytableclass4" ]
+      , [ ( "custom-style" , "mytabstyle2" ) ]
+      )
+      (Caption Nothing [])
+      [ ( AlignDefault , ColWidthDefault )
+      , ( AlignDefault , ColWidthDefault )
+      ]
+      (TableHead ( "" , [] , [] ) [])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para
+                      [ Str "body"
+                      , Space
+                      , Str "cell"
+                      , Space
+                      , Str "1"
+                      ]
+                  ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Para
+                      [ Str "body"
+                      , Space
+                      , Str "cell"
+                      , Space
+                      , Str "2"
+                      ]
+                  ]
+              ]
+          ]
+      ]
+      (TableFoot ( "" , [] , [] ) [])
+  , Para
       [ Str "Multiline"
       , Space
       , Str "table"

--- a/test/docbook-xref.native
+++ b/test/docbook-xref.native
@@ -310,7 +310,7 @@ Pandoc
           ]
       ]
   , Table
-      ( "" , [] , [] )
+      ( "table01" , [] , [] )
       (Caption
          Nothing
          [ Plain


### PR DESCRIPTION
Add parsing of id (xml:id), class, and tabstyle XML attributes for the table and informaltable elements in the DocBook reader. The tabstyle value is put in the 'custom-style' attribute.

fixes #10181