### PR TITLE
Add AVIF to Org Reader image extensions

### DIFF
--- a/src/Text/Pandoc/Readers/Org/Shared.hs
+++ b/src/Text/Pandoc/Readers/Org/Shared.hs
@@ -32,7 +32,7 @@ isImageFilename fp = hasImageExtension && (isValid (T.unpack fp) || isKnownProto
                        `elem` imageExtensions
    isKnownProtocolUri = any (\x -> (x <> "://") `T.isPrefixOf` fp) protocols
 
-   imageExtensions = [ ".jpeg", ".jpg", ".png", ".gif", ".svg", ".webp", ".jxl" ]
+   imageExtensions = [ ".jpeg", ".jpg", ".png", ".gif", ".svg", ".webp", ".jxl", ".avif" ]
    protocols = [ "file", "http", "https" ]
 
 -- | Cleanup and canonicalize a string describing a link.  Return @Nothing@ if


### PR DESCRIPTION
AVIF is an image extension. This commit enables the Org reader to recognise AVIF files as images to be displayed, and not simply as links.

I'm unsure whether this pull request should be merged though, as currently the default Emacs (and hence org-mode) image file name extensions are `("png" "jpeg" "jpg" "gif" "tiff" "tif" "xbm" "xpm" "pbm" "pgm" "ppm" "pnm" "svg" "webp")` and do not include `avif`. However, AVIF is already recognised by pandoc in `MIME.hs` so it seems remiss to not let the Org reader recognise AVIF as an image.
