### PR TITLE
DocBook reader: Fix adding wrong metadata

### DIFF
--- a/test/command/11300.md
+++ b/test/command/11300.md
@@ -1,0 +1,67 @@
+```
+% pandoc -f docbook -t native -s
+<?xml version="1.0"?>
+<book xmlns="http://docbook.org/ns/docbook" version="5.0" dir="ltr">
+  <info>
+    <title>Book title</title>
+    <subtitle>Book subtitle</subtitle>
+  </info>
+  <chapter>
+    <info>
+      <title>Chapter title</title>
+    </info>
+    <para>My sentence</para>
+  </chapter>
+</book>
+^D
+Pandoc
+  Meta
+    { unMeta =
+        fromList
+          [ ( "subtitle"
+            , MetaInlines [ Str "Book" , Space , Str "subtitle" ]
+            )
+          , ( "title"
+            , MetaInlines [ Str "Book" , Space , Str "title" ]
+            )
+          ]
+    }
+  [ Header
+      1 ( "" , [] , [] ) [ Str "Chapter" , Space , Str "title" ]
+  , Para [ Str "My" , Space , Str "sentence" ]
+  ]
+```
+
+```
+% pandoc -f docbook -t native -s
+<?xml version="1.0"?>
+<book xmlns="http://docbook.org/ns/docbook" version="5.0" dir="ltr">
+  <chapter>
+    <info>
+      <title>Chapter title</title>
+    </info>
+    <para>My sentence</para>
+  </chapter>
+  <info>
+    <title>Book title</title>
+    <subtitle>Book subtitle</subtitle>
+  </info>
+</book>
+^D
+Pandoc
+  Meta
+    { unMeta =
+        fromList
+          [ ( "subtitle"
+            , MetaInlines [ Str "Book" , Space , Str "subtitle" ]
+            )
+          , ( "title"
+            , MetaInlines [ Str "Book" , Space , Str "title" ]
+            )
+          ]
+    }
+  [ Header
+      1 ( "" , [] , [] ) [ Str "Chapter" , Space , Str "title" ]
+  , Para [ Str "My" , Space , Str "sentence" ]
+  ]
+```


### PR DESCRIPTION
Now keep track of the current element stack to only add metadata if inside an appropriate parent element.

Fixes: #11300