### PR TITLE
Fix: GFM empty task list conversion to ballot

### DIFF
--- a/src/Text/Pandoc/Shared.hs
+++ b/src/Text/Pandoc/Shared.hs
@@ -672,6 +672,10 @@ taskListItemFromAscii = handleTaskListItem fromMd
 taskListItemToAscii :: Extensions -> [Block] -> [Block]
 taskListItemToAscii = handleTaskListItem toMd
   where
+    toMd [Str "☐"] = [rawMd "[ ]"]
+    toMd [Str "☒"] = [rawMd "[x]"]
+    toMd [Str "❏"] = [rawMd "[ ]"]
+    toMd [Str "✓"] = [rawMd "[x]"]
     toMd (Str "☐" : Space : is) = rawMd "[ ]" : Space : is
     toMd (Str "☒" : Space : is) = rawMd "[x]" : Space : is
     toMd (Str "❏" : Space : is) = rawMd "[ ]" : Space : is

--- a/test/command/gfm.md
+++ b/test/command/gfm.md
@@ -220,3 +220,15 @@ hi
 - [ ] foo
 - [x] bar
 ```
+
+```
+% pandoc -f native -t gfm
+[ BulletList
+    [ [ Plain [ Str "\9744" ] ]
+    , [ Plain [ Str "\9746" ] ]
+    ]
+]
+^D
+- [ ]
+- [x]
+```


### PR DESCRIPTION
- Extended `taskListItemToAscii` to cover task lists without any content that caused markdown writer issue.
- Now, task lists without any content will be written as task lists and not markdown ballot boxes

This PR fixes #11712 