### PR TITLE
fix: preserve nested HTML footnote lists

### DIFF
--- a/src/Text/Pandoc/Readers/HTML.hs
+++ b/src/Text/Pandoc/Readers/HTML.hs
@@ -420,7 +420,9 @@ parseTypeAttr _   = DefaultStyle
 pOrderedList :: PandocMonad m => TagParser m Blocks
 pOrderedList = try $ do
   TagOpen _ attribs' <- pSatisfy (matchTagOpen "ol" [])
-  isNoteList <- inFootnotes <$> getState
+  inNotes <- inFootnotes <$> getState
+  inItem <- asks inListItem
+  let isNoteList = inNotes && not inItem
   let attribs = toStringAttr attribs'
   let start = fromMaybe 1 $ lookup "start" attribs >>= safeRead
   let style = fromMaybe DefaultStyle

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -145,7 +145,7 @@ tests = [ testGroup "base tag"
             <> "<li id=\"fn1\"><p>Outer</p><ol><li><p>Inner</p></li></ol></li>"
             <> "</ol></section>"
             =?> para ("Text" <> note (para "Outer" <>
-              orderedList [para "Inner"]))
+              Text.Pandoc.Builder.orderedList [para "Inner"]))
           ]
         , askOption $ \(QuickCheckTests numtests) ->
             testProperty "Round trip" $

--- a/test/Tests/Readers/HTML.hs
+++ b/test/Tests/Readers/HTML.hs
@@ -138,6 +138,15 @@ tests = [ testGroup "base tag"
             =?>
             codeBlockWith ("c", [], []) "print('hi mom!')"
           ]
+        , testGroup "footnotes"
+          [ test html "ordered lists inside footnotes" $
+            "<p>Text<a href=\"#fn1\" role=\"doc-noteref\">1</a></p>"
+            <> "<section role=\"doc-endnotes\"><ol>"
+            <> "<li id=\"fn1\"><p>Outer</p><ol><li><p>Inner</p></li></ol></li>"
+            <> "</ol></section>"
+            =?> para ("Text" <> note (para "Outer" <>
+              orderedList [para "Inner"]))
+          ]
         , askOption $ \(QuickCheckTests numtests) ->
             testProperty "Round trip" $
               withMaxSuccess (if QuickCheckTests numtests == defaultValue


### PR DESCRIPTION
Fixes #11852

The HTML reader now distinguishes the outer endnotes list from ordered lists nested inside a footnote item, preserving nested list content. A focused regression test covers the noteref and nested list shape.

Validation:
- `git diff --check`
- Focused Haskell tests not run locally because `cabal`, `stack`, and `ghc` are unavailable in this environment.