### PR TITLE
Plain writer: Support the four_space_rule extension.

### DIFF
--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -794,6 +794,9 @@ bulletListItemToMarkdown opts bs = do
               Markdown
                 | isEnabled Ext_four_space_rule opts
                   -> "- " <> T.replicate (writerTabStop opts - 2) " "
+              PlainText
+                | isEnabled Ext_four_space_rule opts
+                  -> "- " <> T.replicate (writerTabStop opts - 2) " "
               _ -> "- "
   -- remove trailing blank line if item ends with a tight list
   let contents' = if itemEndsWithTightList bs

--- a/test/command/10812.md
+++ b/test/command/10812.md
@@ -1,0 +1,41 @@
+Check that the `four_space_rule` extension works for plain writer.
+
+```
+% pandoc -f markdown -t plain+four_space_rule
+This is the title
+
+Here we fix:
+
+- a
+- b
+- c
+^D
+This is the title
+
+Here we fix:
+
+-   a
+-   b
+-   c
+```
+
+Check that the `four_space_rule` extension is off by default.
+
+```
+% pandoc -f markdown -t plain
+This is the title
+
+Here we fix:
+
+- a
+- b
+- c
+^D
+This is the title
+
+Here we fix:
+
+- a
+- b
+- c
+```


### PR DESCRIPTION
Allows using `-t plain+four_space_rule` to emulate the output of pandoc before #7172. This is useful for users that use pandoc e.g. to autoformat commit messages.

Fixes #10812.