### PR TITLE
Test \{,re}newcommand arguments

### DIFF
--- a/test/command/4470.md
+++ b/test/command/4470.md
@@ -1,0 +1,27 @@
+```
+% pandoc -r latex -w plain
+\newcommand{\foo}{123}\renewcommand\foo{456}\foo
+^D
+456
+```
+
+```
+% pandoc -r latex -w plain
+\newcommand\foo{123}\renewcommand\foo{456}\foo
+^D
+456
+```
+
+```
+% pandoc -r latex -w plain
+\newcommand{\foo}{123}\renewcommand{\foo}{456}\foo
+^D
+456
+```
+
+```
+% pandoc -r latex -w plain
+\newcommand\foo{123}\renewcommand{\foo}{456}\foo
+^D
+456
+```


### PR DESCRIPTION
Closes #4470

(Or you could just close that and this if you think LaTeX reader macro expansion is adequately tested elsewhere, I didn't scrutinize the other existing tests that thoroughly.)