### PR TITLE
Respect empty LineBlock lines in plain and ansi writers

### DIFF
--- a/src/Text/Pandoc/Writers/ANSI.hs
+++ b/src/Text/Pandoc/Writers/ANSI.hs
@@ -124,7 +124,11 @@ blockToANSI opts (Plain inlines) = inlineListToANSI opts inlines
 
 blockToANSI opts (Para inlines) = inlineListToANSI opts inlines
 
-blockToANSI opts (LineBlock lns) = blockToANSI opts $ linesToPara lns
+blockToANSI opts (LineBlock lns) = do
+  let go [] = return D.blankline
+      go xs = inlineListToANSI opts xs
+  lns' <- mapM go lns
+  return $ D.vcat lns'
 
 blockToANSI _ b@(RawBlock _ _) = do
     report $ BlockNotRendered b

--- a/test/ansi-test.ansi
+++ b/test/ansi-test.ansi
@@ -113,6 +113,10 @@ small caps
 
 We see a log₁₀ reduction in 2⁹ seconds.
 
+Hello
+
+Goodbye
+
                           ────────────────────
 
   1. Here’s the note.[0m]8;;\

--- a/test/ansi-test.txt
+++ b/test/ansi-test.txt
@@ -121,3 +121,7 @@ More text.
 [small caps]{.smallcaps}
 
 We see a log~10~ reduction in 2^9^ seconds.
+
+| Hello
+|
+| Goodbye

--- a/test/command/jabberwocky.md
+++ b/test/command/jabberwocky.md
@@ -1,0 +1,22 @@
+```
+% pandoc -t plain -f markdown
+| 'Twas brillig, and the slithy toves
+|       Did gyre and gimble in the wabe:
+| All mimsy were the borogoves,
+|       And the mome raths outgrabe.
+|
+| "Beware the Jabberwock, my son!
+|       The jaws that bite, the claws that catch!
+| Beware the Jubjub bird, and shun
+|       The frumious Bandersnatch!"
+^D
+’Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe:
+All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+“Beware the Jabberwock, my son!
+      The jaws that bite, the claws that catch!
+Beware the Jubjub bird, and shun
+      The frumious Bandersnatch!”
+```


### PR DESCRIPTION
The plain writer behaved as a markdown variant with Ext_line_blocks turned off, and so empty lines in a line block would get eliminated.  This is surprising, since if there's anything where the intent can be preserved in plain text output it's empty lines.

It's still a bit surprising to have nbsps in plain text output, as in the test, where the distinction doesn't really matter, but that'd be an orthogonal change.

As presented here the change ignores whether the `line_blocks` extension is enabled. As a write-only format, I'm not sure whether it makes sense for the `plain` writer to behave differently in the presence or absence of this extension.

Ditto ANSI writer.
