### PR TITLE
DOCX template: Improve default handling of East Asian languages

### DIFF
--- a/data/docx/word/styles.xml
+++ b/data/docx/word/styles.xml
@@ -3,7 +3,7 @@
   <w:docDefaults>
     <w:rPrDefault>
       <w:rPr>
-        <w:rFonts w:asciiTheme="minorHAnsi" w:eastAsiaTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />
+        <w:rFonts w:asciiTheme="minorHAnsi" w:eastAsiaTheme="minorEastAsia" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />
         <w:sz w:val="24" />
         <w:szCs w:val="24" />
         <w:lang w:val="en-US" w:eastAsia="zh-CN" w:bidi="ar-SA" />

--- a/data/docx/word/styles.xml
+++ b/data/docx/word/styles.xml
@@ -6,7 +6,7 @@
         <w:rFonts w:asciiTheme="minorHAnsi" w:eastAsiaTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi" w:cstheme="minorBidi" />
         <w:sz w:val="24" />
         <w:szCs w:val="24" />
-        <w:lang w:val="en-US" w:eastAsia="en-US" w:bidi="ar-SA" />
+        <w:lang w:val="en-US" w:eastAsia="zh-CN" w:bidi="ar-SA" />
       </w:rPr>
     </w:rPrDefault>
     <w:pPrDefault>


### PR DESCRIPTION
This pull request improves the default `reference.docx` to better support documents containing East Asian text (Chinese, Japanese, Korean) when **no explicit `lang` metadata** is provided.

**The Problem**

Currently, the default DOCX template that ships with Pandoc contains two settings in [`data/word/styles.xml`](https://github.com/jgm/pandoc/blob/main/data/docx/word/styles.xml) that lead to suboptimal rendering and proofing of East Asian characters:

1.  The default run properties map East Asian characters to the `minorHAnsi` theme font, which is intended for Latin scripts: `<w:rFonts ... w:eastAsiaTheme="minorHAnsi" ... />`.
2.  The default language settings explicitly tag East Asian text as US English: `<w:lang ... w:eastAsia="en-US" ... />`.

When a user converts a Markdown file containing CJK characters without specifying a `lang` variable (e.g., `lang: zh-CN`), Microsoft Word is instructed to treat the text as English. This can lead to incorrect font rendering (e.g., using a Japanese font for Chinese characters or vice-versa) and issues with spell-checking and other proofing tools.

**The Solution**

This PR makes two small but significant changes to the default `data/word/styles.xml` to create a more language-neutral starting point:

1.  **Use the correct theme font for East Asian text.** The `eastAsiaTheme` attribute is changed from `minorHAnsi` to `minorEastAsia`. This allows Word to use the theme's designated East Asian font for CJK characters, improving rendering.

2.  **Set a sensible default for the East Asian language.** The `w:eastAsia` attribute is changed from `en-US` to `zh-CN`. This approach parallels the existing behavior for bidirectional text, where the template already sets a specific language default (`w:bidi="ar-SA"`). Given that Chinese is the most widely spoken language in East Asia, `zh-CN` serves as a more useful and practical default than `en-US`. And it has been [noted](https://github.com/jgm/pandoc/issues/7022#issuecomment-1236589386) this is the default behavior in Microsoft Word. This ensures that in the absence of more specific metadata from the user, Microsoft Word will default to using proofing tools for Chinese rather than English for CJK characters, which is a significant improvement for a large number of users.

The screenshots below compares the language recognition in Microsoft Word before and after the current revision.

![CleanShot 2025-06-10 at 16 21 00@2x](https://github.com/user-attachments/assets/bbb787ba-d141-4898-96b1-025a87a7ec88)

![CleanShot 2025-06-10 at 16 21 31@2x](https://github.com/user-attachments/assets/c13833c4-bbaf-486c-a6a8-6b69db830dd2)
