### PR TITLE
RTF reader: Ensure new paragraph on \pard

### DIFF
--- a/src/Text/Pandoc/Readers/RTF.hs
+++ b/src/Text/Pandoc/Readers/RTF.hs
@@ -628,8 +628,9 @@ processTok bs (Tok pos tok') = do
     ControlWord "ulnone" _ -> bs <$
       modifyGroup (\g -> g{ gUnderline = False })
     ControlWord "pard" _ -> bs <$ do
+      newbs <- emitBlocks bs
       modifyGroup (const def)
-      getStyleFormatting 0 >>= foldM processTok bs
+      getStyleFormatting 0 >>= foldM processTok newbs
     ControlWord "par" _ -> emitBlocks bs
     _ -> pure bs
 

--- a/test/command/8783.md
+++ b/test/command/8783.md
@@ -1,0 +1,21 @@
+```
+% pandoc -f rtf -t native
+{\rtf1\ansi\ansicpg1252\cocoartf2867
+\cocoatextscaling0\cocoaplatform1{\fonttbl\f0\fnil\fcharset0 HelveticaNeue;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
+{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid1\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid1}}
+{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}}
+\paperw11905\paperh16837\margl1133\margr1133\margb1133\margt1133
+\deftab720
+\pard\tx20\tx180\pardeftab720\li180\fi-180\partightenfactor0
+\ls1\ilvl0
+\f0\fs22 \cf2 {\listtext	\uc0\u8226 	}\cf2 \up0 \nosupersub \ulnone Bullet item\
+\pard\pardeftab720\partightenfactor0
+\cf2 New paragraph}
+^D
+[ BulletList
+    [ [ Para [ Str "Bullet" , Space , Str "item" ] ] ]
+, Para [ Str "New" , Space , Str "paragraph" ]
+]
+```


### PR DESCRIPTION
New paragraphs may start with \pard alone without an explicit paragraph break with \par first.

Fixes: #8783