### PR TITLE
LaTeX template: babel changes.

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3043,6 +3043,13 @@ Pandoc uses these variables when [creating a PDF] with a LaTeX engine.
 `csquotesoptions`
 :   options to use for `csquotes` package (repeat for multiple options).
 
+`babeloptions`
+:   options to pass to the babel package (may be repeated for
+    multiple options). This defaults to `provide=*` if the main
+    language isn't a European language written with Latin or
+    Cyrillic script or Vietnamese. Most users will not need to
+    adjust the default setting.
+
 #### Fonts
 
 `fontenc`

--- a/data/templates/common.latex
+++ b/data/templates/common.latex
@@ -183,12 +183,11 @@ $-- Babel language support
 $--
 $if(lang)$
 \ifLuaTeX
-\usepackage[bidi=basic]{babel}
+\usepackage[bidi=basic$for(babeloptions)$,$babeloptions$$endfor$]{babel}
 \else
-\usepackage[bidi=default]{babel}
+\usepackage[bidi=default$for(babeloptions)$,$babeloptions$$endfor$]{babel}
 \fi
 $if(babel-lang)$
-\babelprovide[main,import]{$babel-lang$}
 $if(mainfont)$
 \ifPDFTeX
 \else
@@ -196,9 +195,6 @@ $if(mainfont)$
 \fi
 $endif$
 $endif$
-$for(babel-otherlangs)$
-\babelprovide[import]{$babel-otherlangs$}
-$endfor$
 $for(babelfonts/pairs)$
 \babelfont[$babelfonts.key$]{rm}{$babelfonts.value$}
 $endfor$

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -1,5 +1,11 @@
 $passoptions.latex()$
 \documentclass[
+$for(babel-otherlangs)$
+  $babel-otherlangs$,
+$endfor$
+$if(babel-lang)$
+  $babel-lang$,
+$endif$
 $if(fontsize)$
   $fontsize$,
 $endif$

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -265,9 +265,15 @@ pandocToLaTeX options (Pandoc meta blocks) = do
                       (literal $ renderLang l)) mblang
         $ maybe id (\l -> defField "babel-lang"
                       (literal l)) babelLang
+        $ (case babelLang of -- see #8283
+                Just l | l `notElem` ldfLanguages
+                         -> defField "babeloptions" ("provide=*" :: Text)
+                _ -> id)
         $ defField "babel-otherlangs"
              (map literal
-               (nubOrd . catMaybes . filter (/= babelLang)
+               (filter (`elem` ldfLanguages) .
+                nubOrd . catMaybes .
+                filter (/= babelLang)
                 $ map toBabel docLangs))
         $ defField "selnolig-langs"
              (literal . T.intercalate "," $
@@ -1187,3 +1193,96 @@ inSoulCommand pa = do
   result <- pa
   modify $ \st -> st{ stInSoulCommand = oldInSoulCommand }
   pure result
+
+-- Babel languages with a .ldf that works well with all engines (see #8283).
+-- We follow the guidance from the Babel documentation:
+-- "In general, you should do this for European languages written in Latin
+-- and Cyrillic scripts, as well as for Vietnamese."
+ldfLanguages :: [Text]
+ldfLanguages =
+  [ "magyar"
+  , "croatian"
+  , "ngerman"
+  , "germanb"
+  , "german"
+  , "austrian"
+  , "ngermanb"
+  , "naustrian"
+  , "nswissgerman"
+  , "swissgerman"
+  , "italian"
+  , "greek"
+  , "azerbaijani"
+  , "american"
+  , "newzealand"
+  , "UKenglish"
+  , "USenglish"
+  , "australian"
+  , "british"
+  , "canadian"
+  , "english"
+  , "bahasa"
+  , "slovak"
+  , "finnish"
+  , "occitan"
+  , "swedish"
+  , "brazil"
+  , "portuguese"
+  , "portuges"
+  , "brazilian"
+  , "spanish"
+  , "norwegian"
+  , "norsk"
+  , "nynorsk"
+  , "bulgarian"
+  , "breton"
+  , "belarusian"
+  , "piedmontese"
+  , "esperanto"
+  , "lithuanian"
+  , "ukraineb"
+  , "scottishgaelic"
+  , "scottish"
+  , "dutch"
+  , "afrikaans"
+  , "czech"
+  , "serbian"
+  , "latvian"
+  , "catalan"
+  , "basque"
+  , "albanian"
+  , "irish"
+  , "serbianc"
+  , "interlingua"
+  , "bosnian"
+  , "friulan"
+  , "romanian"
+  , "icelandic"
+  , "classiclatin"
+  , "ecclesiasticlatin"
+  , "medievallatin"
+  , "latin"
+  , "georgian"
+  , "macedonian"
+  , "welsh"
+  , "vietnamese"
+  , "romansh"
+  , "danish"
+  , "lsorbian"
+  , "usorbian"
+  , "polish-compat"
+  , "polish"
+  , "estonian"
+  , "french"
+  , "frenchb"
+  , "canadien"
+  , "acadian"
+  , "francais"
+  , "turkish"
+  , "hindi"
+  , "northernsami"
+  , "samin"
+  , "russianb"
+  , "galician"
+  , "slovene"
+  ]

--- a/test/command/9472.md
+++ b/test/command/9472.md
@@ -12,6 +12,8 @@ More text in English. ['Zitat auf Deutsch.']{lang=de}
 \PassOptionsToPackage{unicode}{hyperref}
 \PassOptionsToPackage{hyphens}{url}
 \documentclass[
+  french,
+  ngerman,
 ]{article}
 \usepackage{xcolor}
 \usepackage{amsmath,amssymb}
@@ -51,8 +53,6 @@ More text in English. ['Zitat auf Deutsch.']{lang=de}
 \else
 \usepackage[bidi=default]{babel}
 \fi
-\babelprovide[main,import]{ngerman}
-\babelprovide[import]{french}
 % get rid of language-specific shorthands (see #6817):
 \let\LanguageShortHands\languageshorthands
 \def\languageshorthands#1{}

--- a/test/writers-lang-and-dir.latex
+++ b/test/writers-lang-and-dir.latex
@@ -2,6 +2,12 @@
 \PassOptionsToPackage{unicode}{hyperref}
 \PassOptionsToPackage{hyphens}{url}
 \documentclass[
+  ngerman,
+  british,
+  nswissgerman,
+  spanish,
+  french,
+  english,
 ]{article}
 \usepackage{xcolor}
 \usepackage{amsmath,amssymb}
@@ -41,12 +47,6 @@
 \else
 \usepackage[bidi=default]{babel}
 \fi
-\babelprovide[main,import]{english}
-\babelprovide[import]{ngerman}
-\babelprovide[import]{british}
-\babelprovide[import]{nswissgerman}
-\babelprovide[import]{spanish}
-\babelprovide[import]{french}
 % get rid of language-specific shorthands (see #6817):
 \let\LanguageShortHands\languageshorthands
 \def\languageshorthands#1{}


### PR DESCRIPTION
Closes #8283.

- Add babel languages to global options.
- Remove languages in `\usepackage{babel}`.
- Remove `\babelprovide` commands.
- Add `babeloptions` variable.

The LaTeX writer will give a default `babeloptions` that makes sense given the main language. If the main language is not well supported in "traditional" babel (i.e., via an .ldx file) then `provide=*` will be added to the babel package options, which will load the .ini file.

This should give better results for the mostly European languages that are supported by .ldx files, while working about the same as current pandoc for other languages.

Untested and perhaps not working without manually setting `babeloptions`: main language English, secondary language Arabic.

Credit to @mxpiotrowski for the template changes.