### PR TITLE
RTF reader: Ensure new paragraph on \pard

### DIFF
--- a/src/Text/Pandoc/Readers/RTF.hs
+++ b/src/Text/Pandoc/Readers/RTF.hs
@@ -627,9 +627,10 @@ processTok bs (Tok pos tok') = do
       modifyGroup (\g -> g{ gUnderline = boolParam mbp })
     ControlWord "ulnone" _ -> bs <$
       modifyGroup (\g -> g{ gUnderline = False })
-    ControlWord "pard" _ -> bs <$ do
+    ControlWord "pard" _ -> do
+      newbs <- emitBlocks bs
       modifyGroup (const def)
-      getStyleFormatting 0 >>= foldM processTok bs
+      getStyleFormatting 0 >>= foldM processTok newbs
     ControlWord "par" _ -> emitBlocks bs
     _ -> pure bs
 

--- a/test/command/8783.md
+++ b/test/command/8783.md
@@ -1,0 +1,33 @@
+```
+% pandoc -f rtf -t native
+{\rtf1\ansi\ansicpg1252\cocoartf2867
+\cocoatextscaling0\cocoaplatform1{\fonttbl\f0\fnil\fcharset0 HelveticaNeue;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
+{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{decimal\}.}{\leveltext\leveltemplateid1\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720\lin720 }{\listname ;}\listid1}
+{\list\listtemplateid2\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid101\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid2}}
+{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}}
+\paperw11905\paperh16837\margl1133\margr1133\margb1133\margt1133
+\deftab720
+\pard\pardeftab720\partightenfactor0
+
+\f0\fs22 \cf2 \up0 \nosupersub \ulnone First paragraph\
+\pard\tx20\tx360\pardeftab720\li360\fi-360\partightenfactor0
+\ls1\ilvl0\cf2 \up0 \nosupersub \ulnone {\listtext	1.	}\cf2 \up0 \nosupersub \ulnone Numbered item\
+\pard\pardeftab720\partightenfactor0
+\cf2 Second paragraph\
+\pard\tx20\tx180\pardeftab720\li180\fi-180\partightenfactor0
+\ls2\ilvl0\cf2 \up0 \nosupersub \ulnone {\listtext	\uc0\u8226 	}\cf2 \up0 \nosupersub \ulnone Bullet item\
+\pard\pardeftab720\partightenfactor0
+\cf2 New paragraph}
+^D
+[ Para [ Str "First" , Space , Str "paragraph" ]
+, OrderedList
+    ( 1 , Decimal , Period )
+    [ [ Para [ Str "Numbered" , Space , Str "item" ] ] ]
+, Para [ Str "Second" , Space , Str "paragraph" ]
+, BulletList
+    [ [ Para [ Str "Bullet" , Space , Str "item" ] ] ]
+, Para [ Str "New" , Space , Str "paragraph" ]
+]
+```


### PR DESCRIPTION
Fixed from previous PR with better test case.

New paragraphs may start with \pard alone without an explicit paragraph break with \par preceding it.

Fixes: #8783