### PR TITLE
LaTeX writer: Protect VERB in caption

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX/Caption.hs
+++ b/src/Text/Pandoc/Writers/LaTeX/Caption.hs
@@ -23,7 +23,7 @@ import Text.Pandoc.Shared
 import Text.Pandoc.Walk
 import Text.Pandoc.Writers.LaTeX.Notes (notesToLaTeX)
 import Text.Pandoc.Writers.LaTeX.Types
-  ( LW, WriterState (stExternalNotes, stNotes) )
+  ( LW, WriterState (stExternalNotes, stNotes, stInCaption) )
 
 
 -- | Produces the components of a LaTeX 'caption' command. Returns a triple
@@ -35,6 +35,7 @@ getCaption :: PandocMonad m
            -> Caption
            -> LW m (Doc Text, Doc Text, Doc Text)
 getCaption inlineListToLaTeX externalNotes (Caption maybeShort long) = do
+  modify $ \st -> st{ stInCaption = True }
   let long' = blocksToInlines long
   oldExternalNotes <- gets stExternalNotes
   modify $ \st -> st{ stExternalNotes = externalNotes, stNotes = [] }
@@ -53,4 +54,5 @@ getCaption inlineListToLaTeX externalNotes (Caption maybeShort long) = do
                              then toShortCapt long'
                              else return empty
                   Just short -> toShortCapt short
+  modify $ \st -> st{ stInCaption = False }
   return (capt, captForLof, footnotes)

--- a/src/Text/Pandoc/Writers/LaTeX/Types.hs
+++ b/src/Text/Pandoc/Writers/LaTeX/Types.hs
@@ -54,6 +54,7 @@ data WriterState =
   , stLang          :: Maybe Lang    -- ^ lang specified in metadata
   , stInSoulCommand :: Bool          -- ^ in a soul command like ul
   , stCancel        :: Bool          -- ^ true if document uses \cancel
+  , stInCaption     :: Bool          -- ^ true if in a caption
   }
 
 startingState :: WriterOptions -> WriterState
@@ -95,4 +96,5 @@ startingState options =
   , stLang = Nothing
   , stInSoulCommand = False
   , stCancel = False
+  , stInCaption = False
   }

--- a/test/command/6821.md
+++ b/test/command/6821.md
@@ -1,0 +1,80 @@
+```
+% pandoc -f native -t latex
+[ Para [ Code ( "" , [ "python" ] , [] ) "x = 5" ]
+, Figure
+    ( "" , [] , [] )
+    (Caption
+       Nothing
+       [ Plain
+           [ Str "This"
+           , Space
+           , Str "is"
+           , Space
+           , Str "a"
+           , Space
+           , Str "test"
+           , Space
+           , Code ( "" , [ "python" ] , [] ) "x = 5"
+           ]
+       ])
+    [ Plain
+        [ Image
+            ( "" , [] , [] )
+            [ Str "This"
+            , Space
+            , Str "is"
+            , Space
+            , Str "a"
+            , Space
+            , Str "test"
+            , Space
+            , Code ( "" , [ "python" ] , [] ) "x = 5"
+            ]
+            ( "test.png" , "" )
+        ]
+    ]
+, Table
+    ( "" , [] , [] )
+    (Caption
+       Nothing
+       [ Plain [ Code ( "" , [ "cpp" ] , [] ) "caption" ] ])
+    [ ( AlignDefault , ColWidthDefault ) ]
+    (TableHead ( "" , [] , [] ) [])
+    [ TableBody ( "" , [] , [] ) (RowHeadColumns 0) [] [] ]
+    (TableFoot
+       ( "" , [] , [] )
+       [ Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "A" ] ]
+           ]
+       ])
+, Para [ Code ( "" , [ "cpp" ] , [] ) "caption" ]
+]
+^D
+\VERB|\NormalTok{x }\OperatorTok{=} \DecValTok{5}|
+
+\begin{figure}
+\centering
+\pandocbounded{\includegraphics[keepaspectratio,alt={This is a test x = 5}]{test.png}}
+\caption{This is a test
+\protect\VERB|\NormalTok{x }\OperatorTok{=} \DecValTok{5}|}
+\end{figure}
+
+\begin{longtable}[]{@{}l@{}}
+\caption{\protect\VERB|\NormalTok{caption}|}\tabularnewline
+\toprule\noalign{}
+\endfirsthead
+\endhead
+\midrule\noalign{}
+A \\
+\bottomrule\noalign{}
+\endlastfoot
+\end{longtable}
+
+\VERB|\NormalTok{caption}|
+```


### PR DESCRIPTION
Fixes #6821
Fixes #6101

Added `stInCaption` to be able to determine whether currentlyl inside a caption or not.
Also applied hlint suggestions.