### PR TITLE
Fix fill syntax in Typst property documentation

### DIFF
--- a/doc/typst-property-output.md
+++ b/doc/typst-property-output.md
@@ -15,13 +15,13 @@ Typst properties
 [Typst](https://typst.app/) allows specification of visual and layout properties as parameters to elements
 
 ```typst
-#block(fill=orange)[Hello]
+#block(fill: orange)[Hello]
 ```
 
 and set-rules
 
 ```typst
-#set text(fill=blue); Hello
+#set text(fill: blue); Hello
 ```
 
 The parameter values are [Typst code](https://typst.app/docs/reference/syntax/#modes) that can use any features of the Typst language.


### PR DESCRIPTION
The two introductory examples in `doc/typst-property-output.md` use `fill=orange` and `fill=blue`, which fail to compile with `unknown variable: fill`. Use Typst's named-argument syntax, `fill: orange` and `fill: blue`, instead.

Validation: Both corrected examples compile successfully with Typst 0.14.0; `git diff --check` passes.
