### PR TITLE
Make CommonState opaque

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -2397,8 +2397,7 @@ Fields:
 :   Output file from command line (string or nil)
 
 `log`
-:   A list of log messages in reverse order ([List] of
-    [LogMessage]s)
+:   A list of log messages ([List] of [LogMessage]s)
 
 `request_headers`
 :   Headers to add for HTTP requests; table with header names as

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Marshal/CommonState.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Marshal/CommonState.hs
@@ -16,41 +16,15 @@ module Text.Pandoc.Lua.Marshal.CommonState
   ) where
 
 import HsLua
-import Text.Pandoc.Class (CommonState (..))
-import Text.Pandoc.Lua.Marshal.List (pushPandocList)
-import Text.Pandoc.Lua.Marshal.LogMessage (pushLogMessage)
+import Text.Pandoc.Class (CommonState)
 
 -- | Lua type used for the @CommonState@ object.
+--
+-- This is an opaque value that is required for the Lua interpreter
+-- to become an instance of "PandocMonad".
+--
 typeCommonState :: LuaError e => DocumentedType e CommonState
-typeCommonState = deftype "CommonState" []
-  [ readonly "input_files" "input files passed to pandoc"
-      (pushPandocList pushString, stInputFiles)
-
-  , readonly "output_file" "the file to which pandoc will write"
-      (maybe pushnil pushString, stOutputFile)
-
-  , readonly "log" "list of log messages"
-      (pushPandocList pushLogMessage, stLog)
-
-  , readonly "request_headers" "headers to add for HTTP requests"
-      (pushPandocList (pushPair pushText pushText), stRequestHeaders)
-
-  , readonly "resource_path"
-      "path to search for resources like included images"
-      (pushPandocList pushString, stResourcePath)
-
-  , readonly "source_url" "absolute URL + dir of 1st source file"
-      (maybe pushnil pushText, stSourceURL)
-
-  , readonly "user_data_dir" "directory to search for data files"
-      (maybe pushnil pushString, stUserDataDir)
-
-  , readonly "trace" "controls whether tracing messages are issued"
-      (pushBool, stTrace)
-
-  , readonly "verbosity" "verbosity level"
-      (pushString . show, stVerbosity)
-  ]
+typeCommonState = deftype "CommonState" [] []
 
 peekCommonState :: LuaError e => Peeker e CommonState
 peekCommonState = peekUD typeCommonState

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Log.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/Log.hs
@@ -14,14 +14,9 @@ module Text.Pandoc.Lua.Module.Log
 
 import Data.Version (makeVersion)
 import HsLua
-import Text.Pandoc.Class
-  ( CommonState (stVerbosity, stLog)
-  , PandocMonad (putCommonState, getCommonState)
-  , report )
+import Text.Pandoc.Class (report, runSilently)
 import Text.Pandoc.Error (PandocError)
-import Text.Pandoc.Logging
-  ( Verbosity (ERROR)
-  , LogMessage (ScriptingInfo, ScriptingWarning) )
+import Text.Pandoc.Logging (LogMessage (ScriptingInfo, ScriptingWarning))
 import Text.Pandoc.Lua.Marshal.List (pushPandocList)
 import Text.Pandoc.Lua.Marshal.LogMessage (pushLogMessage)
 import Text.Pandoc.Lua.PandocLua (liftPandocLua, unPandocLua)
@@ -92,23 +87,12 @@ documentedModule = Module
 -- results of the function call after that.
 silence :: LuaE PandocError NumResults
 silence = unPandocLua $ do
-  -- get current log messages
-  origState <- getCommonState
-  let origLog = stLog origState
-  let origVerbosity = stVerbosity origState
-  putCommonState (origState { stLog = [], stVerbosity = ERROR })
-
   -- call function given as the first argument
-  liftPandocLua $ do
+  ((), messages) <- runSilently . liftPandocLua $ do
     nargs <- (NumArgs . subtract 1 . fromStackIndex) <$> gettop
     call @PandocError nargs multret
 
-  -- restore original log messages
-  newState <- getCommonState
-  let newLog = stLog newState
-  putCommonState (newState { stLog = origLog, stVerbosity = origVerbosity })
-
   liftPandocLua $ do
