### PR TITLE
Update MANUAL.txt with Markdown extensions info

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3595,8 +3595,8 @@ Note that Markdown extensions added to the `ipynb` format
 affect Markdown cells in Jupyter notebooks (as do command-line
 options like `--markdown-headings`).
 
-The following extensions are enabled by defaut. (See also 
-[Non-default extensions] below.)
+The following extensions are enabled by default. (See also 
+[Non-default extensions].)
 
 ## Typography
 


### PR DESCRIPTION
Without my change, users will not realize they have been reading the default extensions section until they finally encounter the non-default section!

Please also hyperlink my see also target if possible.