### PR TITLE
Extract citationSuffix, citationPrefix.

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -5865,6 +5865,19 @@ the suffix as locator by prepending curly braces:
     [@smith, {pp. iv, vi-xi, (xv)-(xvii)} with suffix here]
     [@smith{}, 99 years later]
 
+A prefix or suffix can be marked as going with the whole citation
+rather than an individual item. A horizontal bar (`|`) is used
+to separate the global citation prefix or suffix from the individual
+items:
+
+    [for example, see |@C1; @A3; @B4, in part|, and others]
+
+The global prefix/suffix will always be at the beginning/end
+of the rendered citation, even if the style causes the
+items to be sorted in a different order. By contrast, the
+prefixes and suffixes on each item will move with the items when
+they are sorted.
+
 A minus sign (`-`) before the `@` will suppress mention of
 the author in the citation.  This can be useful when the
 author is already mentioned in the text:

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -6102,6 +6102,19 @@ the suffix as locator by prepending curly braces:
     [@smith, {pp. iv, vi-xi, (xv)-(xvii)} with suffix here]
     [@smith{}, 99 years later]
 
+A prefix or suffix can be marked as going with the whole citation
+rather than an individual item. A horizontal bar (`|`) is used
+to separate the global citation prefix or suffix from the individual
+items:
+
+    [for example, see |@C1; @A3; @B4, in part|, and others]
+
+The global prefix/suffix will always be at the beginning/end
+of the rendered citation, even if the style causes the
+items to be sorted in a different order. By contrast, the
+prefixes and suffixes on each item will move with the items when
+they are sorted.
+
 A minus sign (`-`) before the `@` will suppress mention of
 the author in the citation.  This can be useful when the
 author is already mentioned in the text:

--- a/src/Text/Pandoc/Citeproc.hs
+++ b/src/Text/Pandoc/Citeproc.hs
@@ -7,6 +7,7 @@
 module Text.Pandoc.Citeproc
   ( processCitations,
     getReferences,
+    extractCiteAffixes
   )
 where
 
@@ -311,18 +312,56 @@ getCitations locale otherIdsMap (Pandoc meta blocks) =
   getCitation (Cite cs _fallback) = Seq.singleton $
     Citeproc.Citation { Citeproc.citationId = Nothing
                       , Citeproc.citationResetPosition = False
-                      , Citeproc.citationPrefix = Nothing
-                      , Citeproc.citationSuffix = Nothing
+                      , Citeproc.citationPrefix = pref
+                      , Citeproc.citationSuffix = suff
                       , Citeproc.citationNoteNumber =
                           case cs of
                             []    -> Nothing
                             (Pandoc.Citation{ Pandoc.citationNoteNum = n }:
                                _) | n > 0     -> Just n
                                   | otherwise -> Nothing
-                      , Citeproc.citationItems =
-                           fromPandocCitations locale otherIdsMap cs
+                      , Citeproc.citationItems = items
                       }
