### PR TITLE
Track wikilinks with a class instead of a title

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,3 +18,15 @@ source-repository-package
   type: git
   location: https://github.com/jgm/citeproc.git
   tag: 9cdcdde4a2fa91421dcbbd3febb23096a744c600
+
+source-repository-package
+  type: git
+  location: https://github.com/jgm/commonmark-hs.git
+  tag: 99af4b26ac9fdd3580278204c37252c81305a7f4
+  subdir: commonmark-extensions
+
+source-repository-package
+  type: git
+  location: https://github.com/jgm/commonmark-hs.git
+  tag: 99af4b26ac9fdd3580278204c37252c81305a7f4
+  subdir: commonmark-pandoc

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1859,6 +1859,7 @@ wikilink :: PandocMonad m
   => (Attr -> Text -> Text -> Inlines -> Inlines)
   -> MarkdownParser m (F Inlines)
 wikilink constructor = do
+  let attr = (mempty, ["wikilink"], mempty)
   titleAfter <-
     (True <$ guardEnabled Ext_wikilinks_title_after_pipe) <|>
     (False <$ guardEnabled Ext_wikilinks_title_before_pipe)
@@ -1871,7 +1872,7 @@ wikilink constructor = do
             | titleAfter -> (T.drop 1 after, before)
             | otherwise -> (before, T.drop 1 after)
     guard $ T.all (`notElem` ['\n','\r','\f','\t']) url
-    return . pure . constructor nullAttr url "wikilink" $
+    return . pure . constructor attr url "" $
        B.text $ fromEntities title
 
 link :: PandocMonad m => MarkdownParser m (F Inlines)

--- a/src/Text/Pandoc/Readers/MediaWiki.hs
+++ b/src/Text/Pandoc/Readers/MediaWiki.hs
@@ -667,7 +667,7 @@ internalLink = try $ do
   sym "]]"
   -- see #8525:
   linktrail <- B.text <$> manyChar (satisfy (\c -> isLetter c && not (isCJK c)))
-  let link = B.link (addUnderscores pagename) "wikilink" (label <> linktrail)
+  let link = B.linkWith (mempty, ["wikilink"], mempty) (addUnderscores pagename) (stringify label) (label <> linktrail)
   if "Category:" `T.isPrefixOf` pagename
      then do
        updateState $ \st -> st{ mwCategoryLinks = link : mwCategoryLinks st }

--- a/src/Text/Pandoc/Readers/Vimwiki.hs
+++ b/src/Text/Pandoc/Readers/Vimwiki.hs
@@ -56,15 +56,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Safe (lastMay)
 import Text.Pandoc.Builder (Blocks, Inlines, fromList, toList, trimInlines)
-import qualified Text.Pandoc.Builder as B (blockQuote, bulletList, code,
-                                           codeBlockWith, definitionList,
-                                           displayMath, divWith, emph,
-                                           headerWith, horizontalRule, image,
-                                           imageWith, link, math, orderedList,
-                                           para, plain, setMeta, simpleTable,
-                                           softbreak, space, spanWith, str,
-                                           strikeout, strong, subscript,
-                                           superscript)
+import qualified Text.Pandoc.Builder as B
 import Text.Pandoc.Class.PandocMonad (PandocMonad (..))
 import Text.Pandoc.Definition (Attr, Block (BulletList, OrderedList),
                                Inline (Space), ListNumberDelim (..),
@@ -555,17 +547,14 @@ link = try $ do
                   then do
                     url <- manyTillChar anyChar $ char '|'
                     lab <- mconcat <$> manyTill inline (string "]]")
-                    let tit = if isURI url
-                                 then ""
-                                 else "wikilink"
-                    return $ B.link (procLink url) tit lab
+                    return $ B.linkWith (attr url) (procLink url) "" lab
                   else do
                     manyTill anyChar (string "]]")
 -- not using try here because [[hell]o]] is not rendered as a link in vimwiki
-                    let tit = if isURI contents
-                                 then ""
-                                 else "wikilink"
-                    return $ B.link (procLink contents) tit (B.str contents)
+                    return $ B.linkWith (attr contents) (procLink contents) "" (B.str contents)
+  where
+    attr t | isURI t = B.nullAttr
+           | otherwise = (mempty, ["wikilink"], mempty)
 
 image :: PandocMonad m => VwParser m Inlines
 image = try $ do

--- a/src/Text/Pandoc/Writers/Markdown/Inline.hs
+++ b/src/Text/Pandoc/Writers/Markdown/Inline.hs
@@ -649,7 +649,7 @@ inlineToMarkdown opts lnk@(Link attr@(ident,classes,kvs) txt (src, tit)) = do
                 case txt of
                       [Str s] | escapeURI s == srcSuffix -> True
                       _       -> False
