### PR TITLE
doc/epub.md: use the `-F gladtex` filter form for math

### DIFF
--- a/doc/epub.md
+++ b/doc/epub.md
@@ -149,8 +149,8 @@ or target readers that don't support MathML. Then you have two options:
 
 1.  Use the [`--webtex`](https://pandoc.org/MANUAL.html#option--webtex) option,
     which will use a web service to convert the TeX to an image.
-2.  Use the [`--gladtex`](https://pandoc.org/MANUAL.html#option--gladtex) option
-    to convert maths into SVG images on your local machine.
+2.  Use the [`-F gladtex`][GladTeX] filter to convert maths into SVG
+    images on your local machine.
 
 Both GladTeX and WebTeX add the LaTeX source of the formula as alternative text
 of the image, increasing accessibility for blind users.
@@ -168,4 +168,5 @@ of the image, increasing accessibility for blind users.
 [git]: https://git-scm.com
 [Dublin Core metadata elements]: https://dublincore.org/documents/dces/
 [User's Guide]: https://pandoc.org/MANUAL.html
+[GladTeX]: https://humenda.github.io/GladTeX/
 


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

Closes #11290

## What

In the **Math** section of `doc/epub.md` (the source of
<https://pandoc.org/epub.html#math>), replace the suggestion to use the
`--gladtex` HTML option — which does not work for EPUB output — with the
filter form `-F gladtex`, which is the supported invocation for embedding
GladTeX-rendered SVG math into an EPUB.

A `[GladTeX]` link reference is added to the existing reference list at
the bottom of the file so the new link resolves.

## Why

`--gladtex` only sets the HTML math method (`<eq>` tags expected to be
post-processed by the standalone `gladtex` binary on a `.htex` file); it
is not wired up for the EPUB writer. Users following the EPUB docs hit
errors. Running `gladtex` as a pandoc filter (`-F gladtex`) is the
supported way to embed SVG math in EPUB today.

The `--gladtex` flag itself is left untouched in `MANUAL.txt`, since it
remains valid for HTML output.

## AI disclosure

Per project norms — this PR is AI-generated and unattended, written by a
Cursor Anthropic Claude Opus 4.7 agent under @adv0r as a personal
token-burn initiative before my Cursor billing cycle ends. Opened as
**draft** for review. Happy to iterate on phrasing or scope.

Made with [Cursor](https://cursor.com)
