### PR TITLE
TWiki reader: Fix handling of blank lines in TWiki HTML inline spans

### DIFF
--- a/test/twiki-reader.native
+++ b/test/twiki-reader.native
@@ -79,6 +79,44 @@ Pandoc
           , Str "emph"
           ]
       ]
+  , Para
+      [ Strong
+          [ Str "strong"
+          , Space
+          , Str "with"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "lines"
+          ]
+      ]
+  , Para
+      [ Emph
+          [ Str "emphasis"
+          , Space
+          , Str "with"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "lines"
+          ]
+      ]
+  , Para
+      [ Strong
+          [ Str "bold"
+          , Space
+          , Str "with"
+          , Space
+          , Str "multiple"
+          , Space
+          , Str "blank"
+          , Space
+          , Str "lines"
+          ]
+      ]
+  , Para
+      [ Code ( "" , [] , [] ) "inline code\n\nwith blank\n\nlines"
+      ]
   , Header
       1
       ( "horizontal-rule" , [] , [] )

--- a/test/twiki-reader.twiki
+++ b/test/twiki-reader.twiki
@@ -26,6 +26,26 @@ __strong and emph__
 
 _<b>strong inside</b> emph_
 
+<strong>strong with
+
+blank lines</strong>
+
+<em>emphasis with
+
+blank lines</em>
+
+<b>bold with
+
+multiple
+
+blank lines</b>
+
+<code>inline code
+
+with blank
+
+lines</code>
+
 ---+ horizontal rule
 
 top


### PR DESCRIPTION
Fixes https://github.com/jgm/pandoc/issues/10743

Issue: TWiki reader treats `<strong>/<em>/<b>` elements as plain inline streams, so embedded blank lines triggers parse errors.

Fix: added `parseHtmlInlineContentWithAttrs` that converts blank lines to spaces during inline parsing and switched the bold/emphasis HTML handlers to use it

Testing: included test cases for different elements with multiple lines