### PR TITLE
MANUAL.txt: remove some redundancy

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -151,8 +151,7 @@ scheme that use a colored background. The use of `xelatex` or
 uses [`selnolig`] and [`lua-ul`]. `xelatex` uses [`bidi`] (with
 the `dir` variable set).
 If the `mathspec` variable is set, `xelatex` will use [`mathspec`]
-instead of [`unicode-math`].  The [`upquote`] and [`microtype`]
-packages are used if available, and [`csquotes`] will be used
+instead of [`unicode-math`].  The [`csquotes`] package will be used
 for [typography] if the `csquotes` variable or metadata field is
 set to a true value.  The [`natbib`], [`biblatex`], [`bibtex`],
 and [`biber`] packages can optionally be used for [citation

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -193,6 +193,7 @@ better line breaks in URLs), and [`footnotehyper`] or
 [`longtable`]: https://ctan.org/pkg/longtable
 [`mathspec`]: https://ctan.org/pkg/mathspec
 [`microtype`]: https://ctan.org/pkg/microtype
+[`multirow`]: https://ctan.org/pkg/multirow
 [`natbib`]: https://ctan.org/pkg/natbib
 [`parskip`]: https://ctan.org/pkg/parskip
 [`polyglossia`]: https://ctan.org/pkg/polyglossia


### PR DESCRIPTION
In documenting LaTeX packages used by generated documents, don’t mention
some packages twice in one (already long) paragraph.

This addresses part of #11178.