### PR TITLE
feat: Add basic styling to Alerts in the HTML exporter

### DIFF
--- a/data/templates/styles.html
+++ b/data/templates/styles.html
@@ -91,6 +91,41 @@ blockquote {
   border-left: 2px solid #e6e6e6;
   color: #606060;
 }
+/* Alert styling (when +alerts is active) */
+div.alert {
+  padding: 0.5em 1em;
+  border-radius: 0.25em;
+  margin: 1em 0;
+}
+
+div.alert div.title p, div.alert div.alert-title p {
+  font-weight: bold;
+}
+
+div.alert.note, div.alert.alert-note {
+  color: rgb(125, 125, 125);
+  background-color: rgb(220, 220, 220);
+}
+
+div.alert.tip, div.alert.alert-tip {
+  color: rgb(75, 134, 75);
+  background-color: rgb(200, 250, 200);
+}
+
+div.alert.important, div.alert.alert-important {
+  color: rgb(133, 87, 133);
+  background-color: rgb(250, 180, 250);
+}
+
+div.alert.warning, div.alert.alert-warning {
+  color: rgb(130, 130, 48);
+  background-color: rgb(250, 250, 180);
+}
+
+div.alert.caution, div.alert.alert-caution {
+  color: rgb(148, 76, 76);
+  background-color: rgb(250, 210, 210);
+}
 $if(abstract)$
 div.abstract {
   margin: 2em 2em 2em 2em;

--- a/test/writer.html4
+++ b/test/writer.html4
@@ -92,6 +92,41 @@
       border-left: 2px solid #e6e6e6;
       color: #606060;
     }
+    /* Alert styling (when +alerts is active) */
+    div.alert {
+      padding: 0.5em 1em;
+      border-radius: 0.25em;
+      margin: 1em 0;
+    }
+
+    div.alert div.title p, div.alert div.alert-title p {
+      font-weight: bold;
+    }
+
+    div.alert.note, div.alert.alert-note {
+      color: rgb(125, 125, 125);
+      background-color: rgb(220, 220, 220);
+    }
+
+    div.alert.tip, div.alert.alert-tip {
+      color: rgb(75, 134, 75);
+      background-color: rgb(200, 250, 200);
+    }
+
+    div.alert.important, div.alert.alert-important {
+      color: rgb(133, 87, 133);
+      background-color: rgb(250, 180, 250);
+    }
+
+    div.alert.warning, div.alert.alert-warning {
+      color: rgb(130, 130, 48);
+      background-color: rgb(250, 250, 180);
+    }
+
+    div.alert.caution, div.alert.alert-caution {
+      color: rgb(148, 76, 76);
+      background-color: rgb(250, 210, 210);
+    }
     code {
       white-space: pre-wrap;
       font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;

--- a/test/writer.html5
+++ b/test/writer.html5
@@ -92,6 +92,41 @@
       border-left: 2px solid #e6e6e6;
       color: #606060;
     }
+    /* Alert styling (when +alerts is active) */
+    div.alert {
+      padding: 0.5em 1em;
+      border-radius: 0.25em;
+      margin: 1em 0;
+    }
+
+    div.alert div.title p, div.alert div.alert-title p {
+      font-weight: bold;
+    }
+
+    div.alert.note, div.alert.alert-note {
+      color: rgb(125, 125, 125);
+      background-color: rgb(220, 220, 220);
+    }
+
+    div.alert.tip, div.alert.alert-tip {
+      color: rgb(75, 134, 75);
+      background-color: rgb(200, 250, 200);
+    }
+
+    div.alert.important, div.alert.alert-important {
+      color: rgb(133, 87, 133);
+      background-color: rgb(250, 180, 250);
+    }
+
+    div.alert.warning, div.alert.alert-warning {
+      color: rgb(130, 130, 48);
+      background-color: rgb(250, 250, 180);
+    }
+
+    div.alert.caution, div.alert.alert-caution {
+      color: rgb(148, 76, 76);
+      background-color: rgb(250, 210, 210);
+    }
     code {
       white-space: pre-wrap;
       font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;


### PR DESCRIPTION
This PR contains the style changes I pulled out of #11836. See that PR for context.

EDIT: I just saw that this thing also includes the two changes from the other branch because I drafted this branch from the other one. I suspect we can first merge #11836 and then I can update this branch from main and get rid of the changes to the Markdown parser.