### PR TITLE
minor fix: docs: Correct Asciidoctor name casing.

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -302,7 +302,7 @@ header when requesting a document from a URL:
 
     ::: {#output-formats}
     - `ansi` (text with [ANSI escape codes], for terminal viewing)
-    - `asciidoc` (modern [AsciiDoc] as interpreted by [AsciiDoctor])
+    - `asciidoc` (modern [AsciiDoc] as interpreted by [Asciidoctor])
     - `asciidoc_legacy` ([AsciiDoc] as interpreted by [`asciidoc-py`]).
     - `asciidoctor` (deprecated synonym for `asciidoc`)
     - `bbcode` [BBCode]
@@ -557,7 +557,7 @@ header when requesting a document from a URL:
 [RIS]: https://en.wikipedia.org/wiki/RIS_(file_format)
 [Emacs Org mode]: https://orgmode.org
 [AsciiDoc]: https://asciidoc.org/
-[AsciiDoctor]: https://asciidoctor.org/
+[Asciidoctor]: https://asciidoctor.org/
 [`asciidoc-py`]: https://github.com/asciidoc-py/asciidoc-py
 [DZSlides]: https://paulrouget.com/dzslides/
 [Word docx]: https://en.wikipedia.org/wiki/Office_Open_XML

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ It can convert *to*
   codes](https://en.wikipedia.org/wiki/ANSI_escape_code), for terminal
   viewing)
 - `asciidoc` (modern [AsciiDoc](https://asciidoc.org/) as interpreted by
-  [AsciiDoctor](https://asciidoctor.org/))
+  [Asciidoctor](https://asciidoctor.org/))
 - `asciidoc_legacy` ([AsciiDoc](https://asciidoc.org/) as interpreted by
   [`asciidoc-py`](https://github.com/asciidoc-py/asciidoc-py)).
 - `asciidoctor` (deprecated synonym for `asciidoc`)

--- a/pandoc-cli/man/pandoc.1
+++ b/pandoc-cli/man/pandoc.1
@@ -325,7 +325,7 @@ Specify output format.
 .IP \(bu 2
 \f[CR]ansi\f[R] (text with ANSI escape codes, for terminal viewing)
 .IP \(bu 2
-\f[CR]asciidoc\f[R] (modern AsciiDoc as interpreted by AsciiDoctor)
+\f[CR]asciidoc\f[R] (modern AsciiDoc as interpreted by Asciidoctor)
 .IP \(bu 2
 \f[CR]asciidoc_legacy\f[R] (AsciiDoc as interpreted by
 \f[CR]asciidoc\-py\f[R]).

--- a/wasm/index.js
+++ b/wasm/index.js
@@ -191,7 +191,7 @@ window.pandocApp = function() {
       ansi: 'ANSI terminal',
       asciidoc: 'modern AsciiDoc',
       asciidoc_legacy: 'AsciiDoc for asciidoc-py',
-      asciidoctor: 'AsciiDoctor (= modern AsciiDoc)',
+      asciidoctor: 'Asciidoctor (= modern AsciiDoc)',
       bbcode: 'BBCode',
       beamer: 'LaTeX Beamer slides',
       biblatex: 'BibLaTeX bibliography',


### PR DESCRIPTION
This is a minor fix to use ["Asciidoctor"](https://asciidoctor.org/) instead of "AsciiDoctor" in the documents.  This doesn't change existing function names in the Haskell sources.