### PR TITLE
GitHub workflow 'nightly': bump Mac OS version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,7 @@ jobs:
 
   macos:
 
-    runs-on: macos-12
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The macOS 12 Actions runner image [will be fully unsupported](https://github.com/actions/runner-images/issues/10721) by 12/3/24. This PR addresses this by bumping os version to latest version 15.