### PR TITLE
MANUAL: correct missing 'date' as possible block entry in metadata

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -4828,7 +4828,7 @@ If the file begins with a title block
 
 it will be parsed as bibliographic information, not regular text.  (It
 will be used, for example, in the title of standalone LaTeX or HTML
-output.)  The block may contain just a title, a title and an author,
+output.)  The block may contain just a title, a date and an author,
 or all three elements. If you want to include an author but no
 title, or a title and a date but no author, you need a blank line:
 

--- a/pandoc-cli/man/pandoc.1
+++ b/pandoc-cli/man/pandoc.1
@@ -4877,7 +4877,7 @@ If the file begins with a title block
 it will be parsed as bibliographic information, not regular text.
 (It will be used, for example, in the title of standalone LaTeX or HTML
 output.)
-The block may contain just a title, a title and an author, or all three
+The block may contain just a title, a date and an author, or all three
 elements.
 If you want to include an author but no title, or a title and a date but
 no author, you need a blank line:


### PR DESCRIPTION
As metadata suggests 3 possible values I correct a 'doublon': "just a title, a title and an author" to take 'a date' in account.

This avoids repetition.