### PR TITLE
HTML writer: support parenthesis list delimeters

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -210,3 +210,10 @@ $endif$
 $if(csl-css)$
 $styles.citations.html()$
 $endif$
+$for(counter-styles)$
+@counter-style $it.name$ {
+  system: extends $it.extends$;
+  prefix: "$it.prefix$";
+  suffix: "$it.suffix$";
+}
+$endfor$

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -39,7 +39,7 @@ import Data.List (intercalate, intersperse, partition, delete, (\\))
 import qualified Data.List as L
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Containers.ListUtils (nubOrd)
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -85,6 +85,8 @@ import Text.XML.Light (elChildren, unode, unqual)
 import qualified Text.XML.Light as XML
 import Text.XML.Light.Output
 import Data.String (fromString)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 
 data WriterState = WriterState
     { stNotes        :: [Html]  -- ^ List of notes
@@ -102,6 +104,7 @@ data WriterState = WriterState
     , stCsl          :: Bool    -- ^ Has CSL references
     , stCslEntrySpacing :: Maybe Int  -- ^ CSL entry spacing
     , stBlockLevel   :: Int     -- ^ Current block depth, excluding section divs
+    , stCounterStyles   :: Set.Set (ListNumberStyle, ListNumberDelim)    -- ^ List styles used in this document
     }
 
 defaultWriterState :: WriterState
@@ -119,7 +122,8 @@ defaultWriterState = WriterState {stNotes= [],
                                   stCodeBlockNum = 0,
                                   stCsl = False,
                                   stCslEntrySpacing = Nothing,
-                                  stBlockLevel = 0}
+                                  stBlockLevel = 0,
+                                  stCounterStyles = Set.empty}
 
 -- Helpers to render HTML with the appropriate function.
 
@@ -356,6 +360,16 @@ pandocToHtml opts (Pandoc meta blocks) = do
 
         _ -> mempty
   let mCss :: Maybe [Text] = lookupContext "css" metadata
