### PR TITLE
Update Fedora link to pandoc-cli package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -397,7 +397,7 @@ To run just the markdown benchmarks:
 [Arch]: https://archlinux.org/packages/?q=pandoc
 [Cabal User's Guide]: https://cabal.readthedocs.io/
 [Debian]: https://packages.debian.org/search?keywords=pandoc
-[Fedora]: https://packages.fedoraproject.org/pkgs/pandoc/pandoc/
+[Fedora]: https://packages.fedoraproject.org/pkgs/pandoc-cli/pandoc-cli/
 [FreeBSD]: https://www.freshports.org/textproc/hs-pandoc/
 [GHC]:  https://www.haskell.org/ghc/
 [GitLab CI/CD]: https://about.gitlab.com/stages-devops-lifecycle/continuous-integration/


### PR DESCRIPTION
I was checking the Pandoc docs for the recommended installation on Fedora, and noticed that the link to the Fedora package seems to be outdated. It works (it's not 404), but it points to some package that's for Fedora EPEL 9 and the Pandoc version is `2.14.0.3-17.el9`.

This PR updates the link to the `pandoc-cli` package, for Fedora 43, 44 (latest) and Rawhide (rolling beta), with Pandoc versions 3.6.x / 3.7.x, depending on the Fedora version.