### PR TITLE
RST reader: handle explicit reference links

### DIFF
--- a/test/command/10484.md
+++ b/test/command/10484.md
@@ -1,0 +1,22 @@
+```
+% pandoc -frst -tmarkdown_strict
+- One issue fixed: `issue 123`_.
+
+- One change merged: `Big change <pull 234_>`_.
+
+- Improved the `home page <https://example.com/homepage>`_.
+
+- One more `small change`__.
+
+.. _issue 123: https://github.com/joe/project/issues/123
+.. _pull 234: https://github.com/joe/project/pull/234
+__ https://github.com/joe/project/issues/999
+
+^D
+-   One issue fixed: [issue
+    123](https://github.com/joe/project/issues/123).
+-   One change merged: [Big
+    change](https://github.com/joe/project/pull/234).
+-   Improved the [home page](https://example.com/homepage).
+-   One more [small change](https://github.com/joe/project/issues/999).
+```


### PR DESCRIPTION
This case was missed when changing the reference link strategy for RST to allow a single pass.

Fixes #10484 