### PR TITLE
linux/make_artifacts.sh: add loong64 support

### DIFF
--- a/linux/make_artifacts.sh
+++ b/linux/make_artifacts.sh
@@ -17,6 +17,7 @@ case "$MACHINE" in
   aarch64) ARCHITECTURE=arm64;;
   armv6l | armv7l) ARCHITECTURE=armhf;;
   riscv64) ARCHITECTURE=riscv64;;
+  loongarch64) ARCHITECTURE=loong64;;
   *)       ARCHITECTURE=unknown;;
 esac
 


### PR DESCRIPTION
This PR enables building Pandoc for Linux/LoongArch (64-bit, `linux/loong64`).