### PR TITLE
Reference correct option to use with YAML metadata

### DIFF
--- a/pandoc-cli/man/pandoc.1
+++ b/pandoc-cli/man/pandoc.1
@@ -7135,7 +7135,7 @@ Slide 2 has a special image for its background, even though the heading has no c
 .SS EPUB Metadata
 EPUB metadata may be specified using the \f[CR]\-\-epub\-metadata\f[R]
 option, but if the source document is Markdown, it is better to use a
-YAML metadata block.
+YAML metadata block in conjuction with the \f[CR]\-\-metadata\-file\f[R] option.
 Here is an example:
 .IP
 .EX


### PR DESCRIPTION
Add a reference to the --metadata-file option in the section suggesting YAML for EPUB metadata.  The --epub-metadata option is mention in this same section, but it is not clear that option is incorrect for this usage.

The correct options and their formats can be found in the documentation, but this addition makes it more clear.

This PR is a result of my issue https://github.com/jgm/pandoc/issues/10410 based on misunderstanding this difference.