### PR TITLE
LaTeX writer: Add PDF standard support via DocumentMetadata

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -3276,6 +3276,17 @@ These variables function when using BibLaTeX for [citation rendering].
 
     See the section on [reproducible builds].
 
+`pdfstandard`
+:   PDF standard(s) for the document, e.g. `ua-2`, `a-4f`.
+    Supports PDF/A, PDF/X, and PDF/UA variants.
+    Requires LuaLaTeX and LaTeX 2023+. Repeat for multiple standards:
+
+        ---
+        pdfstandard:
+        - ua-2
+        - a-4f
+        ...
+
 [KOMA-Script]: https://ctan.org/pkg/koma-script
 [LaTeX Font Catalogue]: https://tug.org/FontCatalogue/
 [LaTeX font encodings guide]: https://ctan.org/pkg/encguide
@@ -7780,10 +7791,10 @@ page but do not contain semantic information on the content.
 However, it is possible to generate accessible PDFs, which use
 tagging to add semantic information to the document.
 
-Pandoc defaults to LaTeX to generate PDF. Tagging support in LaTeX
-is in development and not readily available, so PDFs generated in
-this way will always be untagged and not accessible. This means
-that alternative engines must be used to generate accessible PDFs.
+Pandoc defaults to LaTeX to generate PDF. LaTeX's `\DocumentMetadata`
+interface supports PDF standards and tagging when using LuaLaTeX;
+set the `pdfstandard` variable to enable this (see below). For older
+LaTeX installations, alternative engines must be used.
 
 The PDF standards PDF/A and PDF/UA define further restrictions
 intended to optimize PDFs for archiving and accessibility. Tagging
@@ -7794,6 +7805,24 @@ Note, however, that standard compliance depends on many things,
 including the colorspace of embedded images. Pandoc cannot check
 this, and external programs must be used to ensure that generated
 PDFs are in compliance.
+
+## LaTeX
+
+Set the `pdfstandard` variable to produce tagged PDFs conforming
+to PDF/A, PDF/X, or PDF/UA standards. For example:
+
+    pandoc -V pdfstandard=ua-2 --pdf-engine=lualatex doc.md -o doc.pdf
+
+Multiple standards can be combined:
+
+    ---
+    pdfstandard:
+      - ua-2
+      - a-4f
+    ---
+
+The required PDF version is inferred automatically. This feature
+requires LuaLaTeX and a recent LaTeX installation.
 
 ## ConTeXt
 

--- a/data/templates/default.latex
+++ b/data/templates/default.latex
@@ -1,3 +1,4 @@
+$document-metadata.latex()$
 $passoptions.latex()$
 \documentclass[
 $for(babel-otherlangs)$

--- a/data/templates/document-metadata.latex
+++ b/data/templates/document-metadata.latex
@@ -1,0 +1,20 @@
+$--
+$-- PDF standard support (PDF/A, PDF/UA, PDF/X)
+$-- Requires LuaLaTeX and recent LaTeX (2023+)
+$--
+$if(pdfstandard)$
+\DocumentMetadata{
+$if(pdfstandard.version)$
+  pdfversion=$pdfstandard.version$,
+$endif$
+$if(pdfstandard.standards)$
+  pdfstandard={$for(pdfstandard.standards)$$it$$sep$,$endfor$},
+$endif$
+$if(pdfstandard.tagging)$
+  tagging=on,
+$endif$
+$if(lang)$
+  lang=$lang$,
+$endif$
+  xmp=true}
+$endif$

--- a/src/Text/Pandoc/Logging.hs
+++ b/src/Text/Pandoc/Logging.hs
@@ -105,6 +105,7 @@ data LogMessage =
   | UnclosedDiv SourcePos SourcePos
   | UnsupportedCodePage Int
   | YamlWarning SourcePos Text
+  | UnsupportedPdfStandard Text
   deriving (Show, Eq, Data, Ord, Typeable, Generic)
 
 instance ToJSON LogMessage where
@@ -291,6 +292,8 @@ instance ToJSON LogMessage where
            , "column" .= toJSON (sourceColumn pos)
            , "message" .= msg
            ]
