### PR TITLE
fix(templates/default.typst): wrong syntax for bibliography inclusion

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -149,7 +149,7 @@ $elseif(bibliographystyle)$
 $endif$
 $if(bibliography)$
 
-#bibliography($for(bibliography)$"$bibliography$"$sep$,$endfor$$if(full-bibliography)$, full: true$endif$)
+#bibliography(($for(bibliography)$"$bibliography$"$sep$,$endfor$)$if(full-bibliography)$, full: true$endif$)
 $endif$
 $endif$
 $for(include-after)$


### PR DESCRIPTION
`#bibliography(...)` should be an array when multiple bibliography files are provided (https://typst.app/docs/reference/model/bibliography/#parameters-sources).

Currently, `#bibliography("path/one.bib", "path/two.bib")` is produced instead of `#bibliography(("path/one.bib", "path/two.bib"))`
