### PR TITLE
LaTeX writer: set `pdf-trailer-id` if `SOURCE_DATE_EPOCH` envvar is set

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3209,6 +3209,16 @@ These variables function when using BibLaTeX for [citation rendering].
 `natbiboptions`
 :   list of options for natbib
 
+#### Other
+
+`pdf-trailer-id`
+:   the PDF trailer ID; must be two PDF byte strings if set,
+    conventionally with 16 bytes each. E.g.,
+    `<00112233445566778899aabbccddeeff>
+    <00112233445566778899aabbccddeeff>`.
+
+    See the section on [reproducible builds].
+
 [KOMA-Script]: https://ctan.org/pkg/koma-script
 [LaTeX Font Catalogue]: https://tug.org/FontCatalogue/
 [LaTeX font encodings guide]: https://ctan.org/pkg/encguide
@@ -7540,6 +7550,11 @@ differ, even if the source does not.  To avoid this, set the
 be taken from it instead of the current time.
 `SOURCE_DATE_EPOCH` should contain an integer unix timestamp
 (specifying the number of seconds since midnight UTC January 1, 1970).
+
+For reproducible builds with LaTeX, you can either specify the
+`pdf-trailer-id` in the metadata or leave it undefined, in which
+case pandoc will create a trailer-id based on a hash of the
+`SOURCE_DATE_EPOCH` and the document's contents.
 
 Some document formats also include a unique identifier.  For
 EPUB, this can be set explicitly by setting the `identifier`

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -40,6 +40,19 @@ $header-includes$
 $endfor$
 $after-header-includes.latex()$
 $hypersetup.latex()$
+$if(pdf-trailer-id)$
+
+\ifXeTeX
+\special{pdf:trailerid [ $pdf-trailer-id$ ]}
+\fi
+\ifPDFTeX
+\pdftrailerid{}
+\pdftrailer{/ID [ $pdf-trailer-id$ ]}
+\fi
+\ifLuaTeX
+\pdfvariable trailerid {[ $pdf-trailer-id$ ]}
+\fi
+$endif$
 
 $if(title)$
 \title{$title$$if(thanks)$\thanks{$thanks$}$endif$}


### PR DESCRIPTION
The `SOURCE_DATE_EPOCH` environment variable is used to trigger reproducible PDF compilation, i.e., PDFs that are identical down to the byte level for repeated runs.

Closes: #6539