### PR TITLE
LaTeX reader and ODT writer fixes for image handling

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -35,7 +35,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Either (partitionEithers)
 import Skylighting (defaultSyntaxMap)
-import System.FilePath (addExtension, replaceExtension, takeExtension)
+import System.FilePath ((</>), addExtension, replaceExtension, takeExtension)
 import Text.Collate.Lang (renderLang)
 import Text.Pandoc.Builder as B
 import Text.Pandoc.Class (PandocPure, PandocMonad (..), getResourcePath,
@@ -231,7 +231,12 @@ doLHSverb =
     <$> manyTill (satisfyTok (not . isNewlineTok)) (symbol '|')
 
 mkImage :: PandocMonad m => [(Text, Text)] -> Text -> LP m Inlines
-mkImage options (T.unpack -> src) = do
+mkImage options = mkImageWithExts options
+  [".pdf", ".png", ".jpg", ".mps", ".jpeg", ".jbig2", ".jb2"]
+
+mkImageWithExts :: PandocMonad m
+                => [(Text, Text)] -> [String] -> Text -> LP m Inlines
+mkImageWithExts options exts' (T.unpack -> src) = do
    let replaceRelative (k,v) =
          case numUnit v of
               Just (num, "\\textwidth") -> (k, showFl (num * 100) <> "%")
@@ -243,19 +248,30 @@ mkImage options (T.unpack -> src) = do
    let attr = ("",[], kvs)
    let alt = maybe (str "image") str $ lookup "alt" options
    defaultExt <- getOption readerDefaultImageExtension
-   let exts' = [".pdf", ".png", ".jpg", ".mps", ".jpeg", ".jbig2", ".jb2"]
    let exts  = exts' ++ map (map toUpper) exts'
-   let findFile s [] = return s
+   resourcePath <- getResourcePath
+   let candidates s =
+         s : [ dir </> s | dir <- resourcePath, not (null dir), dir /= "." ]
+       findExisting [] = return Nothing
+       findExisting (s:ss) = do
+         exists <- fileExists s
+         if exists
+            then return $ Just s
+            else findExisting ss
+       findFile s [] = do
+         found <- findExisting $ candidates s
+         return $ fromMaybe s found
        findFile s (e:es) = do
          let s' = addExtension s e
-         exists <- fileExists s'
-         if exists
-            then return s'
-            else findFile s es
+         found <- findExisting $ candidates s'
+         case found of
+           Just resolved -> return resolved
+           Nothing       -> findFile s es
    src' <- case takeExtension src of
-               "" | not (T.null defaultExt) -> return $ addExtension src $ T.unpack defaultExt
+               "" | not (T.null defaultExt) ->
+                      findFile src [T.unpack defaultExt]
                   | otherwise -> findFile src exts
-               _  -> return src
+               _  -> findFile src []
    return $ imageWith attr (T.pack src') "" alt
 
 removeDoubleQuotes :: Text -> Text
@@ -432,7 +448,8 @@ inlineCommands = M.unions
     -- svg
     , ("includesvg",      do options <- option [] keyvals
                              src <- bracedFilename
-                             mkImage options . unescapeURL $ src)
+                             mkImageWithExts options [".svg", ".png"]
+                               . unescapeURL $ src)
     -- hyperref
     , ("url", (\url -> linkWith ("",["uri"],[]) url "" (str url))
                         . unescapeURL . untokenize <$> bracedUrl)
@@ -1044,6 +1061,7 @@ blockCommands = M.fromList
    , ("lstinputlisting", inputListing)
    , ("inputminted", inputMinted)
    , ("graphicspath", graphicsPath)
+   , ("svgpath", graphicsPath)
    -- polyglossia
    , ("setdefaultlanguage", setDefaultLanguage)
    , ("setmainlanguage", setDefaultLanguage)

--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -806,7 +806,7 @@ rawBlockOr name fallback = do
 doSubfile :: PandocMonad m => LP m Blocks
 doSubfile = do
   skipMany opt
-  f <- T.unpack <$> bracedFilename
+  f <- T.unpack <$> expandedBracedFilename
   oldToks <- getInput
   setInput $ TokStream False []
   insertIncluded (ensureExtension (/= "") ".tex" f)
@@ -823,10 +823,16 @@ include name = do
           "input" -> (/= "")
           _ -> const False
   skipMany opt
-  fs <- map (T.unpack . removeDoubleQuotes . T.strip) . T.splitOn "," .
-         untokenize . filter (not . isComment) <$> braced
+  fs <- map (T.unpack . removeDoubleQuotes . T.strip) . T.splitOn "," <$>
+        expandedBracedFilename
   mapM_ (insertIncluded . ensureExtension isAllowed ".tex") fs
   return mempty
+
+expandedBracedFilename :: PandocMonad m => LP m Text
+expandedBracedFilename = do
+  toks <- braced
+  expanded <- parseFromToks (many anyTok <* eof) toks
+  return $ untokenize $ filter (not . isComment) expanded
 
 usepackage :: (PandocMonad m, Monoid a) => LP m a
 usepackage = do

--- a/src/Text/Pandoc/Readers/LaTeX/Parsing.hs
+++ b/src/Text/Pandoc/Readers/LaTeX/Parsing.hs
@@ -98,7 +98,7 @@ import Control.Applicative (many, (<|>))
 import Control.Monad
 import Control.Monad.Except (throwError)
 import Control.Monad.Trans (lift)
-import Data.Char (chr, isAlphaNum, isDigit, isLetter, ord)
+import Data.Char (chr, isAlphaNum, isDigit, isLetter, isSpace, ord)
 import Data.Default
 import Data.List (intercalate)
 import qualified Data.IntMap as IntMap
@@ -615,7 +615,7 @@ doMacros' n inp =
         $ throwError $ PandocMacroLoop name
       (macros :| _ ) <- sMacros <$> getState
       case M.lookup name macros of
-           Nothing -> trySpecialMacro name ts
+           Nothing -> trySpecialMacro spos name ts
            Just (Macro _scope expansionPoint argspecs optarg newtoks) -> do
              let getargs' = do
                    args <-
@@ -645,21 +645,38 @@ doMacros' n inp =
 
 -- | Certain macros do low-level tex manipulations that can't
 -- be represented in our Macro type, so we handle them here.
-trySpecialMacro :: PandocMonad m => Text -> [Tok] -> LP m [Tok]
-trySpecialMacro "xspace" ts = do
+trySpecialMacro :: PandocMonad m => SourcePos -> Text -> [Tok] -> LP m [Tok]
+trySpecialMacro _ "xspace" ts = do
   ts' <- doMacros' 1 ts
   case ts' of
     Tok pos Word t : _
       | startsWithAlphaNum t -> return $ Tok pos Spaces " " : ts'
     _ -> return ts'
-trySpecialMacro "iftrue" ts = handleIf (ifParser True) ts
-trySpecialMacro "iffalse" ts = handleIf (ifParser False) ts
-trySpecialMacro "ifmmode" ts = do
+trySpecialMacro spos "csname" ts = do
+  lstate <- getState
+  res <- lift $ runParserT csnameParser lstate "csname" $ TokStream False ts
+  case res of
+    Left _ -> mzero
+    Right (name, rest) ->
+      -- Re-run expansion: the constructed control sequence may itself
+      -- be a macro (cf. the xspace case above).
+      doMacros' 1 $ Tok spos (CtrlSeq name) ("\\" <> name) : rest
+trySpecialMacro _ "iftrue" ts = handleIf (ifParser True) ts
+trySpecialMacro _ "iffalse" ts = handleIf (ifParser False) ts
+trySpecialMacro _ "ifmmode" ts = do
   mathMode <- sMathMode <$> getState
   handleIf (ifParser mathMode) ts
-trySpecialMacro "ifstrequal" ts = do
+trySpecialMacro _ "ifstrequal" ts = do
   handleIf ifStrequalParser ts
-trySpecialMacro _ _ = mzero
+trySpecialMacro _ _ _ = mzero
+
+csnameParser :: PandocMonad m => LP m (Text, [Tok])
+csnameParser = do
+  nameToks <- manyTill anyTok (controlSeq "endcsname")
+  TokStream _ rest <- getInput
+  let name = T.filter (not . isSpace) $ untokenize nameToks
+  guard $ not $ T.null name
+  return (name, rest)
 
 ifStrequalParser :: PandocMonad m => LP m [Tok]
 ifStrequalParser = do

--- a/src/Text/Pandoc/Writers/ODT.hs
+++ b/src/Text/Pandoc/Writers/ODT.hs
@@ -17,7 +17,7 @@ import Control.Monad.Except (catchError, throwError)
 import Control.Monad.State.Strict (StateT, evalStateT, gets, modify, lift)
 import Control.Monad (MonadPlus(mplus))
 import qualified Data.ByteString.Lazy as B
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Generics (everywhere', mkT)
 import Data.List (isPrefixOf)
 import qualified Data.Map as Map
@@ -102,7 +102,8 @@ pandocToODT opts doc@(Pandoc meta _) = do
                                 readDataFile "reference.odt"
   -- handle formulas and pictures
   -- picEntriesRef <- P.newIORef ([] :: [Entry])
-  doc' <- walkM (transformPicMath opts) $ walk fixDisplayMath doc
+  let refTextWidth = referenceTextWidthPt opts refArchive
+  doc' <- walkM (transformPicMath opts refTextWidth) $ walk fixDisplayMath doc
   newContents <- lift $ writeOpenDocument opts{writerWrapText = WrapNone} doc'
   epochtime <- floor `fmap` lift P.getPOSIXTime
   let contentEntry = toEntry "content.xml" epochtime
@@ -303,16 +304,49 @@ addLang lang = everywhere' (mkT updateLangAttr)
           updateLangAttr x = x
 
 -- | transform both Image and Math elements
-transformPicMath :: PandocMonad m => WriterOptions ->Inline -> O m Inline
-transformPicMath opts (Image attr@(id', cls, _) lab (src,t)) = catchError
+-- | Width of the text area in points, from the reference document's
+-- page layout (page width minus horizontal margins).  This mirrors how
+-- the docx writer derives its print width from the reference docx
+-- section properties.
+referenceTextWidthPt :: WriterOptions -> Archive -> Maybe Double
+referenceTextWidthPt opts archive = do
+  entry <- findEntryByPath "styles.xml" archive
+  styles <- either (const Nothing) Just $
+    parseXMLElement $ toTextLazy $ fromEntry entry
+  layout <- listToMaybe $ filterElementsName
+    ((== "page-layout-properties") . qName) styles
+  let dim attrName = do
+        v <- findAttrBy ((== attrName) . qName) layout
+        d <- lengthToDim v
+        Just $ 72 * inInch opts d
+  pageWidth <- dim "page-width"
+  let margin = fromMaybe 0 . dim
+  Just $ pageWidth - margin "margin-left" - margin "margin-right"
+
+transformPicMath :: PandocMonad m
+                 => WriterOptions -> Maybe Double -> Inline -> O m Inline
+transformPicMath opts mbTextWidthPt (Image attr@(id', cls, _) lab (src,t)) =
+  catchError
    (do (img, mbMimeType) <- P.fetchItem src
        (ptX, ptY) <- case imageSize opts img of
                        Right s  -> return $ sizeInPoints s
                        Left msg -> do
                          report $ CouldNotDetermineImageSize src msg
                          return (100, 100)
+       let textWidthPt = fromMaybe 420 mbTextWidthPt
        let dims =
              case (getDim Width, getDim Height) of
+               -- Percent dimensions are not valid ODF lengths.  When both
+               -- dimensions are given and the width is relative, resolve
+               -- it against the reference document's text width (as the
+               -- docx writer does) and let the height follow the image's
+               -- aspect ratio.
+               (Just (Percent wp), Just _) ->
+                 let wIn = wp / 100 * textWidthPt / 72
+                 in [ ("width", tshow (Inch wIn))
+                    , ("height", tshow (Inch (wIn / ratio))) ]
+               (Just w@(Inch i), Just (Percent _)) ->
+                 [("width", tshow w), ("height", tshow (Inch (i / ratio)))]
                (Just w, Just h)              -> [("width", tshow w), ("height", tshow h)]
                (Just w@(Percent _), Nothing) -> [("rel-width", tshow w),("rel-height", "scale"),("width", tshow ptX <> "pt"),("height", tshow ptY <> "pt")]
                (Nothing, Just h@(Percent _)) -> [("rel-width", "scale"),("rel-height", tshow h),("width", tshow ptX <> "pt"),("height", tshow ptY <> "pt")]
@@ -347,7 +381,7 @@ transformPicMath opts (Image attr@(id', cls, _) lab (src,t)) = catchError
        report $ CouldNotFetchResource src $ T.pack (show e)
        return $ Emph lab)
 
-transformPicMath _ (Math t math) = do
+transformPicMath _ _ (Math t math) = do
   entries <- gets stEntries
   let dt = if t == InlineMath then DisplayInline else DisplayBlock
   case readTeX math of
@@ -381,7 +415,7 @@ transformPicMath _ (Math t math) = do
                                         , ("xlink:show", "embed")
                                         , ("xlink:actuate", "onLoad")]
 
-transformPicMath _ x = return x
+transformPicMath _ _ x = return x
 
 starMathCommentFromTeX :: T.Text -> T.Text
 starMathCommentFromTeX tex =

--- a/src/Text/Pandoc/Writers/OpenDocument.hs
+++ b/src/Text/Pandoc/Writers/OpenDocument.hs
@@ -747,8 +747,14 @@ inlineToOpenDocument o ils
                    getDims (("height", h):xs) = ("svg:height", h) : getDims xs
                    getDims (("rel-height", w):xs) = ("style:rel-height", w) : getDims xs
                    getDims (_:xs) =                             getDims xs
+               -- Image is an Inline: anchor the frame as a character so
+               -- it flows with the text.  Without an explicit anchor,
+               -- consumers default to paragraph anchoring and float the
+               -- frame beside the following text.
                return $ inTags False "draw:frame"
-                        (("draw:name", "img" <> tshow id') : getDims kvs) $
+                        (("draw:name", "img" <> tshow id')
+                         : ("text:anchor-type", "as-char")
+                         : getDims kvs) $
                      selfClosingTag "draw:image" [ ("xlink:href"   , s       )
                                                  , ("xlink:type"   , "simple")
                                                  , ("xlink:show"   , "embed" )

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -256,6 +256,12 @@ tests = [ testGroup "basic"
           , "Image with options with spaces" =:
             "\\includegraphics[width=12cm, height = 5cm]{foo.png}" =?>
             para (imageWith ("", [], [("width", "12cm"), ("height", "5cm")]) "foo.png" "" "image")
+          , "SVG image" =:
+            "\\includesvg{foo.svg}" =?>
+            para (image "foo.svg" "" (text "image"))
+          , "SVG image with width option" =:
+            "\\includesvg[width=0.5\\linewidth]{foo.svg}" =?>
+            para (imageWith ("", [], [("width", "50%")]) "foo.svg" "" "image")
           ]
 
         , let hex = ['0'..'9']++['a'..'f'] in

--- a/test/Tests/Readers/LaTeX.hs
+++ b/test/Tests/Readers/LaTeX.hs
@@ -54,6 +54,23 @@ tests = [ testGroup "basic"
             "\\emph{emphasized}" =?> para (emph "emphasized")
           ]
 
+        , testGroup "macros"
+          [ "csname command invocation" =:
+            T.unlines [ "\\expandafter\\def\\csname generated\\endcsname{expanded}"
+                      , "\\generated"
+                      ] =?> para "expanded"
+          , "csname-built user macro expands" =:
+            -- the space after \endcsname is consumed (control word)
+            T.unlines [ "\\def\\figx{Y}"
+                      , "pre \\csname figx\\endcsname post"
+                      ] =?> para "pre Ypost"
+          , "nested csname macro expansion" =:
+            T.unlines [ "\\newcommand{\\figpath}[1]{\\csname fig@#1\\endcsname}"
+                      , "\\expandafter\\def\\csname fig@architecture\\endcsname{figures/architecture}"
+                      , "\\figpath{architecture}"
+                      ] =?> para "figures/architecture"
+          ]
+
         , testGroup "headers"
           [ "level 1" =:
             "\\section{header}" =?> headerWith ("header",[],[]) 1 "header"

--- a/test/command/5474-figures.md
+++ b/test/command/5474-figures.md
@@ -6,10 +6,10 @@
 ![Second image](lalune.jpg)
 
 ^D
-<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1" text:anchor-type="as-char"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
 <text:p text:style-name="FigureCaption">Figure <text:sequence text:ref-name="refIllustration0" text:name="Illustration" text:formula="ooow:Illustration+1" style:num-format="1">1</text:sequence>: First
 image</text:p>
-<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img2"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img2" text:anchor-type="as-char"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
 <text:p text:style-name="FigureCaption">Figure <text:sequence text:ref-name="refIllustration1" text:name="Illustration" text:formula="ooow:Illustration+1" style:num-format="1">2</text:sequence>: Second
 image</text:p>
 ```

--- a/test/command/6774.md
+++ b/test/command/6774.md
@@ -21,7 +21,7 @@ Chapter<text:bookmark-end text:name="chapter1" /></text:h>
 <text:p text:style-name="First_20_paragraph">Chapter 1 references
 <text:bookmark-ref text:reference-format="text" text:ref-name="chapter1">The
 Chapter</text:bookmark-ref></text:p>
-<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1" text:anchor-type="as-char"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
 <text:p text:style-name="FigureCaption">Voyage dans la Lune</text:p>
 <text:p text:style-name="Text_20_body">Image 1 references
 <text:sequence-ref text:reference-format="caption" text:ref-name="lalune">La
@@ -38,7 +38,7 @@ Lune</text:sequence-ref></text:p>
 Chapter<text:bookmark-end text:name="chapter1" /></text:h>
 <text:p text:style-name="First_20_paragraph">Chapter 1 references
 <text:bookmark-ref text:reference-format="number" text:ref-name="chapter1"></text:bookmark-ref></text:p>
-<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1" text:anchor-type="as-char"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
 <text:p text:style-name="FigureCaption">lalune</text:p>
 <text:p text:style-name="Text_20_body">Image 1 references
 <text:sequence-ref text:reference-format="value" text:ref-name="lalune"></text:sequence-ref></text:p>
@@ -55,7 +55,7 @@ Chapter<text:bookmark-end text:name="chapter1" /></text:h>
 <text:p text:style-name="First_20_paragraph">Chapter 1 references
 <text:bookmark-ref text:reference-format="number" text:ref-name="chapter1"></text:bookmark-ref><text:s /><text:bookmark-ref text:reference-format="text" text:ref-name="chapter1">The
 Chapter</text:bookmark-ref></text:p>
-<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1" text:anchor-type="as-char"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
 <text:p text:style-name="FigureCaption">Voyage dans la Lune</text:p>
 <text:p text:style-name="Text_20_body">Image 1 references
 <text:sequence-ref text:reference-format="value" text:ref-name="lalune"></text:sequence-ref><text:s /><text:sequence-ref text:reference-format="caption" text:ref-name="lalune">La

--- a/test/writer.opendocument
+++ b/test/writer.opendocument
@@ -923,10 +923,10 @@ link in pointy braces</text:span></text:a>.</text:p>
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="images" />Images<text:bookmark-end text:name="images" /></text:h>
 <text:p text:style-name="First_20_paragraph">From “Voyage dans la Lune” by
 Georges Melies (1902):</text:p>
-<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
+<text:p text:style-name="FigureWithCaption"><draw:frame draw:name="img1" text:anchor-type="as-char"><draw:image xlink:href="lalune.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame></text:p>
 <text:p text:style-name="FigureCaption">lalune</text:p>
 <text:p text:style-name="Text_20_body">Here is a movie
-<draw:frame draw:name="img2"><draw:image xlink:href="movie.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame>
+<draw:frame draw:name="img2" text:anchor-type="as-char"><draw:image xlink:href="movie.jpg" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" /></draw:frame>
 icon.</text:p>
 <text:p text:style-name="Horizontal_20_Line" />
 <text:h text:style-name="Heading_20_1" text:outline-level="1"><text:bookmark-start text:name="footnotes" />Footnotes<text:bookmark-end text:name="footnotes" /></text:h>


### PR DESCRIPTION
*(Updated: the tikzpicture extraction commits have been dropped per the discussion below — whole-diagram images via a Lua filter are the right approach for that problem. What remains are five self-contained fixes.)*

Working with LaTeX documents that build figures from generated panel layouts surfaced several independent bugs in the LaTeX reader and the ODT/OpenDocument writers:

* **LaTeX reader: expand `\csname...\endcsname`** — dynamically built command names (`\expandafter\def\csname ...\endcsname`, data-driven `\input` paths) now expand. Control sequences built by `\csname` are re-expanded, so csname-built user macros work too.
* **LaTeX reader: resolve `\includesvg` sources, support `\svgpath`** — the svg package's `\includesvg` names an `.svg` file, so resolving it against the raster extension list used for `\includegraphics` found nothing; candidate files are also searched on the resource path.
* **LaTeX reader: expand macros in `\input`/`\include`/`\subfile` filenames** — filenames built from macros were used verbatim and never found.
* **OpenDocument writer: anchor image frames `as-char`** — `Image` is an `Inline`, but frames were emitted without `text:anchor-type`, so consumers applied paragraph anchoring and floated the image beside the surrounding text. (Golden test updates included.)
* **ODT writer: resolve percent image dimensions to valid lengths** — when both width and height are given and the width is a percentage, resolve it against the text width from the reference document's page layout — the same approach the docx writer takes with its reference docx section properties (`envPrintWidth`) — and derive the height from the image's aspect ratio (docx parity: a relative height has no well-defined base).

All tests pass (`cabal test`). Happy to split further if preferred.
