### PR TITLE
Prefer MIME type when determining extensions for MediaBag items

### DIFF
--- a/src/Text/Pandoc/MediaBag.hs
+++ b/src/Text/Pandoc/MediaBag.hs
@@ -107,9 +107,11 @@ insertMedia fp mbMime contents (MediaBag mediamap)
                   _     -> getMimeTypeDef fp''
   mt = fromMaybe fallback mbMime
   path = maybe fp'' (unEscapeString . uriPath) uri
-  ext = case takeExtension path of
-          '.':e | '%' `notElem` e -> '.':e
-          _ -> maybe "" (\x -> '.':T.unpack x) $ extensionFromMimeType mt
+  ext = case extensionFromMimeType mt of
+             Just e -> '.':T.unpack e
+             Nothing -> case takeExtension path of
+                             '.':e | '%' `notElem` e -> '.':e
+                             _ -> ""
 
 -- | Lookup a media item in a 'MediaBag', returning mime type and contents.
 lookupMedia :: FilePath

--- a/test/Tests/MediaBag.hs
+++ b/test/Tests/MediaBag.hs
@@ -29,7 +29,7 @@ tests = [
         assertBool "file in directory is not extracted with original name" exists1
         exists2 <- doesFileExist ("foo" </> "f9d88c3dbe18f6a7f5670e994a947d51216cdf0e.jpg")
         assertBool "file above directory is not extracted with hashed name" exists2
-        exists3 <- doesFileExist ("foo" </> "2a0eaa89f43fada3e6c577beea4f2f8f53ab6a1d.lua")
+        exists3 <- doesFileExist ("foo" </> "2a0eaa89f43fada3e6c577beea4f2f8f53ab6a1d.png")
         exists4 <- doesFileExist "a.lua"
         assertBool "data uri with malicious payload gets written outside of destination dir"
           (exists3 && not exists4)


### PR DESCRIPTION
Currently, remote images added to the MediaBag are stored at paths with extensions determined based on the external URI. For instance, an image from https://example.com/image.png is stored as <hash>.png. If the URI does not contain an extension (e.g., https://example.com/image), then the content-type of the downloaded image is used to determine the extension.

This change switches the precedence such that content-type is preferred over extensions contained in the URI. This is necessary because some images are located at URIs with misleading extensions -- shields.io, for instance, serves SVGs from URIs with .yml extensions. With this change, the image/svg+xml content-type is now preferred over the .yml URI extension. This fixes a bug in the PDF writer in which such an image would be mishandled due to not being identified as an SVG.

Closes #10553