### PR TITLE
HTML writer: unwrap incremental divs without other attributes

### DIFF
--- a/test/command/10328.md
+++ b/test/command/10328.md
@@ -1,0 +1,37 @@
+Unwrap divs if they only have the `nonincremental` or `incremental` classes.
+
+```
+% pandoc --incremental --from=markdown --to=revealjs
+## First slide
+
+::: nonincremental
+
+1.  Note 1
+2.  Note 2
+3.  Note 3
+
+:::
+
+## Second Slide
+
+1.  Note 1
+2.  Note 2
+3.  Note 3
+^D
+<section id="first-slide" class="slide level2">
+<h2>First slide</h2>
+<ol type="1">
+<li>Note 1</li>
+<li>Note 2</li>
+<li>Note 3</li>
+</ol>
+</section>
+<section id="second-slide" class="slide level2">
+<h2>Second Slide</h2>
+<ol type="1">
+<li class="fragment">Note 1</li>
+<li class="fragment">Note 2</li>
+<li class="fragment">Note 3</li>
+</ol>
+</section>
+```


### PR DESCRIPTION
Divs are unwrapped if the only purpose of the div seems to be to control whether lists are presented incrementally on slides.

Closes: #10328