### PR TITLE
Markdown reader: fix quotes in inline notes

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -2086,7 +2086,7 @@ inlineNote = do
     char '^'
     updateState $ \st -> st{ stateInNote = True
                            , stateNoteNumber = stateNoteNumber st + 1 }
-    contents <- inBalancedBrackets inlines
+    contents <- withQuoteContext NoQuote $ inBalancedBrackets inlines
     notFollowedBy (char '(' <|> char '[' <|> ('{' <$ attributes))
       -- ^[link](foo)^ is superscript
     updateState $ \st -> st{ stateInNote = False }

--- a/test/Tests/Readers/Markdown.hs
+++ b/test/Tests/Readers/Markdown.hs
@@ -375,6 +375,12 @@ tests = [ testGroup "inline code"
           , test markdownSmart "unclosed double quote"
             ("**this should \"be bold**"
             =?> para (strong "this should \8220be bold"))
+          , test markdownSmart "single quote in inline note within single quotes" $ -- issue #11613
+              "'a^['b'.] c.'" =?>
+              para (singleQuoted ("a" <> note (para (singleQuoted "b" <> ".")) <> space <> "c."))
+          , test markdownSmart "double quote in inline note within double quotes" $ -- issue #11613
+              "\"a^[\"b\".] c.\"" =?>
+              para (doubleQuoted ("a" <> note (para (doubleQuoted "b" <> ".")) <> space <> "c."))
           ]
         , testGroup "sub- and superscripts"
           [


### PR DESCRIPTION
When parsing an inline note (`^[...]`) inside a quoted span, `stateQuoteContext` was still set to `InSingleQuote`/`InDoubleQuote`, meaning that quotes within notes failed to parse as `Quoted` nodes.  Fix by wrapping the note body parser in `withQuoteContext NoQuote`.

Closes #11613.