+      UnsupportedPdfStandard s ->
+           ["contents" .= s]
 
 showPos :: SourcePos -> Text
 showPos pos = Text.pack $ sn ++ "line " ++
@@ -438,6 +441,8 @@ showLogMessage msg =
        UnsupportedCodePage cpg -> "Unsupported code page " <> tshow cpg <>
           ". Text will likely be garbled."
        YamlWarning pos m -> "YAML warning (" <> showPos pos <> "): " <> m
+       UnsupportedPdfStandard s ->
+         "PDF standard '" <> s <> "' is not supported by LaTeX and will be ignored."
 
 messageVerbosity :: LogMessage -> Verbosity
 messageVerbosity msg =
@@ -497,3 +502,4 @@ messageVerbosity msg =
        UnclosedDiv{}                 -> WARNING
        UnsupportedCodePage{}         -> WARNING
        YamlWarning{}                 -> WARNING
+       UnsupportedPdfStandard{}      -> WARNING

--- a/src/Text/Pandoc/Writers/LaTeX/Types.hs
+++ b/src/Text/Pandoc/Writers/LaTeX/Types.hs
@@ -2,6 +2,7 @@ module Text.Pandoc.Writers.LaTeX.Types
   ( LW
   , WriterState (..)
   , startingState
+  , PdfStandard (..)
   ) where
 
 import Control.Monad.State.Strict (StateT)
@@ -55,6 +56,13 @@ data WriterState =
   , stInSoulCommand :: Bool          -- ^ in a soul command like ul
   , stCancel        :: Bool          -- ^ true if document uses \cancel
   , stInCaption     :: Bool          -- ^ true if in a caption
+  }
+
+-- | PDF standard settings for DocumentMetadata
+data PdfStandard = PdfStandard
+  { pdfStandards :: [Text]     -- ^ list of standards (e.g., ["a-2b", "ua-1"])
+  , pdfVersion   :: Maybe Text -- ^ PDF version (e.g., "1.7", "2.0")
+  , pdfTagging   :: Bool       -- ^ whether tagging is required
   }
 
 startingState :: WriterOptions -> WriterState

