### PR TITLE
Typst writer: rename *numbering* variable to *section-numbering*.

### DIFF
--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -94,7 +94,7 @@ pandocToTypst options (Pandoc meta blocks) = do
                    (toPosition $ writerTableCaptionPosition options)
               $ defField "page-numbering" ("1" :: Text)
               $ (if writerNumberSections options
-                    then defField "numbering" ("1.1.1.1.1" :: Text)
+                    then defField "section-numbering" ("1.1.1.1.1" :: Text)
                     else id)
               $ metadata
   return $ render colwidth $


### PR DESCRIPTION
This is the name expected by the default template. This should fix the `--number-sections`/`-N` option when used with Typst.