### PR TITLE
Typst template: Fix keywords usage.

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -65,7 +65,7 @@ $endfor$
     ),
 $endif$
 $if(keywords)$
-  keywords: ($for(keywords)$$keyword$$sep$,$endfor$),
+  keywords: ($for(keywords)$$keywords$$sep$,$endfor$),
 $endif$
 $if(date)$
   date: [$date$],


### PR DESCRIPTION
Previously the template turned any `keywords` defined in Pandoc metadata into empty objects due to a misnomer in a loop variable. This in turn was rejected by the Typst compiler as invalid syntax, making document generation with keywords impossible.