### PR TITLE
Consume blanks after =encoding in pod reader

### DIFF
--- a/src/Text/Pandoc/Readers/Pod.hs
+++ b/src/Text/Pandoc/Readers/Pod.hs
@@ -112,6 +112,7 @@ encoding :: PandocMonad m => PodParser m Blocks
 encoding = do
   cmd "encoding"
   anyLine
+  optional blanklines
   logMessage $ IgnoredElement "=encoding; Pandoc requires UTF-8 input"
   return mempty
 

--- a/test/command/10537.md
+++ b/test/command/10537.md
@@ -1,0 +1,24 @@
+```
+% pandoc -f pod -t html
+=encoding utf8
+
+=head1 NAME
+
+Test document
+^D
+<h1>NAME</h1>
+<p>Test document</p>
+```
+
+```
+% pandoc -f pod -t html
+=encoding utf8
+
+
+=head1 NAME
+
+Test document
+^D
+<h1>NAME</h1>
+<p>Test document</p>
+```

--- a/test/pod-reader.native
+++ b/test/pod-reader.native
@@ -22,8 +22,7 @@
     , Space
     , Str "pandoc."
     ]
-, Para
-    [ Str "=head2" , Space , Str "Head" , Space , Str "2" ]
+, Header 2 ( "" , [] , [] ) [ Str "Head" , Space , Str "2" ]
 , Header
     3
     ( "" , [] , [] )


### PR DESCRIPTION
I neglected to properly consume empty lines after =encoding commands, which produced various incorrect parses depending on the content between there and the next command. If I had actually looked closely at the golden test I originally generated I might have noticed the problem!

Fixes #10537