### PR TITLE
Typst template: rename horizontalrule to horizontalRule

### DIFF
--- a/data/templates/default.typst
+++ b/data/templates/default.typst
@@ -5,7 +5,7 @@
   stroke: none
 )
 
-#let horizontalrule = line(start: (25%,0%), end: (75%,0%))
+#let horizontalRule = line(start: (25%,0%), end: (75%,0%))
 // Polyfill divider to allow compiling with typst < 0.15:
 #let divider = if "divider" in std { divider } else { horizontalRule }
 

--- a/test/writer.typst
+++ b/test/writer.typst
@@ -5,7 +5,7 @@
   stroke: none
 )
 
-#let horizontalrule = line(start: (25%,0%), end: (75%,0%))
+#let horizontalRule = line(start: (25%,0%), end: (75%,0%))
 // Polyfill divider to allow compiling with typst < 0.15:
 #let divider = if "divider" in std { divider } else { horizontalRule }
 


### PR DESCRIPTION
The polyfill calls a camelCase `horizontalRule` yet the function is not camelCase. It should either be camelCase or not, I chose to use camelCase for the function name, though as long as they match it doesn't matter...