### PR TITLE
Add figure placement for MD to LaTeX

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -5643,9 +5643,13 @@ image's alt text will be used as the caption.
     ![This is the caption](/url/of/image.png)
 
 How this is rendered depends on the output format. Some output
-formats (e.g. RTF) do not yet support figures.  In those
+formats (e.g. RTF) do not yet support figures. In those
 formats, you'll just get an image in a paragraph by itself, with
-no caption.
+no caption. For LaTeX output, you can specify a [figure's
+positioning](https://www.overleaf.com/learn/latex/Positioning_images_and_tables#The_figure_environment)
+by adding the `latex-pos` attribute.
+
+    ![This is the caption](/url/of/image.png){latex-pos="ht"}
 
 If you just want a regular inline image, just make sure it is not
 the only thing in the paragraph. One way to do this is to insert a

--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1057,8 +1057,11 @@ implicitFigure (ident, classes, attribs) capt url title =
   let alt = case "alt" `lookup` attribs of
               Just alt'       -> B.text alt'
               _               -> capt
-      attribs' = filter ((/= "alt") . fst) attribs
-      figattr = (ident, mempty, mempty)
+      attribs' = filter ((/= "latex-pos") . fst) (filter ((/= "alt") . fst) attribs)
+      figattribs = case lookup "latex-pos" attribs of
+        Just p -> [("latex-pos", p)]
+        _      -> mempty
+      figattr = (ident, mempty, figattribs)
       caption = B.simpleCaption $ B.plain capt
       figbody = B.plain $ B.imageWith ("", classes, attribs') url title alt
   in B.figureWith figattr caption figbody

--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -644,11 +644,14 @@ blockToLaTeX (Header level (id',classes,_) lst) = do
 blockToLaTeX (Table attr blkCapt specs thead tbodies tfoot) =
   tableToLaTeX inlineListToLaTeX blockListToLaTeX
                (Ann.toTable attr blkCapt specs thead tbodies tfoot)
-blockToLaTeX (Figure (ident, _, _) captnode body) = do
+blockToLaTeX (Figure (ident, _, kvs) captnode body) = do
   opts <- gets stOptions
   (capt, captForLof, footnotes) <- getCaption inlineListToLaTeX True captnode
   lab <- labelFor ident
   let caption = "\\caption" <> captForLof <> braces capt <> lab
+      placement = case lookup "latex-pos" kvs of
+        Just p -> brackets (text (T.unpack p))
+        _      -> text ""
 
   isSubfigure <- gets stInFigure
   modify $ \st -> st{ stInFigure = True }
@@ -680,7 +683,7 @@ blockToLaTeX (Figure (ident, _, _) captnode body) = do
           cr <> "\\begin{center}" $$ contents $+$ capt $$ "\\end{center}"
     _ | isSubfigure ->
           innards
-    _ ->  cr <> "\\begin{figure}" $$ innards $$ "\\end{figure}")
+    _ ->  cr <> "\\begin{figure}" <> placement $$ innards $$ "\\end{figure}")
     $$ footnotes
 
 toSubfigure :: PandocMonad m => Int -> Block -> LW m (Doc Text)

--- a/test/Tests/Readers/Markdown.hs
+++ b/test/Tests/Readers/Markdown.hs
@@ -578,4 +578,11 @@ tests = [ testGroup "inline code"
                   (str "@cita" <> space <> str "[foo]")
               )
           ]
+      , testGroup "figures"
+        [ "latex placement" =:
+          "![caption](img.jpg){latex-pos=\"htbp\" alt=\"alt text\"}" =?>
+          figureWith ("", [], [("latex-pos", "htbp")])
+            (simpleCaption $ plain "caption")
+            (plain $ image (T.pack "img.jpg") (T.pack "") (text "alt text"))
         ]
+      ]

--- a/test/Tests/Writers/LaTeX.hs
+++ b/test/Tests/Writers/LaTeX.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Tests.Writers.LaTeX (tests) where
 
-import Data.Text (unpack)
+import Data.Text (pack, unpack)
 import Test.Tasty
 import Test.Tasty.HUnit (HasCallStack)
 import Tests.Helpers
@@ -241,5 +241,15 @@ tests = [ testGroup "code blocks"
                       , "\\addcontentsline{toc}{paragraph}{header6}"
                       ]
             ]
+          ]
+        , testGroup "figures"
+          [ "placement" =:
+            figureWith ("", [], [("latex-pos", "htbp")])
+            (simpleCaption $ plain "caption")
+            (plain $ image (pack "img.jpg") (pack "") (text "alt text"))
+            =?>
+              "\\begin{figure}[htbp]\n\\centering\n"
+              <> "\\pandocbounded{\\includegraphics[keepaspectratio,alt={alt text}]{img.jpg}}\n"
+              <> "\\caption{caption}\n\\end{figure}"
           ]
         ]


### PR DESCRIPTION
This PR resolves #10369 by using the `latex-pos` attribute of a figure to set its [positioning](https://www.overleaf.com/learn/latex/Positioning_images_and_tables#The_figure_environment) in LaTeX output. Additionally, the MD reader removes this attribute from the image in a figure and passes it to the figure itself. Originally, only the image's identifier is passed to the figure while all the other attributes are kept with the image.

I think that the LaTeX reader should store a figure's positioning as well, but I am not sure how to edit the reader to do this.