### PR TITLE
Allow doi field in bibtex (input and output)

### DIFF
--- a/src/Text/Pandoc/Citeproc/BibTeX.hs
+++ b/src/Text/Pandoc/Citeproc/BibTeX.hs
@@ -188,6 +188,7 @@ writeBibtexString opts variant mblang ref =
            , "annote"
            , "url" -- not officially supported, but supported by
                    -- some styles (#8287)
+           , "doi"
            ]
 
   valToInlines (TextVal t) = B.text t


### PR DESCRIPTION
Like url, this is supported by some styles, including those used by natbib.sty.

Closes https://github.com/jgm/pandoc/issues/11617