### PR TITLE
data/templates/default.beamer: only emit \date if set

### DIFF
--- a/data/templates/default.beamer
+++ b/data/templates/default.beamer
@@ -114,7 +114,9 @@ $if(subtitle)$
 \subtitle$if(shortsubtitle)$[$shortsubtitle$]$endif${$subtitle$}
 $endif$
 \author$if(shortauthor)$[$shortauthor$]$endif${$for(author)$$author$$sep$ \and $endfor$}
+$if(date)$
 \date$if(shortdate)$[$shortdate$]$endif${$date$}
+$endif$
 $if(institute)$
 \institute$if(shortinstitute)$[$shortinstitute$]$endif${$for(institute)$$institute$$sep$ \and $endfor$}
 $endif$


### PR DESCRIPTION
This allows one, for example, to set a custom \date in the header-includes of the rmarkdown yaml frontmatter. Without this conditional, the custom \date in the frontmatter would be overridden by a (potentially empty) date from this template later.