### PR TITLE
Add rowspan support to DocBook reader. 

### DIFF
--- a/test/docbook-reader.docbook
+++ b/test/docbook-reader.docbook
@@ -1627,6 +1627,40 @@ or here: &lt;http://example.com/&gt;
       </tbody>
     </tgroup>
   </informaltable>
+  <para>
+    Multiline table with cells spanning multiple columns and rows without caption.
+  </para>
+  <informaltable>
+    <tgroup cols="3">
+      <colspec align="left" colname="c1" />
+      <colspec align="left" colname="c2" />
+      <colspec align="left" colname="c3" />
+      <thead>
+  <tr>
+    <th>A</th>
+    <th>B</th>
+    <th>C</th>
+  </tr>
+      </thead>
+      <tbody>
+	<tr>
+	  <td namest="c1" nameend="c2">A1 + B1</td>
+	  <td morerows="1">C1 + C2</td>
+	</tr>
+  <tr>
+	  <td namest="c1" nameend="c2" morerows="1">A2 + B2 + A3 + B3</td>
+	</tr>
+  <tr>
+	  <td>C3</td>
+	</tr>
+  <tr>
+	  <td>A4</td>
+    <td>B4</td>
+    <td>C4</td>
+	</tr>
+      </tbody>
+    </tgroup>
+  </informaltable>
   <procedure><title>An Example Procedure</title>
     <step>
       <para>

--- a/test/docbook-reader.native
+++ b/test/docbook-reader.native
@@ -3046,6 +3046,140 @@ Pandoc
           ]
       ]
       (TableFoot ( "" , [] , [] ) [])
+  , Para
+      [ Str "Multiline"
+      , Space
+      , Str "table"
+      , Space
+      , Str "with"
+      , Space
+      , Str "cells"
+      , Space
+      , Str "spanning"
+      , Space
+      , Str "multiple"
+      , Space
+      , Str "columns"
+      , Space
+      , Str "and"
+      , Space
+      , Str "rows"
+      , Space
+      , Str "without"
+      , Space
+      , Str "caption."
+      ]
+  , Table
+      ( "" , [] , [] )
+      (Caption Nothing [])
+      [ ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      , ( AlignLeft , ColWidthDefault )
+      ]
+      (TableHead
+         ( "" , [] , [] )
+         [ Row
+             ( "" , [] , [] )
+             [ Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Plain [ Str "A" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Plain [ Str "B" ] ]
+             , Cell
+                 ( "" , [] , [] )
+                 AlignDefault
+                 (RowSpan 1)
+                 (ColSpan 1)
+                 [ Plain [ Str "C" ] ]
+             ]
+         ])
+      [ TableBody
+          ( "" , [] , [] )
+          (RowHeadColumns 0)
+          []
+          [ Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 2)
+                  [ Plain
+                      [ Str "A1" , Space , Str "+" , Space , Str "B1" ]
+                  ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 2)
+                  (ColSpan 1)
+                  [ Plain
+                      [ Str "C1" , Space , Str "+" , Space , Str "C2" ]
+                  ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 2)
+                  (ColSpan 2)
+                  [ Plain
+                      [ Str "A2"
+                      , Space
+                      , Str "+"
+                      , Space
+                      , Str "B2"
+                      , Space
+                      , Str "+"
+                      , Space
+                      , Str "A3"
+                      , Space
+                      , Str "+"
+                      , Space
+                      , Str "B3"
+                      ]
+                  ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "C3" ] ]
+              ]
+          , Row
+              ( "" , [] , [] )
+              [ Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "A4" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "B4" ] ]
+              , Cell
+                  ( "" , [] , [] )
+                  AlignDefault
+                  (RowSpan 1)
+                  (ColSpan 1)
+                  [ Plain [ Str "C4" ] ]
+              ]
+          ]
+      ]
+      (TableFoot ( "" , [] , [] ) [])
   , OrderedList
       ( 1 , DefaultStyle , DefaultDelim )
       [ [ Para [ Str "A" , Space , Str "Step" ] ]


### PR DESCRIPTION
This PR adds rowspan support to the DocBook reader by reading the `morerows` attribute in table cells, as mentioned in [#10918]. Previously, the rowspan was always set to 1 regardless of this attribute. I added a test based on the table in the issue as well. 

I also found that the reader does not support multiple rows in the TableHead, and does not consider the number of cells in the Tablehead when setting the number of entries in the `colspecs` parameter. I may open another PR to add these if these are worth looking into.