### PR TITLE
Lua: allow to fill the ersatz file system of the read sandbox

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3775,7 +3775,9 @@ Parameters:
 :   If the value is not given or `nil`, then the global
     environment is used. Passing a list of filenames causes the
     reader to be run in a sandbox. The given files are read from
-    the file system and provided to the sandbox in a ersatz file
+    the file system and provided to the sandbox via an ersatz file
+    system. The table can also contain mappings from filenames to
+    contents, which will be used to populate the ersatz file
     system.
 
 Returns: pandoc document ([Pandoc](#type-pandoc))

--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -3772,17 +3772,11 @@ Parameters:
     documented in the manual. ([ReaderOptions]|table)
 
 `read_env`
-:   which environment the reader operates in: Possible values
-    are:
-
-    - 'io' is the default and gives the behavior described above.
-    - 'global' uses the same environment that was used to read
-      the input files; the parser has full access to the
-      file-system and the mediabag.
-    - 'sandbox' works like 'global' and give the parser access to
-      the mediabag, but prohibits file-system access.
-
-    Defaults to `'io'`. (string)
+:   If the value is not given or `nil`, then the global
+    environment is used. Passing a list of filenames causes the
+    reader to be run in a sandbox. The given files are read from
+    the file system and provided to the sandbox in a ersatz file
+    system.
 
 Returns: pandoc document ([Pandoc](#type-pandoc))
 

--- a/pandoc-lua-engine/test/lua/module/pandoc.lua
+++ b/pandoc-lua-engine/test/lua/module/pandoc.lua
@@ -325,6 +325,29 @@ return {
           pandoc.Blocks{pandoc.Para 'included'}
         )
       end),
+      test('sandbox files can be given as key-value pairs', function ()
+        local tex = '\\include{lua/module/include.tex}'
+        local files = {
+          ['lua/module/include.tex'] = 'Hello'
+        }
+        local doc = pandoc.read(tex, 'latex', nil, files)
+        assert.are_equal(
+          doc.blocks,
+          pandoc.Blocks{pandoc.Para 'Hello'}
+        )
+      end),
+      test('kv-pairs override contents read from file system', function ()
+        local tex = '\\include{lua/module/include.tex}'
+        local files = {
+          'lua/module/include.tex',
+          ['lua/module/include.tex'] = 'Hello'
+        }
+        local doc = pandoc.read(tex, 'latex', nil, files)
+        assert.are_equal(
+          doc.blocks,
+          pandoc.Blocks{pandoc.Para 'Hello'}
+        )
+      end),
     },
     group 'extensions' {
       test('string spec', function ()

--- a/pandoc-lua-engine/test/lua/module/pandoc.lua
+++ b/pandoc-lua-engine/test/lua/module/pandoc.lua
@@ -297,22 +297,16 @@ return {
       test('images are added to the mediabag', function ()
         local epub = io.open('lua/module/sample.epub', 'rb'):read('a')
         local _ = pandoc.read(epub, 'epub')
-        assert.are_equal(
-          #pandoc.mediabag.list(),
-          1
-        )
+        assert.are_equal(#pandoc.mediabag.list(), 1)
       end),
       test('images from EPUB are added when using the sandbox', function ()
         local epub = io.open('lua/module/sample.epub', 'rb'):read('a')
-        local _ = pandoc.read(epub, 'epub', nil, 'sandbox')
-        assert.are_equal(
-          #pandoc.mediabag.list(),
-          1
-        )
+        local _ = pandoc.read(epub, 'epub', nil, {})
+        assert.are_equal(#pandoc.mediabag.list(), 1)
       end),
       test('includes work in global env', function ()
         local tex = '\\include{lua/module/include.tex}'
-        local doc = pandoc.read(tex, 'latex', nil, 'global')
+        local doc = pandoc.read(tex, 'latex')
         assert.are_equal(
           doc.blocks,
           pandoc.Blocks{pandoc.Para 'included'}
@@ -320,10 +314,15 @@ return {
       end),
       test('sandbox disallows access to the filesystem', function ()
         local tex = '\\include{lua/module/include.tex}'
-        local doc = pandoc.read(tex, 'latex', nil, 'sandbox')
+        local doc = pandoc.read(tex, 'latex', nil, {})
+        assert.are_equal(doc.blocks, pandoc.Blocks{})
+      end),
+      test('files can be added to the sandbox', function ()
+        local tex = '\\include{lua/module/include.tex}'
+        local doc = pandoc.read(tex, 'latex', nil, {'lua/module/include.tex'})
         assert.are_equal(
           doc.blocks,
-          pandoc.Blocks{}
+          pandoc.Blocks{pandoc.Para 'included'}
         )
       end),
     },

--- a/src/Text/Pandoc/Class/Sandbox.hs
+++ b/src/Text/Pandoc/Class/Sandbox.hs
@@ -12,7 +12,9 @@ This module provides a way to run PandocMonad actions in a sandbox
 -}
 
 module Text.Pandoc.Class.Sandbox
-  ( sandbox )
+  ( sandbox
+  , sandboxWithFileTree
+  )
 where
 
 import Control.Monad (foldM)
@@ -30,8 +32,18 @@ import Text.Pandoc.Logging (messageVerbosity)
 -- ersatz file system and be available for reading.
 sandbox :: (PandocMonad m, MonadIO m) => [FilePath] -> PandocPure a -> m a
 sandbox files action = do
-  oldState <- getCommonState
   tree <- liftIO $ foldM addToFileTree mempty files
+  sandboxWithFileTree tree action
+
+-- | Lift a PandocPure action into any instance of PandocMonad.
+-- The main computation is done purely, but CommonState is preserved
+-- continuously, and warnings are emitted after the action completes.
+-- The parameter is an ersatz file system which will be available for
+-- reading.
+sandboxWithFileTree :: (PandocMonad m, MonadIO m)
+                    => FileTree -> PandocPure a -> m a
+sandboxWithFileTree tree action = do
+  oldState <- getCommonState
   case runPure (do putCommonState oldState
                    modifyPureState $ \ps -> ps{ stFiles = tree }
                    result <- action


### PR DESCRIPTION
The `pandoc.read` function now allows to populate the ersatz file system of the sandbox via the (optional) fourth parameter. The given value must be a table that lists the files which will be read from the file system before entering the sandbox. It's also possible to use a mapping from filenames to contents in the table.