--- a/test/command/pdfstandard.md
+++ b/test/command/pdfstandard.md
@@ -1,0 +1,588 @@
+PDF standard support: basic PDF/A-2b test (infers version 1.7)
+```
+% pandoc -t latex -s
+---
+pdfstandard: a-2b
+lang: en-US
+---
+
+Test document.
+^D
+\DocumentMetadata{
+  pdfversion=1.7,
+  pdfstandard={a-2b},
+  lang=en-US,
+  xmp=true}
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\documentclass[
+  american,
+]{article}
+\usepackage{xcolor}
+\usepackage{amsmath,amssymb}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math} % this also loads fontspec
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+\usepackage{lmodern}
+\ifPDFTeX\else
+  % xetex/luatex font selection
+\fi
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\ifLuaTeX
+\usepackage[bidi=basic,shorthands=off]{babel}
+\else
+\usepackage[bidi=default,shorthands=off]{babel}
+\fi
+\ifLuaTeX
+  \usepackage{selnolig} % disable illegal ligatures
+\fi
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\usepackage{bookmark}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\urlstyle{same}
+\hypersetup{
+  pdflang={en-US},
+  hidelinks,
+  pdfcreator={LaTeX via pandoc}}
+
+\author{}
+\date{}
+
+\begin{document}
+
+Test document.
+
+\end{document}
+```
+
+PDF standard support: PDF/UA-1 with tagging
+```
+% pandoc -t latex -s
+---
+pdfstandard: ua-1
+lang: en-US
+---
+
+Accessible document.
+^D
+\DocumentMetadata{
+  pdfstandard={ua-1},
+  tagging=on,
+  lang=en-US,
+  xmp=true}
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\documentclass[
+  american,
+]{article}
+\usepackage{xcolor}
+\usepackage{amsmath,amssymb}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math} % this also loads fontspec
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+\usepackage{lmodern}
+\ifPDFTeX\else
+  % xetex/luatex font selection
+\fi
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\ifLuaTeX
+\usepackage[bidi=basic,shorthands=off]{babel}
+\else
+\usepackage[bidi=default,shorthands=off]{babel}
+\fi
+\ifLuaTeX
+  \usepackage{selnolig} % disable illegal ligatures
+\fi
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\usepackage{bookmark}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\urlstyle{same}
+\hypersetup{
+  pdflang={en-US},
+  hidelinks,
+  pdfcreator={LaTeX via pandoc}}
+
+\author{}
+\date{}
+
+\begin{document}
+
+Accessible document.
+
+\end{document}
+```
+
+PDF standard support: multiple standards with version
+```
+% pandoc -t latex -s
+---
+pdfstandard:
+  - a-2b
+  - ua-1
+  - "1.7"
+lang: de-DE
+---
+
+Multi-standard document.
+^D
+\DocumentMetadata{
+  pdfversion=1.7,
+  pdfstandard={a-2b,ua-1},
+  tagging=on,
+  lang=de-DE,
+  xmp=true}
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\documentclass[
+  ngerman,
+]{article}
+\usepackage{xcolor}
+\usepackage{amsmath,amssymb}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math} % this also loads fontspec
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+\usepackage{lmodern}
+\ifPDFTeX\else
+  % xetex/luatex font selection
+\fi
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\ifLuaTeX
+\usepackage[bidi=basic,shorthands=off]{babel}
+\else
+\usepackage[bidi=default,shorthands=off]{babel}
+\fi
+\ifLuaTeX
+  \usepackage{selnolig} % disable illegal ligatures
+\fi
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\usepackage{bookmark}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\urlstyle{same}
+\hypersetup{
+  pdflang={de-DE},
+  hidelinks,
+  pdfcreator={LaTeX via pandoc}}
+
+\author{}
+\date{}
+
+\begin{document}
+
+Multi-standard document.
+
+\end{document}
+```
+
+PDF standard support: PDF/A-1b infers version 1.4
+```
+% pandoc -t latex -s
+---
+pdfstandard: a-1b
+lang: en-US
+---
+
+PDF/A-1 document.
+^D
+\DocumentMetadata{
+  pdfversion=1.4,
+  pdfstandard={a-1b},
+  lang=en-US,
+  xmp=true}
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\documentclass[
+  american,
+]{article}
+\usepackage{xcolor}
+\usepackage{amsmath,amssymb}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math} % this also loads fontspec
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+\usepackage{lmodern}
+\ifPDFTeX\else
+  % xetex/luatex font selection
+\fi
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\ifLuaTeX
+\usepackage[bidi=basic,shorthands=off]{babel}
+\else
+\usepackage[bidi=default,shorthands=off]{babel}
+\fi
+\ifLuaTeX
+  \usepackage{selnolig} % disable illegal ligatures
+\fi
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\usepackage{bookmark}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\urlstyle{same}
+\hypersetup{
+  pdflang={en-US},
+  hidelinks,
+  pdfcreator={LaTeX via pandoc}}
+
+\author{}
+\date{}
+
+\begin{document}
+
+PDF/A-1 document.
+
+\end{document}
+```
+
+PDF standard support: PDF/A-4 with no version inference (uses default 2.0)
+```
+% pandoc -t latex -s
+---
+pdfstandard: a-4
+lang: en-US
+---
+
+PDF/A-4 document.
+^D
+\DocumentMetadata{
+  pdfstandard={a-4},
+  lang=en-US,
+  xmp=true}
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\documentclass[
+  american,
+]{article}
+\usepackage{xcolor}
+\usepackage{amsmath,amssymb}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math} % this also loads fontspec
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+\usepackage{lmodern}
+\ifPDFTeX\else
+  % xetex/luatex font selection
+\fi
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\ifLuaTeX
+\usepackage[bidi=basic,shorthands=off]{babel}
+\else
+\usepackage[bidi=default,shorthands=off]{babel}
+\fi
+\ifLuaTeX
+  \usepackage{selnolig} % disable illegal ligatures
+\fi
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\usepackage{bookmark}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\urlstyle{same}
+\hypersetup{
+  pdflang={en-US},
+  hidelinks,
+  pdfcreator={LaTeX via pandoc}}
+
+\author{}
+\date{}
+
+\begin{document}
+
+PDF/A-4 document.
+
+\end{document}
+```
+
+PDF standard support: numeric YAML version (2 becomes 2.0)
+```
+% pandoc -t latex -s
+---
+pdfstandard:
+  - ua-1
+  - 2
+lang: en-US
+---
+
+PDF 2.0 document.
+^D
+\DocumentMetadata{
+  pdfversion=2.0,
+  pdfstandard={ua-1},
+  tagging=on,
+  lang=en-US,
+  xmp=true}
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\documentclass[
+  american,
+]{article}
+\usepackage{xcolor}
+\usepackage{amsmath,amssymb}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math} % this also loads fontspec
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+\usepackage{lmodern}
+\ifPDFTeX\else
+  % xetex/luatex font selection
+\fi
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\ifLuaTeX
+\usepackage[bidi=basic,shorthands=off]{babel}
+\else
+\usepackage[bidi=default,shorthands=off]{babel}
+\fi
+\ifLuaTeX
+  \usepackage{selnolig} % disable illegal ligatures
+\fi
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\usepackage{bookmark}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\urlstyle{same}
+\hypersetup{
+  pdflang={en-US},
+  hidelinks,
+  pdfcreator={LaTeX via pandoc}}
+
+\author{}
+\date{}
+
+\begin{document}
+
+PDF 2.0 document.
+
+\end{document}
+```
+
+PDF standard support: explicit version overrides inferred version
+```
+% pandoc -t latex -s
+---
+pdfstandard:
+  - a-2b
+  - "1.5"
+lang: en-US
+---
+
+Explicit version document.
+^D
+\DocumentMetadata{
+  pdfversion=1.5,
+  pdfstandard={a-2b},
+  lang=en-US,
+  xmp=true}
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\documentclass[
+  american,
+]{article}
+\usepackage{xcolor}
+\usepackage{amsmath,amssymb}
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math} % this also loads fontspec
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+\usepackage{lmodern}
+\ifPDFTeX\else
+  % xetex/luatex font selection
+\fi
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\ifLuaTeX
+\usepackage[bidi=basic,shorthands=off]{babel}
+\else
+\usepackage[bidi=default,shorthands=off]{babel}
+\fi
+\ifLuaTeX
+  \usepackage{selnolig} % disable illegal ligatures
+\fi
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\usepackage{bookmark}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\urlstyle{same}
+\hypersetup{
+  pdflang={en-US},
+  hidelinks,
+  pdfcreator={LaTeX via pandoc}}
+
+\author{}
+\date{}
+
+\begin{document}
+
+Explicit version document.
+
+\end{document}
+```


