### PR TITLE
Update bash completion options for --pdf-engine

### DIFF
--- a/data/bash_completion.tpl
+++ b/data/bash_completion.tpl
@@ -34,7 +34,7 @@ _pandoc()
              return 0
              ;;
          --pdf-engine)
-             COMPREPLY=( $(compgen -W "pdflatex lualatex xelatex latexmk tectonic wkhtmltopdf weasyprint prince context pdfroff" -- ${cur}) )
+             COMPREPLY=( $(compgen -W "pdflatex lualatex xelatex latexmk tectonic wkhtmltopdf weasyprint prince context" -- ${cur}) )
              return 0
              ;;
          --print-default-data-file)


### PR DESCRIPTION
Removed 'pdfroff' from the list of options for --pdf-engine, to avoid lookup for `pdfroff.exe` win executable on cygwin, and enable native cygwin script...

The alternative `groff -Tpdf` groff engine is not enumerated, and runs perfectly well on cygwin without searching for a Win executable.