-    pushPandocList pushLogMessage newLog
+    pushPandocList pushLogMessage messages
     insert 1
     (NumResults . fromStackIndex) <$> gettop

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/MediaBag.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Module/MediaBag.hs
@@ -18,8 +18,7 @@ import Data.Version (makeVersion)
 import HsLua ( LuaE, DocumentedFunction, Module (..)
              , (<#>), (###), (=#>), (=?>), (#?), defun, functionResult
              , opt, parameter, since, stringParam, textParam)
-import Text.Pandoc.Class ( CommonState (..), fetchItem, fillMediaBag
-                         , getMediaBag, modifyCommonState, setMediaBag)
+import Text.Pandoc.Class ( fetchItem, fillMediaBag, getMediaBag, setMediaBag )
 import Text.Pandoc.Class.IO (writeMedia)
 import Text.Pandoc.Error (PandocError)
 import Text.Pandoc.Lua.Marshal.Pandoc (peekPandoc, pushPandoc)
@@ -71,8 +70,9 @@ documentedModule = Module
 -- | Delete a single item from the media bag.
 delete :: DocumentedFunction PandocError
 delete = defun "delete"
-  ### (\fp -> unPandocLua $ modifyCommonState
-              (\st -> st { stMediaBag = MB.deleteMedia fp (stMediaBag st) }))
+  ### (\fp -> unPandocLua $ do
+          mb <- getMediaBag
+          setMediaBag $ MB.deleteMedia fp mb)
   <#> stringParam "filepath"
       ("Filename of the item to deleted. The media bag will be " <>
        "left unchanged if no entry with the given filename exists.")
@@ -82,7 +82,7 @@ delete = defun "delete"
 -- | Delete all items from the media bag.
 empty :: DocumentedFunction PandocError
 empty = defun "empty"
-  ### unPandocLua (modifyCommonState (\st -> st { stMediaBag = mempty }))
+  ### unPandocLua (setMediaBag mempty)
   =#> []
   #? "Clear-out the media bag, deleting all items."
 

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/PandocLua.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/PandocLua.hs
@@ -81,9 +81,7 @@ instance PandocMonad PandocLua where
     forcePeek $ peekCommonState Lua.top `lastly` pop 1
   putCommonState cst = PandocLua $ do
     pushCommonState cst
-    Lua.pushvalue Lua.top
     Lua.setfield registryindex "PANDOC_STATE"
-    Lua.setglobal "PANDOC_STATE"
 
   logOutput = IO.logOutput
 

--- a/pandoc-lua-engine/src/Text/Pandoc/Lua/Run.hs
+++ b/pandoc-lua-engine/src/Text/Pandoc/Lua/Run.hs
@@ -61,7 +61,7 @@ runPandocLuaWith :: (PandocMonad m, MonadIO m)
                  -> m a
 runPandocLuaWith runner pLua = do
   origState <- getCommonState
-  globals <- defaultGlobals
+  let globals = defaultGlobals
   (result, newState) <- liftIO . runner . unPandocLua $ do
     putCommonState origState
     liftPandocLua $ setGlobals globals
@@ -72,11 +72,9 @@ runPandocLuaWith runner pLua = do
   return result
 
 -- | Global variables which should always be set.
-defaultGlobals :: PandocMonad m => m [Global]
-defaultGlobals = do
-  commonState <- getCommonState
-  return
-    [ PANDOC_API_VERSION
-    , PANDOC_STATE commonState
-    , PANDOC_VERSION
-    ]
+defaultGlobals :: [Global]
+defaultGlobals =
+  [ PANDOC_API_VERSION
+  , PANDOC_STATE
+  , PANDOC_VERSION
+  ]

--- a/pandoc-lua-engine/test/Tests/Lua.hs
+++ b/pandoc-lua-engine/test/Tests/Lua.hs
@@ -24,8 +24,7 @@ import Text.Pandoc.Builder (bulletList, definitionList, displayMath, divWith,
                             linebreak, math, orderedList, para, plain, rawBlock,
                             singleQuoted, space, str, strong,
                             HasMeta (setMeta))
