### PR TITLE
Docx writer: use styleIds not styleNames for Title, Subtitle, etc.

### DIFF
--- a/data/templates/default.openxml
+++ b/data/templates/default.openxml
@@ -4,7 +4,7 @@
 $if(title)$
     <w:p>
       <w:pPr>
-        <w:pStyle w:val="Title" />
+        <w:pStyle w:val="$title-style-id$" />
       </w:pPr>
       $title$
     </w:p>
@@ -12,7 +12,7 @@ $endif$
 $if(subtitle)$
     <w:p>
       <w:pPr>
-        <w:pStyle w:val="Subtitle" />
+        <w:pStyle w:val="$subtitle-style-id$" />
       </w:pPr>
       $subtitle$
     </w:p>
@@ -20,7 +20,7 @@ $endif$
 $for(author)$
     <w:p>
       <w:pPr>
-        <w:pStyle w:val="Author" />
+        <w:pStyle w:val="$author-style-id$" />
       </w:pPr>
       $author$
     </w:p>
@@ -28,7 +28,7 @@ $endfor$
 $if(date)$
     <w:p>
       <w:pPr>
-        <w:pStyle w:val="Date" />
+        <w:pStyle w:val="$date-style-id$" />
       </w:pPr>
       $date$
     </w:p>
@@ -37,7 +37,7 @@ $if(abstract)$
 $if(abstract-title)$
     <w:p>
       <w:pPr>
-        <w:pStyle w:val="AbstractTitle" />
+        <w:pStyle w:val="$abstract-title-style-id$" />
       </w:pPr>
       <w:r><w:t xml:space="preserve">$abstract-title$</w:t></w:r>
     </w:p>

--- a/src/Text/Pandoc/Writers/Docx/OpenXML.hs
+++ b/src/Text/Pandoc/Writers/Docx/OpenXML.hs
@@ -286,6 +286,8 @@ writeOpenXML opts (Pandoc meta blocks) = do
                  (fmap (vcat . map (literal . showContent)) . blocksToOpenXML opts)
                  (fmap (hcat . map (literal . showContent)) . inlinesToOpenXML opts)
                  meta
+  cStyleMap <- gets (smParaStyle . stStyleMaps)
+  let styleIdOf name = fromStyleId $ getStyleIdFromName name cStyleMap
   let context = resetField "body" body
               . resetField "toc"
                    (vcat (map (literal . showElement) toc))
@@ -299,6 +301,12 @@ writeOpenXML opts (Pandoc meta blocks) = do
               . resetField "date" date
               . resetField "abstract-title" abstractTitle
               . resetField "abstract" abstract
+              . resetField "title-style-id" (styleIdOf "Title")
+              . resetField "subtitle-style-id" (styleIdOf "Subtitle")
+              . resetField "author-style-id" (styleIdOf "Author")
+              . resetField "date-style-id" (styleIdOf "Date")
+              . resetField "abstract-title-style-id" (styleIdOf "AbstractTitle")
+              . resetField "abstract-style-id" (styleIdOf "Abstract")
               $ metadata
   tpl <- maybe (lift $ compileDefaultTemplate "openxml") pure $ writerTemplate opts
   let rendered = render Nothing $ renderTemplate tpl context


### PR DESCRIPTION
This change affects the default openxml template as well as the OpenXML writer.

Closes #10282 (regression introduced in pandoc 3.5).