### PR TITLE
JATS: correct suppress attribute

### DIFF
--- a/src/Text/Pandoc/Readers/JATS.hs
+++ b/src/Text/Pandoc/Readers/JATS.hs
@@ -388,7 +388,7 @@ parseBlock (Elem e) = do
                                   Just t -> read $ T.unpack t
                                   Nothing -> if isBook || n == 0 then n + 1 else n
                       headerText <- case filterChild (named "title") e of
-                                       Just t  -> case maybeAttrValue "supress" t of
+                                       Just t  -> case maybeAttrValue "suppress" t of
                                                      Just s -> if s == "no"
                                                                  then getInlines t
                                                                  else return mempty

--- a/test/command/bits-title-supress.md
+++ b/test/command/bits-title-supress.md
@@ -45,7 +45,7 @@
 ```
 % pandoc -f jats -t native
 <sec>
-	<title supress="no">The European Parliament</title>
+	<title suppress="no">The European Parliament</title>
 	<p>Members of the European Parliament (MEPs) are directly elected by EU citizens.</p>
 </sec>
 ^D
@@ -89,7 +89,7 @@
 ```
 % pandoc -f jats -t native
 <sec>
-	<title supress="yes">The European Parliament</title>
+	<title suppress="yes">The European Parliament</title>
 	<p>Members of the European Parliament (MEPs) are directly elected by EU citizens.</p>
 </sec>
 ^D


### PR DESCRIPTION
For `title` element, JATS defines the attribute [`suppress`](https://jats.nlm.nih.gov/extensions/bits/tag-library/2.0/attribute/suppress.html). In the source code, `suppress` is misspelled (one single `p`only) therefore code will not work as intended. This PR fixes that issue.