### PR TITLE
mediawiki reader: improve strong/emph conformance

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -845,6 +845,7 @@ test-suite test-pandoc
                   Tests.Readers.FB2
                   Tests.Readers.Pod
                   Tests.Readers.DokuWiki
+                  Tests.Readers.MediaWiki
                   Tests.Writers.Native
                   Tests.Writers.ConTeXt
                   Tests.Writers.DocBook

--- a/test/Tests/Readers/MediaWiki.hs
+++ b/test/Tests/Readers/MediaWiki.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE OverloadedStrings #-}
+{- |
+   Module      : Tests.Readers.MediaWiki
+   Copyright   : © 2025 Evan Silberman
+   License     : GNU GPL, version 2 or above
+
+   Maintainer  : 
+   Stability   : alpha
+   Portability : portable
+
+Tests for the MediaWiki reader.
+-}
+
+module Tests.Readers.MediaWiki (tests) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Test.Tasty
+import Test.Tasty.HUnit (HasCallStack)
+import Tests.Helpers
+import Text.Pandoc
+import Text.Pandoc.Arbitrary ()
+import Text.Pandoc.Builder
+
+mw :: Text -> Pandoc
+mw = purely $ readMediaWiki def
+
+wikilink :: Text -> Inlines
+wikilink dest = linkWith ("", ["wikilink"], []) (T.replace " " "_" dest) dest (text dest)
+
+infix 4 =:
+(=:) :: (ToString c, HasCallStack)
+     => String -> (Text, c) -> TestTree
+(=:) = test mw
+
+tests :: [TestTree]
+tests = [
+  -- The "quotes" tests are adapted from tests for parsoid, MediaWiki's current
+  -- wikitext parser. Cf. https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/services/parsoid/+/refs/heads/master/tests/parser/quotes.txt
+  testGroup "quotes"
+    [ testGroup "intraword emphasis"
+      [ "italic" =:
+          "plain''italic''plain" =?>
+          para ("plain" <> emph "italic" <> "plain")
+      , "two italics" =:
+          "plain''italic''plain''italic''plain" =?>
+          para ("plain" <> emph "italic" <> "plain" <> emph "italic" <> "plain")
+      , "bold" =:
+          "plain'''bold'''plain" =?>
+          para ("plain" <> strong "bold" <> "plain")
+      , "two bolds" =:
+          "plain'''bold'''plain'''bold'''plain" =?>
+          para ("plain" <> strong "bold" <> "plain" <> strong "bold" <> "plain")
+      , "bold and italic" =:
+          "plain'''bold'''plain''italic''plain" =?>
+          para ("plain" <> strong "bold" <> "plain" <> emph "italic" <> "plain")
+      , "italic and bold" =:
+          "plain''italic''plain'''bold'''plain" =?>
+          para ("plain" <> emph "italic" <> "plain" <> strong "bold" <> "plain")
+      , "italic with bold-italic" =:
+          "plain''italic'''bold-italic'''italic''plain" =?>
+          para ("plain" <> emph ("italic" <> strong "bold-italic" <> "italic") <> "plain")
+      , "bold with bold-italic" =:
+          "plain'''bold''bold-italic''bold'''plain" =?>
+          para ("plain" <> strong ("bold" <> emph "bold-italic" <> "bold") <> "plain")
+      , "bold-italic then italic" =:
+          "plain'''''bold-italic'''italic''plain" =?>
+          para ("plain" <> emph (strong "bold-italic" <> "italic") <> "plain")
+      , "bold-italic then bold" =:
+          "plain'''''bold-italic''bold'''plain" =?>
+          para ("plain" <> strong (emph "bold-italic" <> "bold") <> "plain")
+      , "italic then bold-italic" =:
+          "plain''italic'''bold-italic'''''plain" =?>
+          para ("plain" <> emph ("italic" <> strong "bold-italic") <> "plain")
+      , "bold then bold-italic" =:
+          "plain'''bold''bold-italic'''''plain" =?>
+          para ("plain" <> strong ("bold" <> emph "bold-italic") <> "plain")
+      ]
+    , testGroup "possessives and italics"
+      [ "simple" =:
+          "In ''Flaming Pie'''s liner notes" =?>
+          para ("In " <> emph "Flaming Pie'" <> "s liner notes")
+      , "linked" =:
+          "obtained by ''[[Lunar Prospector]]'''s gamma-ray spectrometer" =?>
+          para ("obtained by " <> emph ((wikilink "Lunar Prospector") <> "'") <> "s gamma-ray spectrometer")
+      , "with following italics" =:
+          "''Sebastián Covarrubias''' ''Tesoro''" =?>
+          para (emph "Sebastián Covarrubias'" <> " " <> emph "Tesoro")
+      , "with internal link" =:
+          "the ''Vocabolario dell'[[Accademia della Crusca]]'', for Italian" =?>
+          para ("the " <> emph ("Vocabolario dell'" <> wikilink "Accademia della Crusca") <>
+            ", for Italian")
+      , "multiple" =:
+          "'''This year''''s election ''should'' beat '''last year''''s." =?>
+          para (strong "This year'" <> "s election " <> emph "should" <> " beat " <> strong "last year'" <> "s.")
+      ]
+    , testGroup "two-quote openings"
+      [ "2 open 3 close" =:
+          "''foo'''" =?>
+          para (emph "foo'")
+      , "2 open 4 close" =:
+          "''foo''''" =?>
+          para (emph "foo''")
+      -- TODO line ends terminate emphases
+      -- , "2 open 5 close" =:
+      --     "''foo'''''" =?>
+      --     para (emph "foo" <> strong "")
+      ]
+    , testGroup "three-quote openings"
+      [ "3 open 2 close" =:
+          "'''foo''" =?>
+          para ("'" <> emph "foo")
+      , "3 open 3 close" =:
+          "'''foo'''" =?>
+          para (strong "foo")
+      , "3 open 4 close" =:
+          "'''foo''''" =?>
+          para (strong "foo'")
+      -- TODO line ends terminate emphases
+      -- , "3 open 5 close" =:
+      --     "'''foo'''''" =?>
+      --     para (strong "foo" <> emph "" )
+      ]
+    , testGroup "four-quote openings"
+      [ "4 open 2 close" =:
+          "''''foo''" =?>
+          para ("''" <> emph "foo")
+      , "4 open 3 close" =:
+          "''''foo'''" =?>
+          para ("'" <> strong "foo")
+      , "4 open 4 close" =:
+          "''''foo''''" =?>
+          para ("'" <> strong "foo'")
+      -- TODO line ends terminate emphases
+      -- , "4 open 5 close" =:
+      --     "''''foo'''''" =?>
+      --     para ("'" <> strong "foo" <> emph "")
+      ]
+    , testGroup "five-quote openings"
+      [ -- TODO line ends terminate emphases
+        -- "5 open 2 close" =:
+        --   "'''''foo''" =?>
+        --   para (strong (emph "foo"))
+        -- , "5 open 3 close" =:
+        -- "'''''foo'''" =?>
+        -- para (emph (strong "foo"))
+        -- , "5 open 4 close" =:
+        --   "'''''foo''''" =?>
+        -- para (emph (strong "foo'"))
+        "5 open 5 close" =:
+          "'''''foo'''''" =?>
+          para (emph (strong "foo"))
+      , "5 open 6 close" =:
+          "'''''foo''''''" =?>
+          para (emph (strong "foo'"))
+      ]
+    , testGroup "multiple quote sequences"
+      [ "2, 4, 2" =:
+          "''foo''''bar''" =?>
+          para (emph ("foo'" <> strong "bar"))
+      , "2, 4, 2, more" =:
+          "''foo''''bar'' something else" =?>
+          para (emph ("foo'" <> strong "bar"))
+      ]
+    ]
+  ]

