### PR TITLE
Typst reader: emit Plain for single-paragraph table cells

### DIFF
--- a/src/Text/Pandoc/Readers/Typst.hs
+++ b/src/Text/Pandoc/Readers/Typst.hs
@@ -732,7 +732,7 @@ parseTable mbident fields = do
   let toCell tableSection tableData contents = do
         case contents of
           [Elt (Identifier "grid.cell") _pos fs] -> do
-            bs <- B.toList <$> (getField "body" fs >>= pWithContents pBlocks)
+            bs <- B.toList . plainify <$> (getField "body" fs >>= pWithContents pBlocks)
             rowspan <- getField "rowspan" fs <|> pure 1
             colspan <- getField "colspan" fs <|> pure 1
             align' <- (toAlign <$> getField "align" fs) <|> pure B.AlignDefault
@@ -752,7 +752,7 @@ parseTable mbident fields = do
             getField "children" fs >>=
               foldM (toCell TFooter) tableData . V.toList
           _ -> do
-            bs <- B.toList <$> pWithContents pBlocks contents
+            bs <- B.toList . plainify <$> pWithContents pBlocks contents
             pure $ addCell tableSection
               (B.Cell B.nullAttr B.AlignDefault (B.RowSpan 1) (B.ColSpan 1) bs)
               tableData
@@ -771,6 +771,12 @@ parseTable mbident fields = do
       (B.TableHead B.nullAttr headRows)
       [B.TableBody B.nullAttr 0 [] bodyRows]
       (B.TableFoot B.nullAttr footRows)
+
+-- | Convert a singleton Para to Plain, for consistency with other readers.
+plainify :: B.Blocks -> B.Blocks
+plainify blks = case B.toList blks of
+  [Para ils] -> B.fromList [Plain ils]
+  _          -> blks
 
 data TableSection = THeader | TBody | TFooter
   deriving (Show, Ord, Eq)

--- a/test/typst-reader.native
+++ b/test/typst-reader.native
@@ -88,49 +88,49 @@ Pandoc
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Math InlineMath "F_{1}" ] ]
+                      [ Plain [ Math InlineMath "F_{1}" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Math InlineMath "F_{2}" ] ]
+                      [ Plain [ Math InlineMath "F_{2}" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Math InlineMath "F_{3}" ] ]
+                      [ Plain [ Math InlineMath "F_{3}" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Math InlineMath "F_{4}" ] ]
+                      [ Plain [ Math InlineMath "F_{4}" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Math InlineMath "F_{5}" ] ]
+                      [ Plain [ Math InlineMath "F_{5}" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Math InlineMath "F_{6}" ] ]
+                      [ Plain [ Math InlineMath "F_{6}" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Math InlineMath "F_{7}" ] ]
+                      [ Plain [ Math InlineMath "F_{7}" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Math InlineMath "F_{8}" ] ]
+                      [ Plain [ Math InlineMath "F_{8}" ] ]
                   ]
               , Row
                   ( "" , [] , [] )
@@ -139,49 +139,49 @@ Pandoc
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Str "1" ] ]
+                      [ Plain [ Str "1" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Str "1" ] ]
+                      [ Plain [ Str "1" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Str "2" ] ]
+                      [ Plain [ Str "2" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Str "3" ] ]
+                      [ Plain [ Str "3" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Str "5" ] ]
+                      [ Plain [ Str "5" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Str "8" ] ]
+                      [ Plain [ Str "8" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Str "13" ] ]
+                      [ Plain [ Str "13" ] ]
                   , Cell
                       ( "" , [] , [] )
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para [ Str "21" ] ]
+                      [ Plain [ Str "21" ] ]
                   ]
               ]
           ]
