### PR TITLE
typst: use both place and 100% width block for title

### DIFF
--- a/data/templates/template.typst
+++ b/data/templates/template.typst
@@ -73,7 +73,7 @@
     }
   }
 
-  block(below: 1em, width: 100%)[
+  place(top, float: true, scope: "parent", clearance: 4mm, block(below: 1em, width: 100%)[
     #if title != none {
       align(center, block[
           #text(weight: "bold", size: 1.5em, hyphenate: false)[#title #if thanks != none {
@@ -113,7 +113,7 @@
         #text(weight: "semibold")[#abstract-title] #h(1em) #abstract
       ]
     }
-  ]
+  ])
 
   doc
 }

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -93,7 +93,7 @@
     }
   }
 
-  block(below: 1em, width: 100%)[
+  place(top, float: true, scope: "parent", clearance: 4mm, block(below: 1em, width: 100%)[
     #if title != none {
       align(center, block[
           #text(weight: "bold", size: 1.5em, hyphenate: false)[#title #if thanks != none {
@@ -133,7 +133,7 @@
         #text(weight: "semibold")[#abstract-title] #h(1em) #abstract
       ]
     }
-  ]
+  ])
 
   doc
 }


### PR DESCRIPTION
Otherwise the title will be confined to the left column.

Titles need both `place(top, ...)` and `block(width: 100%)` with the new Typst page `columns` parameter. 

There was an accidental regression here, and titles never had both; Claude's analysis below.

## Fix title block placement in two-column Typst layouts

### Problem

When using two-column layouts (`-V columns=2`), the title block (title, subtitle, authors, date, abstract) is confined to the left column instead of spanning the full page width.

### Reproduction

* `test.md`
```
---
title: Test Title
---

Body text.
```

```bash
pandoc test.md -o test.pdf -s -V columns=2 --pdf-engine=typst
```

With any document containing a title, the title appears only in the left column.
<img width="612" height="792" alt="image" src="https://github.com/user-attachments/assets/3dea413a-15c2-45a8-b4fd-61b119a5910d" />


### Cause

This is a regression from PR #10324 (commit e01023c1f, October 2024), which added `place(top, float: true, scope: "parent")` to make the title block span both columns in Typst 0.12+'s new column model.

The `place()` wrapper was accidentally removed in commit 6070ad29c (September 2025) when new template features were added. That PR was originally authored in July 2024—before the `place()` fix existed—and when it was rebased and merged 14 months later, the `place()` fix was lost in the process.

The centering fix in #11221 (commit 36cea7c97, October 2025) added `width: 100%` to the title block, but by that point `place()` was already gone, so it only fixed centering without restoring column-spanning behavior.

### Solution

Restore `place(top, float: true, scope: "parent")` and nest `block(width: 100%)` inside it:

```typst
place(top, float: true, scope: "parent", clearance: 4mm,
  block(below: 1em, width: 100%)[
    // title, authors, date, abstract
])
```

This combines:
- `place(scope: "parent")` — escapes the column layout to span full page width (the October 2024 fix)
- `block(width: 100%)` — ensures correct centering within the placed region (the October 2025 fix)

### Timeline

| Date | Commit | Change | Centering | Column-spanning |
|------|--------|--------|-----------|-----------------|
| Oct 2024 | e01023c1f | Added `place()` for Typst 0.12 | ❌ buggy | ✅ works |
| Sep 2025 | 6070ad29c | `place()` accidentally removed | ❌ buggy | ❌ broken |
| Oct 2025 | 36cea7c97 | Added `width: 100%` | ✅ works | ❌ broken |
| This PR | | Restore `place()` + keep `width: 100%` | ✅ works | ✅ works |
