### PR TITLE
Fix revealjs scroll-view option types

### DIFF
--- a/data/templates/default.revealjs
+++ b/data/templates/default.revealjs
@@ -243,7 +243,13 @@ $if(view)$
         // Enable scroll view
         view: '$view/nowrap$',
         // see https://revealjs.com/scroll-view/#scrollbar
+$if(scrollProgressAuto)$
+        scrollProgress: 'auto',
+$elseif(scrollProgress)$
         scrollProgress: $scrollProgress$,
+$else$
+        scrollProgress: false,
+$endif$
         // see https://revealjs.com/scroll-view/#url-activation
         scrollActivationWidth: $scrollActivationWidth$,
         // see https://revealjs.com/scroll-view/#scroll-snapping

--- a/src/Text/Pandoc/Writers/HTML.hs
+++ b/src/Text/Pandoc/Writers/HTML.hs
@@ -434,7 +434,11 @@ pandocToHtml opts (Pandoc meta blocks) = do
                          defField "backgroundTransition" ("fade" :: Doc Text) .
                          defField "viewDistance" ("3" :: Doc Text) .
                          defField "mobileViewDistance" ("2" :: Doc Text) .
-                         defField "scrollProgress" True .
+                         (case lookupMeta "scrollProgress" meta of
+                            Just (MetaBool False) -> id
+                            Just (MetaBool True)  ->
+                              defField "scrollProgress" True
+                            _  -> defField "scrollProgressAuto" True) .
                          defField "scrollActivationWidth" ("0" :: Doc Text) .
                          defField "scrollSnap" ("mandatory" :: Doc Text) .
                          defField "scrollLayout" ("full" :: Doc Text) .

--- a/test/command/11486.md
+++ b/test/command/11486.md
@@ -6,6 +6,7 @@ view: scroll
 ^D
         scrollActivationWidth: 0,
         scrollSnap: 'mandatory',
+        scrollProgress: 'auto',
 ```
 
 ```
@@ -17,6 +18,7 @@ scrollSnap: false
 ^D
         scrollActivationWidth: 0,
         scrollSnap: false,
+        scrollProgress: 'auto',
 ```
 
 ```
@@ -28,6 +30,7 @@ scrollSnap: proximity
 ^D
         scrollActivationWidth: 0,
         scrollSnap: 'proximity',
+        scrollProgress: 'auto',
 ```
 
 ```
@@ -39,4 +42,41 @@ scrollActivationWidth: 500
 ^D
         scrollActivationWidth: 500,
         scrollSnap: 'mandatory',
+        scrollProgress: 'auto',
+```
+
+```
+% pandoc -t revealjs --template=command/11486/scroll.revealjs
+---
+view: scroll
+scrollProgress: true
+---
+^D
+        scrollActivationWidth: 0,
+        scrollSnap: 'mandatory',
+        scrollProgress: true,
+```
+
+```
+% pandoc -t revealjs --template=command/11486/scroll.revealjs
+---
+view: scroll
+scrollProgress: false
+---
+^D
+        scrollActivationWidth: 0,
+        scrollSnap: 'mandatory',
+        scrollProgress: false,
+```
+
+```
+% pandoc -t revealjs --template=command/11486/scroll.revealjs
+---
+view: scroll
+scrollProgress: auto
+---
+^D
+        scrollActivationWidth: 0,
+        scrollSnap: 'mandatory',
+        scrollProgress: 'auto',
 ```

--- a/test/command/11486/scroll.revealjs
+++ b/test/command/11486/scroll.revealjs
@@ -5,4 +5,11 @@ $if(scrollSnap)$
 $else$
         scrollSnap: false,
 $endif$
+$if(scrollProgressAuto)$
+        scrollProgress: 'auto',
+$elseif(scrollProgress)$
+        scrollProgress: $scrollProgress$,
+$else$
+        scrollProgress: false,
+$endif$
 $endif$


### PR DESCRIPTION
Fix type rendering issues in revealjs scroll-view configuration options reported in #11486.

## scrollSnap

`scrollSnap: false` was rendered as the string `'false'`, which reveal.js interprets as a valid snap type (producing invalid CSS `scroll-snap-type: y false`). Use `$if/$else$` guard so `false` renders as a boolean literal. String values (`mandatory`, `proximity`) remain quoted.

## scrollActivationWidth

Was rendered as a quoted string (`'800'`), but reveal.js checks `typeof config.scrollActivationWidth === 'number'`. Remove quotes so numeric values render correctly.

## scrollProgress default

The writer defaulted `scrollProgress` to `true` (always visible), but reveal.js defaults to `'auto'` (show on scroll, auto-hide). Use `lookupMeta` to distinguish `true`, `false`, and unset, defaulting unset to `'auto'` via a `scrollProgressAuto` template variable.

Fixes #11486