@@ -294,7 +294,7 @@ Pandoc
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para
+                      [ Plain
                           [ Span
                               ( "" , [ "box" ] , [] )
                               [ Str "2023-05-22"
@@ -308,7 +308,7 @@ Pandoc
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para
+                      [ Plain
                           [ Str "This"
                           , Space
                           , Str "is"
@@ -349,7 +349,7 @@ Pandoc
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para
+                      [ Plain
                           [ Span
                               ( "" , [ "box" ] , [] ) [ Str "\128166" ]
                           ]
@@ -359,7 +359,7 @@ Pandoc
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para
+                      [ Plain
                           [ Str "Get"
                           , Space
                           , Str "this"
@@ -404,7 +404,7 @@ Pandoc
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para
+                      [ Plain
                           [ Span
                               ( "" , [ "box" ] , [] )
                               [ Str "No"
@@ -420,7 +420,7 @@ Pandoc
                       AlignDefault
                       (RowSpan 1)
                       (ColSpan 1)
-                      [ Para
+                      [ Plain
                           [ Str "Don\8217t"
                           , Space
                           , Str "know"
@@ -558,7 +558,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "x^{2}"
@@ -572,7 +572,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\sqrt{2}"
@@ -595,7 +595,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "x_{i,j}"
@@ -609,7 +609,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\frac{2}{3}"
@@ -683,7 +683,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\alpha"
@@ -697,7 +697,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\xi"
@@ -720,7 +720,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\beta"
@@ -734,7 +734,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\959"
@@ -751,7 +751,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\gamma"
@@ -771,7 +771,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\pi"
@@ -794,7 +794,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\delta"
@@ -814,7 +814,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\varpi"
@@ -831,7 +831,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\epsilon"
@@ -845,7 +845,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\rho"
@@ -862,7 +862,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\varepsilon"
@@ -876,7 +876,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\varrho"
@@ -893,7 +893,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\zeta"
@@ -907,7 +907,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\sigma"
@@ -930,7 +930,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\eta"
@@ -944,7 +944,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\varsigma"
@@ -966,7 +966,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\theta"
@@ -986,7 +986,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\tau"
@@ -1003,7 +1003,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\vartheta"
@@ -1017,7 +1017,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\upsilon"
@@ -1040,7 +1040,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\iota"
@@ -1054,7 +1054,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\phi"
@@ -1077,7 +1077,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\kappa"
@@ -1091,7 +1091,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\varphi"
@@ -1108,7 +1108,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\lambda"
@@ -1128,7 +1128,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\chi"
@@ -1145,7 +1145,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mu"
@@ -1159,7 +1159,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\psi"
@@ -1182,7 +1182,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\nu"
@@ -1196,7 +1196,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\omega"
@@ -1246,7 +1246,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\cup"
@@ -1260,7 +1260,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mathbb{R}"
@@ -1277,7 +1277,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\forall"
@@ -1294,7 +1294,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\cap"
@@ -1308,7 +1308,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mathbb{Z}"
@@ -1325,7 +1325,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\exists"
@@ -1342,7 +1342,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\subset"
@@ -1356,7 +1356,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mathbb{Q}"
@@ -1373,7 +1373,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\neg"
@@ -1390,7 +1390,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\subseteq"
@@ -1404,7 +1404,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mathbb{N}"
@@ -1421,7 +1421,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\vee"
@@ -1438,7 +1438,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\supset"
@@ -1452,7 +1452,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mathbb{C}"
@@ -1469,7 +1469,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\land"
@@ -1486,7 +1486,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\supseteq"
@@ -1500,7 +1500,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\varnothing"
@@ -1514,7 +1514,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\vdash"
@@ -1531,7 +1531,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\in"
@@ -1545,7 +1545,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\varnothing"
@@ -1559,7 +1559,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\models"
@@ -1576,7 +1576,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\notin"
@@ -1590,7 +1590,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\1488"
@@ -1604,7 +1604,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\smallsetminus"
@@ -1814,7 +1814,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "f'"
@@ -1831,7 +1831,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\dot{a}"
@@ -1845,7 +1845,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\widetilde{a}"
@@ -1862,7 +1862,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "f''"
@@ -1877,7 +1877,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\ddot{a}"
@@ -1891,7 +1891,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\overline{a}"
@@ -1908,7 +1908,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\Sigma^{\\ast}"
@@ -1922,7 +1922,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\hat{a}"
@@ -1936,7 +1936,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math
@@ -2181,7 +2181,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\sin"
@@ -2195,7 +2195,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\sinh"
@@ -2209,7 +2209,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\arcsin"
@@ -2226,7 +2226,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\cos"
@@ -2240,7 +2240,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\cosh"
@@ -2254,7 +2254,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\arccos"
@@ -2271,7 +2271,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\tan"
@@ -2285,7 +2285,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\tanh"
@@ -2299,7 +2299,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\arctan"
@@ -2316,7 +2316,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\sec"
@@ -2330,7 +2330,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\coth"
@@ -2344,7 +2344,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\min"
@@ -2361,7 +2361,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\csc"
@@ -2375,7 +2375,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\det"
@@ -2389,7 +2389,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\max"
@@ -2406,7 +2406,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\cot"
@@ -2420,7 +2420,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\dim"
@@ -2434,7 +2434,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\inf"
@@ -2451,7 +2451,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\exp"
@@ -2465,7 +2465,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\ker"
@@ -2479,7 +2479,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\sup"
@@ -2496,7 +2496,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\log"
@@ -2510,7 +2510,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\deg"
@@ -2524,7 +2524,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\liminf"
@@ -2541,7 +2541,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\ln"
@@ -2555,7 +2555,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\arg"
@@ -2569,7 +2569,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\limsup"
@@ -2586,7 +2586,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\lg"
@@ -2600,7 +2600,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\gcd"
@@ -2614,7 +2614,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\lim"
@@ -2651,7 +2651,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "<"
@@ -2668,7 +2668,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\angle"
@@ -2682,7 +2682,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\cdot"
@@ -2699,7 +2699,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\leq"
@@ -2716,7 +2716,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\measuredangle"
@@ -2730,7 +2730,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\pm"
@@ -2747,7 +2747,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath ">"
@@ -2764,7 +2764,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\ell"
@@ -2778,7 +2778,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mp"
@@ -2795,7 +2795,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\geq"
@@ -2812,7 +2812,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\parallel"
@@ -2826,7 +2826,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\times"
@@ -2843,7 +2843,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\neq"
@@ -2860,7 +2860,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "45{^\\circ}"
@@ -2874,7 +2874,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\div"
@@ -2891,7 +2891,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\ll"
@@ -2908,7 +2908,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\cong"
@@ -2922,7 +2922,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\ast"
@@ -2942,7 +2942,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\gg"
@@ -2959,7 +2959,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\ncong"
@@ -2974,7 +2974,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mid"
@@ -2991,7 +2991,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\approx"
@@ -3005,7 +3005,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\sim"
@@ -3019,7 +3019,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\nmid"
@@ -3036,7 +3036,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\asymp"
@@ -3055,7 +3055,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\simeq"
@@ -3069,7 +3069,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "n!"
@@ -3086,7 +3086,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\equiv"
@@ -3100,7 +3100,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\nsim"
@@ -3114,7 +3114,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\partial"
@@ -3131,7 +3131,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\prec"
@@ -3145,7 +3145,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\oplus"
@@ -3159,7 +3159,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\nabla"
@@ -3176,7 +3176,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\preceq"
@@ -3190,7 +3190,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\ominus"
@@ -3204,7 +3204,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\295"
@@ -3221,7 +3221,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\succ"
@@ -3235,7 +3235,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\odot"
@@ -3249,7 +3249,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\circ"
@@ -3268,7 +3268,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\succeq"
@@ -3282,7 +3282,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\otimes"
@@ -3296,7 +3296,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\star"
@@ -3313,7 +3313,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\propto"
@@ -3327,7 +3327,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\oslash"
@@ -3346,7 +3346,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\sqrt{}"
@@ -3363,7 +3363,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\doteq"
@@ -3382,7 +3382,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\upharpoonright"
@@ -3396,7 +3396,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\10003"
@@ -3483,7 +3483,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\rightarrow"
@@ -3500,7 +3500,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\mapsto"
@@ -3520,7 +3520,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\nrightarrow"
@@ -3534,7 +3534,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\longmapsto"
@@ -3553,7 +3553,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\longrightarrow"
@@ -3567,7 +3567,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\leftarrow"
@@ -3587,7 +3587,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\Rightarrow"
@@ -3605,7 +3605,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math
@@ -3627,7 +3627,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\nRightarrow"
@@ -3643,7 +3643,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\downarrow"
@@ -3660,7 +3660,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\Longrightarrow"
@@ -3676,7 +3676,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\uparrow"
@@ -3693,7 +3693,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\rightsquigarrow"
@@ -3708,7 +3708,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\updownarrow"
@@ -3837,7 +3837,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\int"
@@ -3851,7 +3851,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\iiint"
@@ -3866,7 +3866,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\bigcup"
@@ -3883,7 +3883,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\iint"
@@ -3898,7 +3898,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\oint"
@@ -3913,7 +3913,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\bigcap"
@@ -3949,7 +3949,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "()"
@@ -3963,7 +3963,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\langle\\rangle"
@@ -3979,7 +3979,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math
@@ -3997,7 +3997,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math InlineMath "\\lbrack\\rbrack"
@@ -4011,7 +4011,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math
@@ -4027,7 +4027,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math
@@ -4046,7 +4046,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math
@@ -4061,7 +4061,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Span
                                   ( "" , [ "box" ] , [] )
                                   [ Math
@@ -4118,7 +4118,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\left. \\left\\lbrack \\sum_{k = 0}^{n}e^{k^{2}} \\right\\rbrack \\right."
@@ -4185,7 +4185,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\left\\langle i,2^{2^{i}} \\right\\rangle"
@@ -4262,7 +4262,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\left( \\frac{1}{n^{\\alpha}} \\right)"
@@ -4283,7 +4283,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath "(\\frac{1}{n^{\\alpha}})"
                               ]
@@ -4347,7 +4347,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\left. \\frac{df}{dx} \\right|_{x_{0}}"
@@ -4417,7 +4417,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\begin{pmatrix}\na & b \\\\\nc & d\n\\end{pmatrix}"
@@ -4561,7 +4561,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "f_{n} = \\begin{cases}\na & \\text{if }n = 0 \\\\\nr \\cdot f_{n - 1} & \\text{else }\n\\end{cases}"
@@ -4773,7 +4773,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math DisplayMath "S = k \\cdot \\lg W" ]
                           ]
                       , Cell
@@ -4822,7 +4822,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\begin{array}{r}\n\\sin(x) = x - \\frac{x^{3}}{3!} \\\\\n + \\frac{x^{5}}{5!} - \\cdots\n\\end{array}"
@@ -4871,7 +4871,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\begin{aligned}\n\\nabla \\cdot \\mathbf{D} & = \\rho \\\\\n\\nabla \\cdot \\mathbf{B} & = 0\n\\end{aligned}"
@@ -4964,7 +4964,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   InlineMath
                                   "f:{\\mathbb{R}} \\rightarrow {\\mathbb{R}}"
@@ -4984,7 +4984,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math InlineMath "9.8\\ \\text{ m/s}^{2}"
                               ]
                           ]
@@ -4993,7 +4993,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Code
                                   ( "" , [] , [] ) "\"9.8\" \"m/s\"^2"
                               , Space
@@ -5011,7 +5011,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\lim\\limits_{h \\rightarrow 0}\\frac{f(x + h) - f(x)}{h}"
@@ -5034,7 +5034,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\int x^{2}dx = x^{3}/3 + C"
@@ -5057,7 +5057,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   DisplayMath
                                   "\\nabla = \\mathbf{i}\\frac{d}{dx} + \\mathbf{j}\\frac{d}{dy} + \\mathbf{k}\\frac{d}{dz}"
@@ -5209,7 +5209,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   InlineMath
                                   "\\sigma^{2} = \\sqrt{{\\sum(x_{i} - \\mu)}^{2}/N}"
@@ -5232,7 +5232,7 @@ Pandoc
                           AlignDefault
                           (RowSpan 1)
                           (ColSpan 1)
-                          [ Para
+                          [ Plain
                               [ Math
                                   InlineMath
                                   "E(X) = \\mu_{X} = \\sum(x_{i} - P\\left( x_{i} \\right))"


### PR DESCRIPTION
## Summary

Table cells consisting of a single paragraph are now emitted as `Plain` instead of `Para` by the Typst reader, per cell. This matches the convention of every other table-capable reader and fixes the bloated docx spacing reported in #11864.

Partially addresses #11864.

## Problem

The Typst reader always wrapped cell content in `Para`, no matter how simple the cell. Downstream, the docx writer maps `Plain` in table cells to the Compact paragraph style (1.8pt before/after) but `Para` to Body Text (9pt before/after). As a result every table converted from Typst rendered with bloated rows in docx, and a cell's styling depended on an encoding artifact rather than its content.

Every other reader normalizes single-paragraph cells to `Plain`, per cell:

| Reader | mechanism |
|---|---|
| Markdown pipe tables | `B.plain` in `pipeTableCell` |
| Markdown / RST grid tables | `plainify` in `Text.Pandoc.Parsing.GridTable` |
| LaTeX | `plainify` in `LaTeX/Table.hs` |
| Org | `B.plain` per cell |
| HTML | reflects markup: bare `<td>` content is `Plain`, `<p>` is `Para` |
| docx | `singleParaToPlain` per cell |

The Typst reader was the only outlier.

## Fix

New `plainifyCell` helper applied in `addCell` in `parseTable`, converting `[Para ils]` to `[Plain ils]`. Covers header, body, and footer cells. Cells with more than one block are untouched and keep `Para`, preserving Body Text separation between paragraphs in docx output.

The criterion is per cell rather than per table, following the established convention: mixed `Plain`/`Para` tables already arise from grid tables, LaTeX, HTML, and docx round trips, so writers must handle them regardless.

## Tests

- Regenerated `test/typst-reader.native`; the diffs are exactly the expected `Para` to `Plain` conversions inside table cells.
- All 40 Typst reader/writer tests pass.
- End to end: the table from #11864 now produces Compact-styled cells in docx output.

## Notes

- This supersedes the earlier writer-side version of this PR, which applied Compact to `Para` cells in the docx writer.
- #11867 (docx writer drops `pStyle` when cell alignment is set) is a separate writer-side issue and remains open.
- The branch name predates the pivot; the fix is now entirely in the Typst reader.
