### PR TITLE
Add default WebTeX URL to Options.hs [API change]

### DIFF
--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -1023,8 +1023,8 @@ options =
     , Option "" ["webtex"]
                  (OptArg
                   (\arg opt -> do
-                      let url' = fromMaybe defaultWebTeXURL arg
-                      return opt { optHTMLMathMethod = WebTeX $ T.pack url' })
+                      let url' = maybe defaultWebTeXURL T.pack arg
+                      return opt { optHTMLMathMethod = WebTeX url' })
                   "URL")
                  "" -- "Use web service for HTML math"
 

--- a/src/Text/Pandoc/App/CommandLineOptions.hs
+++ b/src/Text/Pandoc/App/CommandLineOptions.hs
@@ -1023,7 +1023,7 @@ options =
     , Option "" ["webtex"]
                  (OptArg
                   (\arg opt -> do
-                      let url' = fromMaybe "https://latex.codecogs.com/png.latex?" arg
+                      let url' = fromMaybe defaultWebTeXURL arg
                       return opt { optHTMLMathMethod = WebTeX $ T.pack url' })
                   "URL")
                  "" -- "Use web service for HTML math"

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -114,7 +114,8 @@ instance FromJSON HTMLMathMethod where
         mburl <- m .:? "url"
         case method :: Text of
           "plain" -> return PlainMath
-          "webtex" -> return $ WebTeX $ fromMaybe "" mburl
+          "webtex" -> return $ WebTeX $ 
+                         fromMaybe defaultWebTeXURL mburl
           "gladtex" -> return GladTeX
           "mathml" -> return MathML
           "mathjax" -> return $ MathJax $
@@ -124,7 +125,7 @@ instance FromJSON HTMLMathMethod where
           _ -> fail $ "Unknown HTML math method " ++ show method) node
        <|> (case node of
                String "plain" -> return PlainMath
-               String "webtex" -> return $ WebTeX ""
+               String "webtex" -> return $ WebTeX defaultWebTeXURL
                String "gladtex" -> return GladTeX
                String "mathml" -> return MathML
                String "mathjax" -> return $ MathJax defaultMathJaxURL
@@ -401,6 +402,9 @@ isEnabled ext opts = ext `extensionEnabled` getExtensions opts
 
 defaultMathJaxURL :: Text
 defaultMathJaxURL = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"
+
+defaultWebTeXURL :: Text
+defaultWebTeXURL = "https://latex.codecogs.com/png.latex?"
 
 defaultKaTeXURL :: Text
 defaultKaTeXURL = "https://cdn.jsdelivr.net/npm/katex@latest/dist/"

--- a/src/Text/Pandoc/Options.hs
+++ b/src/Text/Pandoc/Options.hs
@@ -32,6 +32,7 @@ module Text.Pandoc.Options ( module Text.Pandoc.Extensions
                            , def
                            , isEnabled
                            , defaultMathJaxURL
+                           , defaultWebTeXURL
                            , defaultKaTeXURL
                            ) where
 import Control.Applicative ((<|>))


### PR DESCRIPTION
When using WebTeX in a defaults file without giving a URL, it doesn't use the default URL <https://latex.codecogs.com/png.latex?> given in the documentation. I think it is because in Options.hs, the URL defaults to a blank string instead. This PR replaces the blank string with the default URL <https://latex.codecogs.com/png.latex?>.

https://github.com/jgm/pandoc/blob/7639e800c5af85e5ded862a6e218d54489d17bfc/src/Text/Pandoc/Options.hs#L117

https://github.com/jgm/pandoc/blob/7639e800c5af85e5ded862a6e218d54489d17bfc/src/Text/Pandoc/App/CommandLineOptions.hs#L1023-L1029