### PR TITLE
Modify prefix logic for quoted LaTeX elements

### DIFF
--- a/src/Text/Pandoc/Writers/LaTeX.hs
+++ b/src/Text/Pandoc/Writers/LaTeX.hs
@@ -832,7 +832,7 @@ sectionHeader classes ident level lst = do
                           5  -> "subparagraph"
                           _  -> ""
   inQuote <- gets stInQuote
-  let prefix = if inQuote && level' >= 4
+  let prefix = if inQuote
                   then text "\\mbox{}%"
                   -- needed for \paragraph, \subparagraph in quote environment
                   -- see http://tex.stackexchange.com/questions/169830/


### PR DESCRIPTION
Adjust prefix for quoted paragraphs and subparagraphs in LaTeX.

Ref [Issue 11281: H1-H3 Headers Inside Blockquotes Generate Invalid LaTeX](https://github.com/jgm/pandoc/issues/11281)

> Have you tried testing LaTeX with the mbox before a \section command inside a block quote? If this works properly, I see no reason not to implement this simple change. It should just be a simple matter of changing https://github.com/jgm/pandoc/blob/main/src/Text/Pandoc/Writers/LaTeX.hs#L835-L839