### PR TITLE
Docx writer: fix empty keywords in core document properties

### DIFF
--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -738,8 +738,13 @@ mkStylesEntry epochtime styledoc styleMaps st opts =
 -- | Create core document properties entry
 mkCorePropsEntry :: Integer -> UTCTime -> Meta -> Entry
 mkCorePropsEntry epochtime utctime meta =
-  let keywords = case lookupMeta "keywords" meta of
-                       Just (MetaList xs) -> map stringify xs
+  let metaValueToText (MetaString s)    = s
+      metaValueToText (MetaInlines ils) = stringify ils
+      metaValueToText (MetaBlocks bs)   = stringify bs
+      metaValueToText (MetaBool b)      = T.pack (show b)
+      metaValueToText _                 = ""
+      keywords = case lookupMeta "keywords" meta of
+                       Just (MetaList xs) -> map metaValueToText xs
                        _                  -> []
       docPropsPath = "docProps/core.xml"
       extraCoreProps = ["subject","lang","category","description"]

--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -738,13 +738,9 @@ mkStylesEntry epochtime styledoc styleMaps st opts =
 -- | Create core document properties entry
 mkCorePropsEntry :: Integer -> UTCTime -> Meta -> Entry
 mkCorePropsEntry epochtime utctime meta =
-  let metaValueToText (MetaString s)    = s
-      metaValueToText (MetaInlines ils) = stringify ils
-      metaValueToText (MetaBlocks bs)   = stringify bs
-      metaValueToText (MetaBool b)      = T.pack (show b)
-      metaValueToText _                 = ""
+  let toText v = lookupMetaString "x" (Meta $ M.singleton "x" v)
       keywords = case lookupMeta "keywords" meta of
-                       Just (MetaList xs) -> map metaValueToText xs
+                       Just (MetaList xs) -> map toText xs
                        _                  -> []
       docPropsPath = "docProps/core.xml"
       extraCoreProps = ["subject","lang","category","description"]

--- a/src/Text/Pandoc/Writers/Docx.hs
+++ b/src/Text/Pandoc/Writers/Docx.hs
@@ -738,9 +738,13 @@ mkStylesEntry epochtime styledoc styleMaps st opts =
 -- | Create core document properties entry
 mkCorePropsEntry :: Integer -> UTCTime -> Meta -> Entry
 mkCorePropsEntry epochtime utctime meta =
-  let toText v = lookupMetaString "x" (Meta $ M.singleton "x" v)
+  let metaValueToText (MetaString s)    = s
+      metaValueToText (MetaInlines ils) = stringify ils
+      metaValueToText (MetaBlocks bs)   = stringify bs
+      metaValueToText (MetaBool b)      = T.pack (show b)
+      metaValueToText _                 = ""
       keywords = case lookupMeta "keywords" meta of
-                       Just (MetaList xs) -> map toText xs
+                       Just (MetaList xs) -> map metaValueToText xs
                        _                  -> []
       docPropsPath = "docProps/core.xml"
       extraCoreProps = ["subject","lang","category","description"]


### PR DESCRIPTION
Fixes #11665.

When keywords are supplied as a metadata list, every entry in `<cp:keywords>` of `docProps/core.xml` was rendered empty:

```
$ echo test | pandoc -s -M keywords:a -M keywords:b -M keywords:c -o test.docx
$ unzip -p test.docx docProps/core.xml | grep -o '<cp:keywords>.*</cp:keywords>'
<cp:keywords>, , </cp:keywords>
```

The list elements are `MetaString` values, and `stringify` returns the empty string for a `MetaString` (it only collects `Inline`s). The fix converts each element the same way `lookupMetaString` does, so `MetaString`/`MetaInlines`/`MetaBlocks` are all handled.

Verified the repro and the fix output against pandoc 3.9. I was not able to run the docx golden-test harness locally (no GHC toolchain available); happy to add a core.xml properties test if you'd like one.