### PR TITLE
Add testing on ghc v9.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             ghcopts: ''
           - ghc: '9.12'
             cabal: 'latest'
-            cabalopts: ''
+            cabalopts: '--allow-newer'
             ghcopts: ''
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
             cabal: 'latest'
             cabalopts: ''
             ghcopts: ''
+          - ghc: '9.12'
+            cabal: 'latest'
+            cabalopts: ''
+            ghcopts: ''
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
This adds a new element to the `ci.yml` configuration to include the newer version of `ghc` in testing. Possibly related to #10597 