### PR TITLE
Docx reader: check recursively for caption styles.

### DIFF
--- a/src/Text/Pandoc/Readers/Docx/Parse.hs
+++ b/src/Text/Pandoc/Readers/Docx/Parse.hs
@@ -1361,13 +1361,19 @@ findBlip el = do
   -- return svg if present:
   filterElementName (\(QName tag _ _) -> tag == "svgBlip") el `mplus` pure blip
 
+-- | Checks if any style in the style hierarchy is a caption style.
 hasCaptionStyle :: ParagraphStyle -> Bool
-hasCaptionStyle parstyle = any (isCaptionStyleName . pStyleName) (pStyle parstyle)
+hasCaptionStyle =
+  any (isCaptionStyleName . pStyleName) . concatMap nestedStyles . pStyle
  where -- note that these are case insensitive:
    isCaptionStyleName "caption" = True
    isCaptionStyleName "table caption" = True
    isCaptionStyleName "image caption" = True
    isCaptionStyleName _ = False
+
+   -- Gets all the style names in the style hierarchy
+   nestedStyles :: ParStyle -> [ParStyle]
+   nestedStyles ps = ps : maybe [] nestedStyles (psParentStyle ps)
 
 stripCaptionLabel :: [Element] -> [Element]
 stripCaptionLabel els =


### PR DESCRIPTION
The docx reader uses caption styles to identify figures and captioned tables. It now checks for known caption styles in the full styles hierarchy of a paragraph instead of just checking the style directly. This allows to recognize caption styles that are built on top of the basic *caption* style, as is sometimes the case in sophisticated styles.