### PR DESCRIPTION
Hi @jgm! 

We want to do something like this to support PDF standards in Quarto 1.9, releasing in a month or so.

We'd prefer to have this upstream in Pandoc, as it's going to be an essential feature for Pandoc LaTeX users in public institutions in the US.

It's pretty much the same behavior as Typst's `--pdf-standard` option.

## Summary

Adds `pdfstandard` metadata variable for generating PDF/A, PDF/X, and PDF/UA compliant documents via LaTeX's `\DocumentMetadata` command.

## Example usage

```yaml
---
pdfstandard: ua-2
lang: en-US
---
```

Or multiple standards:

```yaml
---
pdfstandard:
  - ua-2
  - a-4f
lang: en-US
---
```

## Features

- Supports PDF/A (`a-1b`, `a-2a`, `a-2b`, `a-2u`, `a-3a`, `a-3b`, `a-3u`, `a-4`, `a-4e`, `a-4f`), PDF/X, and PDF/UA (`ua-1`, `ua-2`) variants
- Automatically infers required PDF version (e.g., `a-2b` sets PDF 1.7), or accepts an explicit version (e.g., `1.7`, `2.0`)
- Automatically enables tagging for standards that require it (`ua-1`, `ua-2`, `a-2a`, `a-3a`)
- Warns on unsupported standard names

## Notes

The `\DocumentMetadata` command must appear before `\documentclass`, which is handled by a new `document-metadata.latex` partial template.