-  let useWikilink = tit == "wikilink" &&
+  let useWikilink = "wikilink" `elem` classes &&
                     (isEnabled Ext_wikilinks_title_after_pipe opts ||
                      isEnabled Ext_wikilinks_title_before_pipe opts)
   let useRefLinks = writerReferenceLinks opts && not useAuto

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,6 +18,9 @@ extra-deps:
   commit: 109ad055af75c9dcf51a7d188b6ef750ac3ef7c1
 - git: https://github.com/jgm/citeproc.git
   commit: 9cdcdde4a2fa91421dcbbd3febb23096a744c600
+- git: https://github.com/jgm/commonmark-hs.git
+  commit: 99af4b26ac9fdd3580278204c37252c81305a7f4
+  subdirs: [commonmark-extensions, commonmark-pandoc]
 ghc-options:
    "$locals": -fhide-source-paths -Wno-missing-home-modules
 resolver: lts-23.0

--- a/test/Tests/Readers/Markdown.hs
+++ b/test/Tests/Readers/Markdown.hs
@@ -58,6 +58,9 @@ autolinkWith :: Attr -> String -> Inlines
 autolinkWith attr s = linkWith attr s' "" (str s')
   where s' = T.pack s
 
+wikilink :: Attr
+wikilink = (mempty, ["wikilink"], mempty)
+
 bareLinkTests :: [(Text, Inlines)]
 bareLinkTests =
   [ ("http://google.com is a search engine.",
@@ -312,22 +315,22 @@ tests = [ testGroup "inline code"
         , testGroup "Github wiki links"
           [ test markdownGH "autolink" $
             "[[https://example.org]]" =?>
-            para (link "https://example.org" "wikilink" (str "https://example.org"))
+            para (linkWith wikilink "https://example.org" "" (str "https://example.org"))
           , test markdownGH "link with title" $
             "[[title|https://example.org]]" =?>
-            para (link "https://example.org" "wikilink" (str "title"))
+            para (linkWith wikilink "https://example.org" "" (str "title"))
           , test markdownGH "bad link with title" $
             "[[title|random string]]" =?>
-            para (link "random string" "wikilink" (str "title"))
+            para (linkWith wikilink "random string" "" (str "title"))
           , test markdownGH "autolink not being a link" $
             "[[Name of page]]" =?>
-            para (link "Name of page" "wikilink" (text "Name of page"))
+            para (linkWith wikilink "Name of page" "" (text "Name of page"))
           , test markdownGH "autolink not being a link with a square bracket" $
             "[[Name of ]page]]" =?>
-            para (link "Name of ]page" "wikilink" (text "Name of ]page"))
+            para (linkWith wikilink "Name of ]page" "" (text "Name of ]page"))
           , test markdownGH "link with inline start should be a link" $
             "[[t`i*t_le|https://example.org]]" =?>
-            para (link "https://example.org" "wikilink" (str "t`i*t_le"))
+            para (linkWith wikilink "https://example.org" "" (str "t`i*t_le"))
           ]
         , testGroup "Headers"
           [ "blank line before header" =:

--- a/test/command/2649.md
+++ b/test/command/2649.md
@@ -90,19 +90,20 @@
 <tr>
 <td><p>1</p></td>
 <td style="text-align: left;"><p><a href="Sébastien_Loeb"
-title="wikilink">Sébastien Loeb</a></p></td>
+class="wikilink" title="Sébastien Loeb">Sébastien Loeb</a></p></td>
 <td><p>78</p></td>
 </tr>
 <tr>
 <td><p>2</p></td>
 <td style="text-align: left;"><p><strong><a href="Sébastien_Ogier"
-title="wikilink">Sébastien Ogier</a></strong></p></td>
+class="wikilink" title="Sébastien Ogier">Sébastien
+Ogier</a></strong></p></td>
 <td><p>38</p></td>
 </tr>
 <tr>
 <td><p>10</p></td>
 <td style="text-align: left;"><p><a href="Hannu_Mikkola"
-title="wikilink">Hannu Mikkola</a></p></td>
+class="wikilink" title="Hannu Mikkola">Hannu Mikkola</a></p></td>
 <td><p>18</p></td>
 </tr>
 </tbody>

--- a/test/command/8853.md
+++ b/test/command/8853.md
@@ -2,5 +2,5 @@
 % pandoc -f markdown+wikilinks_title_after_pipe --wrap=none
 [[hi]] and ![[hi]]
 ^D
-<p><a href="hi" title="wikilink">hi</a> and <img src="hi" title="wikilink" alt="hi" /></p>
+<p><a href="hi" class="wikilink">hi</a> and <img src="hi" class="wikilink" alt="hi" /></p>
 ```

--- a/test/command/wikilinks_title_after_pipe.md
+++ b/test/command/wikilinks_title_after_pipe.md
@@ -11,20 +11,20 @@
 
 [[name of page|title]]
 ^D
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
-<p><a href="https://example.org" title="wikilink">title</a></p>
-<p><a href="name of page" title="wikilink">name of page</a></p>
-<p><a href="name of page" title="wikilink">title</a></p>
+<p><a href="https://example.org" class="wikilink">https://example.org</a></p>
+<p><a href="https://example.org" class="wikilink">title</a></p>
+<p><a href="name of page" class="wikilink">name of page</a></p>
+<p><a href="name of page" class="wikilink">title</a></p>
 ```
 
 ## Writer
 
 ```
 % pandoc -t commonmark_x+wikilinks_title_after_pipe -f html
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
-<p><a href="https://example.org" title="wikilink">title</a></p>
-<p><a href="Home" title="wikilink">Home</a></p>
-<p><a href="Name of page" title="wikilink">Title</a></p>
+<p><a href="https://example.org" class="wikilink">https://example.org</a></p>
+<p><a href="https://example.org" class="wikilink">title</a></p>
+<p><a href="Home" class="wikilink">Home</a></p>
+<p><a href="Name of page" class="wikilink">Title</a></p>
 ^D
 [[https://example.org]]
 
@@ -48,20 +48,20 @@
 
 [[name of page|title]]
 ^D
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
-<p><a href="https://example.org" title="wikilink">title</a></p>
-<p><a href="name of page" title="wikilink">name of page</a></p>
-<p><a href="name of page" title="wikilink">title</a></p>
+<p><a href="https://example.org" class="wikilink">https://example.org</a></p>
+<p><a href="https://example.org" class="wikilink">title</a></p>
+<p><a href="name of page" class="wikilink">name of page</a></p>
+<p><a href="name of page" class="wikilink">title</a></p>
 ```
 
 ## Writer
 
 ```
 % pandoc -t markdown+wikilinks_title_after_pipe -f html
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
-<p><a href="https://example.org" title="wikilink">title</a></p>
-<p><a href="Home" title="wikilink">Home</a></p>
-<p><a href="Name of page" title="wikilink">Title</a></p>
+<p><a href="https://example.org" class="wikilink">https://example.org</a></p>
+<p><a href="https://example.org" class="wikilink">title</a></p>
+<p><a href="Home" class="wikilink">Home</a></p>
+<p><a href="Name of page" class="wikilink">Title</a></p>
 ^D
 [[https://example.org]]
 

--- a/test/command/wikilinks_title_before_pipe.md
+++ b/test/command/wikilinks_title_before_pipe.md
@@ -12,20 +12,20 @@
 
 [[Title|Name of page]]
 ^D
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
-<p><a href="https://example.org" title="wikilink">title</a></p>
-<p><a href="Name of page" title="wikilink">Name of page</a></p>
-<p><a href="Name of page" title="wikilink">Title</a></p>
+<p><a href="https://example.org" class="wikilink">https://example.org</a></p>
+<p><a href="https://example.org" class="wikilink">title</a></p>
+<p><a href="Name of page" class="wikilink">Name of page</a></p>
+<p><a href="Name of page" class="wikilink">Title</a></p>
 ```
 
 ## Writer
 
 ```
 % pandoc -t commonmark_x+wikilinks_title_before_pipe -f html
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
-<p><a href="https://example.org" title="wikilink">title</a></p>
-<p><a href="Home" title="wikilink">Home</a></p>
-<p><a href="Name of page" title="wikilink">Title</a></p>
+<p><a href="https://example.org" class="wikilink">https://example.org</a></p>
+<p><a href="https://example.org" class="wikilink">title</a></p>
+<p><a href="Home" class="wikilink">Home</a></p>
+<p><a href="Name of page" class="wikilink">Title</a></p>
 ^D
 [[https://example.org]]
 
@@ -59,20 +59,20 @@
 
 [[Title|Name of page]]
 ^D
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
-<p><a href="https://example.org" title="wikilink">title</a></p>
-<p><a href="Name of page" title="wikilink">Name of page</a></p>
-<p><a href="Name of page" title="wikilink">Title</a></p>
+<p><a href="https://example.org" class="wikilink">https://example.org</a></p>
+<p><a href="https://example.org" class="wikilink">title</a></p>
+<p><a href="Name of page" class="wikilink">Name of page</a></p>
+<p><a href="Name of page" class="wikilink">Title</a></p>
 ```
 
 ## Writer
 
 ```
 % pandoc -t markdown+wikilinks_title_before_pipe -f html
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
-<p><a href="https://example.org" title="wikilink">title</a></p>
-<p><a href="Home" title="wikilink">Home</a></p>
-<p><a href="Name of page" title="wikilink">Title</a></p>
+<p><a href="https://example.org" class="wikilink">https://example.org</a></p>
+<p><a href="https://example.org" class="wikilink">title</a></p>
+<p><a href="Home" class="wikilink">Home</a></p>
+<p><a href="Name of page" class="wikilink">Title</a></p>
 ^D
 [[https://example.org]]
 

--- a/test/mediawiki-reader.native
+++ b/test/mediawiki-reader.native
@@ -254,40 +254,46 @@ Pandoc
       [ Str "internal" , Space , Str "links" ]
   , Para
       [ Link
-          ( "" , [] , [] ) [ Str "Help" ] ( "Help" , "wikilink" )
+          ( "" , [ "wikilink" ] , [] )
+          [ Str "Help" ]
+          ( "Help" , "Help" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "the" , Space , Str "help" , Space , Str "page" ]
-          ( "Help" , "wikilink" )
+          ( "Help" , "the help page" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] ) [ Str "Helpers" ] ( "Help" , "wikilink" )
+          ( "" , [ "wikilink" ] , [] )
+          [ Str "Helpers" ]
+          ( "Help" , "Help" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] ) [ Str "Help" ] ( "Help" , "wikilink" )
+          ( "" , [ "wikilink" ] , [] )
+          [ Str "Help" ]
+          ( "Help" , "Help" )
       , Str "ers"
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "Contents" ]
-          ( "Help:Contents" , "wikilink" )
+          ( "Help:Contents" , "Contents" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "#My" , Space , Str "anchor" ]
-          ( "#My_anchor" , "wikilink" )
+          ( "#My_anchor" , "#My anchor" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "and" , Space , Str "text" ]
-          ( "Page#with_anchor" , "wikilink" )
+          ( "Page#with_anchor" , "and text" )
       ]
   , Header 2 ( "images" , [] , [] ) [ Str "images" ]
   , Figure

--- a/test/vimwiki-reader.native
+++ b/test/vimwiki-reader.native
@@ -559,13 +559,13 @@ Pandoc
       [ Str "internal" , Space , Str "links" ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "This is a link" ]
-          ( "This is a link" , "wikilink" )
+          ( "This is a link" , "" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "Description"
           , Space
           , Str "of"
@@ -574,27 +574,27 @@ Pandoc
           , Space
           , Str "link"
           ]
-          ( "This is a link source" , "wikilink" )
+          ( "This is a link source" , "" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "projects/Important Project 1" ]
-          ( "projects/Important Project 1" , "wikilink" )
+          ( "projects/Important Project 1" , "" )
       , SoftBreak
       , Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "../index" ]
-          ( "../index" , "wikilink" )
+          ( "../index" , "" )
       , SoftBreak
       , Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "Other" , Space , Str "files" ]
-          ( "a subdirectory/" , "wikilink" )
+          ( "a subdirectory/" , "" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "try"
           , Space
           , Str "me"
@@ -607,11 +607,11 @@ Pandoc
           , Space
           , Str "anchors"
           ]
-          ( "#tag-one" , "wikilink" )
+          ( "#tag-one" , "" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "try"
           , Space
           , Str "me"
@@ -624,11 +624,11 @@ Pandoc
           , Space
           , Str "anchors"
           ]
-          ( "#block quotes" , "wikilink" )
+          ( "#block quotes" , "" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "try"
           , Space
           , Str "me"
@@ -641,19 +641,19 @@ Pandoc
           , Space
           , Str "anchors"
           ]
-          ( "#strong" , "wikilink" )
+          ( "#strong" , "" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "Tasks" , Space , Str "for" , Space , Str "tomorrow" ]
-          ( "Todo List#Tomorrow" , "wikilink" )
+          ( "Todo List#Tomorrow" , "" )
       ]
   , Para
       [ Link
-          ( "" , [] , [] )
+          ( "" , [ "wikilink" ] , [] )
           [ Str "diary:2017-05-01" ]
-          ( "diary/2017-05-01" , "wikilink" )
+          ( "diary/2017-05-01" , "" )
       ]
   , Para
       [ Link


### PR DESCRIPTION
Once upon a time the only metadata element for links in Pandoc's AST was a title, and it was hijacked to track certain links as having originated in the wikilink syntax. Now we have Attrs and we can use a class to handle wikilinks instead.

Requires coordinated changes to commonmark-hs: https://github.com/jgm/commonmark-hs/pull/160