### PR TITLE
Skip at most one argument to LaTeX tabular newline

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX/Table.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Table.hs
@@ -57,7 +57,7 @@ hline = try $ do
 
 lbreak :: PandocMonad m => LP m Tok
 lbreak = (controlSeq "\\" <|> controlSeq "tabularnewline")
-         <* skipopts <* spaces
+         <* optional (void rawopt) <* spaces
 
 amp :: PandocMonad m => LP m Tok
 amp = symbol '&'

--- a/test/command/7512.md
+++ b/test/command/7512.md
@@ -1,0 +1,65 @@
+```
+% pandoc -t native -f latex
+\begin{equation*}
+[d,\delta]=0.
+\end{equation*}
+^D
+[ Para [ Math DisplayMath "[d,\\delta]=0." ] ]
+```
+
+```
+% pandoc -t native -f latex
+\begin{table}[htb]
+  \begin{tabular}{|c|c|}
+       $W$      & rel. err. \\[0mm]
+       [$\mu$m] & [\%]\\
+  \end{tabular}
+\end{table}
+^D
+[ Table
+    ( "" , [] , [] )
+    (Caption Nothing [])
+    [ ( AlignCenter , ColWidthDefault )
+    , ( AlignCenter , ColWidthDefault )
+    ]
+    (TableHead ( "" , [] , [] ) [])
+    [ TableBody
+        ( "" , [] , [] )
+        (RowHeadColumns 0)
+        []
+        [ Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Math InlineMath "W" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "rel." , Space , Str "err." ] ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "[" , Math InlineMath "\\mu" , Str "m]" ]
+                ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "[%]" ] ]
+            ]
+        ]
+    ]
+    (TableFoot ( "" , [] , [] ) [])
+]
+```


### PR DESCRIPTION
In LaTeX's tabular environment, the tabular newline takes an optional argument that we skip. But it only takes a single optional argument, and any further square-bracketed text that follows shouldn't be skipped.

Fixes #7512, specifically [the followup issue](https://github.com/jgm/pandoc/issues/7512#issuecomment-905245320) identified by @fedeinthemix, and also adds a test for the original problem raised in that issue which was already fixed at some point.