### PR TITLE
fix changelog: pod is reader, not writer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## pandoc 3.6.2 (2025-01-12)
 
-  * New output format: `pod` (Evan Silberman). Pod ("Plain old documentation")
+  * New input format: `pod` (Evan Silberman). Pod ("Plain old documentation")
     is a markup languaged used principally to document Perl modules and
     programs.
 


### PR DESCRIPTION
I was excited to read in the latest changelog that pandoc could now write Perl's POD format. But upon further examination, it looks like v3.6.2 can only read POD, not write it.