### PR TITLE
Text.Pandoc.Format: remove duplicate typst entry

### DIFF
--- a/src/Text/Pandoc/Format.hs
+++ b/src/Text/Pandoc/Format.hs
@@ -222,7 +222,6 @@ formatFromFilePath x =
     ".text"     -> defFlavor "markdown"
     ".textile"  -> defFlavor "textile"
     ".tsv"      -> defFlavor "tsv"
-    ".typ"      -> defFlavor "typst"
     ".txt"      -> defFlavor "markdown"
     ".typ"      -> defFlavor "typst"
     ".wiki"     -> defFlavor "mediawiki"


### PR DESCRIPTION
If .typ is typst, but .typ is also typst, which one wins?
