### PR TITLE
Respect Exif orientation in LaTeX, Docx, ODT output

### DIFF
--- a/src/Text/Pandoc/ImageSize.hs
+++ b/src/Text/Pandoc/ImageSize.hs
@@ -27,6 +27,7 @@ module Text.Pandoc.ImageSize ( ImageType(..)
                              , Flip(..)
                              , Rotate(..)
                              , dimension
+                             , rotateDirection
                              , lengthToDim
                              , scaleDimension
                              , inInch
@@ -515,3 +516,11 @@ imageTransform img =
     exifToTransform 7 = def{tFlip = FlipH, tRotate = R90}
     exifToTransform 8 = def{tRotate = R270}
     exifToTransform _ = def
+
+rotateDirection :: Rotate -> Direction -> Direction
+rotateDirection R0 x = x
+rotateDirection R90 Width = Height
+rotateDirection R90 Height = Width
+rotateDirection R180 x = x
+rotateDirection R270 Width = Height
+rotateDirection R270 Height = Width

--- a/src/Text/Pandoc/Writers/Docx/OpenXML.hs
+++ b/src/Text/Pandoc/Writers/Docx/OpenXML.hs
@@ -962,7 +962,17 @@ inlineToOpenXML' opts (Image attr@(imgident, _, _) alt (src, title)) = do
           , mknode "a:stretch" [] $
               mknode "a:fillRect" [] ()
           ]
-        xfrm =    mknode "a:xfrm" []
+        transform = imageTransform img
+        attrflip NoFlip = []
+        attrflip FlipH = [("flipH", "1")]
+        attrflip FlipV = [("flipV", "1")]
+        -- 60,000ths of a degree
+        rotate R0 = []
+        rotate R90 = [("rot", "5400000")]
+        rotate R180 = [("rot", "10800000")]
+        rotate R270 = [("rot", "16200000")]
+
+        xfrm =    mknode "a:xfrm" ((attrflip (tFlip transform)) <> (rotate (tRotate transform)))
                         [ mknode "a:off" [("x","0"),("y","0")] ()
                         , mknode "a:ext" [("cx",tshow xemu)
                                          ,("cy",tshow yemu)] () ]

--- a/test/command/6792.md
+++ b/test/command/6792.md
@@ -22,6 +22,8 @@
     <style:font-face style:name="Courier New" style:font-family-generic="modern" style:font-pitch="fixed" svg:font-family="'Courier New'" />
   </office:font-face-decls>
   <office:automatic-styles>
+    <style:style style:name="mirror-vertical" style:family="graphic" style:parent-style-name="Graphics"><style:graphic-properties style:mirror="vertical" /></style:style>
+    <style:style style:name="mirror-horizontal" style:family="graphic" style:parent-style-name="Graphics"><style:graphic-properties style:mirror="horizontal" /></style:style>
     <style:style style:name="fr2" style:family="graphic" style:parent-style-name="Formula"><style:graphic-properties style:vertical-pos="middle" style:vertical-rel="text" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" style:wrap="none" /></style:style>
     <style:style style:name="fr1" style:family="graphic" style:parent-style-name="Formula"><style:graphic-properties style:vertical-pos="middle" style:vertical-rel="text" /></style:style>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Table_20_Contents">

--- a/test/command/8256.md
+++ b/test/command/8256.md
@@ -17,6 +17,8 @@ Testing.
   </office:font-face-decls>
   <office:automatic-styles>
     <style:style style:name="T1" style:family="text"><style:text-properties fo:font-style="italic" style:font-style-asian="italic" style:font-style-complex="italic" /></style:style>
+    <style:style style:name="mirror-vertical" style:family="graphic" style:parent-style-name="Graphics"><style:graphic-properties style:mirror="vertical" /></style:style>
+    <style:style style:name="mirror-horizontal" style:family="graphic" style:parent-style-name="Graphics"><style:graphic-properties style:mirror="horizontal" /></style:style>
     <style:style style:name="fr2" style:family="graphic" style:parent-style-name="Formula"><style:graphic-properties style:vertical-pos="middle" style:vertical-rel="text" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" style:wrap="none" /></style:style>
     <style:style style:name="fr1" style:family="graphic" style:parent-style-name="Formula"><style:graphic-properties style:vertical-pos="middle" style:vertical-rel="text" /></style:style>
   </office:automatic-styles>

--- a/test/writer.opendocument
+++ b/test/writer.opendocument
@@ -1017,6 +1017,8 @@
     <style:style style:name="T6" style:family="text"><style:text-properties style:text-position="super 58%" /></style:style>
     <style:style style:name="T7" style:family="text"><style:text-properties fo:font-style="italic" style:font-style-asian="italic" style:font-style-complex="italic" style:text-position="super 58%" /></style:style>
     <style:style style:name="T8" style:family="text"><style:text-properties style:text-position="sub 58%" /></style:style>
+    <style:style style:name="mirror-vertical" style:family="graphic" style:parent-style-name="Graphics"><style:graphic-properties style:mirror="vertical" /></style:style>
+    <style:style style:name="mirror-horizontal" style:family="graphic" style:parent-style-name="Graphics"><style:graphic-properties style:mirror="horizontal" /></style:style>
     <style:style style:name="fr2" style:family="graphic" style:parent-style-name="Formula"><style:graphic-properties style:vertical-pos="middle" style:vertical-rel="text" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" style:wrap="none" /></style:style>
     <style:style style:name="fr1" style:family="graphic" style:parent-style-name="Formula"><style:graphic-properties style:vertical-pos="middle" style:vertical-rel="text" /></style:style>
     <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Quotations">


### PR DESCRIPTION
This branch uses EXIF orientation metadata in image files to affect the output of images in Docx, ODT, and LaTeX writers. Addresses #10311 for these three writers only.

Having worked on this for a few days I am a bit dubious that this in scope for Pandoc. On the one hand, it's probably somewhat common for users to encounter images with a flipped/rotated orientation, given the behavior smartphone cameras and so on, and common to not know what's going on or how to fix it when you generate a PDF with Pandoc. On the other hand, the problem has to be addressed in a specific way for each output format and the results can questionable.

The LaTeX case is particularly bad here, I think. For one thing, it introduces a need to read the image bytes in the LaTeX writer where it was previously unnecessary, and so I'm just ignoring all `fetchItem` exceptions and defaulting to no rotation. There's also no _necessary_ relationship between the environment where `pandoc` is being run and the environment where LaTeX is being run: if someone has a rotated `foo.jpg` in their working directory when they run pandoc, then they execute LaTeX in a directory with an unrotated `foo.jpg`, have we done the right thing or not?

In the ODT case, there's no good-looking solution available without actually rotating the pixels of the image data. See the commit message for cc73c01.

I think the approach here is more or less reasonable but I don't wholeheartedly endorse it.

Incidentally, typst natively respects EXIF orientation, seemingly by actually rotating and flipping the pixels, [see here](https://github.com/typst/typst/blob/main/crates/typst-library/src/visualize/image/raster.rs#L158-L176)