### PR TITLE
Improve message for asciidoc input error #8416

### DIFF
--- a/src/Text/Pandoc/Error.hs
+++ b/src/Text/Pandoc/Error.hs
@@ -124,6 +124,7 @@ renderError e =
                  "\nTry using Word to save your DOC file as DOCX," <>
                  " and convert that with pandoc."
         "pdf" -> "\nPandoc can convert to PDF, but not from PDF."
+        "asciidoc" -> "\nPandoc can convert to asciidoc, but not from asciidoc."
         _     -> ""
     PandocUnknownWriterError w ->
        "Unknown output format " <> w <>


### PR DESCRIPTION
I noticed that asciidoct is not supported as input format, so in this case its
better to be clear about what the failure is about.

```
fursixnine@pakhet cndk8 % pandoc -t markdown  ./CNDK8.adoc $OUTPUT.md
Unknown input format asciidoc
```

This should improve the error being presented to the user.
