### PR TITLE
Fix outdated OPML spec URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ It can convert *from*
 - `native` (native Haskell)
 - `odt` ([OpenDocument text
   document](https://en.wikipedia.org/wiki/OpenDocument))
-- `opml` ([OPML](https://opml.org/spec2.opml))
+- `opml` ([OPML](http://dev.opml.org/spec2.html))
 - `org` ([Emacs Org mode](https://orgmode.org))
 - `pod` (Perl’s [Plain Old
   Documentation](https://perldoc.perl.org/perlpod))
@@ -206,7 +206,7 @@ It can convert *to*
 - `native` (native Haskell)
 - `odt` ([OpenDocument text
   document](https://en.wikipedia.org/wiki/OpenDocument))
-- `opml` ([OPML](https://opml.org/spec2.opml))
+- `opml` ([OPML](http://dev.opml.org/spec2.html))
 - `opendocument` ([OpenDocument
   XML](https://www.oasis-open.org/2021/06/16/opendocument-v1-3-oasis-standard-published/))
 - `org` ([Emacs Org mode](https://orgmode.org))


### PR DESCRIPTION
I know the README.md has a comment at the top that says not to edit it manually—but I don't have a local pandoc enviroment so I hope my manual change is correct in README.

Not sure what the process for is getting this onto jgm/pandoc-website—manual or semi-automated.

Thanks!