### PR TITLE
feat(typst): map `form: "prose"` citations to AuthorInText.

### DIFF
--- a/src/Text/Pandoc/Readers/Typst.hs
+++ b/src/Text/Pandoc/Readers/Typst.hs
@@ -468,7 +468,10 @@ inlineHandlers = M.fromList
                 B.citationPrefix = mempty,
                 B.citationSuffix = mempty,
                 B.citationMode = case form of
+                                    "prose" -> B.AuthorInText
                                     "year" -> B.SuppressAuthor
+                                    -- "author" and "full" have no pandoc
+                                    -- equivalent; fall back to normal
                                     _ -> B.NormalCitation,
                 B.citationNoteNum = 0,
                 B.citationHash = 0

--- a/test/typst-reader.native
+++ b/test/typst-reader.native
@@ -5346,4 +5346,80 @@ Pandoc
           , Str "2023-05-22"
           ]
       ]
+  , Header 1 ( "" , [] , [] ) [ Str "Citations" ]
+  , Para
+      [ Str "Normal:"
+      , Space
+      , Cite
+          [ Citation
+              { citationId = "brown01"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = NormalCitation
+              , citationNoteNum = 0
+              , citationHash = 0
+              }
+          ]
+          [ Str "[brown01]" ]
+      , Space
+      , Str "or"
+      , Space
+      , Cite
+          [ Citation
+              { citationId = "brown01"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = NormalCitation
+              , citationNoteNum = 0
+              , citationHash = 0
+              }
+          ]
+          [ Str "[brown01]" ]
+      , Str "."
+      ]
+  , Para
+      [ Str "Prose:"
+      , Space
+      , Cite
+          [ Citation
+              { citationId = "brown01"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = AuthorInText
+              , citationNoteNum = 0
+              , citationHash = 0
+              }
+          ]
+          [ Str "[brown01]" ]
+      ]
+  , Para
+      [ Str "Year:"
+      , Space
+      , Cite
+          [ Citation
+              { citationId = "brown01"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = SuppressAuthor
+              , citationNoteNum = 0
+              , citationHash = 0
+              }
+          ]
+          [ Str "[brown01]" ]
+      ]
+  , Para
+      [ Str "Author:"
+      , Space
+      , Cite
+          [ Citation
+              { citationId = "brown01"
+              , citationPrefix = []
+              , citationSuffix = []
+              , citationMode = NormalCitation
+              , citationNoteNum = 0
+              , citationHash = 0
+              }
+          ]
+          [ Str "[brown01]" ]
+      ]
   ]

--- a/test/typst-reader.typ
+++ b/test/typst-reader.typ
@@ -26,3 +26,13 @@ The first #count numbers of the sequence are:
 
 #include "undergradmath.typ"
 
+
+= Citations
+
+Normal: #cite(<brown01>) or @brown01.
+
+Prose: #cite(<brown01>, form: "prose")
+
+Year: #cite(<brown01>, form: "year")
+
+Author: #cite(<brown01>, form: "author")


### PR DESCRIPTION
 Typst's #cite supports a form parameter: "normal", "prose", "full", "author", and "year". The reader previously only special-cased
 "year" (→ SuppressAuthor); everything else became NormalCitation.

 Minimal repro:

 ```typst
   #cite(<doe2020>, form: "prose")
   #bibliography("refs.bib")
 ```

 With --citeproc, this rendered (Doe and Smith 2020); Typst renders narrative form Doe and Smith (2020), which corresponds to pandoc's
 AuthorInText.

 This PR maps form: "prose" → AuthorInText. The author and full forms have no pandoc citation-mode equivalent, so they intentionally
 still fall back to NormalCitation (noted in a code comment); proper support for those would need a design discussion (e.g. author-only
 citations aren't expressible in pandoc's AST today).

 Adds golden test coverage for all four forms in test/typst-reader.typ / .native.