### PR TITLE
DOCX reader: do not issue warning for comments with ext. `+styles`

### DIFF
--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -359,7 +359,7 @@ blocksToInlinesWarn cmtId blks = do
   let paraOrPlain :: Block -> Bool
       paraOrPlain (Para _)       = True
       paraOrPlain (Plain _)      = True
-      paraOrPlain (Div _ nested) = (all paraOrPlain nested)
+      paraOrPlain (Div _ nested) = all paraOrPlain nested
       paraOrPlain _              = False
   unless (all paraOrPlain blks) $
     lift $ P.report $ DocxParserWarning $

--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -58,7 +58,6 @@ implemented, [-] means partially implemented):
 module Text.Pandoc.Readers.Docx
        ( readDocx
        ) where
-
 import Codec.Archive.Zip
 import Control.Monad ( liftM, unless )
 import Control.Monad.Reader
@@ -359,6 +358,7 @@ blocksToInlinesWarn cmtId blks = do
   let paraOrPlain :: Block -> Bool
       paraOrPlain (Para _)  = True
       paraOrPlain (Plain _) = True
+      paraOrPlain (Div _ _) = True
       paraOrPlain _         = False
   unless (all paraOrPlain blks) $
     lift $ P.report $ DocxParserWarning $

--- a/src/Text/Pandoc/Readers/Docx.hs
+++ b/src/Text/Pandoc/Readers/Docx.hs
@@ -58,6 +58,7 @@ implemented, [-] means partially implemented):
 module Text.Pandoc.Readers.Docx
        ( readDocx
        ) where
+
 import Codec.Archive.Zip
 import Control.Monad ( liftM, unless )
 import Control.Monad.Reader
@@ -356,10 +357,10 @@ extentToAttr _ = nullAttr
 blocksToInlinesWarn :: PandocMonad m => T.Text -> Blocks -> DocxContext m Inlines
 blocksToInlinesWarn cmtId blks = do
   let paraOrPlain :: Block -> Bool
-      paraOrPlain (Para _)  = True
-      paraOrPlain (Plain _) = True
-      paraOrPlain (Div _ _) = True
-      paraOrPlain _         = False
+      paraOrPlain (Para _)       = True
+      paraOrPlain (Plain _)      = True
+      paraOrPlain (Div _ nested) = (all paraOrPlain nested)
+      paraOrPlain _              = False
   unless (all paraOrPlain blks) $
     lift $ P.report $ DocxParserWarning $
       "Docx comment " <> cmtId <> " will not retain formatting"

--- a/test/Tests/Readers/Docx.hs
+++ b/test/Tests/Readers/Docx.hs
@@ -487,6 +487,11 @@ tests = [ testGroup "document"
             "comment warnings (all)"
             "docx/comments_warning.docx"
             ["Docx comment 1 will not retain formatting"]
+          , testForWarningsWithOpts def{readerTrackChanges=AllChanges,
+                                        readerExtensions=extensionsFromList [Ext_styles]}
+            "comments (with styles extension)"
+            "docx/comments.docx"
+            []
           ]
         , testGroup "media"
           [ testMediaBag


### PR DESCRIPTION
This fixes #10571 by also allowing `Div` as a block element