### PR TITLE
Fix named entity lookup in POD reader

### DIFF
--- a/src/Text/Pandoc/Readers/Pod.hs
+++ b/src/Text/Pandoc/Readers/Pod.hs
@@ -258,7 +258,11 @@ format = try $ do
     entity (T.stripPrefix "0" -> Just suf)
         | Just (n, "") <- oct (T.unpack suf) = lookupEntity $ "#" <> tshow n
     entity (TR.decimal @Integer -> Right (x, "")) = lookupEntity $ "#" <> tshow x
-    entity x = lookupEntity x
+    -- named entities in Commonmark.Entity de facto have to be looked up with
+    -- the semicolon at the end. perlpodspec says arguments to E<> must be
+    -- alphanumeric, so an argument that already has a trailing semicolon
+    -- is bogus anyway, so just paste the semicolon on unconditionally.
+    entity x = lookupEntity (x <> ";")
 
 -- god knows there must be a higher order way of writing this thing, where we
 -- have multiple different possible parser states within the link argument

--- a/test/Tests/Readers/Pod.hs
+++ b/test/Tests/Readers/Pod.hs
@@ -145,6 +145,17 @@ tests = [
             "E<rchevron>" =?>
             para "»"
         ]
+      , testGroup "html"
+        [ "trade" =:
+           "E<trade>" =?>
+           para "™"
+        , "ccaron" =:
+           "E<ccaron>" =?>
+           para "č"
+        , "cent" =:
+           "E<cent>" =?>
+           para "¢"
+        ]
       , testGroup "numeric"
         [ "decimal" =:
             "E<162>" =?>
@@ -170,6 +181,7 @@ tests = [
         , bogusEntity "0xhh"
         , bogusEntity "077x"
         , bogusEntity "0x63 skidoo"
+        , bogusEntity "trade;"
         ]
       ]
     ]


### PR DESCRIPTION
Translating entities by name ultimately relies on
Commonmark.Entity.lookupEntity, which de facto requires the entity name to be followed by a semicolon. Paste a semicolon onto the end of the entity name read from POD to look it up.

Fixes #11015

It's noteworthy that `lookupEntity`, when called with a numeric entity, is _indifferent_ to the presence of a trailing semicolon in the query, whereas for named entities it depends entirely on the weirdness of the table in the HTML spec. This isn't documented by `lookupEntity` either way.

```
ghci> lookupEntity (T.pack "#8482")
Just "\8482"
ghci> lookupEntity (T.pack "#8482;")
Just "\8482"
ghci> lookupEntity (T.pack "trade")
Nothing
ghci> lookupEntity (T.pack "#8482;")
Just "\8482"
ghci> lookupEntity (T.pack "aacute")
Just "\225"
ghci> lookupEntity (T.pack "aacute;")
Just "\225"
```