### PR TITLE
Note mystery behaviour in both spots in MANUAL.txt

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -394,7 +394,8 @@ header when requesting a document from a URL:
     then instead of producing a `.zip` file pandoc will create
     a directory *FILE* and unpack the zip archive there
     (unless *FILE* already exists, in which case an error
-    will be raised).
+    will be raised). Note: `-o`/`--output` must come before
+    any `--print-default-template`.
 
 `--data-dir=`*DIRECTORY*
 


### PR DESCRIPTION
This mysterious quirk needs to also be documented here as well as the other spot already in the man page.

Else half of users will still scratch their heads as to why output goes to STDOUT.

Consider also triggering an error if the user uses an --output setting that will be ignored.

Or consider making it work as users expect, and removing mention in the man pages of this quirk.



Wait, it turns out
- --print-highlight-style
- --print-default-data-file
- --print-default-template

all need to be mentioned. No, the user doesn't necessarily check each one of them, some users only check --output.

Anyway, currently if the order is not followed, output mysteriously goes to STDOUT. Just like a bug.