### PR TITLE
Typst: preserve labels on no-figure tables

### DIFF
--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -364,7 +364,7 @@ blockToTypst block =
             )
             $$ ")"
       return $ if "typst:no-figure" `elem` tabclasses
-        then toTypstBracesSetText typstTextAttrs table
+        then toTypstBracesSetText typstTextAttrs table $$ lab
         else "#figure("
             $$
             nest 2

--- a/test/command/typst-table-labels.md
+++ b/test/command/typst-table-labels.md
@@ -1,0 +1,50 @@
+Identifiers are preserved on tables without a figure wrapper.
+
+```
+% pandoc -f html -t typst
+<table id="table-id" class="typst:no-figure">
+  <tr><td>A</td><td>B</td></tr>
+</table>
+^D
+#table(
+  columns: 2,
+  align: (auto,auto,),
+  [A], [B],
+)
+<table-id>
+```
+
+An explicit Typst label takes precedence over the identifier.
+
+```
+% pandoc -f html -t typst
+<table id="table-id" class="typst:no-figure" typst-label="table-label">
+  <tr><td>A</td><td>B</td></tr>
+</table>
+^D
+#table(
+  columns: 2,
+  align: (auto,auto,),
+  [A], [B],
+)
+<table-label>
+```
+
+Labels follow scoped text properties.
+
+```
+% pandoc -f html -t typst
+<table class="typst:no-figure" typst-label="table label"
+       typst:text:size="3em">
+  <tr><td>A</td><td>B</td></tr>
+</table>
+<p>Paragraph after.</p>
+^D
+#{set text(size: 3em);table(
+  columns: 2,
+  align: (auto,auto,),
+  [A], [B],
+)}
+#label("table label")
+Paragraph after.
+```


### PR DESCRIPTION
Fixes #11849.

Tables with `typst:no-figure` currently lose the label derived from
their identifier or explicit `typst-label` attribute. Preserve that
label when emitting a table without a figure wrapper.

## Change

The table branch in `src/Text/Pandoc/Writers/Typst.hs` already computes
`lab` from `typst-label`, or from the table identifier when no explicit
label is supplied. The figure-wrapped branch appends `lab`, but the
`typst:no-figure` branch returns only the table output and discards it.

Append that existing label to the result of `toTypstBracesSetText`:

```haskell
then toTypstBracesSetText typstTextAttrs table $$ lab
```

This places the label after `#table(...)`, or after the complete
`#{set text(...);table(...)}` block when text properties require a
scope. In the latter case, the label attaches to the scoped content
containing the table, and the text settings remain local to that block.
The existing `toLabel` function continues to handle label syntax,
including labels with spaces that require `#label(...)`.

## Regression coverage

Add three command tests covering:

1. A table identifier preserved with `typst:no-figure`.
2. An explicit `typst-label` taking precedence over the identifier.
3. A label containing spaces emitted after scoped text properties,
   followed by another paragraph.

All three fail before the fix solely because their label lines are
missing, and pass after it. The patch changes one writer line and adds
one 50-line command-test file.

## Validation

After the fix, all 43 Typst tests and the full suites (4163 Pandoc tests
and 48 Lua engine tests) pass. Checks of the generated output with
Typst 0.14.0 confirm the labels and preserved text scope.
HLint reports no hints for the modified writer.

The source build succeeds with `-Werror`. Local warnings about
dynamic-symbol metadata also occur with the unmodified writer using
the system C toolchain (GCC 11.4.0 and GNU ld 2.38).
