### PR TITLE
LaTeX reader: fix spurious paragraph breaks in math environments

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX/Math.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Math.hs
@@ -21,7 +21,7 @@ import qualified Data.Sequence as Seq
 import Text.Pandoc.Readers.LaTeX.Parsing
 import Text.Pandoc.TeX
 import Text.Pandoc.Class
-import Text.Pandoc.Shared (trimMath, stripTrailingNewlines)
+import Text.Pandoc.Shared (trimMath, trimr)
 import Text.Pandoc.Parsing hiding (blankline, mathDisplay, mathInline,
                             optional, space, spaces, withRaw, (<|>))
 import Control.Applicative ((<|>), optional)
@@ -82,7 +82,7 @@ mathEnv :: PandocMonad m => Text -> LP m Text
 mathEnv name = withMathMode $ do
   optional blankline
   res <- manyTill anyTok (end_ name)
-  return $ stripTrailingNewlines $ untokenize res
+  return $ trimr $ untokenize res
 
 inlineEnvironment :: PandocMonad m => LP m Inlines
 inlineEnvironment = try $ do

--- a/test/command/latex-math-trailing-space.md
+++ b/test/command/latex-math-trailing-space.md
@@ -1,0 +1,38 @@
+Test that trailing spaces before \end{equation} don't create spurious paragraph breaks:
+
+```
+% pandoc -f latex -t latex
+\begin{equation}
+  a
+ \end{equation}
+^D
+\begin{equation}
+  a
+\end{equation}
+```
+
+Same for align environment:
+
+```
+% pandoc -f latex -t latex
+\begin{align}
+  x &= y \\
+ \end{align}
+^D
+\begin{align}
+  x &= y \\
+\end{align}
+```
+
+Test with multiple trailing spaces:
+
+```
+% pandoc -f latex -t latex
+\begin{equation}
+  a + b
+   \end{equation}
+^D
+\begin{equation}
+  a + b
+\end{equation}
+```


### PR DESCRIPTION
## PR Summary
When trailing spaces appeared before `\end{equation}` or `\end{align}`, pandoc incorrectly inserted blank lines in the output, breaking the math environment. This occurred because `mathEnv` used `stripTrailingNewlines` which only removed newlines but left spaces. The fix changes to `trimr` which removes all trailing whitespace (spaces, tabs, and newlines).

Example input:
```latex
\begin{equation}
 a
 \end{equation}
```
Outpt before (broken):
```latex
\begin{equation}
 a

\end{equation}
```
Spurious blank line creates paragraph break
Output after (fixed):
```latex
\begin{equation}
 a
\end{equation}
```

Note: The added tests may be a bit too specific, but I included them for completeness. Let me know if we should drop them.

Fixes #11257.