### PR TITLE
Markdown writer: escape list markers after a line break.

### DIFF
--- a/src/Text/Pandoc/Writers/Markdown.hs
+++ b/src/Text/Pandoc/Writers/Markdown.hs
@@ -429,28 +429,39 @@ blockToMarkdown' opts (Div attrs@(_,classes,_) bs)
          where (id',classes',kvs') = attrs
                attrs' = (id',classes',("markdown","1"):kvs')
 blockToMarkdown' opts (Plain inlines) = do
-  -- escape if para starts with ordered list marker
+  -- escape if a line starts with a list marker.  This must be done at the
+  -- start of every line, not just the start of the block: a sublist can
+  -- interrupt a list item's text after a LineBreak, so an unescaped marker
+  -- there would be read back as a nested list, destroying the LineBreak.
   variant <- asks envVariant
   let escapeMarker = T.concatMap $ \x -> if T.any (== x) ".()"
                                          then T.pack ['\\', x]
                                          else T.singleton x
   let startsWithSpace (Space:_)     = True
       startsWithSpace (SoftBreak:_) = True
+      startsWithSpace (LineBreak:_) = True
       startsWithSpace _             = False
+  let escapeLineStart ils =
+        case ils of
+          (Str t:ys)
+            | null ys || startsWithSpace ys
+            , beginsWithOrderedListMarker t
+            -> RawInline (Format "markdown") (escapeMarker t):ys
+          (Str t:_)
+            | t == "+" || t == "-" ||
+              (t == "%" && isEnabled Ext_pandoc_title_block opts &&
+                           isEnabled Ext_all_symbols_escapable opts)
+            -> RawInline (Format "markdown") "\\" : ils
+          _ -> ils
+  -- apply escapeLineStart to the head of the list, then after each LineBreak
+  let go ils = case ils of
+                 []             -> []
+                 (LineBreak:ys) -> LineBreak : go (escapeLineStart ys)
+                 (y:ys)         -> y : go ys
   let inlines' =
         if variant == PlainText
            then inlines
-           else case inlines of
-                  (Str t:ys)
-                    | null ys || startsWithSpace ys
-                    , beginsWithOrderedListMarker t
-                    -> RawInline (Format "markdown") (escapeMarker t):ys
-                  (Str t:_)
-                    | t == "+" || t == "-" ||
-                      (t == "%" && isEnabled Ext_pandoc_title_block opts &&
-                                   isEnabled Ext_all_symbols_escapable opts)
-                    -> RawInline (Format "markdown") "\\" : inlines
-                  _ -> inlines
+           else go (escapeLineStart inlines)
   contents <- inlineListToMarkdown opts inlines'
   return $ contents <> cr
 blockToMarkdown' opts (Para inlines) =

--- a/test/Tests/Writers/Markdown.hs
+++ b/test/Tests/Writers/Markdown.hs
@@ -49,6 +49,20 @@ tests = [ "indented code after list"
         , "emph/strong with spaces (#10696)"
              =: emph (str "f" <> strong (space <> str "d" <> space)) <> str "l" =?>
              "*f **d*** l"
+        , "bullet marker after linebreak in list item"
+             =: orderedList [ plain (str "Lead:" <> linebreak <>
+                                     str "-" <> space <> str "alpha") ]
+             =?> "1.  Lead:\\\n    \\- alpha\n"
+        , "ordered marker after linebreak in list item"
+             =: orderedList [ plain (str "Lead:" <> linebreak <>
+                                     str "3." <> space <> str "alpha") ]
+             =?> "1.  Lead:\\\n    3\\. alpha\n"
+        , "lone bullet marker after linebreak"
+             =: plain (str "Lead:" <> linebreak <> str "-")
+             =?> "Lead:\\\n\\-"
+        , "lone ordered marker after linebreak in list item"
+             =: orderedList [ plain (str "Lead:" <> linebreak <> str "3.") ]
+             =?> "1.  Lead:\\\n    3\\."
         ] ++ [noteTests] ++ [shortcutLinkRefsTests]
 
 {-


### PR DESCRIPTION
Closes #11862.

The markdown writer escaped a literal list marker at the start of a block, but not at the start of a line after a `LineBreak`. Inside a list item a sublist can interrupt the item's text without a blank line, so the unescaped marker was read back as a nested list and the `LineBreak` was lost:

```
$ printf '3.  Lead:\\\n    \\- alpha\n' | pandoc -f markdown -t markdown
3.  Lead:\
    - alpha
```

The escaping in `blockToMarkdown' opts (Plain inlines)` is factored out into `escapeLineStart` and applied after each `LineBreak` as well as at the head of the block. `startsWithSpace` now also treats a following `LineBreak` as end-of-line, which covers a marker that ends a line (a lone `3.`).

I did not restrict the new escaping to list items, even though that is the only destructive context. An escaped marker reads back identically anywhere. 