+  let counterStyle :: ListNumberStyle -> ListNumberDelim -> Maybe (Map Text Text)
+      counterStyle _ DefaultDelim = Nothing
+      counterStyle _ Period = Nothing
+      counterStyle num del = Just $ Map.fromList [
+        ("name", (counterStyleName num del)),
+        ("extends", (camelCaseToHyphenated $ tshow num)),
+        ("prefix", case del of
+          OneParen -> ""
+          TwoParens -> "("),
+        ("suffix", ")") ]
   let context :: Context Text
       context =   (if stHighlighting st
                       then case writerHighlightMethod opts of
@@ -461,6 +475,7 @@ pandocToHtml opts (Pandoc meta blocks) = do
                   defField "s5-url" ("s5/default" :: Doc Text) .
                   defField "table-caption-below"
                      (writerTableCaptionPosition opts == CaptionBelow) .
+                  defField "counter-styles" (mapMaybe (uncurry counterStyle) (Set.toList $ stCounterStyles st)) .
                   defField "html5" (stHtml5 st) $
                   metadata
   return (thebody, context)
@@ -1025,26 +1040,28 @@ blockToHtmlInner opts (BulletList lst) = do
   contents <- mapM (listItemToHtml opts) lst
   (if isJust (mapM toTaskListItem lst) then (! A.class_ "task-list") else id) <$>
     unordList opts contents
-blockToHtmlInner opts (OrderedList (startnum, numstyle, _) lst) = do
+blockToHtmlInner opts (OrderedList (startnum, numstyle, delstyle) lst) = do
   contents <- mapM (listItemToHtml opts) lst
   html5 <- gets stHtml5
-  let numstyle' = case numstyle of
-                       Example -> "decimal"
-                       _       -> camelCaseToHyphenated $ tshow numstyle
+  modify (\st -> st{stCounterStyles = Set.insert (numstyle, delstyle) (stCounterStyles st)})
+  let counterStyle = case writerTemplate opts of
+                       Nothing -> case numstyle of
+                         Example -> "decimal"
+                         _       -> camelCaseToHyphenated $ tshow numstyle
+                       Just _ -> counterStyleName numstyle delstyle
   let attribs = [A.start $ toValue startnum | startnum /= 1] ++
                 [A.class_ "example" | numstyle == Example] ++
                 (if numstyle /= DefaultStyle
-                   then if html5
-                           then [A.type_ $
-                                 case numstyle of
-                                      Decimal    -> "1"
-                                      LowerAlpha -> "a"
-                                      UpperAlpha -> "A"
-                                      LowerRoman -> "i"
-                                      UpperRoman -> "I"
-                                      _          -> "1"]
-                           else [A.style $ toValue $ "list-style-type: " <>
-                                   numstyle']
+                    then [A.style $ toValue $ "list-style-type: " <> counterStyle] ++
+                      if html5 then [A.type_ $
+                           case numstyle of
+                                Decimal    -> "1"
+                                LowerAlpha -> "a"
+                                UpperAlpha -> "A"
+                                LowerRoman -> "i"
+                                UpperRoman -> "I"
+                                _          -> "1"]
+                      else []
                    else [])
   l <- ordList opts contents
   return $ L.foldl' (!) l attribs
@@ -1713,6 +1730,12 @@ inDiv cls x = do
 isRef :: Text -> Bool
 isRef t = "\\ref{" `T.isPrefixOf` t || "\\eqref{" `T.isPrefixOf` t
 
+counterStyleName :: ListNumberStyle -> ListNumberDelim -> Text
+counterStyleName Example _ = "decimal"
+counterStyleName num DefaultDelim = camelCaseToHyphenated $ tshow num
+counterStyleName num Period = camelCaseToHyphenated $ tshow num
+counterStyleName num del = mconcat [camelCaseToHyphenated $ tshow num, "-", camelCaseToHyphenated $ tshow del]
+
 isMathEnvironment :: Text -> Bool
 isMathEnvironment s = "\\begin{" `T.isPrefixOf` s &&
                          envName `elem` mathmlenvs
@@ -1795,3 +1818,4 @@ hasVariable var = checkVar
    checkVar (DT.Concat t1 t2) = checkVar t1 || checkVar t2
    checkVar (DT.Literal _) = False
    checkVar DT.Empty = False
+

--- a/test/command/10328.md
+++ b/test/command/10328.md
@@ -20,7 +20,7 @@ Unwrap divs if they only have the `nonincremental` or `incremental` classes.
 ^D
 <section id="first-slide" class="slide level2">
 <h2>First slide</h2>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li>Note 1</li>
 <li>Note 2</li>
 <li>Note 3</li>
@@ -28,7 +28,7 @@ Unwrap divs if they only have the `nonincremental` or `incremental` classes.
 </section>
 <section id="second-slide" class="slide level2">
 <h2>Second Slide</h2>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li class="fragment">Note 1</li>
 <li class="fragment">Note 2</li>
 <li class="fragment">Note 3</li>

--- a/test/command/11335.md
+++ b/test/command/11335.md
@@ -1,0 +1,109 @@
+Without fancy_lists, we get the Default counter styles
+
+```
+% pandoc -t native -f markdown_strict
+1. A
+2. B
+
+(a) A
+(b) B
+^D
+[ OrderedList
+    ( 1 , DefaultStyle , DefaultDelim )
+    [ [ Plain [ Str "A" ] ] , [ Plain [ Str "B" ] ] ]
+, Para
+    [ Str "(a)"
+    , Space
+    , Str "A"
+    , SoftBreak
+    , Str "(b)"
+    , Space
+    , Str "B"
+    ]
+]
+```
+
+and thus as HTML we don't have `style` or `type` in the `<ol>`:
+
+```
+% pandoc -t html -f markdown_strict
+1. A
+2. B
+
+(a) A
+(b) B
+^D
+<ol>
+<li>A</li>
+<li>B</li>
+</ol>
+<p>(a) A (b) B</p>
+```
+
+With fancy_lists, we get Decimal and Period instead of Default.
+
+```
+% pandoc -t native -f markdown_strict+fancy_lists
+1. A
+2. B
+
+(a) A
+(b) B
+^D
+[ OrderedList
+    ( 1 , Decimal , Period )
+    [ [ Plain [ Str "A" ] ] , [ Plain [ Str "B" ] ] ]
+, OrderedList
+    ( 1 , LowerAlpha , TwoParens )
+    [ [ Plain [ Str "A" ] ] , [ Plain [ Str "B" ] ] ]
+]
+```
+
+With commonmark, we get Decimal and Period even without fancy_lists.
+
+```
+% pandoc -t native -f commonmark
+1. A
+2. B
+
+(a) A
+(b) B
+^D
+[ OrderedList
+    ( 1 , Decimal , Period )
+    [ [ Plain [ Str "A" ] ] , [ Plain [ Str "B" ] ] ]
+, Para
+    [ Str "(a)"
+    , Space
+    , Str "A"
+    , SoftBreak
+    , Str "(b)"
+    , Space
+    , Str "B"
+    ]
+]
+```
+
+With fancy_lists and parens in the markdown source, we don't try to use a
+custom counter-style as the list-style-type in HTML output when no template is
+used.
+
+```
+% pandoc -t html -f markdown
+1. A
+2. B
+
+(a) A
+(b) B
+^D
+<ol style="list-style-type: decimal" type="1">
+<li>A</li>
+<li>B</li>
+</ol>
+<ol style="list-style-type: lower-alpha" type="a">
+<li>A</li>
+<li>B</li>
+</ol>
+```
+
+The `@counter-style` rules are demonstrated in the writer.html5 golden output.

--- a/test/command/5627.md
+++ b/test/command/5627.md
@@ -15,7 +15,7 @@ Something
 ~~~
 ^D
 <h2 id="example">Example</h2>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li>One</li>
 <li>Two <code>--&gt;something&lt;!--</code></li>
 <li>Three</li>
@@ -69,7 +69,7 @@ class="sourceCode html"><code class="sourceCode html"><span id="cb2-1"><a href="
 42. forty-two, separate ordered list
 ^D
 <h2 id="example-3">Example 3</h2>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li><code>--&gt;one&lt;!--</code></li>
 <li>bye <code>--&gt;two &lt;!--</code></li>
 <li>` three, not in block</li>
@@ -81,7 +81,7 @@ class="sourceCode html"><code class="sourceCode html"><span id="cb2-1"><a href="
 <ul>
 <li>separate unordered list `</li>
 </ul>
-<ol start="42" type="1">
+<ol start="42" style="list-style-type: decimal" type="1">
 <li>forty-two, separate ordered list</li>
 </ol>
 ```

--- a/test/command/9042.md
+++ b/test/command/9042.md
@@ -23,7 +23,7 @@ p. lower case
 P. Upper Case
 ^D
 <h1 id="testing-1">Testing</h1>
-<ol type="a">
+<ol style="list-style-type: lower-alpha" type="a">
 <li><p>lower case</p></li>
 <li><p>Upper Case</p></li>
 </ol>

--- a/test/command/tasklist.md
+++ b/test/command/tasklist.md
@@ -58,7 +58,7 @@ paragraph
 <li><label><input type="checkbox" checked="" />checked</label></li>
 </ul>
 <p>paragraph</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li><label><input type="checkbox" />ordered unchecked</label></li>
 <li>[] plain item</li>
 <li><label><input type="checkbox" checked="" />ordered

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -172,6 +172,21 @@
       vertical-align: middle;
     }
     .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+    @counter-style decimal-two-parens {
+      system: extends decimal;
+      prefix: "(";
+      suffix: ")";
+    }
+    @counter-style lower-alpha-one-paren {
+      system: extends lower-alpha;
+      prefix: "";
+      suffix: ")";
+    }
+    @counter-style upper-alpha-two-parens {
+      system: extends upper-alpha;
+      prefix: "(";
+      suffix: ")";
+    }
   </style>
 </head>
 <body>
@@ -359,14 +374,14 @@ back.</p></li>
 </ul></li>
 </ul>
 <h2 id="fancy-list-markers">Fancy list markers</h2>
-<ol start="2" style="list-style-type: decimal">
+<ol start="2" style="list-style-type: decimal-two-parens">
 <li><p>begins with 2</p></li>
 <li><p>and now 3</p>
 <p>with a continuation</p>
 <ol start="4" style="list-style-type: lower-roman">
 <li>sublist with roman numerals, starting with 4</li>
 <li>more items
-<ol style="list-style-type: upper-alpha">
+<ol style="list-style-type: upper-alpha-two-parens">
 <li>a subsublist</li>
 <li>a subsublist</li>
 </ol></li>
@@ -377,9 +392,9 @@ back.</p></li>
 <li>Upper Alpha
 <ol style="list-style-type: upper-roman">
 <li>Upper Roman.
-<ol start="6" style="list-style-type: decimal">
+<ol start="6" style="list-style-type: decimal-two-parens">
 <li>Decimal start with 6
-<ol start="3" style="list-style-type: lower-alpha">
+<ol start="3" style="list-style-type: lower-alpha-one-paren">
 <li>Lower alpha with paren</li>
 </ol></li>
 </ol></li>

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -172,6 +172,21 @@
       vertical-align: middle;
     }
     .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+    @counter-style decimal-two-parens {
+      system: extends decimal;
+      prefix: "(";
+      suffix: ")";
+    }
+    @counter-style lower-alpha-one-paren {
+      system: extends lower-alpha;
+      prefix: "";
+      suffix: ")";
+    }
+    @counter-style upper-alpha-two-parens {
+      system: extends upper-alpha;
+      prefix: "(";
+      suffix: ")";
+    }
   </style>
 </head>
 <body>
@@ -217,7 +232,7 @@ here.</p>
     print &quot;working&quot;;
 }</code></pre>
 <p>A list:</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li>item one</li>
 <li>item two</li>
 </ol>
@@ -286,31 +301,31 @@ These should not be escaped:  \$ \\ \&gt; \[ \{</code></pre>
 </ul>
 <h2 id="ordered">Ordered</h2>
 <p>Tight:</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li>First</li>
 <li>Second</li>
 <li>Third</li>
 </ol>
 <p>and:</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li>One</li>
 <li>Two</li>
 <li>Three</li>
 </ol>
 <p>Loose using tabs:</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li><p>First</p></li>
 <li><p>Second</p></li>
 <li><p>Third</p></li>
 </ol>
 <p>and using spaces:</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li><p>One</p></li>
 <li><p>Two</p></li>
 <li><p>Three</p></li>
 </ol>
 <p>Multiple paragraphs:</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li><p>Item 1, graf one.</p>
 <p>Item 1. graf two. The quick brown fox jumped over the lazy dog’s
 back.</p></li>
@@ -328,7 +343,7 @@ back.</p></li>
 </ul></li>
 </ul>
 <p>Here’s another:</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li>First</li>
 <li>Second:
 <ul>
@@ -339,7 +354,7 @@ back.</p></li>
 <li>Third</li>
 </ol>
 <p>Same thing but with paragraphs:</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li><p>First</p></li>
 <li><p>Second:</p>
 <ul>
@@ -359,27 +374,27 @@ back.</p></li>
 </ul></li>
 </ul>
 <h2 id="fancy-list-markers">Fancy list markers</h2>
-<ol start="2" type="1">
+<ol start="2" style="list-style-type: decimal-two-parens" type="1">
 <li><p>begins with 2</p></li>
 <li><p>and now 3</p>
 <p>with a continuation</p>
-<ol start="4" type="i">
+<ol start="4" style="list-style-type: lower-roman" type="i">
 <li>sublist with roman numerals, starting with 4</li>
 <li>more items
-<ol type="A">
+<ol style="list-style-type: upper-alpha-two-parens" type="A">
 <li>a subsublist</li>
 <li>a subsublist</li>
 </ol></li>
 </ol></li>
 </ol>
 <p>Nesting:</p>
-<ol type="A">
+<ol style="list-style-type: upper-alpha" type="A">
 <li>Upper Alpha
-<ol type="I">
+<ol style="list-style-type: upper-roman" type="I">
 <li>Upper Roman.
-<ol start="6" type="1">
+<ol start="6" style="list-style-type: decimal-two-parens" type="1">
 <li>Decimal start with 6
-<ol start="3" type="a">
+<ol start="3" style="list-style-type: lower-alpha-one-paren" type="a">
 <li>Lower alpha with paren</li>
 </ol></li>
 </ol></li>
@@ -505,7 +520,7 @@ bank
 <dt>orange</dt>
 <dd>
 <p>orange fruit</p>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li>sublist</li>
 <li>sublist</li>
 </ol>
@@ -735,7 +750,7 @@ role="doc-noteref"><sup>3</sup></a></p>
 <p>Notes can go in quotes.<a href="#fn4" class="footnote-ref" id="fnref4"
 role="doc-noteref"><sup>4</sup></a></p>
 </blockquote>
-<ol type="1">
+<ol style="list-style-type: decimal" type="1">
 <li>And in list items.<a href="#fn5" class="footnote-ref" id="fnref5"
 role="doc-noteref"><sup>5</sup></a></li>
 </ol>


### PR DESCRIPTION
Current browsers support defining custom @counter-styles to be used as list-style-type values for lists. This change adds rules to the default HTML styles, as needed, to support lists using the OneParen or TwoParens style. The type="1" (etc.) attribute is retained, which means the browser should do the next-best thing if the @counter-style rule goes missing in somebody's workflow. The custom @counter-styles will not be used in markup written without a template. ("Is there a template at all" doesn't actualy answer the question "will the styles.html partial emit the @counter-styles like we expect" but we resort to this sort of thing in other places.)

This change unconditionally, and arguably redundantly, adds `style="list-style-type: decimal"` (or "lower-alpha", etc.) to `<ol>` elements where it didn't appear before, including in non-standalone output.

That last bit is somewhat unaesthetic (cf. the changed tests) but the code to eliminate the problem would've been conditional-heavy.

Fixes #11326.