### PR TITLE
Add support for tight terms in Typst writer

### DIFF
--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -264,8 +264,11 @@ blockToTypst block =
       return $ (if isTightList items
                    then vcat items'
                    else vsep items') $$ blankline
-    DefinitionList items ->
-      ($$ blankline) . vsep <$> mapM defListItemToTypst items
+    DefinitionList items -> do
+      let concat' = if all (isTightList . snd) items
+                    then vcat
+                    else vsep
+      ($$ blankline) . concat' <$> mapM defListItemToTypst items
     Table (ident,tabclasses,tabkvs) (Caption _ caption) colspecs thead tbodies tfoot -> do
       let lab = toLabel FreestandingLabel ident
       capt' <- if null caption

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -447,11 +447,9 @@ Tight using spaces:
 / apple: #block[
 red fruit
 ]
-
 / orange: #block[
 orange fruit
 ]
-
 / banana: #block[
 yellow fruit
 ]
@@ -461,11 +459,9 @@ Tight using tabs:
 / apple: #block[
 red fruit
 ]
-
 / orange: #block[
 orange fruit
 ]
-
 / banana: #block[
 yellow fruit
 ]
@@ -511,7 +507,6 @@ red fruit
 
 computer
 ]
-
 / orange: #block[
 orange fruit
 


### PR DESCRIPTION
By making the item concatenation function depend on `isTightList`.