### PR TITLE
Update MANUAL.txt with output argument note

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -395,6 +395,10 @@ header when requesting a document from a URL:
     a directory *FILE* and unpack the zip archive there
     (unless *FILE* already exists, in which case an error
     will be raised).
+    Note: on the command line `-o`/`--output` must come before
+    any `--print-highlight-style`,
+    `--print-default-data-file`, or
+    `--print-default-template`.
 
 `--data-dir=`*DIRECTORY*
 


### PR DESCRIPTION
Add note about command line argument order for output.

Users looking at the paragraphs for
--print-highlight-style,
--print-default-data-file, or
--print-default-template
will see an --output caveat.

This pull request adds the corresponding caveat
to the --output paragraph. Else users only looking at the --output paragraph will miss the caveat.

(No need to specify what happens if the user doesn't do as instructed.)

Replaces #11706.