### PR TITLE
Typst writer: preserve attributes on Divs starting with a heading

### DIFF
--- a/src/Text/Pandoc/Writers/Typst.hs
+++ b/src/Text/Pandoc/Writers/Typst.hs
@@ -394,18 +394,26 @@ blockToTypst block =
                                      ("caption: [" $$ nest 2 caption $$ "]")
                                     )
                           $$ ")" $$ lab $$ blankline
-    Div (ident,_,_) (Header lev ("",cls,kvs) ils:rest) ->
-      blocksToTypst (Header lev (ident,cls,kvs) ils:rest)
     Div (ident,_,kvs) blocks -> do
-      let lab = case lookup "typst-label" kvs of
-                  Just l -> toLabel FreestandingLabel l
-                  Nothing -> toLabel FreestandingLabel ident
       let (typstAttrs,typstTextAttrs) = pickTypstAttrs kvs
-      contents <- blocksToTypst blocks
-      return $ "#block" <> toTypstPropsListParens typstAttrs <> "["
-        $$ toTypstPoundSetText typstTextAttrs
-        $$ chomp contents
-        $$ ("]" <+> lab)
+      -- Keep section labels on headings even when the Div needs a scope.
+      let (blocks', lab, unwrap) =
+            case (lookup "typst-label" kvs, blocks) of
+              (Nothing, Header lev ("",cls,hkvs) ils:rest) ->
+                ( Header lev (ident,cls,hkvs) ils:rest
+                , mempty
+                , null typstAttrs && null typstTextAttrs )
+              (l,_) ->
+                ( blocks
+                , toLabel FreestandingLabel (fromMaybe ident l)
+                , False )
+      contents <- blocksToTypst blocks'
+      return $ if unwrap
+                  then contents
+                  else "#block" <> toTypstPropsListParens typstAttrs <> "["
+                    $$ toTypstPoundSetText typstTextAttrs
+                    $$ chomp contents
+                    $$ ("]" <+> lab)
 
 defListItemToTypst :: PandocMonad m => ([Inline], [[Block]]) -> TW m (Doc Text)
 defListItemToTypst (term, defns) = do

--- a/test/command/11854.md
+++ b/test/command/11854.md
@@ -1,0 +1,92 @@
+```
+% pandoc -f markdown-auto_identifiers -t typst
+::: {#intro}
+# Intro
+
+Body.
+:::
+^D
+= Intro
+<intro>
+Body.
+```
+
+```
+% pandoc -f markdown-auto_identifiers -t typst
+::: {#intro typst:inset=4pt}
+# Intro
+
+Body.
+:::
+^D
+#block(inset: 4pt)[
+= Intro
+<intro>
+Body.
+]
+```
+
+```
+% pandoc -f markdown-auto_identifiers -t typst
+::: {lang=zh}
+# Intro
+
+Body.
+:::
+
+Outside.
+^D
+#block[
+#set text(lang: "zh");
+= Intro
+Body.
+]
+Outside.
+```
+
+```
+% pandoc -f markdown-auto_identifiers -t typst
+::: {typst:text:fill=red}
+# Intro
+
+Body.
+:::
+
+Outside.
+^D
+#block[
+#set text(fill: red);
+= Intro
+Body.
+]
+Outside.
+```
+
+```
+% pandoc -f markdown-auto_identifiers -t typst
+::: {#intro typst-label=styled}
+# Intro
+
+Body.
+:::
+^D
+#block[
+= Intro
+Body.
+] <styled>
+```
+
+```
+% pandoc -t typst
+::: {#section-id typst:inset=4pt}
+# Intro {#heading-id}
+
+Body.
+:::
+^D
+#block(inset: 4pt)[
+= Intro
+<heading-id>
+Body.
+] <section-id>
+```


### PR DESCRIPTION
Fixes #11854.

Preserve `typst:*`, `lang`, and `typst-label` when a Div starts with a heading without an identifier.

The special `Div` case transfers the Div's ID to the heading and emits the contents directly, bypassing `pickTypstAttrs` and `typst-label` handling.

Handle this case in the common `Div` branch so attributes are processed before deciding whether a block is needed. Keep section IDs on headings for numbered references unless `typst-label` overrides them; explicit labels belong to the enclosing block. Sections without relevant attributes remain unwrapped.

Adds six cases in `test/command/11854.md`: four fail on baseline `1b175477a` and pass with the fix; two protect existing label behavior.

Validation: 4,184 main tests and 48 Typst-related tests passed; Typst compilation and semantic checks passed; HLint reported no hints.
