### PR TITLE
refactor(typst): improve terms accessibility

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -1,13 +1,9 @@
 #let horizontalrule = line(start: (25%,0%), end: (75%,0%))
 
-#show terms: it => {
-  it.children
-    .map(child => [
-      #strong[#child.term]
-      #block(inset: (left: 1.5em, top: -0.4em))[#child.description]
-      ])
-    .join()
-}
+#show terms.item: it => block(breakable: false)[
+  #text(weight: "bold")[#it.term]
+  #block(inset: (left: 1.5em, top: -0.4em))[#it.description]
+]
 
 #set table(
   inset: 6pt,

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -1,13 +1,9 @@
 #let horizontalrule = line(start: (25%,0%), end: (75%,0%))
 
-#show terms: it => {
-  it.children
-    .map(child => [
-      #strong[#child.term]
-      #block(inset: (left: 1.5em, top: -0.4em))[#child.description]
-      ])
-    .join()
-}
+#show terms.item: it => block(breakable: false)[
+  #text(weight: "bold")[#it.term]
+  #block(inset: (left: 1.5em, top: -0.4em))[#it.description]
+]
 
 #set table(
   inset: 6pt,


### PR DESCRIPTION
Refactor the terms display in Typst to enhance accessibility by using a more semantic structure.

The current code basically reconstruct the list making it fail UA-1 accessibility check from Typst 0.14.

The new rule is simpler, keep the structure of the list.
it also add an explicit `breakable: false` to ensure definition and term stay together.

For reference, the current Typst check error:

```typ
#set document(title: "Demo Document")

#show terms: it => {
  it
    .children
    .map(child => [
      #strong[#child.term]
      #block(inset: (left: 1.5em, top: -0.4em))[#child.description]
    ])
    .join()
}

/ term: #block[
    definition
  ]
```

```sh
typst compile demo.typ --pdf-standard=ua-1
```

```txt
error: PDF/UA-1 error: invalid list (L) structure
   ┌─ demo.typ:13:2
   │
13 │ / term: #block[
   │   ^^^^
   │
   = hint: list (L) may not contain paragraph (P)
   = hint: this is probably caused by a show rule

error: PDF/UA-1 error: invalid list (L) structure
   ┌─ demo.typ:13:0
   │  
13 │ ╭ / term: #block[
14 │ │     definition
15 │ │   ]
   │ ╰───^
   │  
   = hint: list (L) may not contain marked content directly
   = hint: this is probably caused by a show rule
```