### PR TITLE
Typst Writer: Check XID_Continue in identifiers

### DIFF
--- a/pandoc.cabal
+++ b/pandoc.cabal
@@ -542,6 +542,7 @@ library
                  text-conversions      >= 0.3      && < 0.4,
                  time                  >= 1.5      && < 1.15,
                  unicode-collation     >= 0.1.1    && < 0.2,
+                 unicode-data          >= 0.6      && < 0.7,
                  unicode-transforms    >= 0.3      && < 0.5,
                  yaml                  >= 0.11     && < 0.12,
                  libyaml               >= 0.1.4    && < 0.2,

--- a/test/command/10816.md
+++ b/test/command/10816.md
@@ -1,0 +1,7 @@
+```
+% pandoc -f markdown -t typst
+# Test①
+^D
+= Test①
+#label("test①")
+```


### PR DESCRIPTION
Check for `XID_Continue` for the identifiers in typst to match the rust implementation.

Added `unicode-data` as a dependency for this for access to the `isXIDContinue` function to be able to easily check this. I hope this is an acceptable dependency addition in this case.

Also applied the following types of hlint suggestions that came up:
- redundant $
- literal pattern
- moving brackets to avoid $

Fixes: #10816