### PR TITLE
Typst template: allow multiword keywords

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -61,7 +61,7 @@ $endfor$
     ),
 $endif$
 $if(keywords)$
-  keywords: ($for(keywords)$$keywords$$sep$,$endfor$),
+  keywords: ($for(keywords)$"$keywords/nowrap$"$sep$,$endfor$),
 $endif$
 $if(date)$
   date: [$date$],


### PR DESCRIPTION
Typst expects single words as keywords, so keywords consisting of multiple words must be quoted (and should not be wrapped).