### PR TITLE
Correct luacheck URL in doc/lua-filters.md

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -399,9 +399,9 @@ colon syntax (`mystring:uc_upper()`).
 # Debugging Lua filters
 
 Many errors can be avoided by performing static analysis.
-[`luacheck`](https://github.com/rnwst/pandoc.git) may be used for this
-purpose. A Luacheck configuration file for pandoc filters is available
-at <https://github.com/rnwst/pandoc-luacheckrc>.
+[`luacheck`](https://github.com/lunarmodules/luacheck) may be used
+for this purpose. A Luacheck configuration file for pandoc filters
+is available at <https://github.com/rnwst/pandoc-luacheckrc>.
 
 William Lupton has written a Lua module with some handy
 functions for debugging Lua filters, including functions


### PR DESCRIPTION
See #10568. I used the wrong luacheck URL in my earlier PR. Sorry about that!