### PR TITLE
RTF reader: Improve hyperlink parsing more

### DIFF
--- a/test/command/10942.md
+++ b/test/command/10942.md
@@ -1,0 +1,97 @@
+Ungrouped field instruction:
+```
+% pandoc -f rtf -t native
+{\rtf1\ansi\deff0
+{\fonttbl{\f0\froman Times New Roman;}}
+{\colortbl;\red0\green0\blue0;}
+\deftab720
+
+\trowd\trleft0\cellx2000\cellx4000
+\pard\intbl
+{{\field{\*\fldinst HYPERLINK "https://example.com" }{\fldrslt {\hich\af0\loch\hich\af0\loch\cf0\f0\cf0\f0\loch
+{\*\bkmkstart _dx_frag_StartFragment}{\*\bkmkend _dx_frag_StartFragment}Problem Text}}}}\cell
+\pard\intbl Normal Text\cell
+\row
+
+\trowd\trleft0\cellx2000\cellx4000
+\pard\intbl Simple Text\cell
+\pard\intbl More Text\cell
+\row
+}
+^D
+[ Table
+    ( "" , [] , [] )
+    (Caption Nothing [])
+    [ ( AlignDefault , ColWidthDefault )
+    , ( AlignDefault , ColWidthDefault )
+    ]
+    (TableHead ( "" , [] , [] ) [])
+    [ TableBody
+        ( "" , [] , [] )
+        (RowHeadColumns 0)
+        []
+        [ Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Para
+                    [ Link
+                        ( "" , [] , [] )
+                        [ Str "Problem" , Space , Str "Text" ]
+                        ( "https://example.com" , "" )
+                    ]
+                ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Para [ Str "Normal" , Space , Str "Text" ] ]
+            ]
+        , Row
+            ( "" , [] , [] )
+            [ Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Para [ Str "Simple" , Space , Str "Text" ] ]
+            , Cell
+                ( "" , [] , [] )
+                AlignDefault
+                (RowSpan 1)
+                (ColSpan 1)
+                [ Para [ Str "More" , Space , Str "Text" ] ]
+            ]
+        ]
+    ]
+    (TableFoot ( "" , [] , [] ) [])
+]
+```
+
+Additionally, ungrouped field result:
+```
+% pandoc -f rtf -t native
+{\rtf1\ansi\ansicpg1252\cocoartf2867
+\cocoatextscaling0\cocoaplatform1{\fonttbl\f0\fnil\fcharset0 HelveticaNeue;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0;}
+\paperw11905\paperh16837\margl1133\margr1133\margb1133\margt1133
+\deftab720
+\pard\pardeftab720\partightenfactor0
+{\field{\*\fldinst{HYPERLINK "https://example.com"}}{\fldrslt 
+\f0\fs22 \cf2 \up0 \nosupersub \ul \ulc2 link}}}
+^D
+[ Para
+    [ Underline
+        [ Link
+            ( "" , [] , [] )
+            [ Str "link" ]
+            ( "https://example.com" , "" )
+        ]
+    ]
+]
+```


### PR DESCRIPTION
Both the field instruction and its result may be ungrouped.

Fixes: #10942