### PR TITLE
MANUAL.txt: fix typo in template syntax

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2489,9 +2489,9 @@ in square brackets, immediately after the variable name
 or partial:
 
 ```
-${months[, ]}$
+${months[, ]}
 
-${articles:bibentry()[; ]$
+${articles:bibentry()[; ]}
 ```
 
 The separator in this case is literal and (unlike with `sep`


### PR DESCRIPTION
That seems to me to be a typo:

```
${months[, ]}$

${articles:bibentry()[; ]$
```

> To mark variables and control structures in the template,
either `$`...`$` or `${`...`}` may be used as delimiters.
The styles may also be mixed in the same template, but the
opening and closing delimiter must match in each case.