### PR TITLE
Fix upgrade detection for per-machine installations

### DIFF
--- a/windows/AdvancedWelcomeEulaDlg_Custom.wxs
+++ b/windows/AdvancedWelcomeEulaDlg_Custom.wxs
@@ -49,6 +49,7 @@
                 </Control>
               
                 <Control Id="Install" Type="PushButton" ElevationShield="yes" X="212" Y="243" Width="80" Height="17" Default="yes" Text="!(loc.AdvancedWelcomeEulaDlgInstall)" Hidden="yes">
+                    <Publish Event="DoAction" Value="FindRelatedProducts">1</Publish>
                     <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg">!(wix.WixUICostingPopupOptOut) OR CostingComplete = 1</Publish>
                     <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
                     <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)</Publish>
@@ -61,6 +62,7 @@
                     <Condition Action="hide">NOT (ALLUSERS = 1)</Condition>
                 </Control>
                 <Control Id="InstallNoShield" Type="PushButton" ElevationShield="no" X="212" Y="243" Width="80" Height="17" Default="yes" Text="!(loc.AdvancedWelcomeEulaDlgInstall)" Hidden="yes">
+                    <Publish Event="DoAction" Value="FindRelatedProducts">1</Publish>
                     <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg">!(wix.WixUICostingPopupOptOut) OR CostingComplete = 1</Publish>
                     <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
                     <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg">OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)</Publish>

--- a/windows/pandoc.wxs
+++ b/windows/pandoc.wxs
@@ -20,6 +20,10 @@
         Maximum="99.0.0.0" IncludeMaximum="no" />
     </Upgrade>
 
+    <InstallUISequence>
+      <FindRelatedProducts Suppress="yes" />
+    </InstallUISequence>
+
     <InstallExecuteSequence>
       <RemoveExistingProducts After="InstallFinalize"/>
     </InstallExecuteSequence>


### PR DESCRIPTION
This fixes an upgrade issue when `Pandoc` is installed per-machine.

`FindRelatedProducts` was being executed during the UI sequence before the user had selected the installation scope. With the default installer flow, this meant that the new package was initially treated as a per-user installation, while the existing `Pandoc` installation was per-machine:

```
FindRelatedProducts: current install is per-user.
Related install for product '{...}' is per-machine. Skipping...
```

As a result, the previous installation was not detected and remained registered as a separate product.

The installer UI subsequently sets `ALLUSERS=1` when the user selects the per-machine installation option, but by that point the initial `FindRelatedProducts` had already been skipped.

This change:

- suppresses the automatic `FindRelatedProducts` execution in the UI sequence;
- explicitly invokes `FindRelatedProducts` from the installation dialog after the installation scope has been selected.

The existing `RemoveExistingProducts` action is left unchanged.

I reproduced the problem with `Pandoc` 3.10.1 → 3.10.2 and verified that forcing ALLUSERS=1 on the command line causes the previous version to be detected and removed correctly. The proposed change makes the normal graphical installer follow the same path, without requiring a command-line property.

I have not built the installer locally, so this PR should be verified with a test build, particularly for both per-user and per-machine installation/upgrade scenarios.