### PR TITLE
HTML writer: use the ID prefix in the ID for the footnotes section.

### DIFF
--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -558,7 +558,7 @@ footnoteSection opts refLocation startCounter notes = do
         | html5
         , refLocation == EndOfDocument
         -- Note: we need a section for a new slide in slide formats.
-                = H5.section ! A5.id (fromString idName)
+                = H5.section ! prefixedId opts (fromString idName)
                              ! A5.class_ className
                              ! A5.role "doc-endnotes"
                              $ x

--- a/test/command/4235.md
+++ b/test/command/4235.md
@@ -4,7 +4,7 @@ This.^[Has a footnote.]
 ^D
 <p>This.<a href="#foofn1" class="footnote-ref" id="foofnref1"
 role="doc-noteref"><sup>1</sup></a></p>
-<section id="footnotes" class="footnotes footnotes-end-of-document"
+<section id="foofootnotes" class="footnotes footnotes-end-of-document"
 role="doc-endnotes">
 <hr />
 <ol>


### PR DESCRIPTION
In commit 9190b19fc, we began to use the ID prefix for the `<aside>` holding the footnotes. In commit 41da8ad9e, we started to use a `<section>` for this instead and the ID-prefix functionality was lost. This commit resumes using the ID prefix in the ID of this element so that multiple documents can be combined into one without ID conflicts.