### PR TITLE
Document top-level-division functionality with Docx

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1123,7 +1123,8 @@ header when requesting a document from a URL:
     remain as their default type.
 
     In Docx output, this option adds section breaks before first-level
-    headings if `chapter` is selected.
+    headings if `chapter` is selected. Footnote numbers will restart
+    with each section break unless the reference doc modifies this.
 
 `-N`, `--number-sections=[true|false]`
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1109,7 +1109,7 @@ header when requesting a document from a URL:
 `--top-level-division=default`|`section`|`chapter`|`part`
 
 :   Treat top-level headings as the given division type in
-    LaTeX, ConTeXt, DocBook, and  TEI output. The hierarchy
+    LaTeX, ConTeXt, DocBook, and TEI output. The hierarchy
     order is part, chapter, then section; all headings are
     shifted such that the top-level heading becomes the
     specified type. The default behavior is to determine the
@@ -1121,6 +1121,9 @@ header when requesting a document from a URL:
     specifying either `chapter` or `part` will cause top-level
     headings to become `\part{..}`, while second-level headings
     remain as their default type.
+
+    In Docx output, this option adds section breaks before first-level
+    headings if `chapter` is selected.
 
 `-N`, `--number-sections=[true|false]`
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1123,7 +1123,8 @@ header when requesting a document from a URL:
     remain as their default type.
 
     In Docx output, this option adds section breaks before first-level
-    headings if `chapter` is selected. Footnote numbers will restart
+    headings if `chapter` is selected, and before first- and second-level
+    headings if `part` is selected. Footnote numbers will restart
     with each section break unless the reference doc modifies this.
 
 `-N`, `--number-sections=[true|false]`


### PR DESCRIPTION
Note the Docx support for top-level-division added in <https://github.com/sthagen/jgm-pandoc/commit/b6aff2145231a7284b47b030c08a6410fb114ec1> in the manual.