+   where (pref', suff', cs') = extractCiteAffixes cs
+         items = fromPandocCitations locale otherIdsMap cs'
+         pref = B.fromList <$> pref'
+         suff = B.fromList <$> suff'
   getCitation _ = mempty
+
+-- | Extract a global prefix from the first Citation prefix (up to `|`),
+-- and a global suffix from the last one (following `|`).
+extractCiteAffixes :: [Pandoc.Citation]
+                   -> (Maybe [Inline], Maybe [Inline], [Pandoc.Citation])
+extractCiteAffixes cs =
+  case cs of
+    [] -> (Nothing, Nothing, [])
+    (i:is) ->
+      let (pref', i') =
+            case splitInlinesOnPipe (Pandoc.citationPrefix i) of
+               Nothing -> (Nothing, i)
+               Just (as,bs) -> (Just as,
+                                 i{ Pandoc.citationPrefix = bs })
+          (suff', cs') =
+            case reverse (i':is) of
+               [] -> (Nothing, [])
+               (i'':is'') ->
+                 case splitInlinesOnPipe (Pandoc.citationSuffix i'') of
+                   Nothing -> (Nothing, i':is)
+                   Just (as,bs) -> (Just bs, reverse
+                                     (i''{ Pandoc.citationSuffix = as }:is''))
+       in (pref', suff', cs')
+  where
+     splitInlinesOnPipe [] = Nothing
+     splitInlinesOnPipe ils =
+       case break isStrWithPipe ils of
+         (xs,Str s : ys) ->
+           let (as,bs) = T.break (=='|') s
+               bs' = T.drop 1 bs
+           in  Just (xs ++ [Str as | not (T.null as)],
+                [Str bs' | not (T.null bs')] ++ ys)
+         _ -> Nothing
+     isStrWithPipe (Str s) = T.any (=='|') s
+     isStrWithPipe _ = False
 
 fromPandocCitations :: Locale
                     -> M.Map Text ItemId

--- a/src/Text/Pandoc/Citeproc/Locator.hs
+++ b/src/Text/Pandoc/Citeproc/Locator.hs
@@ -19,7 +19,6 @@ import Control.Monad (mzero)
 import qualified Data.Map as M
 import Data.Char (isSpace, isPunctuation, isDigit)
 
-
 data LocatorInfo =
   LocatorInfo{ locatorRaw :: Text
              , locatorLabel :: Text
@@ -57,9 +56,11 @@ pLocatorWords locMap = do
 maybeAddComma :: [Inline] -> [Inline]
 maybeAddComma [] = []
 maybeAddComma ils@(Space : _) = ils
+maybeAddComma ils@(SoftBreak : _) = ils
+maybeAddComma ils@(LineBreak : _) = ils
 maybeAddComma ils@(Str t : _)
   | Just (c, _) <- T.uncons t
-  , isPunctuation c = ils
+  , isPunctuation c || c == '|' = ils
 maybeAddComma ils = Str "," : Space : ils
 
 pLocatorDelimited :: LocatorMap -> LocatorParser LocatorInfo

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -56,7 +56,6 @@ import Text.Pandoc.Shared
 import Text.Pandoc.URI (escapeURI, isURI, pBase64DataURI)
 import Text.Pandoc.XML (fromEntities)
 import Text.Pandoc.Readers.Metadata (yamlBsToMeta, yamlBsToRefs, yamlMetaBlock)
--- import Debug.Trace (traceShowId)
 
 type MarkdownParser m = ParsecT Sources ParserState m
 
@@ -2313,14 +2312,8 @@ normalCite = try $ do
   return citations
 
 suffix :: PandocMonad m => MarkdownParser m (F Inlines)
-suffix = try $ do
-  hasSpace <- option False (notFollowedBy nonspaceChar >> return True)
-  spnl
-  ils <- many (notFollowedBy (oneOf ";]") >> inline)
-  let rest = trimInlinesF (mconcat ils)
-  return $ if hasSpace && not (null ils)
-              then (B.space <>) <$> rest
-              else rest
+suffix = try $
+  mconcat <$> many (notFollowedBy (oneOf ";]") >> inline)
 
 prefix :: PandocMonad m => MarkdownParser m (F Inlines)
 prefix = trimInlinesF . mconcat <$>
@@ -2340,11 +2333,11 @@ citation = try $ do
   suff <- suffix
   noteNum <- stateNoteNumber <$> getState
   return $ do
-    x <- pref
-    y <- suff
+    pref' <- B.toList <$> pref
+    suff' <- B.toList <$> suff
     return Citation{ citationId      = key
-                   , citationPrefix  = B.toList x
-                   , citationSuffix  = B.toList y
+                   , citationPrefix  = pref'
+                   , citationSuffix  = suff'
                    , citationMode    = if suppress_author
                                           then SuppressAuthor
                                           else NormalCitation

--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -183,21 +183,26 @@ adjustCiteStyle sty cs = do
 addPrefixToFirstItem :: (F Inlines) -> (F [Citation]) -> (F [Citation])
 addPrefixToFirstItem aff cs = do
   cs' <- cs
-  aff' <- aff
+  aff' <- B.toList <$> aff
   case cs' of
     [] -> return []
     (d:ds) -> return (d{ citationPrefix =
-                          B.toList aff' <> citationPrefix d }:ds)
+                          if null aff'
+                             then citationPrefix d
+                             else aff' ++ (Str "|" : citationPrefix d) }:ds)
 
 addSuffixToLastItem :: (F Inlines) -> (F [Citation]) -> (F [Citation])
 addSuffixToLastItem aff cs = do
   cs' <- cs
-  aff' <- aff
+  aff' <- B.toList <$> aff
   case lastMay cs' of
     Nothing -> return cs'
     Just d  ->
       return (init cs' ++ [d{ citationSuffix =
-                                citationSuffix d <> B.toList aff' }])
+                                citationSuffix d <>
+                                if null aff'
+                                   then []
+                                   else Str "|" : aff' }])
 
 citeItems :: PandocMonad m => OrgParser m (F [Citation])
 citeItems = sequence <$> sepBy1' citeItem (char ';' <* void (many spaceChar))

--- a/src/Text/Pandoc/Readers/Org/Inlines.hs
+++ b/src/Text/Pandoc/Readers/Org/Inlines.hs
@@ -182,21 +182,26 @@ adjustCiteStyle sty cs = do
 addPrefixToFirstItem :: (F Inlines) -> (F [Citation]) -> (F [Citation])
 addPrefixToFirstItem aff cs = do
   cs' <- cs
-  aff' <- aff
+  aff' <- B.toList <$> aff
   case cs' of
     [] -> return []
     (d:ds) -> return (d{ citationPrefix =
-                          B.toList aff' <> citationPrefix d }:ds)
+                          if null aff'
+                             then citationPrefix d
+                             else aff' ++ (Str "|" : citationPrefix d) }:ds)
 
 addSuffixToLastItem :: (F Inlines) -> (F [Citation]) -> (F [Citation])
 addSuffixToLastItem aff cs = do
   cs' <- cs
-  aff' <- aff
+  aff' <- B.toList <$> aff
   case lastMay cs' of
     Nothing -> return cs'
     Just d  ->
       return (init cs' ++ [d{ citationSuffix =
-                                citationSuffix d <> B.toList aff' }])
+                                citationSuffix d <>
+                                if null aff'
+                                   then []
+                                   else Str "|" : aff' }])
 
 citeItems :: PandocMonad m => OrgParser m (F [Citation])
 citeItems = sequence <$> sepBy1' citeItem (char ';' <* void (many spaceChar))

--- a/src/Text/Pandoc/Writers/Org.hs
+++ b/src/Text/Pandoc/Writers/Org.hs
@@ -34,7 +34,9 @@ import Text.Pandoc.Options
 import Text.Pandoc.Shared
 import Text.Pandoc.URI
 import Text.Pandoc.Templates (renderTemplate)
-import Text.Pandoc.Citeproc.Locator (parseLocator, LocatorMap(..), LocatorInfo(..))
+import Text.Pandoc.Citeproc.Locator (parseLocator, LocatorMap(..),
+                                     LocatorInfo(..))
+import Text.Pandoc.Citeproc (extractCiteAffixes)
 import Text.Pandoc.Walk (query)
 import Text.Pandoc.Writers.Shared
 
@@ -537,8 +539,11 @@ inlineToOrg (Cite cs lst) = do
                            , ("@" <> literal (citationId c))
                            , locator
                            , citeSuff ]
-       citeItems <- mconcat . intersperse "; " <$> mapM renderCiteItem cs
-       let sty = case cs of
+       let (mbPref, mbSuff, cs') = extractCiteAffixes cs
+       pref <- maybe (pure "") inlineListToOrg mbPref
+       suff <- maybe (pure "") inlineListToOrg mbSuff
+       citeItems <- mconcat . intersperse "; " <$> mapM renderCiteItem cs'
+       let sty = case cs' of
                    (d:_)
                      | citationMode d == AuthorInText
                      -> literal "/t"
@@ -546,7 +551,15 @@ inlineToOrg (Cite cs lst) = do
                      | citationMode d == SuppressAuthor
                      -> literal "/na"
                    _ -> mempty
-       return $ "[cite" <> sty <> ":" <> citeItems <> "]"
+       return $ "[cite" <> sty <> ":" <>
+                     (case mbPref of
+                         Nothing -> ""
+                         Just _ -> pref <> ";") <>
+                     citeItems <>
+                     (case mbSuff of
+                         Nothing -> ""
+                         Just _ -> ":" <> suff) <>
+                     "]"
      else inlineListToOrg lst
 inlineToOrg (Code _ str) = return $ "=" <> literal str <> "="
 inlineToOrg (Str str) = do

--- a/test/command/10894.md
+++ b/test/command/10894.md
@@ -1,0 +1,34 @@
+```
+% pandoc --citeproc -t plain --csl command/apa.csl
+---
+references:
+- author:
+  - family: Doe
+    given: John
+  container-title: Journal of Examples
+  id: doe2020
+  issue: 1
+  issued: 2020
+  page: 1-10
+  title: An example article
+  type: article-journal
+  volume: 1
+- author:
+  - family: Smith
+    given: Jane
+  id: smith2021
+  issued: 2021
+  publisher: Example Press
+  title: A sample book
+  type: book
+suppress-bibliography: true
+---
+[@smith2021; @doe2020]
+
+[see |@smith2021; @doe2020|, and others]
+^D
+(Doe, 2020; Smith, 2021)
+
+(see Smith, 2021; Doe, 2020, and others)
+```
+

--- a/test/command/10894.md
+++ b/test/command/10894.md
@@ -1,0 +1,34 @@
+```
+% pandoc --citeproc -t plain --csl command/apa.csl
+---
+references:
+- author:
+  - family: Doe
+    given: John
+  container-title: Journal of Examples
+  id: doe2020
+  issue: 1
+  issued: 2020
+  page: 1-10
+  title: An example article
+  type: article-journal
+  volume: 1
+- author:
+  - family: Smith
+    given: Jane
+  id: smith2021
+  issued: 2021
+  publisher: Example Press
+  title: A sample book
+  type: book
+suppress-bibliography: true
+---
+[@smith2021; @doe2020]
+
+[see |@smith2021; @doe2020|, and others]
+^D
+(Doe, 2020; Smith, 2021)
+
+(see Doe, 2020; Smith, 2021, and others)
+```
+


### PR DESCRIPTION
In transforming pandoc Cite to citeproc Citation,
extract a `citationSuffix` and `citationPrefix` from the last item's suffix and first item's prefix, respectively, if they contain a `|` character which separates the item's suffix or prefix from the whole Citation's.

for example:

    [for example, see |@C1; @A3; @B4|, and others]

Here "for example, see" acts as a prefix for the whole group and will remain at the beginning even if the citation items are reordered by citeproc. Similarly, ", and others" will be a suffix for the whole group.

The terminology is confusing, because a pandoc Citation is a citeproc CitationItem, and a pandoc Cite (which can contain multiple Citations) is a citeproc Citation. A citeproc `citationPrefix` is a prefix on the whole group of items.

Closes #10894.

Notes:

1. The org reader now adds global prefixes and suffixes the same way as the Markdown reader: as affixes to the first item's prefix or the last item's suffix, separated by a pipe (`|`).

2. The org writer, however, has not been modified to convert the `|` to a `;`, as required by org-cite syntax.

3. This change doesn't currently do what one would expect, because of changes that were made to citeproc to prevent citation items with prefixes and suffixes from being sorted.  Hence in `test/command/10894.md`, we have test output

   ```
   (Doe, 2020; Smith, 2021)
   ```
   without affixes, but
   ```
   (see Smith, 2021; Doe, 2020, and others)
   ```

   with affixes.  To make this work well, we'd need to remove the citeproc code that prevented bad results before we had proper global prefixes and suffixes.  However, removing this code would mean that existing documents would render differently, unless the new pipe syntax for citation affixes were used.  That may be something we want to avoid.

4. The use of pipes to separate out global affixes from item-level affixes is a kludge that could be avoided if we added additional fields to Cite in the pandoc AST. However, AST changes are disruptive, so perhaps it's not worth doing that.