### PR TITLE
RST Reader: Add multiple header rows

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1204,7 +1204,7 @@ dashedLine ch = do
 -- one (or zero) line of text.
 simpleTableHeader :: PandocMonad m
                   => Bool  -- ^ Headerless table
-                  -> MarkdownParser m (F [Blocks], [Alignment], [Int])
+                  -> MarkdownParser m (F [[Blocks]], [Alignment], [Int])
 simpleTableHeader headless = try $ do
   rawContent  <- if headless
                     then return ""
@@ -1226,7 +1226,7 @@ simpleTableHeader headless = try $ do
   heads <- fmap sequence
            $
             mapM (parseFromString' (mconcat <$> many plain).trim) rawHeads'
-  return (heads, aligns, indices)
+  return (fmap (:[]) heads, aligns, indices)
 
 -- Returns an alignment type for a table, based on a list of strings
 -- (the rows of the column header) and a number (the length of the
@@ -1320,7 +1320,7 @@ multilineTable headless =
 
 multilineTableHeader :: PandocMonad m
                      => Bool -- ^ Headerless table
-                     -> MarkdownParser m (F [Blocks], [Alignment], [Int])
+                     -> MarkdownParser m (F [[Blocks]], [Alignment], [Int])
 multilineTableHeader headless = try $ do
   unless headless $
      tableSep >> notFollowedBy blankline
@@ -1349,7 +1349,7 @@ multilineTableHeader headless = try $ do
                     else map (T.unlines . map trim) rawHeadsList
   heads <- fmap sequence $
             mapM (parseFromString' (mconcat <$> many plain).trim) rawHeads
-  return (heads, aligns, indices')
+  return (fmap (:[]) heads, aligns, indices')
 
 -- Parse a grid table:  starts with row of '-' on top, then header
 -- (which may be grid), then the rows,
@@ -1394,7 +1394,7 @@ pipeTable = try $ do
   (rows :: F [[Blocks]]) <- sequence <$>
                             mapM (fmap sequence . mapM cellContents) lines''
   return $
-    toTableComponents' NormalizeHeader aligns widths <$> headCells <*> rows
+    toTableComponents' NormalizeHeader aligns widths <$> fmap (:[]) headCells <*> rows
 
 sepPipe :: PandocMonad m => MarkdownParser m ()
 sepPipe = try $ do

--- a/test/command/10338-rst-multiple-header-rows.md
+++ b/test/command/10338-rst-multiple-header-rows.md
@@ -1,0 +1,155 @@
+```
+% pandoc -f rst -t native
+Multiple Headers
+================
+
+========== =========
+Header A1  Header A2
+Header B1  Header B2
+========== =========
+body a1    body a1
+body b1    body b2
+========== =========
+
+Headless
+========
+
+========== =========
+body a1    body a1
+body b1    body b2
+========== =========
+
+End Section
+===========
+^D
+[ Header
+    1
+    ( "multiple-headers" , [] , [] )
+    [ Str "Multiple" , Space , Str "Headers" ]
+, Table
+    ( "" , [] , [] )
+    (Caption Nothing [])
+    [ ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    ]
+    (TableHead
+       ( "" , [] , [] )
+       [ Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "Header" , Space , Str "A1" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "Header" , Space , Str "A2" ] ]
+           ]
+       , Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "Header" , Space , Str "B1" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "Header" , Space , Str "B2" ] ]
+           ]
+       ])
+    [ TableBody
+        ( "" , [] , [] )
+        (RowHeadColumns 0)
+        []
+        [ Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "body" , Space , Str "a1" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "body" , Space , Str "a1" ] ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "body" , Space , Str "b1" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "body" , Space , Str "b2" ] ]
+            ]
+        ]
+    ]
+    (TableFoot ( "" , [] , [] ) [])
+, Header 1 ( "headless" , [] , [] ) [ Str "Headless" ]
+, Table
+    ( "" , [] , [] )
+    (Caption Nothing [])
+    [ ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    ]
+    (TableHead ( "" , [] , [] ) [])
+    [ TableBody
+        ( "" , [] , [] )
+        (RowHeadColumns 0)
+        []
+        [ Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "body" , Space , Str "a1" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "body" , Space , Str "a1" ] ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "body" , Space , Str "b1" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "body" , Space , Str "b2" ] ]
+            ]
+        ]
+    ]
+    (TableFoot ( "" , [] , [] ) [])
+, Header
+    1
+    ( "end-section" , [] , [] )
+    [ Str "End" , Space , Str "Section" ]
+]
+```


### PR DESCRIPTION
This adds support for multiple header rows into tables.

In order to accomplish this, the shared `GridTable` module was to extended to also be able to handle tables with multiple header rows.
Also adjusted the `simpleTableRow` function to prevent headless tables from being interpreted as multiple header rows and fixed hlint warnings about redundant `$`.

Fixes #10338