### PR TITLE
Add WebP support to ImageSize

### DIFF
--- a/src/Text/Pandoc/ImageSize.hs
+++ b/src/Text/Pandoc/ImageSize.hs
@@ -37,6 +37,9 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy as BL
 import Data.Binary.Get
+import Data.Bits ((.&.), shiftR, shiftL)
+import Data.Word (bitReverse32)
+import Data.Maybe (isJust, fromMaybe)
 import Data.Char (isDigit)
 import Control.Monad
 import Text.Pandoc.Shared (safeRead)
@@ -50,6 +53,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Encoding as TE
 import Control.Applicative
+import qualified Data.Attoparsec.ByteString as AW
 import qualified Data.Attoparsec.ByteString.Char8 as A
 import qualified Codec.Picture.Metadata as Metadata
 import Codec.Picture (decodeImageWithMetadata)
@@ -57,7 +61,7 @@ import Codec.Picture (decodeImageWithMetadata)
 -- quick and dirty functions to get image sizes
 -- algorithms borrowed from wwwis.pl
 
-data ImageType = Png | Gif | Jpeg | Svg | Pdf | Eps | Emf | Tiff
+data ImageType = Png | Gif | Jpeg | Svg | Pdf | Eps | Emf | Tiff | Webp
                  deriving Show
 data Direction = Width | Height
 instance Show Direction where
@@ -124,6 +128,9 @@ imageType img = case B.take 4 img of
                                         -> return Emf
                      "\xEF\xBB\xBF<" -- BOM before svg
                           -> imageType (B.drop 3 img)
+                     "RIFF"
+                       | B.take 4 (B.drop 8 img) == "WEBP"
+                                        -> return Webp
                      _ -> mzero
 
 findSvgTag :: ByteString -> Bool
@@ -140,6 +147,7 @@ imageSize opts img = checkDpi <$>
        Just Eps  -> mbToEither "could not determine EPS size" $ epsSize img
        Just Pdf  -> mbToEither "could not determine PDF size" $ pdfSize img
        Just Emf  -> mbToEither "could not determine EMF size" $ emfSize img
+       Just Webp -> mbToEither "could not determine WebP size" $ webpSize opts img
        Nothing   -> Left "could not determine image type"
   where mbToEither msg Nothing  = Left msg
         mbToEither _   (Just x) = Right x
@@ -376,3 +384,70 @@ emfSize img =
     case parseheader . BL.fromStrict $ img of
       Left _ -> Nothing
       Right (_, _, size) -> Just size
+
+-- See https://developers.google.com/speed/webp/docs/riff_container
+-- and RFC 6386
+pWebpSize :: AW.Parser ImageSize
+pWebpSize = do
+  AW.string "RIFF"
+  AW.take 4
+  AW.string "WEBP"
+  (w, h) <- lossy <|> lossless <|> extended
+  return $ def
+    { pxX = fromIntegral w
+    , pxY = fromIntegral h
+    }
+  where
+    lossy = do
+      AW.string "VP8 "
+      AW.take 4 -- length in bytes of VP8 Lossy stream size
+      keyFrame <-  AW.anyWord8
+      guard $ keyFrame .&. 1 == 0
+      AW.take 2 -- remaining bytes of frame header
+      AW.word8 0x9d  -- VP8 keyframe magic
+      AW.word8 0x01
+      AW.word8 0x2a
+      width16 <- AW.take 2
+      height16 <- AW.take 2
+      let w = d width16
+          h = d height16
+      guard $ isJust w && isJust h
+      return (fromMaybe 0 w, fromMaybe 0 h)
+    lossless = do
+      AW.string "VP8L"
+      AW.take 4 -- length in bytes of VP8 Lossless chunk size
+      AW.word8 0x2f  -- webp lossless stream magic
+      sizes <- AW.take 4
+      let word = mb . sizesAsWord . BL.fromStrict $ sizes
+      guard $ isJust word
+      return $ decodeLosslessSizes $ fromIntegral (fromMaybe 0 word)
+    extended = do
+      AW.string "VP8X"
+      AW.take 8  -- VP8X chunk length, flags and reserved area
+      width24 <- AW.take 3
+      height24 <- AW.take 3
+      let w = mb . decode24Plus1 . BL.fromStrict $ width24
+          h = mb . decode24Plus1 . BL.fromStrict $ height24
+      guard $ isJust w && isJust h
+      return (fromMaybe 0 w, fromMaybe 0 h)
+    d = mb . decodeFrameDim . BL.fromStrict
+    mb = either (const Nothing) (\((_, _, s)) -> Just s)
+    decodeLosslessSizes word =
+      let width = 1 + (word .&. 0x3FFF)
+          height = 1 + (word `shiftR` 14 .&. 0x3FFF)
+       in (width, height)
+    decodeFrameDim = runGetOrFail $ do
+      word <- getWord16le
+      return $ word .&. 0x3FFF
+    sizesAsWord = runGetOrFail $ do
+      bitReverse32 <$> getWord32le
+    decode24Plus1 = runGetOrFail $ do
+      low <- getWord16le
+      high <- getWord8
+      return (fromIntegral (high `shiftL` 16) + low + 1)
+
+webpSize :: WriterOptions -> ByteString -> Maybe ImageSize
+webpSize opts img =
+  case AW.parseOnly pWebpSize img of
+    Left _   -> Nothing
+    Right sz -> Just sz { dpiX = fromIntegral $ writerDpi opts, dpiY = fromIntegral $ writerDpi opts}

--- a/src/Text/Pandoc/Writers/Docx/OpenXML.hs
+++ b/src/Text/Pandoc/Writers/Docx/OpenXML.hs
@@ -1017,6 +1017,7 @@ inlineToOpenXML' opts (Image attr@(imgident, _, _) alt (src, title)) = do
             Just Svg  -> ".svg"
             Just Emf  -> ".emf"
             Just Tiff -> ".tiff"
+            Just Webp -> ".webp"
             Nothing   -> ""
         imgpath = "media/" <> ident <> imgext
         mbMimeType = mt <|> getMimeType (T.unpack imgpath)

--- a/src/Text/Pandoc/Writers/Powerpoint/Output.hs
+++ b/src/Text/Pandoc/Writers/Powerpoint/Output.hs
@@ -914,6 +914,7 @@ registerMedia fp caption = do
                  Just Svg  -> Just ".svg"
                  Just Emf  -> Just ".emf"
                  Just Tiff -> Just ".tiff"
+                 Just Webp -> Just ".webp"
                  Nothing   -> Nothing
 
   let newGlobalId = fromMaybe (maxGlobalId + 1) (M.lookup fp globalIds)


### PR DESCRIPTION
My code feels a bit messy and I've tested it with like precisely one WebP image per variant (lossy, lossless, and extended). I found myself having/wanting to combine attoparsec (to get `Alternative` and backtracking) and Data.Binary.Get (to get numbers); maybe there's a less awkward looking way to do this.

This is an API change because the constructors of ImageType are public.

Closes #9561 