### PR TITLE
RST writer: Add col spans for simple tables

### DIFF
--- a/test/command/10127.md
+++ b/test/command/10127.md
@@ -1,3 +1,5 @@
+RST Reader
+
 ```
 % pandoc -f rst -t native
 =====  =====  ======
@@ -24,7 +26,7 @@ Full column row
 ----------------------------------------------------
 Row with         Col spans     For visual separation
 ---------------  ------------  ---------------------  
-Row with col span 1            On the left
+Row with col span 2            On the left
 -----------------------------  ---------------------
 Final row
 ===============  ============  =====================
@@ -335,7 +337,7 @@ Final row
                     , Space
                     , Str "span"
                     , Space
-                    , Str "1"
+                    , Str "2"
                     ]
                 ]
             , Cell
@@ -369,4 +371,343 @@ Final row
     ]
     (TableFoot ( "" , [] , [] ) [])
 ]
+```
+
+RST Writer
+```
+% pandoc -f native -t rst
+[ Table
+    ( "" , [] , [] )
+    (Caption Nothing [])
+    [ ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    ]
+    (TableHead
+       ( "" , [] , [] )
+       [ Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 2)
+               [ Plain [ Str "Inputs" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "Output" ] ]
+           ]
+       , Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "A" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "B" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "A" , Space , Str "or" , Space , Str "B" ]
+               ]
+           ]
+       ])
+    [ TableBody
+        ( "" , [] , [] )
+        (RowHeadColumns 0)
+        []
+        [ Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "False" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "False" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "False" ] ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "True" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "False" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "True" ] ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "False" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "True" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "True" ] ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "True" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "True" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "True" ] ]
+            ]
+        ]
+    ]
+    (TableFoot ( "" , [] , [] ) [])
+, Table
+    ( "" , [] , [] )
+    (Caption Nothing [])
+    [ ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    ]
+    (TableHead
+       ( "" , [] , [] )
+       [ Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 3)
+               [ Plain
+                   [ Str "Full"
+                   , Space
+                   , Str "column"
+                   , Space
+                   , Str "header"
+                   ]
+               ]
+           ]
+       , Row
+           ( "" , [] , [] )
+           [ Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "Header" , Space , Str "One" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "Header" , Space , Str "Two" ] ]
+           , Cell
+               ( "" , [] , [] )
+               AlignDefault
+               (RowSpan 1)
+               (ColSpan 1)
+               [ Plain [ Str "Header" , Space , Str "3" ] ]
+           ]
+       ])
+    [ TableBody
+        ( "" , [] , [] )
+        (RowHeadColumns 0)
+        []
+        [ Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "Row" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 2)
+                [ Plain
+                    [ Str "With"
+                    , Space
+                    , Str "col"
+                    , Space
+                    , Str "span"
+                    , Space
+                    , Str "2"
+                    , Space
+                    , Str "on"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "right"
+                    ]
+                ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 3)
+                [ Plain
+                    [ Str "Full"
+                    , Space
+                    , Str "column"
+                    , Space
+                    , Str "row"
+                    ]
+                ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 2)
+                [ Plain
+                    [ Str "Row"
+                    , Space
+                    , Str "with"
+                    , Space
+                    , Str "col"
+                    , Space
+                    , Str "span"
+                    , Space
+                    , Str "2"
+                    ]
+                ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain
+                    [ Str "On"
+                    , Space
+                    , Str "the"
+                    , Space
+                    , Str "left"
+                    ]
+                ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Plain [ Str "Final" , Space , Str "row" ] ]
+            , Cell
+                ( "" , [] , [] ) AlignDefault (RowSpan 1) (ColSpan 1) []
+            , Cell
+                ( "" , [] , [] ) AlignDefault (RowSpan 1) (ColSpan 1) []
+            ]
+        ]
+    ]
+    (TableFoot
+      ( "" , [] , [] ) 
+      [ Row
+          ( "" , [] , [] )
+          [ Cell
+              ( "" , [] , [] )
+              AlignDefault
+              (RowSpan 1)
+              (ColSpan 1)
+              [ Plain [ Str "Footer" , Space , Str "Row" ] ]
+          , Cell
+              ( "" , [] , [] )
+              AlignDefault
+              (RowSpan 1)
+              (ColSpan 1)
+              [ Plain [ Str "at" , Space , Str "the" ] ]
+          , Cell
+              ( "" , [] , [] )
+              AlignDefault
+              (RowSpan 1)
+              (ColSpan 1)
+              [ Plain [ Str "bottom" ] ]
+          ]
+      ])
+]
+^D
+====== ===== ======
+Inputs       Output
+------------ ------
+A      B     A or B
+====== ===== ======
+False  False False
+True   False True
+False  True  True
+True   True  True
+====== ===== ======
+
+=================== ============================ ===========
+Full column header                               
+------------------------------------------------------------
+Header One          Header Two                   Header 3
+=================== ============================ ===========
+Row                 With col span 2 on the right 
+------------------- ----------------------------------------
+Full column row                                  
+------------------------------------------------------------
+Row with col span 2                              On the left
+------------------------------------------------ -----------
+Final row                                        
+Footer Row          at the                       bottom
+=================== ============================ ===========
 ```


### PR DESCRIPTION
Together with the reader part from https://github.com/jgm/pandoc/pull/11115 this writer part fixes #10127