### PR TITLE
LaTeX reader and writer: add support for soft hypens

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX/Inline.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Inline.hs
@@ -281,6 +281,7 @@ charCommands = M.fromList
   , ("_", lit "_")
   , ("{", lit "{")
   , ("}", lit "}")
+  , ("-", lit "\x00ad") -- soft hyphen
   , ("qed", lit "\a0\x25FB")
   , ("lq", return (str "‘"))
   , ("rq", return (str "’"))

--- a/src/Text/Pandoc/Writers/LaTeX/Util.hs
+++ b/src/Text/Pandoc/Writers/LaTeX/Util.hs
@@ -134,6 +134,7 @@ stringToLaTeX context zs = do
          ']'  -> emits "{]}"  -- optional arguments
          '\'' -> emitcseq "\\textquotesingle"
          '\160' -> emits "~"
+         '\x00AD' -> emits "\\-"  -- shy hyphen
          '\x200B' -> emits "\\hspace{0pt}"  -- zero-width space
          '\x202F' -> emits "\\,"
          '\x2026' | ligatures -> emitcseq "\\ldots"


### PR DESCRIPTION
The `\-` command is parsed as a soft hyphen character; likewise, the character is written as that command when outputting LaTeX.