-import Text.Pandoc.Class ( CommonState (stVerbosity)
-                         , modifyCommonState, runIOorExplode, setUserDataDir)
+import Text.Pandoc.Class ( runIOorExplode, setUserDataDir, setVerbosity )
 import Text.Pandoc.Definition (Attr, Block (BlockQuote, Div, Para), Pandoc,
                                Inline (Emph, Str), pandocTypesVersion)
 import Text.Pandoc.Error (PandocError (PandocLuaError))
@@ -242,7 +241,7 @@ runLuaTest :: HasCallStack => Lua.LuaE PandocError a -> IO a
 runLuaTest op = runIOorExplode $ do
   -- Disable printing of warnings on stderr: some tests will generate
   -- warnings, we don't want to see those messages.
-  modifyCommonState $ \st -> st { stVerbosity = ERROR }
+  setVerbosity ERROR
   res <- runLua $ do
     setGlobals [ PANDOC_WRITER_OPTIONS def ]
     op

--- a/pandoc-lua-engine/test/lua/module/globals.lua
+++ b/pandoc-lua-engine/test/lua/module/globals.lua
@@ -110,8 +110,8 @@ return {
   },
 
   group 'PANDOC_STATE' {
-    test('is a userdata object', function ()
-      assert.are_equal(type(PANDOC_STATE), 'userdata')
+    test('is a table object', function ()
+      assert.are_equal(type(PANDOC_STATE), 'table')
     end),
     test('has property "input_files"', function ()
       assert.are_equal(type(PANDOC_STATE.input_files), 'table')

--- a/pandoc-lua-engine/test/lua/module/pandoc-log.lua
+++ b/pandoc-lua-engine/test/lua/module/pandoc-log.lua
@@ -22,13 +22,13 @@ return {
     end),
     test('reports a warning', function ()
       log.info('info test')
-      local msg = json.decode(json.encode(PANDOC_STATE.log[1]))
+      local msg = json.decode(json.encode(PANDOC_STATE.log:at(-1)))
       assert.are_equal(msg.message, 'info test')
       assert.are_equal(msg.type, 'ScriptingInfo')
     end),
     test('info includes the correct number', function ()
       log.info('line number test')
-      local msg = json.decode(json.encode(PANDOC_STATE.log[1]))
+      local msg = json.decode(json.encode(PANDOC_STATE.log:at(-1)))
       -- THIS NEEDS UPDATING if lines above are shifted.
       assert.are_equal(msg.line, 30)
     end),
@@ -40,7 +40,7 @@ return {
     end),
     test('reports a warning', function ()
       log.warn('testing')
-      local msg = json.decode(json.encode(PANDOC_STATE.log[1]))
+      local msg = json.decode(json.encode(PANDOC_STATE.log:at(-1)))
       assert.are_equal(msg.message, 'testing')
       assert.are_equal(msg.type, 'ScriptingWarning')
     end),

--- a/src/Text/Pandoc/Class.hs
+++ b/src/Text/Pandoc/Class.hs
@@ -23,7 +23,9 @@ module Text.Pandoc.Class
   , Translations
   ) where
 
-import Text.Pandoc.Class.CommonState (CommonState (..))
+-- We export CommonState as an opaque object.  Accessors for
+-- its fields are provided in Text.Pandoc.Class.PandocMonad.
+import Text.Pandoc.Class.CommonState (CommonState)
 import Text.Pandoc.Class.PandocMonad
 import Text.Pandoc.Class.PandocIO
 import Text.Pandoc.Class.PandocPure

--- a/src/Text/Pandoc/Translations.hs
+++ b/src/Text/Pandoc/Translations.hs
@@ -20,7 +20,8 @@ module Text.Pandoc.Translations (
                          )
 where
 import Text.Pandoc.Translations.Types
-import Text.Pandoc.Class (PandocMonad(..), CommonState(..), toTextM, report)
+import Text.Pandoc.Class (PandocMonad(..), toTextM, report)
+import Text.Pandoc.Class.CommonState (CommonState(..))
 import Text.Pandoc.Data (readDataFile)
 import Text.Pandoc.Error (PandocError(..))
 import Text.Pandoc.Logging (LogMessage(..))


### PR DESCRIPTION
The public API still has CommonState, but can't see its fields.
We provide some additional getter/setter functions to manipulate it.
The Lua interface is unchanged; you can still look at `PANDOC_STATE`.

Closes #11005.
