### PR TITLE
fix: default HR styling from `background-color` to `border-top`

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -130,8 +130,8 @@ pre code {
  overflow: visible;
 }
 hr {
-  background-color: #1a1a1a;
   border: none;
+  border-top: 1px solid #1a1a1a;
   height: 1px;
   margin: 1em 0;
 }

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -110,8 +110,8 @@
      overflow: visible;
     }
     hr {
-      background-color: #1a1a1a;
       border: none;
+      border-top: 1px solid #1a1a1a;
       height: 1px;
       margin: 1em 0;
     }

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -110,8 +110,8 @@
      overflow: visible;
     }
     hr {
-      background-color: #1a1a1a;
       border: none;
+      border-top: 1px solid #1a1a1a;
       height: 1px;
       margin: 1em 0;
     }


### PR DESCRIPTION
Hi all,

I propose to change the way horizontal rules are styled in HTML exports from applying a `background-color` to using `border-top`. This change does not affect how they are displayed; so all exports will still look like before.

However, this way, horizontal rules will be printed out if someone decides to save a document exported to HTML to PDF or print it.

## Why?

I just had a user mentioning that, if you use a horizontal rule in a document, export it to HTML and then print it, the horizontal rule doesn't show up (see https://github.com/Zettlr/Zettlr/issues/5562). After some fiddling around, I found that in the styles section, Pandoc applies a background instead of a border color. By default, every browser will not print backgrounds to save toner/ink, which applies even if someone wants to save down a PDF file.

In my specific case, it affects the way Zettlr's "Simple PDF" exporter works (which literally exports to HTML and then "prints" it using Chromium's HTML-to-PDF converter), but I believe that changing this will yield benefits for anyone using Pandoc to export to HTML. In addition, using a border color rather than a background color brings horizontal rule styling closer to how these elements are styled by default in a browser (using borders, not backgrounds).

## Caveats

This PR does not affect the way horizontal rules are displayed, only how browsers treat them during PDF export/printing.

However, I want to note that this PR would necessitate minimal changes to two other open PRs:

* #7226 would need to change the way the background color is applied in dark mode
* Same for #7131 