### PR TITLE
LaTeX writer: Fix strikeout in links

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -1120,23 +1120,25 @@ inlineToLaTeX (Link (id',_,_) txt (src,_)) =
                      then "\\hyperlink" <> braces (literal lab) <> braces contents
                      else "\\hyperref" <> brackets (literal lab) <> braces contents
      _ -> case txt of
+          -- For soul sommands we need to protect \url and \href in an mbox or
+          -- we get an error (see #9366)
           [Str x] | T.all isAscii x  -- see #8802
                   , unEscapeString (T.unpack x) ==
                     unEscapeString (T.unpack src) ->  -- autolink
                do modify $ \s -> s{ stUrl = True }
                   src' <- stringToLaTeX URLString (escapeURI src)
-                  return $ literal $ "\\url{" <> src' <> "}"
+                  protectInMboxIfInSoul $ literal $ "\\url{" <> src' <> "}"
           [Str x] | Just rest <- T.stripPrefix "mailto:" src,
                     unEscapeString (T.unpack x) == unEscapeString (T.unpack rest) -> -- email autolink
                do modify $ \s -> s{ stUrl = True }
                   src' <- stringToLaTeX URLString (escapeURI src)
                   contents <- inlineListToLaTeX txt
-                  return $ "\\href" <> braces (literal src') <>
+                  protectInMboxIfInSoul $ "\\href" <> braces (literal src') <>
                      braces ("\\nolinkurl" <> braces contents)
           _ -> do contents <- inlineListToLaTeX txt
                   src' <- stringToLaTeX URLString (escapeURI src)
-                  return $ literal ("\\href{" <> src' <> "}{") <>
-                           contents <> char '}')
+                  protectInMboxIfInSoul $ literal ("\\href{" <> src' <> "}{") <>
+                    contents <> char '}')
      >>= (if T.null id'
              then return
              else \x -> do
@@ -1268,6 +1270,15 @@ inSoulCommand pa = do
   result <- pa
   modify $ \st -> st{ stInSoulCommand = oldInSoulCommand }
   pure result
+
+-- Inside soul commands some commands need to be protected in an mbox
+-- or we get an error (e.g. see #1294)
+protectInMboxIfInSoul :: (PandocMonad m, HasChars a) => Doc a -> LW m (Doc a)
+protectInMboxIfInSoul command = do
+  inSoul <- gets stInSoulCommand
+  return $ if inSoul
+    then "\\mbox" <> braces command
+    else command
 
 -- Babel languages with a .ldf that works well with all engines (see #8283).
 -- We follow the guidance from the Babel documentation:

--- a/test/command/9366.md
+++ b/test/command/9366.md
@@ -1,0 +1,34 @@
+```
+% pandoc -f native -t latex
+[ Para
+    [ Strikeout
+        [ Link
+            ( "" , [] , [] )
+            [ Str "Example" ]
+            ( "https://example.com" , "" )
+        ]
+    ]
+, Para
+    [ Strikeout
+        [ Link
+            ( "" , [] , [] )
+            [ Str "https://example.com" ]
+            ( "https://example.com" , "" )
+        ]
+    ]
+, Para
+    [ Strikeout
+        [ Link
+            ( "" , [] , [] )
+            [ Str "info@example.com" ]
+            ( "mailto:info@example.com" , "" )
+        ]
+    ]
+]
+^D
+\st{\mbox{\href{https://example.com}{Example}}}
+
+\st{\mbox{\url{https://example.com}}}
+
+\st{\mbox{\href{mailto:info@example.com}{\nolinkurl{info@example.com}}}}
+```


### PR DESCRIPTION
As in #1294 `\url` and `\href` need to be protected inside an mbox for soul commands.

Fixes: #9366