--- a/test/mediawiki-reader.native
+++ b/test/mediawiki-reader.native
@@ -46,8 +46,8 @@ Pandoc
   , Para
       [ Emph [ Str "emph" ] , Space , Strong [ Str "strong" ] ]
   , Para
-      [ Strong
-          [ Emph
+      [ Emph
+          [ Strong
               [ Str "strong" , Space , Str "and" , Space , Str "emph" ]
           ]
       ]
@@ -766,7 +766,7 @@ Pandoc
       , LineBreak
       , Emph [ Code ( "" , [] , [] ) "markups" ]
       , Code ( "" , [] , [] ) "\160"
-      , Strong [ Emph [ Code ( "" , [] , [] ) "can" ] ]
+      , Emph [ Strong [ Code ( "" , [] , [] ) "can" ] ]
       , Code ( "" , [] , [] ) "\160be\160done."
       ]
   , Para

--- a/test/test-pandoc.hs
+++ b/test/test-pandoc.hs
@@ -30,6 +30,7 @@ import qualified Tests.Readers.RTF
 import qualified Tests.Readers.Txt2Tags
 import qualified Tests.Readers.Man
 import qualified Tests.Readers.Mdoc
+import qualified Tests.Readers.MediaWiki
 import qualified Tests.Readers.Pod
 import qualified Tests.Shared
 import qualified Tests.Writers.AsciiDoc
@@ -103,6 +104,7 @@ tests pandocPath = testGroup "pandoc tests"
           , testGroup "FB2" Tests.Readers.FB2.tests
           , testGroup "DokuWiki" Tests.Readers.DokuWiki.tests
           , testGroup "Pod" Tests.Readers.Pod.tests
+          , testGroup "MediaWiki" Tests.Readers.MediaWiki.tests
           ]
         ]
 


### PR DESCRIPTION
cf. #10761 and #3044.

I made some progress with this today without completely blowing up the existing strong and emph parsers but weird edge cases remain. E.g. consider `''foo''''bar''`. Pandoc today will give you `Emph [ Str "foo" , Str "bar" ]`, which has an obvious appeal. My work in progress gives `Emph [ Str "foo''" ] , Str "bar''"`, which is odder but defensible given other requirements for emphasized quote marks. The actual _correct_ answer, according to MediaWiki, is `Emph [ Str "foo'" , Strong [ Str "bar" ] ]`, i.e. _foo'**bar**_, which is basically a koan.

Parsoid has a lot of code just for [processing quotes](https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/services/parsoid/+/refs/heads/master/src/Wt2Html/TT/QuoteTransformer.php), presumably aiming to maintain bug-for-bug compatibility with whatever MediaWiki's first parser did. So what a string of single-quotes means varies depending on what comes after it in the line, in a more context-sensitive way than I expected.

Would it be better to merge code that makes us more conformant with MediaWiki for some cases and "wrong in a different way" for others, or to try to reach perfection?