### PR TITLE
Markdown reader: allow grid tables to be indented

### DIFF
--- a/src/Text/Pandoc/Readers/Markdown.hs
+++ b/src/Text/Pandoc/Readers/Markdown.hs
@@ -1403,7 +1403,20 @@ multilineTableHeader headless = try $ do
 -- ending with a footer (dashed line followed by blank line).
 gridTable :: PandocMonad m
           => MarkdownParser m (F TableComponents)
-gridTable = gridTableWith' NormalizeHeader parseBlocks
+gridTable = try $ do
+  -- Like other block-level constructs, a grid table may be indented by
+  -- up to three spaces.  The underlying grid-table parser expects the
+  -- table to begin at the left margin, so strip a uniform indentation
+  -- from every line before handing it off.
+  indent <- T.length <$> lookAhead nonindentSpaces
+  if indent == 0
+     then gridTableWith' NormalizeHeader parseBlocks
+     else do
+       let gridLine = try $ count indent (char ' ')
+                              *> lookAhead (oneOf "+|")
+                              *> anyLineNewline
+       rawTable <- T.concat <$> many1 gridLine
+       parseFromString' (gridTableWith' NormalizeHeader parseBlocks) rawTable
 
 pipeBreak :: PandocMonad m => MarkdownParser m ([Alignment], [Int])
 pipeBreak = try $ do

--- a/test/command/grid-table-indented.md
+++ b/test/command/grid-table-indented.md
@@ -1,0 +1,65 @@
+Like other block-level constructs, grid tables may be indented by up to
+three spaces and are still recognized as tables.
+
+```
+% pandoc -f markdown -t html
+   +---+---+
+   | a | b |
+   +===+===+
+   | 1 | 2 |
+   +---+---+
+^D
+<table style="width:11%;">
+<colgroup>
+<col style="width: 5%" />
+<col style="width: 5%" />
+</colgroup>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>2</td>
+</tr>
+</tbody>
+</table>
+```
+
+A headerless indented grid table is recognized too.
+
+```
+% pandoc -f markdown -t html
+  +------+------+
+  | foo  | bar  |
+  +------+------+
+^D
+<table style="width:19%;">
+<colgroup>
+<col style="width: 9%" />
+<col style="width: 9%" />
+</colgroup>
+<tbody>
+<tr>
+<td>foo</td>
+<td>bar</td>
+</tr>
+</tbody>
+</table>
+```
+
+A grid table indented four spaces is a code block, not a table.
+
+```
+% pandoc -f markdown -t html
+    +---+---+
+    | a | b |
+    +---+---+
+^D
+<pre><code>+---+---+
+| a | b |
++---+---+</code></pre>
+```


### PR DESCRIPTION
Like the other table syntaxes (pipe, simple, and multiline tables) and block-level constructs generally, a grid table may now be indented by up to three spaces and still be recognized as a table.  Previously the grid-table parser required the table to begin at the left margin, so an indented grid table was parsed as a paragraph.

The leading indentation is stripped uniformly from each line before the table is parsed, so an indented grid table produces the same AST as its non-indented equivalent.

Adds a command test.