### PR TITLE
Move nocite

### DIFF
--- a/data/templates/common.latex
+++ b/data/templates/common.latex
@@ -257,9 +257,6 @@ $for(bibliography)$
 \addbibresource{$bibliography$}
 $endfor$
 $endif$
-$if(nocite-ids)$
-\nocite{$for(nocite-ids)$$it$$sep$, $endfor$}
-$endif$
 $--
 $-- csquotes
 $--

--- a/data/templates/default.beamer
+++ b/data/templates/default.beamer
@@ -168,6 +168,9 @@ $if(linestretch)$
 $endif$
 $body$
 
+$if(nocite-ids)$
+\nocite{$for(nocite-ids)$$it$$sep$, $endfor$}
+$endif$
 $if(natbib)$
 $if(bibliography)$
 $if(biblio-title)$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -96,6 +96,9 @@ $body$
 $if(has-frontmatter)$
 \backmatter
 $endif$
+$if(nocite-ids)$
+\nocite{$for(nocite-ids)$$it$$sep$, $endfor$}
+$endif$
 $if(natbib)$
 $if(bibliography)$
 $if(biblio-title)$


### PR DESCRIPTION
The \nocite command will now be in the document body.

This works with both bibtex and biblatex.

Closes https://github.com/jgm/pandoc/issues/10461 