### PR TITLE
LaTeX reader: parse `\minisec` as unlisted level 6 headings.

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -963,6 +963,7 @@ blockCommands = M.fromList
    , ("paragraph*", section ("",["unnumbered"],[]) 4)
    , ("subparagraph", section nullAttr 5)
    , ("subparagraph*", section ("",["unnumbered"],[]) 5)
+   , ("minisec", section ("",["unnumbered","unlisted"],[]) 6) -- from KOMA
    -- beamer slides
    , ("frametitle", section nullAttr 3)
    , ("framesubtitle", section nullAttr 4)

--- a/test/command/10635.md
+++ b/test/command/10635.md
@@ -1,0 +1,24 @@
+# Support for KOMA's `\minisec` command
+
+```
+% pandoc -f latex -t native
+\minisec{Montage}
+Zunächst suche man das Mauseloch.
+^D
+[ Header
+    6
+    ( "montage" , [ "unnumbered" , "unlisted" ] , [] )
+    [ Str "Montage" ]
+, Para
+    [ Str "Zun\228chst"
+    , Space
+    , Str "suche"
+    , Space
+    , Str "man"
+    , Space
+    , Str "das"
+    , Space
+    , Str "Mauseloch."
+    ]
+]
+```


### PR DESCRIPTION
Closes: #10635