### PR TITLE
Fix author prefix placeholder in JATS template

### DIFF
--- a/data/templates/default.jats_articleauthoring
+++ b/data/templates/default.jats_articleauthoring
@@ -31,7 +31,7 @@ $if(author.surname)$
 <surname>$if(author.non-dropping-particle)$${author.non-dropping-particle} $endif$${author.surname}</surname>
 <given-names>${author.given-names}$if(author.dropping-particle)$ ${author.dropping-particle}$endif$</given-names>
 $if(author.prefix)$
-<prefix>${author.suffix}</prefix>
+<prefix>${author.prefix}</prefix>
 $endif$
 $if(author.suffix)$
 <suffix>${author.suffix}</suffix>


### PR DESCRIPTION
Follow up on https://github.com/jgm/pandoc/pull/10622 that fix typo in other file