### PR TITLE
Update MANUAL.txt with missing cross reference

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1029,6 +1029,7 @@ header when requesting a document from a URL:
     CSS or JavaScript in HTML documents.  This option can be used
     repeatedly to include multiple files in the header.  They will be
     included in the order specified.  Implies `--standalone`.
+    See also variable `header-includes`.
 
 `-B` *FILE*, `--include-before-body=`*FILE*|*URL*
 


### PR DESCRIPTION
Add missing cross reference from --include-in-header to header-includes.
