### PR TITLE
fix(revealjs)!: upgrade reveal.js to v5

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -2866,7 +2866,7 @@ pandoc](#slide-shows).
 
 `revealjs-url`
 :   base URL for reveal.js documents (defaults to
-    `https://unpkg.com/reveal.js@^4`)
+    `https://unpkg.com/reveal.js@^5`)
 
 `s5-url`
 :   base URL for S5 documents (defaults to `s5/default`)

--- a/pandoc-cli/man/pandoc.1
+++ b/pandoc-cli/man/pandoc.1
@@ -2807,7 +2807,7 @@ author affiliations: can be a list when there are multiple authors
 .TP
 \f[CR]revealjs\-url\f[R]
 base URL for reveal.js documents (defaults to
-\f[CR]https://unpkg.com/reveal.js\[at]\[ha]4/\f[R])
+\f[CR]https://unpkg.com/reveal.js\[at]\[ha]5/\f[R])
 .TP
 \f[CR]s5\-url\f[R]
 base URL for S5 documents (defaults to \f[CR]s5/default\f[R])

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -447,7 +447,7 @@ pandocToHtml opts (Pandoc meta blocks) = do
                   defField "slidy-url"
                     ("https://www.w3.org/Talks/Tools/Slidy2" :: Doc Text) .
                   defField "slideous-url" ("slideous" :: Doc Text) .
-                  defField "revealjs-url" ("https://unpkg.com/reveal.js@^4" :: Doc Text) $
+                  defField "revealjs-url" ("https://unpkg.com/reveal.js@^5" :: Doc Text) $
                   defField "s5-url" ("s5/default" :: Doc Text) .
                   defField "table-caption-below"
                      (writerTableCaptionPosition opts == CaptionBelow) .


### PR DESCRIPTION
because v4 on unpkg.com is no longer available.